### PR TITLE
Remove instance_id_segmentation_fast from OVRTX renderer integration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -168,6 +168,7 @@ Guidelines for modifications:
 * Rebecca Zhang
 * Renaud Poncelet
 * René Zurbrügg
+* Richard Lei
 * Richard Schmitt
 * RinZ27
 * Ritvik Singh

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -251,7 +251,7 @@ is :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`, and ``Newton Warp`` is
      - ✅
    * - ``instance_id_segmentation_fast``
      - ✅
-     - ✅
+     - ❌
      - ❌
 
 RGB and RGBA

--- a/source/isaaclab_ov/changelog.d/ovrtx-remove-instance-id-seg.minor.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-remove-instance-id-seg.minor.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Removed support for ``instance_id_segmentation_fast`` from the OVRTX renderer.
+  Requesting this data type via :class:`~isaaclab_ov.renderers.OVRTXRendererCfg` will now raise an
+  error at camera allocation time. Use :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg` if
+  ``instance_id_segmentation_fast`` is required.

--- a/source/isaaclab_ov/changelog.d/ovrtx-remove-instance-id-seg.minor.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-remove-instance-id-seg.minor.rst
@@ -1,7 +1,7 @@
 Changed
 ^^^^^^^
 
-* Removed support for ``instance_id_segmentation_fast`` from the OVRTX renderer.
-  Requesting this data type via :class:`~isaaclab_ov.renderers.OVRTXRendererCfg` will now raise an
-  error at camera allocation time. Use :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg` if
-  ``instance_id_segmentation_fast`` is required.
+* Removed support for ``instance_id_segmentation_fast`` from the OVRTX renderer, as it has no
+  real-world sensor equivalent. Requesting this data type via
+  :class:`~isaaclab_ov.renderers.OVRTXRendererCfg` will now raise an error at camera allocation
+  time. Use ``instance_segmentation_fast`` or ``semantic_segmentation`` instead.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -265,11 +265,6 @@ class OVRTXRenderer(BaseRenderer):
         instance_seg_spec = (
             RenderBufferSpec(4, wp.uint8) if self.cfg.colorize_instance_segmentation else RenderBufferSpec(1, wp.uint32)
         )
-        instance_id_seg_spec = (
-            RenderBufferSpec(4, wp.uint8)
-            if self.cfg.colorize_instance_id_segmentation
-            else RenderBufferSpec(1, wp.uint32)
-        )
         # Semantic segmentation: colorized RGBA (uint8), else raw int32 IDs (matches Isaac RTX, whose
         # non-colorized per-pixel value is the semantic ID).
         semantic_seg_spec = (
@@ -285,7 +280,6 @@ class OVRTXRenderer(BaseRenderer):
             RenderBufferKind.SIMPLE_SHADING_FULL_MDL: RenderBufferSpec(3, wp.uint8),
             RenderBufferKind.SEMANTIC_SEGMENTATION: semantic_seg_spec,
             RenderBufferKind.INSTANCE_SEGMENTATION_FAST: instance_seg_spec,
-            RenderBufferKind.INSTANCE_ID_SEGMENTATION_FAST: instance_id_seg_spec,
             RenderBufferKind.DEPTH: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_IMAGE_PLANE: RenderBufferSpec(1, wp.float32),
             RenderBufferKind.DISTANCE_TO_CAMERA: RenderBufferSpec(1, wp.float32),
@@ -890,9 +884,9 @@ class OVRTXRenderer(BaseRenderer):
     ) -> None:
         """Extract a uint32 ID-segmentation render var into ``output_buffers[buffer_key]``.
 
-        Shared by ``semantic_segmentation`` (``SemanticSegmentation``), ``instance_segmentation_fast``
-        (``NonStableInstanceSegmentation``), and ``instance_id_segmentation_fast`` (``InstanceSegmentationSD``),
-        which only differ in the source render var, the destination buffer, and whether to colorize.
+        Shared by ``semantic_segmentation`` (``SemanticSegmentation``) and ``instance_segmentation_fast``
+        (``NonStableInstanceSegmentation``), which only differ in the source render var, the destination buffer,
+        and whether to colorize.
 
         Args:
             render_data: OVRTX render data for the current frame.
@@ -1169,15 +1163,6 @@ class OVRTXRenderer(BaseRenderer):
         # camera.data.info["instance_segmentation_fast"]["idToLabels"] and ["idToSemantics"].
         if "instance_segmentation_fast" in output_buffers:
             self._process_instance_segmentation_maps(render_data, frame)
-
-        self._process_id_segmentation_render_var(
-            render_data,
-            frame,
-            output_buffers,
-            "InstanceSegmentationSD",
-            "instance_id_segmentation_fast",
-            self.cfg.colorize_instance_id_segmentation,
-        )
 
         if "NormalSD" in frame.render_vars and "normals" in output_buffers:
             with frame.render_vars["NormalSD"].map(device=Device.CUDA) as mapping:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -24,67 +24,34 @@ def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
     use_albedo = "albedo" in data_types
     use_semantic = "semantic_segmentation" in data_types
     use_instance_seg = "instance_segmentation_fast" in data_types
-    use_instance_id_seg = "instance_id_segmentation_fast" in data_types
     use_normals = "normals" in data_types
     use_motion_vectors = "motion_vectors" in data_types
     use_rgb = any(dt in ["rgb", "rgba"] for dt in data_types)
     use_hdr = "rgb_hdr" in data_types
 
     if use_depth and not (
-        use_rgb
-        or use_albedo
-        or use_semantic
-        or use_instance_seg
-        or use_instance_id_seg
-        or use_normals
-        or use_motion_vectors
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_normals or use_motion_vectors
     ):
         source = "DistanceToCameraSD" if use_distance_to_camera else "DistanceToImagePlaneSD"
         return "/Render/Vars/depth", "depth", source
-    if use_albedo and not (
-        use_rgb or use_semantic or use_instance_seg or use_instance_id_seg or use_normals or use_motion_vectors
-    ):
+    if use_albedo and not (use_rgb or use_semantic or use_instance_seg or use_normals or use_motion_vectors):
         return "/Render/Vars/albedo", "albedo", "DiffuseAlbedoSD"
     if use_semantic and not (use_rgb or use_albedo or use_normals or use_motion_vectors):
         return "/Render/Vars/semantic", "semantic", "SemanticSegmentation"
     if use_instance_seg and not (
-        use_rgb
-        or use_albedo
-        or use_semantic
-        or use_instance_id_seg
-        or use_normals
-        or use_depth
-        or use_hdr
-        or use_motion_vectors
+        use_rgb or use_albedo or use_semantic or use_normals or use_depth or use_hdr or use_motion_vectors
     ):
         return (
             "/Render/Vars/NonStableInstanceSegmentation",
             "NonStableInstanceSegmentation",
             "NonStableInstanceSegmentation",
         )
-    if use_instance_id_seg and not (
-        use_rgb
-        or use_albedo
-        or use_semantic
-        or use_instance_seg
-        or use_normals
-        or use_depth
-        or use_hdr
-        or use_motion_vectors
-    ):
-        return "/Render/Vars/InstanceSegmentationSD", "InstanceSegmentationSD", "InstanceSegmentationSD"
     if use_normals and not (
-        use_rgb
-        or use_albedo
-        or use_semantic
-        or use_instance_seg
-        or use_instance_id_seg
-        or use_depth
-        or use_motion_vectors
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_depth or use_motion_vectors
     ):
         return "/Render/Vars/NormalSD", "NormalSD", "NormalSD"
     if use_motion_vectors and not (
-        use_rgb or use_albedo or use_semantic or use_instance_seg or use_instance_id_seg or use_depth or use_normals
+        use_rgb or use_albedo or use_semantic or use_instance_seg or use_depth or use_normals
     ):
         return "/Render/Vars/TargetMotionSD", "TargetMotionSD", "TargetMotionSD"
     if use_hdr and not use_rgb:

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -84,7 +84,6 @@ def test_ovrtx_supported_output_types_key_set():
         RenderBufferKind.SIMPLE_SHADING_FULL_MDL,
         RenderBufferKind.SEMANTIC_SEGMENTATION,
         RenderBufferKind.INSTANCE_SEGMENTATION_FAST,
-        RenderBufferKind.INSTANCE_ID_SEGMENTATION_FAST,
         RenderBufferKind.DEPTH,
         RenderBufferKind.DISTANCE_TO_IMAGE_PLANE,
         RenderBufferKind.DISTANCE_TO_CAMERA,

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -90,15 +90,6 @@ def test_ovrtx_instance_segmentation_fast_uses_non_stable_instance_segmentation_
     )
 
 
-def test_ovrtx_instance_id_segmentation_fast_uses_instance_segmentation_sd_render_var():
-    """Requesting instance_id_segmentation_fast from OVRTX selects the InstanceSegmentationSD render variable."""
-    assert get_render_var_config(["instance_id_segmentation_fast"]) == (
-        "/Render/Vars/InstanceSegmentationSD",
-        "InstanceSegmentationSD",
-        "InstanceSegmentationSD",
-    )
-
-
 def test_ovrtx_motion_vectors_uses_target_motion_render_var():
     """Requesting motion vectors from OVRTX selects the TargetMotionSD render variable."""
     assert get_render_var_config(["motion_vectors"]) == (

--- a/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45a4f2dc3c72e0c1472a66c096f106fca193ec18921ad86635f8ef862980a419
-size 596

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df0dacf8a21ac62bfbd9d4c43354a108283d99eb26d7c661156dded7f9216718
-size 593

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_hetero/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e71bcee0ed23c5eb3f243b626560c34f40f9b7d7aec8a3a7fcaa39452512d5a7
-size 1258

--- a/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/dexsuite_kuka_homo/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50ebc2502eca0cab618f5e28238724cf7e921d105c4d777889a95dff32b04b9b
-size 1285

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35c71443a5a2d8d509975f32c7dd551505ce86cdae8a76285afabdfff015b30f
-size 4539

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b26757021d744c810ea1a944d2819ddef89920c720d676367c0fcc0571edb7e9
-size 3427

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_id_segmentation_fast.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/newton-ovrtx_renderer-instance_id_segmentation_fast.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07e2bec85c84cbf9884176ac07d37dfead6f8f7a72217095f2bd3a1a1e4bdd5d
-size 3768

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -132,6 +132,10 @@ _NEWTON_WARP_DATA_TYPES = (
     "normals",
 )
 
+# Data types the OVRTX renderer supports. ``instance_id_segmentation_fast`` is intentionally
+# excluded; the OVRTX renderer does not support it.
+_OVRTX_DATA_TYPES = tuple(dt for dt in _DEFAULT_SENSOR_DATA_TYPES if dt != "instance_id_segmentation_fast")
+
 
 def _make_sensor_data_type_params(
     physics_backend: str,
@@ -176,8 +180,8 @@ PHYSICS_RENDERER_AOV_COMBINATIONS = [
 ]
 
 KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = [
-    *_make_sensor_data_type_params("ovphysx", "ovrtx"),
-    *_make_sensor_data_type_params("newton", "ovrtx"),
+    *_make_sensor_data_type_params("ovphysx", "ovrtx", _OVRTX_DATA_TYPES),
+    *_make_sensor_data_type_params("newton", "ovrtx", _OVRTX_DATA_TYPES),
     *_make_sensor_data_type_params(
         "ovphysx", "newton", _NEWTON_WARP_DATA_TYPES, flaky=False, renderer_label="newton_warp"
     ),

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -133,7 +133,8 @@ _NEWTON_WARP_DATA_TYPES = (
 )
 
 # Data types the OVRTX renderer supports. ``instance_id_segmentation_fast`` is intentionally
-# excluded; the OVRTX renderer does not support it.
+# excluded: it has no real-world sensor equivalent, so the OVRTX integration does not support it.
+# Users should use ``instance_segmentation_fast`` or ``semantic_segmentation`` instead.
 _OVRTX_DATA_TYPES = tuple(dt for dt in _DEFAULT_SENSOR_DATA_TYPES if dt != "instance_id_segmentation_fast")
 
 


### PR DESCRIPTION
# Description

Remove instance_id_segmentation_fast from OVRTX renderer integration

We decided not to support this output in the OVRTX integration going forward as there is no real-world sensor that is representative of it

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there