### PR TITLE
Fix contact sensor filter matching geometry children with same name

### DIFF
--- a/source/isaaclab_physx/changelog.d/octi-fix-contact-filter-rigid-body-only.rst
+++ b/source/isaaclab_physx/changelog.d/octi-fix-contact-filter-rigid-body-only.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.sensors.ContactSensor` incorrectly matching geometry children
+  when resolving ``filter_prim_paths_expr``. URDF-to-USD conversion creates prim hierarchies
+  where a rigid body and its geometry child share the same leaf name (e.g. ``Object`` and
+  ``Object/Object``). PhysX's glob engine prefix-matches bare leaf patterns, finding both
+  prims and raising a count-consistency error. The fix wraps the leaf segment in PhysX
+  alternation syntax ``(leaf)`` before the ``.*`` → ``*`` conversion, anchoring the match
+  to the correct path depth.

--- a/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/contact_sensor/contact_sensor.py
@@ -340,7 +340,14 @@ class ContactSensor(BaseContactSensor):
         # note: with a list of patterns, the views order bodies pattern-major:
         #   view_id = body_id * num_envs + env_id
         body_path_globs = [expr.replace(".*", "*") for _, expr in body_matches]
-        filter_prim_paths_glob = [expr.replace(".*", "*") for expr in self.cfg.filter_prim_paths_expr]
+        # Wrap the leaf segment of each filter expression in PhysX alternation syntax before
+        # the standard .* -> * conversion. PhysX's glob engine prefix-matches bare leaf
+        # patterns, so env_*/Object also matches env_0/Object/Object (a geometry child
+        # sharing the same name -- a common URDF-to-USD artifact). Wrapping in (leaf)
+        # anchors the match to that exact path depth.
+        filter_prim_paths_glob = [
+            re.sub(r"([^/]+)$", r"(\1)", expr).replace(".*", "*") for expr in self.cfg.filter_prim_paths_expr
+        ]
 
         # create a rigid prim view for the sensor
         self._body_physx_view = self._physics_sim_view.create_rigid_body_view(body_path_globs)

--- a/source/isaaclab_physx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_physx/test/sensors/test_contact_sensor.py
@@ -519,19 +519,23 @@ def test_contact_sensor_filter_same_name_geometry_child(setup_simulation, device
             env_xform = UsdGeom.Xform.Define(stage, env_path)
             env_xform.AddTranslateOp().Set(Gf.Vec3d(3.0 * env_id, 0.0, 0.0))
 
-            # Sensor subject: a simple kinematic rigid body cube.
+            # Sensor subject: an Xform rigid body with a separate geometry child.
+            # RigidBodyAPI must be on the Xform parent, not the geometry prim itself,
+            # so PhysX can resolve the body for the contact view.
             cube_path = f"{env_path}/Cube"
-            cube = UsdGeom.Cube.Define(stage, cube_path)
-            cube_rb = UsdPhysics.RigidBodyAPI.Apply(cube.GetPrim())
+            cube_xform = UsdGeom.Xform.Define(stage, cube_path)
+            cube_rb = UsdPhysics.RigidBodyAPI.Apply(cube_xform.GetPrim())
             cube_rb.CreateKinematicEnabledAttr(True)
-            UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+            cube_geom = UsdGeom.Cube.Define(stage, f"{cube_path}/geom")
+            cube_geom.GetSizeAttr().Set(0.5)
+            UsdPhysics.CollisionAPI.Apply(cube_geom.GetPrim())
 
             # Filter target: a link prim (Table) whose collision geometry is nested
             # under a child prim with the same name — the URDF-to-USD import pattern.
             table_path = f"{env_path}/Table"
             table_xform = UsdGeom.Xform.Define(stage, table_path)
             table_xform.AddTranslateOp().Set(Gf.Vec3d(0.0, 1.0, 0.0))
-            table_rb = UsdPhysics.RigidBodyAPI.Apply(stage.GetPrimAtPath(table_path))
+            table_rb = UsdPhysics.RigidBodyAPI.Apply(table_xform.GetPrim())
             table_rb.CreateKinematicEnabledAttr(True)
             # Geometry child shares the parent link name — this is what triggers the bug.
             table_geom_path = f"{table_path}/Table"

--- a/source/isaaclab_physx/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_physx/test/sensors/test_contact_sensor.py
@@ -460,6 +460,105 @@ def test_cube_stack_contact_filtering(setup_simulation, device, num_envs):
         assert contact_sensor.data.net_forces_w.torch.sum().item() > 0.0
 
 
+@pytest.mark.parametrize(
+    "expr, expected_old, expected_new",
+    [
+        # simple leaf — old bare glob prefix-matches geometry children sharing the same name
+        ("/World/envs/env_.*/Table", "/World/envs/env_*/Table", "/World/envs/env_*/(Table)"),
+        # wildcard leaf — wildcard is preserved inside the alternation group
+        ("/World/envs/env_.*/Robot/.*_FOOT", "/World/envs/env_*/Robot/*_FOOT", "/World/envs/env_*/Robot/(*_FOOT)"),
+        # absolute path without env wildcard — only the leaf gets wrapped
+        ("/World/ground/CollisionPlane", "/World/ground/CollisionPlane", "/World/ground/(CollisionPlane)"),
+    ],
+)
+def test_filter_prim_paths_glob_leaf_wrapping(expr, expected_old, expected_new):
+    """Verify the leaf-wrapping transformation anchors the last path segment.
+
+    Positive test: the new ``re.sub`` + ``replace`` form produces a PhysX alternation
+    group ``(leaf)`` that anchors to just the named prim.
+
+    Negative test (encoded in ``expected_old``): the pre-fix plain ``replace`` form
+    produces a bare-leaf glob that PhysX prefix-matches, so a filter target whose
+    geometry child shares the same name (URDF-to-USD pattern) would match *two*
+    prims per env instead of one, causing ``create_rigid_contact_view`` to raise a
+    count-consistency error.
+    """
+    import re
+
+    old_glob = expr.replace(".*", "*")
+    new_glob = re.sub(r"([^/]+)$", r"(\1)", expr).replace(".*", "*")
+
+    assert old_glob == expected_old
+    assert new_glob == expected_new
+    assert old_glob != new_glob
+
+
+@pytest.mark.isaacsim_ci
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("num_envs", [1, 4])
+def test_contact_sensor_filter_same_name_geometry_child(setup_simulation, device, num_envs):
+    """Contact sensor with a filter target whose geometry child shares the link's name must initialize.
+
+    Regression test for the ``filter_prim_paths_expr`` leaf-wrapping fix. The
+    URDF-to-USD importer nests collision geometry under a child prim with the
+    same name as the link (e.g. ``.../Table`` body with ``.../Table/Table``
+    geometry). Before the fix, ``filter_prim_paths_glob`` was produced by a plain
+    ``.*`` → ``*`` replacement, yielding ``env_*/Table``. PhysX prefix-matched that
+    against both ``.../Table`` and ``.../Table/Table``, returning 2 filter shapes
+    per env instead of 1 and raising a count-consistency error at
+    ``create_rigid_contact_view``. After the fix, the glob is ``env_*/(Table)``,
+    which anchors to the link prim only.
+    """
+    sim_dt, *_ = setup_simulation
+    with build_simulation_context(device=device, dt=sim_dt, add_lighting=False) as sim:
+        sim._app_control_on_stop_handle = None
+        stage = get_current_stage()
+
+        for env_id in range(num_envs):
+            env_path = f"/World/envs/env_{env_id}"
+            env_xform = UsdGeom.Xform.Define(stage, env_path)
+            env_xform.AddTranslateOp().Set(Gf.Vec3d(3.0 * env_id, 0.0, 0.0))
+
+            # Sensor subject: a simple kinematic rigid body cube.
+            cube_path = f"{env_path}/Cube"
+            cube = UsdGeom.Cube.Define(stage, cube_path)
+            cube_rb = UsdPhysics.RigidBodyAPI.Apply(cube.GetPrim())
+            cube_rb.CreateKinematicEnabledAttr(True)
+            UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+            # Filter target: a link prim (Table) whose collision geometry is nested
+            # under a child prim with the same name — the URDF-to-USD import pattern.
+            table_path = f"{env_path}/Table"
+            table_xform = UsdGeom.Xform.Define(stage, table_path)
+            table_xform.AddTranslateOp().Set(Gf.Vec3d(0.0, 1.0, 0.0))
+            table_rb = UsdPhysics.RigidBodyAPI.Apply(stage.GetPrimAtPath(table_path))
+            table_rb.CreateKinematicEnabledAttr(True)
+            # Geometry child shares the parent link name — this is what triggers the bug.
+            table_geom_path = f"{table_path}/Table"
+            table_geom = UsdGeom.Cube.Define(stage, table_geom_path)
+            table_geom.GetSizeAttr().Set(0.5)
+            UsdPhysics.CollisionAPI.Apply(table_geom.GetPrim())
+
+        schemas.activate_contact_sensors("/World/envs")
+
+        # Before the fix, create_rigid_contact_view raised a RuntimeError because
+        # env_*/Table matched both .../Table and .../Table/Table (2 shapes per env).
+        # After the fix, env_*/(Table) anchors to the link prim only (1 shape per env).
+        contact_sensor = ContactSensor(
+            ContactSensorCfg(
+                prim_path="/World/envs/env_.*/Cube",
+                update_period=0.0,
+                filter_prim_paths_expr=["/World/envs/env_.*/Table"],
+            )
+        )
+
+        sim.reset()
+
+        assert contact_sensor.num_sensors == num_envs
+        # Exactly 1 filter shape per env (the Table link prim, not Table/Table geometry).
+        assert contact_sensor.contact_view.filter_count == 1
+
+
 def _author_nested_chain(prim_path: str):
     """Author a chain of kinematic rigid bodies whose link prims are nested under each other.
 


### PR DESCRIPTION
## Summary

- Wrap the leaf segment of each `filter_prim_paths_expr` in PhysX alternation syntax `(leaf)` before the `.*` → `*` conversion.

**Root cause:** URDF-to-USD conversion nests a rigid body and its geometry child under the same leaf name (e.g. `.../Object` body, `.../Object/Object` geometry). PhysX's glob engine prefix-matches a bare leaf pattern `env_*/Object` against both prims and raises a count-consistency error (`expected 1, got 2`). The same issue does not affect the sensor body resolution because `body_names_glob` already wraps leaf names in alternation `(name1|name2)` — anchoring the match to the correct path depth.

**Fix:**

```python
# before
filter_prim_paths_glob = [expr.replace(".*", "*") for expr in self.cfg.filter_prim_paths_expr]

# after
filter_prim_paths_glob = [
    re.sub(r"([^/]+)$", r"(\1)", expr).replace(".*", "*")
    for expr in self.cfg.filter_prim_paths_expr
]
```

`re.sub(r"([^/]+)$", r"(\1)", expr)` captures the last path segment and wraps it in `()`. Example:

| expression | before | after |
|---|---|---|
| `env_.*/Object` | `env_*/Object` | `env_*/(Object)` |
| `env_.*/Robot/.*_FOOT` | `env_*/Robot/*_FOOT` | `env_*/Robot/(*_FOOT)` |

**Not affected:** Newton backend — it uses Python `fnmatch` against physics-model body labels, which never crosses `/`.

## Test plan

- [ ] Reproduce with a URDF asset where a link body and its geometry share a leaf name (standard URDF-to-USD output), configure a `ContactSensorCfg` pointing at another such asset in `filter_prim_paths_expr`, verify initialization no longer raises a count error.
- [ ] Existing contact sensor tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)