### PR TITLE
Skip PhysX replicator for fully-heterogeneous 1:1 layouts (fixes mGPU double-free)

### DIFF
--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -283,26 +283,34 @@ Every backend supplies its own :class:`~isaaclab.cloner.UsdReplicateContext` /
 ``PhysxReplicateContext`` / ``NewtonReplicateContext``, a class that hides the
 timing and granularity differences above behind a single uniform interface. A
 shared :data:`~isaaclab.cloner.REPLICATION_QUEUE` then remembers which asset
-belongs to which backend's context until it is time to run. The three
+cfgs participate until it is time to run. The three
 subsections below explain the queue, the contexts, and the function that joins
 them against a plan.
 
 The registration queue
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Asset constructors do not replicate inline. They register their intent with
-:data:`~isaaclab.cloner.REPLICATION_QUEUE` and the framework defers the actual
-work to the drain. The queue ends up holding one entry per ``(asset, backend)``
-pair:
+Assets do not replicate inline. Construction only registers the asset's cfg
+through :func:`~isaaclab.cloner.queue_replication`; the queue records *which*
+cfgs participate:
 
 .. code-block:: text
 
     REPLICATION_QUEUE
-        (cartpole_cfg, PhysxReplicateContext)
-        (cartpole_cfg, UsdReplicateContext)
-        (cube_cfg,     UsdReplicateContext)
-        (light_cfg,    UsdReplicateContext)
+        cartpole_cfg
+        cube_cfg
+        camera_cfg
         ...
+
+*How* each cfg is cloned is resolved by :func:`~isaaclab.cloner.replicate` at
+dispatch: the cfg's :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`
+when set, otherwise the active backend's default stack. Each backend cloner
+exports that stack under the conventional name ``REPLICATION`` — PhysX pairs
+its native replication with USD clones, Newton includes USD only under Kit,
+and OvPhysX replicates alone because its clone replay authors USD itself.
+With :attr:`~isaaclab.cloner.CloneCfg.replicate_physics` disabled, cloning is
+USD-only: every context except ``UsdReplicateContext`` is dropped and the
+physics engine parses the per-env USD prims directly.
 
 Deferring the work like this buys three things at once:
 
@@ -312,6 +320,11 @@ Deferring the work like this buys three things at once:
   call per asset.
 * Asset code stays free of any branching on which backend is active — it just
   registers and lets the framework take it from there.
+
+:attr:`~isaaclab.scene.InteractiveSceneCfg.replicate_physics` is piped into
+:attr:`~isaaclab.cloner.CloneCfg.replicate_physics` and applied at dispatch;
+an asset whose only cloning mechanism is physics replication is then simply
+not cloned.
 
 Backend contexts
 ~~~~~~~~~~~~~~~~
@@ -326,12 +339,12 @@ runtime:
     PhysxReplicateContext    # replicates PhysX rigid bodies and articulations
     NewtonReplicateContext   # replicates Newton bodies in its parallel pipeline
 
-A single asset can register more than one context — a PhysX articulation
-registers a PhysX context and a USD context so physics and visuals both follow,
-a Newton articulation registers a Newton context plus a USD context only if it
-owns visual prims. This is where backend differences are absorbed: swapping a
-scene from PhysX to Newton swaps which context an asset registers with, while
-the cfgs and the rest of the user code stay unchanged.
+A single asset usually resolves to more than one context — PhysX pairs its
+context with USD so physics and visuals both follow; Newton's default stack
+includes USD only under Kit, so kitless runs skip the authoring cost. This is
+where backend differences are absorbed: swapping a scene from PhysX to Newton
+swaps which default stack resolves at dispatch, while the cfgs and the rest of
+the user code stay unchanged.
 
 Running replication
 ~~~~~~~~~~~~~~~~~~~

--- a/source/isaaclab/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
@@ -1,0 +1,35 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab.scene.InteractiveSceneCfg.replicate_physics` being ignored since the
+  replication-session refactor: scenes configured with ``replicate_physics=False`` invoked
+  native physics replication anyway, silently discarding per-environment USD differences
+  (e.g. prestartup scale randomization). Cloning is now USD-only in that case, so the physics
+  engine parses each environment's USD prims directly; assets whose only cloning mechanism is
+  physics replication are not cloned.
+
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.cloner.CloneCfg.replicate_physics` as the cloner-side home of the
+  policy; :class:`~isaaclab.scene.InteractiveScene` pipes the scene flag into it and
+  :func:`~isaaclab.cloner.replicate` applies it.
+* Added :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` to override, per asset, the
+  cloning contexts resolved at replication time; ``None`` uses the active backend's default
+  stack (``isaaclab_<backend>.cloner.REPLICATION``).
+
+Changed
+^^^^^^^
+
+* **Breaking:** Changed :data:`~isaaclab.cloner.REPLICATION_QUEUE` to hold asset cfgs instead
+  of ``(cfg, BackendCtxCls)`` pairs: construction registers *which* cfgs participate via
+  :func:`~isaaclab.cloner.queue_replication`, and *how* each is cloned resolves inside
+  :func:`~isaaclab.cloner.replicate`. Code appending pairs should register the cfg and direct
+  contexts through :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
+
+Removed
+^^^^^^^
+
+* Removed ``queue_usd_replication``: register the cfg with
+  :func:`~isaaclab.cloner.queue_replication` and direct contexts through the cfg's
+  ``cloning_contexts`` field instead.

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -15,6 +15,7 @@ import torch
 import warp as wp
 
 import isaaclab.sim as sim_utils
+from isaaclab.cloner import queue_replication
 from isaaclab.physics import PhysicsEvent, PhysicsManager
 from isaaclab.sim.simulation_context import SimulationContext
 from isaaclab.sim.utils.stage import get_current_stage
@@ -68,6 +69,9 @@ class AssetBase(ABC):
         """
         # check that the config is valid
         cfg.validate()
+        # register the original cfg object for cloning: the clone plan keys rows by the
+        # cfg identity the scene collected; contexts and policy resolve at replication time
+        queue_replication(cfg)
         # store inputs
         self.cfg = cfg.copy()
         # Resolve shape-check flag once: True means checks are active.

--- a/source/isaaclab/isaaclab/assets/asset_base_cfg.py
+++ b/source/isaaclab/isaaclab/assets/asset_base_cfg.py
@@ -46,6 +46,15 @@ class AssetBaseCfg:
     The class should inherit from :class:`isaaclab.assets.asset_base.AssetBase`.
     """
 
+    cloning_contexts: tuple[str | type, ...] | None = None
+    """Cloning contexts for this asset. Defaults to None.
+
+    Entries are ``"module:ContextClass"`` references (or classes) that clone this asset
+    across environments. If None, :func:`~isaaclab.cloner.replicate` uses the active
+    physics backend's default stack (``isaaclab_<backend>.cloner.REPLICATION``); an empty
+    tuple means the asset is not cloned.
+    """
+
     prim_path: str = MISSING
     """Prim path (or expression) to the asset.
 

--- a/source/isaaclab/isaaclab/cloner/__init__.pyi
+++ b/source/isaaclab/isaaclab/cloner/__init__.pyi
@@ -16,9 +16,9 @@ __all__ = [
     "ReplicateSession",
     "REPLICATION_QUEUE",
     "replicate",
+    "queue_replication",
     "resolve_clone_plan_source",
     "split_clone_template",
-    "queue_usd_replication",
     "sequential",
     "UsdReplicateContext",
     "usd_replicate",
@@ -40,10 +40,10 @@ from .cloner_utils import (
 from .replicate_session import (
     REPLICATION_QUEUE,
     ReplicateSession,
+    queue_replication,
     replicate,
 )
 from .usd import (
     UsdReplicateContext,
-    queue_usd_replication,
     usd_replicate,
 )

--- a/source/isaaclab/isaaclab/cloner/clone_plan.py
+++ b/source/isaaclab/isaaclab/cloner/clone_plan.py
@@ -50,8 +50,8 @@ class ClonePlan:
         Auto-populates :attr:`cfg_rows` from
         :data:`~isaaclab.cloner.REPLICATION_QUEUE`, including only cfgs whose
         ``prim_path`` falls under the env-root prefix of ``destination``. Must be
-        called *after* all asset constructors have run, so their replication entries
-        are already in the queue; otherwise those assets will be skipped by the
+        called *after* all asset constructors have run, so their cfgs are already
+        registered in the queue; otherwise those assets will be skipped by the
         subsequent :func:`~isaaclab.cloner.replicate` call.
 
         Args:
@@ -66,7 +66,7 @@ class ClonePlan:
 
         prefix, _ = split_clone_template(destination)
         cfg_rows: dict[int, tuple[int, ...]] = {
-            id(cfg): (0,) for cfg, _ in REPLICATION_QUEUE if cfg.prim_path.startswith(prefix)
+            id(cfg): (0,) for cfg in REPLICATION_QUEUE if cfg.prim_path.startswith(prefix)
         }
         return cls(
             sources=(source,),

--- a/source/isaaclab/isaaclab/cloner/cloner_cfg.py
+++ b/source/isaaclab/isaaclab/cloner/cloner_cfg.py
@@ -28,3 +28,10 @@ class CloneCfg:
 
     clone_regex: str = "/World/envs/env_.*"
     """Regex matching every replicated env prim. Used to expand ``{ENV_REGEX_NS}`` cfg macros."""
+
+    replicate_physics: bool = True
+    """Whether physics replication clones each environment. Default is True.
+
+    If False, cloning is USD-only: the physics engine parses the per-env USD prims directly
+    instead of replicating env_0's parsed structure. Applied by :func:`~isaaclab.cloner.replicate`.
+    """

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -7,10 +7,15 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
+from isaaclab.utils.backend_utils import FactoryBase
+from isaaclab.utils.string import string_to_callable
+
 from .cloner_strategies import sequential
+from .usd import UsdReplicateContext
 
 if TYPE_CHECKING:
     import torch
@@ -20,16 +25,44 @@ if TYPE_CHECKING:
     from .clone_plan import ClonePlan
 
 
-REPLICATION_QUEUE: list[tuple[Any, type]] = []
-"""``(cfg, BackendCtxCls)`` pairs appended by ``queue_<backend>_replication`` and drained by :func:`replicate`."""
+REPLICATION_QUEUE: list[Any] = []
+"""Asset cfgs registered by :func:`queue_replication` and drained by :func:`replicate`.
+
+The queue only records *which* cfgs participate in cloning; how each cfg is cloned is
+resolved at dispatch from :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` or the
+active backend's default stack.
+"""
 
 
-def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
+def queue_replication(cfg: Any) -> None:
+    """Register ``cfg`` for cloning when :func:`replicate` next runs.
+
+    Args:
+        cfg: Asset cfg with resolved ``prim_path``.
+    """
+    REPLICATION_QUEUE.append(cfg)
+
+
+def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = True) -> None:
     """Drain :data:`REPLICATION_QUEUE` against ``plan``, dispatch each backend, publish the plan.
+
+    Each cfg's cloning contexts come from
+    :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` when set, otherwise from the
+    active backend's default stack (``isaaclab_<backend>.cloner.REPLICATION``); entries may
+    be ``"module:ContextClass"`` references or classes. With ``replicate_physics=False``
+    cloning is USD-only: contexts other than
+    :class:`~isaaclab.cloner.UsdReplicateContext` are dropped, and the physics engine
+    parses the per-env USD prims directly.
 
     Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
     failure cannot leak stale entries into the next call.
+
+    Args:
+        plan: Replication layout to dispatch.
+        stage: USD stage to author replicated prim specs into.
+        replicate_physics: Whether physics replication clones each environment. If False,
+            cloning is USD-only; an asset whose contexts are all physics-based is not cloned.
     """
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
@@ -37,15 +70,22 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage) -> None:
     REPLICATION_QUEUE.clear()
 
     # Group queued cfgs by backend, taking the union of row indices each backend owns.
-    # In the homogeneous plan every cfg maps to row 0, so multiple queue_<backend>_replication
+    # In the homogeneous plan every cfg maps to row 0, so multiple queue_replication
     # calls (e.g. one per body type in RigidObjectCollection) all contribute {0} and the set
     # union keeps it as a single row — no redundant copy specs are authored.
     backend_rows: dict[type, set[int]] = {}
-    for cfg, BackendCtxCls in queued:
+    for cfg in queued:
         rows = plan.cfg_rows.get(id(cfg))
         if rows is None:
             continue
-        backend_rows.setdefault(BackendCtxCls, set()).update(rows)
+        contexts = cfg.cloning_contexts
+        if contexts is None:
+            contexts = getattr(importlib.import_module(f"isaaclab_{FactoryBase._get_backend()}.cloner"), "REPLICATION")
+        contexts = [string_to_callable(c) if isinstance(c, str) else c for c in contexts]
+        if not replicate_physics:
+            contexts = [c for c in contexts if c is UsdReplicateContext]
+        for BackendCtxCls in contexts:
+            backend_rows.setdefault(BackendCtxCls, set()).update(rows)
 
     backend_ctxs: dict[type, Any] = {}
     for BackendCtxCls, row_set in backend_rows.items():
@@ -70,7 +110,7 @@ class ReplicateSession:
     """Folds :func:`make_clone_plan` and :func:`replicate` into a ``with`` block.
 
     ``__enter__`` builds the plan (and mutates each cfg's ``spawn_path``); asset
-    constructors inside the block register backend replication into
+    constructors inside the block register their cfgs into
     :data:`REPLICATION_QUEUE`; ``__exit__`` drains and dispatches.
 
     Example:
@@ -92,6 +132,7 @@ class ReplicateSession:
         stage: Usd.Stage,
         clone_strategy: Callable = sequential,
         valid_set: torch.Tensor | None = None,
+        replicate_physics: bool = True,
     ):
         """Capture arguments for :func:`make_clone_plan` and :func:`replicate`.
 
@@ -104,9 +145,12 @@ class ReplicateSession:
             clone_strategy: Prototype-to-env assignment function.
             valid_set: Optional ``[num_combos, num_groups]`` long tensor of valid
                 prototype combinations; ``None`` uses the full cartesian product.
+            replicate_physics: Whether physics replication clones each environment;
+                forwarded to :func:`replicate`.
         """
         self._cfgs = cfgs
         self._stage = stage
+        self._replicate_physics = replicate_physics
         self._kwargs = dict(
             num_clones=num_clones,
             env_spacing=env_spacing,
@@ -125,7 +169,7 @@ class ReplicateSession:
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         if exc_type is None:
             assert self._plan is not None
-            replicate(self._plan, stage=self._stage)
+            replicate(self._plan, stage=self._stage, replicate_physics=self._replicate_physics)
         else:
             # Drop cfgs registered before the failure so the next session is clean.
             REPLICATION_QUEUE.clear()

--- a/source/isaaclab/isaaclab/cloner/usd.py
+++ b/source/isaaclab/isaaclab/cloner/usd.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import torch
 
@@ -14,7 +13,6 @@ from pxr import Gf, Sdf, Usd, UsdGeom, Vt
 
 from ._fabric_notices import disabled_fabric_change_notifies
 from .cloner_utils import split_clone_template
-from .replicate_session import REPLICATION_QUEUE
 
 
 def _select_env_ids(env_ids: torch.Tensor, mask: torch.Tensor | None, row: int) -> torch.Tensor:
@@ -153,16 +151,6 @@ class UsdReplicateContext:
                                     ps, UsdGeom.Tokens.xformOpOrder, Sdf.ValueTypeNames.TokenArray
                                 )
                                 op_order.default = Vt.TokenArray(op_names)
-
-
-def queue_usd_replication(cfg: Any) -> None:
-    """Register ``cfg`` for USD replication when :func:`~isaaclab.cloner.replicate` next runs.
-
-    Appends ``(cfg, UsdReplicateContext)`` to :data:`~isaaclab.cloner.REPLICATION_QUEUE`.
-    The actual row resolution and dispatch happen inside :func:`~isaaclab.cloner.replicate`,
-    so this helper is safe to call from any asset constructor — no active session is required.
-    """
-    REPLICATION_QUEUE.append((cfg, UsdReplicateContext))
 
 
 def usd_replicate(

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -156,7 +156,7 @@ class InteractiveScene:
         # physics scene path
         self._physics_scene_path = None
         # prepare cloner for environment replication
-        self.cloner_cfg = cloner.CloneCfg(device=self.device)
+        self.cloner_cfg = cloner.CloneCfg(device=self.device, replicate_physics=self.cfg.replicate_physics)
         env_root = self.cloner_cfg.clone_regex.rsplit("/", 1)[0]
         self.env_prim_paths = [f"{env_root}/env_{i}" for i in range(self.cfg.num_envs)]
 
@@ -184,6 +184,7 @@ class InteractiveScene:
             device=self.device,
             stage=self.stage,
             clone_strategy=self.cloner_cfg.clone_strategy,
+            replicate_physics=self.cloner_cfg.replicate_physics,
         ):
             if self._is_scene_setup_from_cfg():
                 self._add_entities_from_cfg()

--- a/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene_cfg.py
@@ -108,6 +108,17 @@ class InteractiveSceneCfg:
     .. note::
         Optimized parsing of certain prim types (such as deformable objects) is not currently supported
         by the physics engine. In these cases, this flag needs to be set to False.
+
+    .. attention::
+        Setting this flag to False is currently not supported on the Newton physics backend:
+        Newton discovers the scene through its replication path, which stage parsing cannot
+        replace for cloned environments.
+
+    .. note::
+        The scene pipes this flag into :attr:`~isaaclab.cloner.CloneCfg.replicate_physics`;
+        the policy is applied by :func:`~isaaclab.cloner.replicate`. Direct workflows that
+        call :func:`~isaaclab.cloner.replicate` themselves pass ``replicate_physics``
+        explicitly.
     """
 
     filter_collisions: bool = True

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -17,7 +17,7 @@ from pxr import UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.sensors as sensor_utils
-from isaaclab.cloner import queue_usd_replication
+from isaaclab.cloner import queue_replication
 from isaaclab.renderers import BaseRenderer, CameraRenderSpec
 from isaaclab.sim.views import FrameView
 from isaaclab.utils import to_camel_case
@@ -172,7 +172,7 @@ class Camera(SensorBase):
                 spawn.func(spawn_target, spawn, translation=self.cfg.offset.pos, orientation=rot_offset)
             if not sim_utils.find_matching_prims(spawn_target):
                 raise RuntimeError(f"Could not find prim with path {spawn_target!r}.")
-        queue_usd_replication(self._source_cfg)
+        queue_replication(self._source_cfg)
 
         # An ISP (any ``isp_cfg`` other than ``None``) requires the HDR AOV;
         # an explicit ``"rgb_hdr"`` in ``data_types`` also requires the

--- a/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
+++ b/source/isaaclab/isaaclab/sensors/ray_caster/base_ray_caster.py
@@ -17,7 +17,7 @@ from pxr import Gf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
-from isaaclab.cloner import queue_usd_replication
+from isaaclab.cloner import queue_replication
 from isaaclab.markers import VisualizationMarkers
 from isaaclab.terrains.trimesh.utils import make_plane
 from isaaclab.utils.warp import ProxyArray, convert_to_warp_mesh
@@ -70,7 +70,7 @@ class BaseRayCaster(SensorBase):
         """
         BaseRayCaster._instance_count += 1
         super().__init__(cfg)
-        queue_usd_replication(self._source_cfg)
+        queue_replication(self._source_cfg)
         self._data = RayCasterData()
 
     def __str__(self) -> str:

--- a/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
@@ -22,6 +22,12 @@ class SensorBaseCfg:
     The class should inherit from :class:`isaaclab.sensors.sensor_base.SensorBase`.
     """
 
+    cloning_contexts: tuple[str | type, ...] | None = ("isaaclab.cloner:UsdReplicateContext",)
+    """Cloning contexts for this sensor. Defaults to USD-only cloning.
+
+    Sensors carry no physics of their own; see :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
+    """
+
     prim_path: str = MISSING
     """Prim path (or expression) to the sensor.
 

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -143,8 +143,8 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
 
     captured: list = []
 
-    def fake_replicate(plan, *, stage):
-        captured.append((plan, stage))
+    def fake_replicate(plan, *, stage, replicate_physics=True):
+        captured.append((plan, stage, replicate_physics))
 
     monkeypatch.setattr(replicate_session_module, "replicate", fake_replicate)
 
@@ -153,11 +153,87 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
         scene = InteractiveScene(MySceneCfg(num_envs=4, env_spacing=1.0))
 
     assert len(captured) == 1
-    plan, stage = captured[0]
+    plan, stage, replicate_physics = captured[0]
     assert plan.sources == ("/World/envs/env_0",)
     assert plan.destinations == ("/World/envs/env_{}",)
     assert plan.clone_mask.shape == (1, 4)
     assert stage is scene.stage
+    assert replicate_physics is True
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.parametrize("replicate_physics", [True, False])
+def test_replicate_physics_flag_controls_physx_replicator(device, replicate_physics, setup_scene, monkeypatch):
+    """replicate_physics=False must not register the PhysX replicator while envs still simulate.
+
+    The True case asserts the spy actually intercepts registration, so the False case
+    cannot pass vacuously.
+    """
+    physx_replicate_module = pytest.importorskip("isaaclab_physx.cloner.replicate")
+
+    register_calls: list = []
+    real_get_iface = physx_replicate_module.get_physx_replicator_interface
+
+    class SpyInterface:
+        def __init__(self, real):
+            self._real = real
+
+        def register_replicator(self, *args, **kwargs):
+            register_calls.append(args)
+            return self._real.register_replicator(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    monkeypatch.setattr(
+        physx_replicate_module, "get_physx_replicator_interface", lambda: SpyInterface(real_get_iface())
+    )
+
+    make_scene, sim = setup_scene
+    scene_cfg = make_scene(num_envs=3)
+    scene_cfg.replicate_physics = replicate_physics
+    scene = InteractiveScene(scene_cfg)
+    if not scene.physics_backend.startswith("physx"):
+        pytest.skip("PhysX replicator flag is only meaningful on a PhysX backend.")
+    sim.reset()
+
+    if replicate_physics:
+        assert len(register_calls) > 0
+    else:
+        assert register_calls == []
+    # all environments exist and simulate on both paths
+    assert scene["rigid_obj"].data.root_pos_w.torch.shape[0] == 3
+    assert scene["robot"].data.joint_pos.torch.shape[0] == 3
+    for _ in range(2):
+        sim.step()
+        scene.update(sim.get_physics_dt())
+    assert torch.isfinite(scene["rigid_obj"].data.root_pos_w.torch).all()
+    assert torch.isfinite(scene["robot"].data.joint_pos.torch).all()
+
+
+def test_cfg_cloning_contexts_override_backend_default(monkeypatch: pytest.MonkeyPatch):
+    """AssetBaseCfg.cloning_contexts replaces the backend default stack for that asset."""
+    import isaaclab.cloner.replicate_session as replicate_session_module
+    from isaaclab.cloner import REPLICATION_QUEUE
+
+    # keep the queue for inspection: the fake drain does not clear it
+    monkeypatch.setattr(replicate_session_module, "replicate", lambda plan, *, stage, replicate_physics=True: None)
+
+    with build_simulation_context(device="cpu", auto_add_lighting=False, add_ground_plane=False) as sim:
+        sim._app_control_on_stop_handle = None
+        scene_cfg = MySceneCfg(num_envs=2, env_spacing=1.0)
+        scene_cfg.rigid_obj.cloning_contexts = ("isaaclab.cloner:UsdReplicateContext",)
+        try:
+            InteractiveScene(scene_cfg)
+            queued_by_path = {cfg.prim_path: cfg for cfg in REPLICATION_QUEUE}
+            # the override rides the queued cfg; resolution happens at replicate()
+            assert queued_by_path["/World/envs/env_.*/RigidObj"].cloning_contexts == (
+                "isaaclab.cloner:UsdReplicateContext",
+            )
+            # untouched asset resolves to the backend default stack at replicate()
+            assert queued_by_path["/World/envs/env_.*/Robot"].cloning_contexts is None
+        finally:
+            REPLICATION_QUEUE.clear()
 
 
 def test_collect_asset_cfgs_resolves_env_regex_macros():

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -30,7 +30,7 @@ from isaaclab.cloner import (
     grid_transforms,
     iter_clone_plan_matches,
     make_clone_plan,
-    queue_usd_replication,
+    queue_replication,
     replicate,
     resolve_clone_plan_source,
     sequential,
@@ -321,15 +321,15 @@ def test_clone_decorator_wildcard_patterns(
     )
 
 
-def test_queue_usd_replication_only_appends(sim):
-    """queue_usd_replication must only append to REPLICATION_QUEUE — no other side effects."""
+def test_queue_replication_only_appends(sim):
+    """queue_replication must only append the cfg-directed contexts — no other side effects."""
     cfg_a = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
     cfg_b = SimpleNamespace(prim_path="/World/envs/env_.*/Object")
 
-    queue_usd_replication(cfg_a)
-    queue_usd_replication(cfg_b)
+    queue_replication(cfg_a)
+    queue_replication(cfg_b)
 
-    assert [(cfg_a, UsdReplicateContext), (cfg_b, UsdReplicateContext)] == REPLICATION_QUEUE
+    assert [cfg_a, cfg_b] == REPLICATION_QUEUE
 
 
 def test_make_clone_plan_homogeneous_returns_env_root_plan(sim):
@@ -417,9 +417,9 @@ def test_clone_plan_from_env_0_populates_cfg_rows(sim):
     env_cfg_b = SimpleNamespace(prim_path="/World/envs/env_.*/Object")
     global_cfg = SimpleNamespace(prim_path="/World/global/Light")
 
-    queue_usd_replication(env_cfg_a)
-    queue_usd_replication(env_cfg_b)
-    queue_usd_replication(global_cfg)
+    for cfg in (env_cfg_a, env_cfg_b, global_cfg):
+        cfg.cloning_contexts = (UsdReplicateContext,)
+        queue_replication(cfg)
 
     plan = ClonePlan.from_env_0(
         source="/World/envs/env_0",
@@ -434,6 +434,41 @@ def test_clone_plan_from_env_0_populates_cfg_rows(sim):
     assert plan.cfg_rows == {id(env_cfg_a): (0,), id(env_cfg_b): (0,)}
     assert plan.clone_mask.all() and plan.clone_mask.shape == (1, 4)
     assert torch.equal(plan.env_ids, torch.arange(4, dtype=torch.long, device=sim.cfg.device))
+
+
+def test_replicate_physics_false_keeps_usd_only(sim):
+    """replicate(replicate_physics=False) drops every context except UsdReplicateContext."""
+
+    class FakePhysicsCtx:
+        replicate_priority = 0
+        instances: list["FakePhysicsCtx"] = []
+
+        def __init__(self, stage):
+            FakePhysicsCtx.instances.append(self)
+
+        def queue_mapping(self, sources, destinations, env_ids, mask, *, positions=None):
+            pass
+
+        def replicate(self):
+            pass
+
+    stage = sim_utils.get_current_stage()
+    stage.DefinePrim("/World/envs/env_0/Robot", "Xform")
+    cfg = SimpleNamespace(prim_path="/World/envs/env_.*/Robot", cloning_contexts=(UsdReplicateContext, FakePhysicsCtx))
+    REPLICATION_QUEUE.append(cfg)
+
+    plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot",),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool, device=sim.cfg.device),
+        env_ids=torch.arange(2, dtype=torch.long, device=sim.cfg.device),
+        positions=grid_transforms(2, 1.0, device=sim.cfg.device)[0],
+        cfg_rows={id(cfg): (0,)},
+    )
+    replicate(plan, stage=stage, replicate_physics=False)
+
+    assert FakePhysicsCtx.instances == []
+    assert stage.GetPrimAtPath("/World/envs/env_1/Robot").IsValid()
 
 
 def test_replicate_drains_queue_dispatches_and_publishes(sim):
@@ -457,8 +492,10 @@ def test_replicate_drains_queue_dispatches_and_publishes(sim):
 
     cfg_a = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
     cfg_b = SimpleNamespace(prim_path="/World/envs/env_.*/Object")
-    REPLICATION_QUEUE.append((cfg_a, FakeCtx))
-    REPLICATION_QUEUE.append((cfg_b, FakeCtx))
+    cfg_a.cloning_contexts = (FakeCtx,)
+    cfg_b.cloning_contexts = (FakeCtx,)
+    REPLICATION_QUEUE.append(cfg_a)
+    REPLICATION_QUEUE.append(cfg_b)
 
     plan = ClonePlan(
         sources=("/World/envs/env_0/Robot", "/World/envs/env_0/Object"),
@@ -510,7 +547,8 @@ def test_replicate_dedupes_shared_rows_across_cfgs(sim):
 
     cfgs = [SimpleNamespace(prim_path=f"/World/envs/env_.*/asset_{i}") for i in range(5)]
     for cfg in cfgs:
-        REPLICATION_QUEUE.append((cfg, FakeCtx))
+        cfg.cloning_contexts = (FakeCtx,)
+        REPLICATION_QUEUE.append(cfg)
 
     plan = ClonePlan(
         sources=("/World/envs/env_0",),
@@ -562,8 +600,8 @@ def test_replicate_runs_lower_priority_backends_first(sim):
             call_order.append("high")
 
     cfg = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
-    REPLICATION_QUEUE.append((cfg, HighPriority))
-    REPLICATION_QUEUE.append((cfg, LowPriority))
+    cfg.cloning_contexts = (HighPriority, LowPriority)
+    REPLICATION_QUEUE.append(cfg)
 
     plan = ClonePlan(
         sources=("/World/envs/env_0",),
@@ -586,7 +624,8 @@ def test_replicate_skips_cfgs_not_in_plan(sim):
     sentinel_cls = MagicMock(return_value=sentinel)
 
     excluded_cfg = SimpleNamespace(prim_path="/World/global/Skip")
-    REPLICATION_QUEUE.append((excluded_cfg, sentinel_cls))
+    excluded_cfg.cloning_contexts = (sentinel_cls,)
+    REPLICATION_QUEUE.append(excluded_cfg)
 
     plan = ClonePlan(
         sources=("/World/envs/env_0",),
@@ -617,7 +656,8 @@ def test_replicate_clears_queue_on_backend_failure(sim):
             raise RuntimeError("backend boom")
 
     cfg = SimpleNamespace(prim_path="/World/envs/env_.*/Robot")
-    REPLICATION_QUEUE.append((cfg, ExplodingCtx))
+    cfg.cloning_contexts = (ExplodingCtx,)
+    REPLICATION_QUEUE.append(cfg)
 
     plan = ClonePlan(
         sources=("/World/envs/env_0",),
@@ -651,7 +691,8 @@ def test_replicate_session_clears_queue_when_asset_init_fails(sim):
             device=sim.cfg.device,
             stage=sim_utils.get_current_stage(),
         ):
-            REPLICATION_QUEUE.append((leaked_cfg, sentinel_cls))
+            leaked_cfg.cloning_contexts = (sentinel_cls,)
+            REPLICATION_QUEUE.append(leaked_cfg)
             raise RuntimeError("asset boom")
 
     assert REPLICATION_QUEUE == []

--- a/source/isaaclab_contrib/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.minor.rst
+++ b/source/isaaclab_contrib/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.minor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_contrib.deformable.DeformableObject` to follow the backend's
+  default replication stack directed by the asset cfg: USD clones now accompany Newton
+  replication only under Kit, instead of unconditionally, matching the other Newton assets.

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/deformable_object.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/deformable_object.py
@@ -13,12 +13,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 import warp as wp
-from isaaclab_newton.cloner import queue_newton_physics_replication
 from isaaclab_newton.physics import NewtonManager as SimulationManager
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets.deformable_object.base_deformable_object import BaseDeformableObject
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.markers import VisualizationMarkers
 from isaaclab.physics import PhysicsEvent
 from isaaclab.utils.warp import ProxyArray
@@ -299,8 +297,6 @@ class DeformableObject(BaseDeformableObject):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_usd_replication(cfg)
-        queue_newton_physics_replication(cfg)
 
         # initialize deformable type to None, should be set to either surface or volume on initialization
         self._deformable_type: str | None = None

--- a/source/isaaclab_contrib/test/deformable/test_deformable_builder_hooks.py
+++ b/source/isaaclab_contrib/test/deformable/test_deformable_builder_hooks.py
@@ -13,8 +13,6 @@ from isaaclab_newton.cloner.replicate import NewtonReplicateContext
 from isaaclab_newton.physics import NewtonManager
 from isaaclab_newton.sim.spawners.materials import NewtonDeformableMaterialCfg
 
-from isaaclab.assets.deformable_object.base_deformable_object import BaseDeformableObject
-from isaaclab.cloner.replicate_session import REPLICATION_QUEUE
 from isaaclab.cloner.usd import UsdReplicateContext
 
 from isaaclab_contrib.deformable import DeformableObject, VBDSolverCfg
@@ -137,30 +135,14 @@ def test_builder_hook_resets_entry_offsets_on_first_environment():
     assert entry.particles_per_body == 3
 
 
-def test_newton_deformable_queues_usd_and_newton_replication(monkeypatch):
-    """Test that Newton deformables participate in both clone products."""
-    cfg = SimpleNamespace()
+def test_newton_replication_stack_matches_kit_mode():
+    """Test that Newton's stack always replicates physics and adds USD clones only under Kit."""
+    from isaaclab_newton.cloner import REPLICATION
 
-    def fake_base_init(self, cfg):
-        self.cfg = cfg
-        self._DTYPE_TO_TORCH_TRAILING_DIMS = {}
-        self._initialize_handle = None
-        self._invalidate_initialize_handle = None
-        self._prim_deletion_handle = None
-        self._debug_vis_handle = None
-        self._physics_ready_handle = None
+    from isaaclab.utils.version import has_kit
 
-    monkeypatch.setattr(BaseDeformableObject, "__init__", fake_base_init)
-    monkeypatch.setattr(DeformableObject, "_register_deformable", lambda self: object())
-    REPLICATION_QUEUE.clear()
-
-    try:
-        DeformableObject(cfg)
-        queued_contexts = [ctx_cls for queued_cfg, ctx_cls in REPLICATION_QUEUE if queued_cfg is cfg]
-    finally:
-        REPLICATION_QUEUE.clear()
-
-    assert queued_contexts == [UsdReplicateContext, NewtonReplicateContext]
+    assert REPLICATION[-1] is NewtonReplicateContext
+    assert (UsdReplicateContext in REPLICATION) == has_kit()
 
 
 def test_fabric_particle_sync_skips_missing_fabric_prim(monkeypatch):

--- a/source/isaaclab_newton/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
+++ b/source/isaaclab_newton/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :data:`~isaaclab_newton.cloner.REPLICATION`, the backend's default replication stack
+  referenced by asset cfgs: USD clones accompany Newton replication only under Kit, so
+  headless runs skip the USD authoring cost without assets branching on Kit availability.
+
+Removed
+^^^^^^^
+
+* Removed ``queue_newton_physics_replication``: direct the contexts through
+  :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` and
+  :func:`~isaaclab.cloner.queue_replication` instead.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -31,7 +31,6 @@ from isaaclab.sim.utils.queries import resolve_matching_prims_from_source
 
 _HAS_NEWTON_ACTUATORS = importlib.util.find_spec("isaaclab_newton.actuators") is not None
 
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.physics import PhysicsEvent
 from isaaclab.utils.string import resolve_matching_names, resolve_matching_names_values
 from isaaclab.utils.types import ArticulationActions
@@ -40,7 +39,6 @@ from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_newton.assets import kernels as shared_kernels
 from isaaclab_newton.assets.articulation import kernels as articulation_kernels
-from isaaclab_newton.cloner import queue_newton_physics_replication
 from isaaclab_newton.physics import NewtonManager as SimulationManager
 
 from .articulation_data import ArticulationData
@@ -127,9 +125,6 @@ class Articulation(BaseArticulation):
         from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
         super().__init__(cfg)
-        if has_kit():
-            queue_usd_replication(cfg)
-        queue_newton_physics_replication(cfg)
 
         sim_ctx = SimulationContext.instance()
         self._sim_cfg = sim_ctx.cfg if sim_ctx is not None else None

--- a/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
@@ -18,7 +18,6 @@ from isaaclab.assets.deformable_object.base_deformable_object import BaseDeforma
 from isaaclab.physics import PhysicsEvent
 from isaaclab.utils.warp import ProxyArray
 
-from isaaclab_newton.cloner import queue_newton_physics_replication
 from isaaclab_newton.physics import NewtonManager as SimulationManager
 from isaaclab_newton.sim.spawners.mpm import create_mpm_particle_visualization, emit_mpm_particles
 
@@ -101,7 +100,6 @@ class MPMObject(BaseDeformableObject):
 
     def __init__(self, cfg: MPMObjectCfg):
         super().__init__(cfg)
-        queue_newton_physics_replication(cfg)
         self._registry_entry = MPMObjectRegistryEntry(self.cfg)
         SimulationManager._mpm_object_registry.append(self._registry_entry)
         if add_registered_mpm_objects_to_builder not in SimulationManager._per_world_builder_hooks:

--- a/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object_cfg.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 class MPMObjectCfg(DeformableObjectCfg):
     """Configuration parameters for a Newton MPM particle object."""
 
+    cloning_contexts: tuple[str | type, ...] | None = ("isaaclab_newton.cloner:NewtonReplicateContext",)
+    """Cloning contexts for the MPM object; particle rendering syncs through Fabric, so no USD clones."""
+
     class_type: type[MPMObject] | str = "{DIR}.mpm_object:MPMObject"
 
     spawn: MPMParticleSpawnerCfg = MISSING

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -19,14 +19,11 @@ from pxr import UsdPhysics
 
 import isaaclab.utils.string as string_utils
 from isaaclab.assets.rigid_object.base_rigid_object import BaseRigidObject
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.utils.queries import resolve_matching_prims_from_source
-from isaaclab.utils.version import has_kit
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_newton.assets import kernels as shared_kernels
-from isaaclab_newton.cloner import queue_newton_physics_replication
 from isaaclab_newton.physics import NewtonManager as SimulationManager
 
 from .rigid_object_data import RigidObjectData
@@ -62,9 +59,6 @@ class RigidObject(BaseRigidObject):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        if has_kit():
-            queue_usd_replication(cfg)
-        queue_newton_physics_replication(cfg)
 
     """
     Properties

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -20,13 +20,11 @@ from pxr import UsdPhysics
 import isaaclab.sim as sim_utils
 import isaaclab.utils.string as string_utils
 from isaaclab.assets.rigid_object_collection.base_rigid_object_collection import BaseRigidObjectCollection
-from isaaclab.cloner import queue_usd_replication
+from isaaclab.cloner import queue_replication
 from isaaclab.physics import PhysicsEvent
-from isaaclab.utils.version import has_kit
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_newton.assets import kernels as shared_kernels
-from isaaclab_newton.cloner import queue_newton_physics_replication
 from isaaclab_newton.physics import NewtonManager as SimulationManager
 
 from .rigid_object_collection_data import RigidObjectCollectionData
@@ -92,9 +90,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
             if len(matching_prims) == 0:
                 raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
-            if has_kit():
-                queue_usd_replication(source_rigid_object_cfgs[rigid_body_name])
-            queue_newton_physics_replication(source_rigid_object_cfgs[rigid_body_name])
+            queue_replication(source_rigid_object_cfgs[rigid_body_name])
         # stores object names
         self._body_names_list = []
 

--- a/source/isaaclab_newton/isaaclab_newton/cloner/__init__.pyi
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/__init__.pyi
@@ -5,12 +5,12 @@
 
 __all__ = [
     "NewtonReplicateContext",
+    "REPLICATION",
     "newton_physics_replicate",
-    "queue_newton_physics_replication",
 ]
 
 from .replicate import (
+    REPLICATION,
     NewtonReplicateContext,
     newton_physics_replicate,
-    queue_newton_physics_replication,
 )

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 import torch
 from newton import ModelBuilder
@@ -15,9 +15,10 @@ from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 
 from pxr import Usd
 
-from isaaclab.cloner.replicate_session import REPLICATION_QUEUE
+from isaaclab.cloner.usd import UsdReplicateContext
 from isaaclab.physics import PhysicsManager
 from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
+from isaaclab.utils.version import has_kit
 
 from isaaclab_newton.cloner.newton_clone_utils import (
     build_source_builders,
@@ -238,15 +239,11 @@ class NewtonReplicateContext:
         return builder, stage_info, site_index_map
 
 
-def queue_newton_physics_replication(cfg: Any) -> None:
-    """Register ``cfg`` for Newton replication when :func:`~isaaclab.cloner.replicate` next runs.
-
-    Appends ``(cfg, NewtonReplicateContext)`` to
-    :data:`~isaaclab.cloner.REPLICATION_QUEUE`. The actual row resolution and dispatch
-    happen inside :func:`~isaaclab.cloner.replicate`, so this helper is safe to call from
-    any asset constructor — no active session is required.
-    """
-    REPLICATION_QUEUE.append((cfg, NewtonReplicateContext))
+# evaluated at import: this module must only be imported after AppLauncher starts Kit
+# (cfg modules reference it by string), otherwise has_kit() locks in the kitless stack
+REPLICATION = (UsdReplicateContext, NewtonReplicateContext) if has_kit() else (NewtonReplicateContext,)
+"""Default replication stack for Newton assets: USD clones accompany physics only under Kit,
+where they are needed for rendering; kitless runs skip the authoring cost."""
 
 
 def newton_physics_replicate(

--- a/source/isaaclab_ovphysx/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
+++ b/source/isaaclab_ovphysx/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :data:`~isaaclab_ovphysx.cloner.REPLICATION`, the backend's default replication stack
+  referenced by asset cfgs: the clone replay authors USD itself, so it replicates alone. With
+  physics replication disabled, OvPhysX assets are not cloned.
+
+Removed
+^^^^^^^
+
+* Removed ``queue_ovphysx_replication``: direct the contexts through
+  :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` and
+  :func:`~isaaclab.cloner.queue_replication` instead.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/articulation/articulation.py
@@ -30,7 +30,6 @@ from isaaclab.utils.wrench_composer import WrenchComposer
 from isaaclab_ovphysx import tensor_types as TT
 from isaaclab_ovphysx.assets import kernels as shared_kernels
 from isaaclab_ovphysx.assets.kernels import _body_wrench_to_world
-from isaaclab_ovphysx.cloner import queue_ovphysx_replication
 from isaaclab_ovphysx.physics import OvPhysxManager
 from isaaclab_ovphysx.sim.views.ovphysx_view import OvPhysxView
 
@@ -86,7 +85,6 @@ class Articulation(BaseArticulation):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_ovphysx_replication(cfg)
         # the binding manager is created in ``_initialize_impl``; it owns all
         # TensorBinding creation, caching, and the CPU/GPU device policy.
         self._root_view: OvPhysxView | None = None

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
@@ -26,7 +26,6 @@ from isaaclab.utils.wrench_composer import WrenchComposer
 from isaaclab_ovphysx import tensor_types as TT
 from isaaclab_ovphysx.assets import kernels as shared_kernels
 from isaaclab_ovphysx.assets.kernels import _body_wrench_to_world
-from isaaclab_ovphysx.cloner import queue_ovphysx_replication
 from isaaclab_ovphysx.physics import OvPhysxManager
 from isaaclab_ovphysx.sim.views.ovphysx_view import OvPhysxView
 
@@ -63,7 +62,6 @@ class RigidObject(BaseRigidObject):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_ovphysx_replication(cfg)
         # The binding manager is created in ``_initialize_impl``; it owns all
         # TensorBinding creation, caching, and the CPU/GPU device policy.
         self._root_view: OvPhysxView | None = None

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
@@ -18,13 +18,13 @@ from pxr import UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets.rigid_object_collection.base_rigid_object_collection import BaseRigidObjectCollection
+from isaaclab.cloner import queue_replication
 from isaaclab.utils.string import resolve_matching_names
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_ovphysx import tensor_types as TT
 from isaaclab_ovphysx.assets import kernels as shared_kernels
 from isaaclab_ovphysx.assets.kernels import _body_wrench_to_world, resolve_view_ids
-from isaaclab_ovphysx.cloner import queue_ovphysx_replication
 from isaaclab_ovphysx.physics import OvPhysxManager
 from isaaclab_ovphysx.sim.views.ovphysx_view import OvPhysxView
 
@@ -89,7 +89,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
             if len(matching_prims) == 0:
                 raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
-            queue_ovphysx_replication(cfg.rigid_objects[rigid_body_name])
+            queue_replication(cfg.rigid_objects[rigid_body_name])
         # stores object names
         self._body_names_list: list[str] = []
         # binding manager over the fused multi-prim bindings; created in _initialize_impl

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/__init__.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/__init__.py
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-from .replicate import OvPhysxReplicateContext, ovphysx_replicate, queue_ovphysx_replication
+from .replicate import REPLICATION, OvPhysxReplicateContext, ovphysx_replicate
 
-__all__ = ["OvPhysxReplicateContext", "ovphysx_replicate", "queue_ovphysx_replication"]
+__all__ = ["REPLICATION", "OvPhysxReplicateContext", "ovphysx_replicate"]

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/replicate.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/cloner/replicate.py
@@ -21,14 +21,12 @@ environments entirely inside the physics runtime without touching USD.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import torch
 
 from pxr import Sdf, Usd
 
 from isaaclab.cloner.cloner_utils import split_clone_template
-from isaaclab.cloner.replicate_session import REPLICATION_QUEUE
 
 
 def _select_env_ids(env_ids: torch.Tensor, mapping: torch.Tensor, row: int) -> torch.Tensor:
@@ -122,15 +120,8 @@ class OvPhysxReplicateContext:
         self._queue.clear()
 
 
-def queue_ovphysx_replication(cfg: Any) -> None:
-    """Register ``cfg`` for OvPhysX replication when :func:`~isaaclab.cloner.replicate` next runs.
-
-    Appends ``(cfg, OvPhysxReplicateContext)`` to
-    :data:`~isaaclab.cloner.REPLICATION_QUEUE`. The actual row resolution and dispatch
-    happen inside :func:`~isaaclab.cloner.replicate`, so this helper is safe to call from
-    any asset constructor — no active session is required.
-    """
-    REPLICATION_QUEUE.append((cfg, OvPhysxReplicateContext))
+REPLICATION = (OvPhysxReplicateContext,)
+"""Default replication stack for OvPhysX assets: the clone replay authors USD itself."""
 
 
 def ovphysx_replicate(

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -216,7 +216,7 @@ class OvPhysxManager(PhysicsManager):
     # if a later :class:`~isaaclab.sim.SimulationContext` requests a different device.
     _locked_device: ClassVar[str | None] = None
     # Pending (source, targets, parent_positions) triples queued by
-    # queue_ovphysx_replication() before the PhysX instance exists.  Replayed via
+    # replication is queued before the PhysX instance exists.  Replayed via
     # physx.clone() in _warmup_and_load().
     # parent_positions is a list of (x, y, z) tuples — one per target.
     _pending_clones: ClassVar[list[tuple[str, list[str], list[tuple[float, float, float]]]]] = []

--- a/source/isaaclab_physx/changelog.d/octi-fix-physx-hetero-mgpu-double-free.rst
+++ b/source/isaaclab_physx/changelog.d/octi-fix-physx-hetero-mgpu-double-free.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed intermittent ``double free or corruption`` (SIGABRT) in
+  :class:`~isaaclab_physx.cloner.PhysxReplicateContext` when running fully-heterogeneous
+  scenes with one variant per environment on multiple GPUs. Calling
+  ``rep.replicate()`` once per source with a single self-target is known to trigger
+  native heap corruption under mGPU due to per-call PhysX-internal allocations.
+  For layouts where every source maps only to its own environment no cross-env
+  replication is needed; the replicator registration is now skipped so PhysX parses
+  the source prims directly from the stage.

--- a/source/isaaclab_physx/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
+++ b/source/isaaclab_physx/changelog.d/zhengyuz-fix-replicate-physics-cfg-registration.major.rst
@@ -1,0 +1,12 @@
+Added
+^^^^^
+
+* Added :data:`~isaaclab_physx.cloner.REPLICATION`, the backend's default replication stack
+  referenced by asset cfgs: native physics replication plus USD clones for visuals.
+
+Removed
+^^^^^^^
+
+* Removed ``queue_physx_replication``: direct the contexts through
+  :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` and
+  :func:`~isaaclab.cloner.queue_replication` instead.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -23,7 +23,6 @@ from pxr import UsdPhysics
 
 from isaaclab.actuators import ActuatorBase, ActuatorBaseCfg, ImplicitActuator
 from isaaclab.assets.articulation.base_articulation import BaseArticulation
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.sim.utils.queries import find_first_matching_prim, resolve_matching_prims_from_source
 from isaaclab.utils.string import resolve_matching_names, resolve_matching_names_values
 from isaaclab.utils.types import ArticulationActions
@@ -35,7 +34,6 @@ _HAS_NEWTON_ACTUATORS = importlib.util.find_spec("isaaclab_newton.actuators") is
 
 from isaaclab_physx.assets import kernels as shared_kernels
 from isaaclab_physx.assets.articulation import kernels as articulation_kernels
-from isaaclab_physx.cloner import queue_physx_replication
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 from .articulation_data import ArticulationData
@@ -122,8 +120,6 @@ class Articulation(BaseArticulation):
         from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
         super().__init__(cfg)
-        queue_usd_replication(cfg)
-        queue_physx_replication(cfg)
 
         sim_ctx = SimulationContext.instance()
         self._sim_cfg = sim_ctx.cfg if sim_ctx is not None else None

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
@@ -19,11 +19,9 @@ from pxr import UsdShade
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
 from isaaclab.assets.asset_base import AssetBase
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.markers import VisualizationMarkers
 from isaaclab.utils.warp import ProxyArray
 
-from isaaclab_physx.cloner import queue_physx_replication
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 from .deformable_object_data import DeformableObjectData
@@ -82,8 +80,6 @@ class DeformableObject(AssetBase):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_usd_replication(cfg)
-        queue_physx_replication(cfg)
         # Register custom vec6f type for nodal state validation.
         self._DTYPE_TO_TORCH_TRAILING_DIMS = {**self._DTYPE_TO_TORCH_TRAILING_DIMS, vec6f: (6,)}
         # initialize deformable type to None, should be set to either surface or volume on initialization

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -17,12 +17,10 @@ from pxr import UsdPhysics
 
 import isaaclab.utils.string as string_utils
 from isaaclab.assets.rigid_object.base_rigid_object import BaseRigidObject
-from isaaclab.cloner import queue_usd_replication
 from isaaclab.sim.utils.queries import resolve_matching_prims_from_source
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_physx.assets import kernels as shared_kernels
-from isaaclab_physx.cloner import queue_physx_replication
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 from .rigid_object_data import RigidObjectData
@@ -67,8 +65,6 @@ class RigidObject(BaseRigidObject):
             cfg: A configuration instance.
         """
         super().__init__(cfg)
-        queue_usd_replication(cfg)
-        queue_physx_replication(cfg)
 
     """
     Properties

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -20,11 +20,10 @@ from pxr import UsdPhysics
 import isaaclab.sim as sim_utils
 import isaaclab.utils.string as string_utils
 from isaaclab.assets.rigid_object_collection.base_rigid_object_collection import BaseRigidObjectCollection
-from isaaclab.cloner import queue_usd_replication
+from isaaclab.cloner import queue_replication
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 from isaaclab_physx.assets import kernels as shared_kernels
-from isaaclab_physx.cloner import queue_physx_replication
 from isaaclab_physx.physics import PhysxManager as SimulationManager
 
 from .kernels import resolve_view_ids
@@ -93,8 +92,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             matching_prims = sim_utils.find_matching_prims(rigid_body_cfg.prim_path)
             if len(matching_prims) == 0:
                 raise RuntimeError(f"Could not find prim with path {rigid_body_cfg.prim_path}.")
-            queue_usd_replication(cfg.rigid_objects[rigid_body_name])
-            queue_physx_replication(cfg.rigid_objects[rigid_body_name])
+            queue_replication(cfg.rigid_objects[rigid_body_name])
         # stores object names
         self._body_names_list = []
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/surface_gripper/surface_gripper.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/surface_gripper/surface_gripper.py
@@ -18,10 +18,8 @@ from isaacsim.core.experimental.utils.app import enable_extension
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBase
-from isaaclab.cloner import queue_usd_replication
+from isaaclab.cloner import queue_replication
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
-
-from isaaclab_physx.cloner import queue_physx_replication
 
 if TYPE_CHECKING:
     from isaacsim.robot.surface_gripper import GripperView
@@ -89,6 +87,8 @@ class SurfaceGripper(AssetBase):
             cfg: A configuration instance.
         """
         # copy the configuration
+        # this class does not run AssetBase.__init__, so it registers its cfg itself
+        queue_replication(cfg)
         self._cfg = cfg.copy()
 
         # checks for Isaac Sim v5.0 to ensure that the surface gripper is supported
@@ -101,9 +101,6 @@ class SurfaceGripper(AssetBase):
         # flag for whether the sensor is initialized
         self._is_initialized = False
         self._debug_vis_handle = None
-
-        queue_usd_replication(cfg)
-        queue_physx_replication(cfg)
 
         # register various callback functions
         self._register_callbacks()

--- a/source/isaaclab_physx/isaaclab_physx/cloner/__init__.pyi
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/__init__.pyi
@@ -5,8 +5,8 @@
 
 __all__ = [
     "PhysxReplicateContext",
+    "REPLICATION",
     "physx_replicate",
-    "queue_physx_replication",
 ]
 
-from .replicate import PhysxReplicateContext, physx_replicate, queue_physx_replication
+from .replicate import REPLICATION, PhysxReplicateContext, physx_replicate

--- a/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
@@ -94,6 +94,25 @@ class PhysxReplicateContext:
             return
 
         physx_queue = tuple(self._queue)
+        self._queue.clear()
+
+        # Fully-heterogeneous 1:1 layouts have every source mapped only to its own
+        # environment (no cross-env replication needed). Calling rep.replicate() once
+        # per source with a single self-target is known to trigger intermittent native
+        # heap corruption (double-free / SIGABRT) under mGPU, likely due to per-call
+        # PhysX-internal allocations summing to a problematic total across processes.
+        # For these layouts the source prims are already in their correct env positions
+        # and PhysX can parse them from the stage without any replicator registration.
+        def _is_self_only(src: str, destination: str, target_envs: tuple[int, ...]) -> bool:
+            if len(target_envs) != 1:
+                return False
+            pre, suf = split_clone_template(destination)
+            env_id = src.removeprefix(pre).removesuffix(suf)
+            return env_id.isdigit() and int(env_id) == target_envs[0]
+
+        if all(_is_self_only(src, dst, envs) for src, dst, envs in physx_queue):
+            return
+
         current_worlds: list[int] = []
         current_template: str = ""
 
@@ -122,7 +141,6 @@ class PhysxReplicateContext:
             rep.unregister_replicator(_stage_id)
 
         get_physx_replicator_interface().register_replicator(self._stage_id, attach_fn, attach_end_fn, rename_fn)
-        self._queue.clear()
 
 
 REPLICATION = (UsdReplicateContext, PhysxReplicateContext)

--- a/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
+++ b/source/isaaclab_physx/isaaclab_physx/cloner/replicate.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import torch
 
@@ -14,7 +13,7 @@ from omni.physx import get_physx_replicator_interface
 from pxr import Sdf, Usd, UsdUtils
 
 from isaaclab.cloner.cloner_utils import split_clone_template
-from isaaclab.cloner.replicate_session import REPLICATION_QUEUE
+from isaaclab.cloner.usd import UsdReplicateContext
 
 
 def _select_env_ids(env_ids: torch.Tensor, mapping: torch.Tensor, row: int) -> torch.Tensor:
@@ -126,15 +125,12 @@ class PhysxReplicateContext:
         self._queue.clear()
 
 
-def queue_physx_replication(cfg: Any) -> None:
-    """Register ``cfg`` for PhysX replication when :func:`~isaaclab.cloner.replicate` next runs.
+REPLICATION = (UsdReplicateContext, PhysxReplicateContext)
+"""Default replication stack for PhysX assets.
 
-    Appends ``(cfg, PhysxReplicateContext)`` to
-    :data:`~isaaclab.cloner.REPLICATION_QUEUE`. The actual row resolution and dispatch
-    happen inside :func:`~isaaclab.cloner.replicate`, so this helper is safe to call from
-    any asset constructor — no active session is required.
-    """
-    REPLICATION_QUEUE.append((cfg, PhysxReplicateContext))
+PhysX always needs the per-env USD prims, not just for rendering: cross-environment collision
+filtering is authored on them as USD collision groups, and PhysX only runs under Kit (there is
+no kitless PhysX, so unlike Newton there is no USD-free mode to gate on)."""
 
 
 def physx_replicate(


### PR DESCRIPTION
## Summary

Fixes intermittent `double free or corruption` (SIGABRT) in `PhysxReplicateContext.replicate()` when running fully-heterogeneous scenes (one variant per env) across multiple GPUs. Stacks onto #6550.

**Root cause:** For a fully-heterogeneous 1:1 layout (N variants → N envs, each source mapped only to its own env), `replicate()` calls `rep.replicate()` N times — once per source with a single self-target each. This causes intermittent native heap corruption under mGPU. The source prims are already in their correct env positions; no cross-env replication is needed. Each call has PhysX-internal per-call allocations that apparently sum to a problematic total across concurrent processes.

**Fix:** Check whether all queued rows are self-only (`target_envs == (own_env_id,)`). When true, skip `register_replicator` entirely — PhysX parses the source prims directly from the stage, which is correct and avoids the crash.

**Controls (from `mgpu_repro.zip` in #6550):**
| Condition | Before | After |
|---|---|---|
| Heterogeneous mGPU (4 GPU, 192 variants) | 3/4 pass, 1/4 SIGABRT | expected 4/4 |
| Heterogeneous 1-GPU | 2/2 pass | unaffected |
| Homogeneous mGPU | 2/2 pass | unaffected |

## Failure signature (before fix)

```
Replicate physics     : True
Starting the simulation. This may take a few seconds. Please wait...
double free or corruption (!prev)
torch.distributed.elastic.multiprocessing.errors.ChildFailedError
traceback : Signal 6 (SIGABRT)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)