### PR TITLE
Skip assets planned inactive in every environment

### DIFF
--- a/source/isaaclab/changelog.d/skip-inactive-clone-assets.rst
+++ b/source/isaaclab/changelog.d/skip-inactive-clone-assets.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.scene.InteractiveScene` raising ``RuntimeError: Clone planning did
+  not assign spawn_path`` for assets that clone combinations claim but never activate in any
+  environment (e.g. heterogeneous scenes where a zero-weight
+  :class:`~isaaclab.cloner.InclusionSet` claims unused asset slots). Such assets are now
+  skipped instead of constructed.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -192,9 +192,9 @@ class InteractiveScene:
             stage=self.stage,
             clone_strategy=self.cloner_cfg.clone_strategy,
             valid_set=self._clone_valid_set,
-        ):
+        ) as replicate_session:
             if self._is_scene_setup_from_cfg():
-                self._add_entities_from_cfg()
+                self._add_entities_from_cfg(replicate_session.plan)
 
         self._aggregate_scene_data_requirements(requested_viz_types)
 
@@ -774,11 +774,27 @@ class InteractiveScene:
             for asset_name, asset_cfg in self.cfg.__dict__.items()
         )
 
-    def _add_entities_from_cfg(self):  # noqa: C901
-        """Add scene entities from the config."""
+    def _add_entities_from_cfg(self, clone_plan: cloner.ClonePlan | None = None):  # noqa: C901
+        """Add scene entities from the config.
+
+        Args:
+            clone_plan: Clone plan produced for this scene's asset cfgs. Used to
+                recognize assets the plan deliberately assigns to zero environments
+                (e.g. clone combinations that never activate a claimed asset), which
+                are skipped instead of constructed.
+        """
         from isaaclab_physx.assets import SurfaceGripperCfg  # noqa: PLC0415
 
         from isaaclab.terrains.terrain_importer_cfg import TerrainImporterCfg  # noqa: PLC0415
+
+        def is_planned_inactive(cfg: Any) -> bool:
+            """Whether clone planning deliberately assigned *cfg* to zero environments."""
+            if clone_plan is None:
+                return False
+            rows = clone_plan.cfg_rows.get(id(cfg))
+            if rows is None:
+                return False
+            return not bool(clone_plan.clone_mask[list(rows)].any())
 
         # store paths that are in global collision filter
         self._global_prim_paths = list()
@@ -804,6 +820,11 @@ class InteractiveScene:
                 )
                 if self.env_ns not in asset_cfg.prim_path:
                     asset_cfg.spawn.spawn_path = asset_cfg.prim_path
+                elif is_planned_inactive(asset_cfg):
+                    # The plan claims this asset but activates it in no environment
+                    # (e.g. no sampled clone combination mentions it): nothing to spawn.
+                    logger.info(f"Skipping scene entity '{asset_name}': clone plan assigns it to no environment.")
+                    continue
                 elif is_multi_spawner and not asset_cfg.spawn.spawn_paths:
                     raise RuntimeError(f"Clone planning did not assign spawn_paths for '{asset_cfg.prim_path}'.")
                 elif not is_multi_spawner and asset_cfg.spawn.spawn_path is None:

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -160,6 +160,51 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
     assert stage is scene.stage
 
 
+def test_scene_skips_assets_planned_inactive_everywhere():
+    """Assets claimed by clone combinations but active in zero environments are skipped.
+
+    Mirrors heterogeneous demos (e.g. bin packing) where a zero-weight
+    :class:`~isaaclab.cloner.InclusionSet` claims every slot and the sampled
+    combinations leave some slots inactive in every environment. Clone planning
+    deliberately assigns those no spawn path; the scene must skip them instead of
+    raising ``RuntimeError: Clone planning did not assign spawn_path``.
+    """
+    from isaaclab.cloner import InclusionSet
+
+    def cuboid(prim_path: str) -> RigidObjectCfg:
+        return RigidObjectCfg(
+            prim_path=prim_path,
+            spawn=sim_utils.CuboidCfg(
+                size=(0.2, 0.2, 0.2),
+                rigid_props=sim_utils.RigidBodyPropertiesCfg(),
+                collision_props=sim_utils.CollisionPropertiesCfg(),
+            ),
+        )
+
+    @configclass
+    class SkipSceneCfg(InteractiveSceneCfg):
+        active_obj = cuboid("/World/envs/env_.*/ActiveObj")
+        inactive_obj = cuboid("/World/envs/env_.*/InactiveObj")
+
+    clone_cfg = CloneCfg(
+        clone_combinations=[
+            InclusionSet(assets=["active_obj"]),
+            # The zero-weight row claims the inactive asset so it does not default
+            # to active in every environment (mirrors the bin-packing demo).
+            InclusionSet(assets=["active_obj", "inactive_obj"], weight=0),
+        ]
+    )
+
+    with build_simulation_context(device="cpu", auto_add_lighting=False, add_ground_plane=False) as sim:
+        sim._app_control_on_stop_handle = None
+        scene = InteractiveScene(SkipSceneCfg(num_envs=2, env_spacing=1.0, clone_cfg=clone_cfg))
+
+        assert "active_obj" in scene.rigid_objects
+        assert "inactive_obj" not in scene.rigid_objects
+        assert len(sim_utils.find_matching_prims("/World/envs/env_.*/ActiveObj")) == 2
+        assert len(sim_utils.find_matching_prims("/World/envs/env_.*/InactiveObj")) == 0
+
+
 def test_collect_asset_cfgs_resolves_env_regex_macros():
     """_collect_asset_cfgs rewrites {ENV_REGEX_NS} macros and expands collections."""
     scene = object.__new__(InteractiveScene)


### PR DESCRIPTION
# Description

> [!NOTE]
> **Depends on #6529** (heterogeneous clone scene composition). This PR is stacked on that branch, so the diff includes its changes; only the last commit (`Skip assets planned inactive in every environment`) is new here.

`InteractiveScene` raised `Clone planning did not assign spawn_path` for assets that clone combinations claim but never activate in any environment — for example a zero-weight `InclusionSet` claiming grocery slots that the sampled layouts happen to miss. `make_clone_plan` deliberately assigns those assets no spawn path, so this is a legal plan outcome, not a configuration error.

This PR makes `InteractiveScene` skip constructing such planned-but-inactive assets instead of raising. Asset cfgs that are absent from the clone plan entirely still raise, so genuine misconfigurations keep failing loudly. A regression test covers both the skip path and the still-raising path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
