### PR TITLE
Migrate docs deployment to Pages artifacts

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -118,10 +118,9 @@ jobs:
         git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
-    - name: Upload docs artifact
-      uses: actions/upload-artifact@v7
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        name: docs-html
         path: ./docs/_build
 
   deploy-docs:
@@ -131,16 +130,15 @@ jobs:
     # deploy only on "deploy" branches
     if: needs.doc-build-type.outputs.trigger-deploy == 'true'
 
-    steps:
-    - name: Download docs artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: docs-html
-        path: ./docs/_build
+    permissions:
+      pages: write
+      id-token: write
 
-    - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build
-        keep_files: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Description

Migrate the multi-version documentation deployment from commits on the
`gh-pages` branch to GitHub Pages artifacts.

The current nightly workflow uses `peaceiris/actions-gh-pages`, which commits
the complete generated documentation site to `gh-pages` after every deploy.
That branch now contributes approximately 656 MiB of compressed Git data and
accounts for about 95% of the repository's clone payload.

This change uploads the generated site with `actions/upload-pages-artifact`
and deploys it with `actions/deploy-pages`. It also grants the deploy job the
minimal `pages: write` and `id-token: write` permissions and records the
deployment URL on the `github-pages` environment.

After this workflow is merged and a deployment is verified, a repository
administrator must:

1. Set **Settings > Pages > Build and deployment > Source** to **GitHub Actions**.
2. Run the Docs workflow once and verify the versioned documentation site.
3. Delete the remote `gh-pages` branch.

Deleting `gh-pages` is expected to reduce a normal clone's compressed Git
payload from approximately 694 MiB to 84 MiB without requiring users to pass
`--single-branch` or `--depth 1`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; the generated documentation content and URLs are unchanged.

## Validation

- `./isaaclab.sh -f`
- YAML validation through the repository pre-commit hooks

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh -f`
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove the fix is effective (workflow-only change)
- [ ] I have added a changelog fragment (no package is changed)
- [x] I have added my name to `CONTRIBUTORS.md` or my name already exists there
