### PR TITLE
Update kit-less installation commands

### DIFF
--- a/docs/_extensions/isaaclab_docs.py
+++ b/docs/_extensions/isaaclab_docs.py
@@ -113,7 +113,9 @@ class IsaacLabKitlessInstallSnippet(SphinxDirective):
 
    git clone https://github.com/isaac-sim/IsaacLab.git --branch {branch}
    cd IsaacLab
-   ./isaaclab.sh --install   # or ./isaaclab.sh -i
+   ./isaaclab.sh --uv
+   source env_isaaclab/bin/activate
+   ./isaaclab.sh --install
 """
         return _parse_rst(self, content)
 

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -39,6 +39,30 @@ Local Installation
    required for this mode. See :doc:`kitless_installation` for which features are available
    without Isaac Sim.
 
+   The ``--uv`` command requires `uv <https://docs.astral.sh/uv/getting-started/installation/>`__
+   and creates a repository-local Python environment. Activating that environment prevents the
+   installer from falling back to the operating system's Python.
+
+   If the environment creation and activation steps are skipped on a Debian-based system, the
+   install may fail with an error similar to:
+
+   .. code-block:: text
+
+      [INFO] Using Python: "/usr/bin/python3.12"
+      [INFO] Upgrading pip...
+      error: externally-managed-environment
+
+      × This environment is externally managed
+      ╰─> To install Python packages system-wide, try apt install
+          python3-xyz, where xyz is the package you are trying to install.
+
+      [ERROR] Command failed with code 1: "/usr/bin/python3.12 -m pip install --upgrade pip"
+
+   This happens because Debian and Ubuntu mark the system Python as externally managed according
+   to :pep:`668`. The protection prevents ``pip`` from upgrading or installing packages into the
+   Python environment managed by the operating system. Do not bypass it with
+   ``--break-system-packages``; create and activate the uv environment as shown above instead.
+
    When you need full simulation features — including PhysX, ROS, URDF/MJCF
    importers — install Isaac Sim via pip (see the
    :doc:`pip_installation` guide).


### PR DESCRIPTION
# Description

Update the abbreviated kit-less installation snippet to create and activate the repository-local
uv environment before installing Isaac Lab:

```bash
./isaaclab.sh --uv
source env_isaaclab/bin/activate
./isaaclab.sh --install
```

The previous snippet ran `./isaaclab.sh --install` immediately after cloning. On Debian-based
systems with no active virtual environment, the installer can fall back to the operating system's
Python and fail while upgrading pip:

```text
[INFO] cmake is already installed.
[INFO] Installing extensions inside the Isaac Lab repository...
[INFO] Using Python: "/usr/bin/python3.12"
[INFO] Python executable: /usr/bin/python3.12
[INFO] Temporarily filtering 1 Isaac Sim pre-bundled package path(s) from PYTHONPATH during pip operations to prevent interference with pre-bundled packages.
[INFO] Upgrading pip...
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
[ERROR] Command failed with code 1: "/usr/bin/python3.12 -m pip install --upgrade pip"
```

This happens because Debian and Ubuntu mark their system Python as externally managed under
PEP 668. Pip therefore refuses to upgrade or install packages in `/usr/bin/python3.12`. Creating
and activating `env_isaaclab` keeps installation isolated without using
`--break-system-packages`.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Validation

- `./isaaclab.sh --format`
- `./isaaclab.sh --docs` (full Sphinx HTML build succeeded)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Tests are not applicable because this is a documentation-only change; the full docs build succeeded
- [x] A changelog fragment is not required because no `source/<pkg>/` package changed
- [x] My name already exists in `CONTRIBUTORS.md`
