### PR TITLE
[CI] Drop shadow-hand kitless rendering test from arm-ci to stop intermittent hangs

### DIFF
--- a/source/isaaclab_tasks/changelog.d/disable-shadow-hand-kitless-arm.skip
+++ b/source/isaaclab_tasks/changelog.d/disable-shadow-hand-kitless-arm.skip
@@ -1,0 +1,2 @@
+Test-only change: removed the ``arm_ci`` marker from the shadow-hand kitless rendering test
+to stop intermittent hangs on the arm64 CI runner. No user-facing changes.

--- a/source/isaaclab_tasks/test/core/test_rendering_shadow_hand_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_shadow_hand_kitless.py
@@ -17,7 +17,9 @@ from rendering_test_utils import (
     rendering_test_shadow_hand,
 )
 
-pytestmark = [pytest.mark.isaacsim_ci, pytest.mark.arm_ci]
+# no arm_ci marker: intermittently stalls the arm64 runner mid-file (renderer hang after a few
+# passing cases, killed at the per-file timeout); x86 kitless coverage remains in place
+pytestmark = [pytest.mark.isaacsim_ci]
 
 _COMPARISON_SCORES: list[dict] = []
 


### PR DESCRIPTION
# Description

## 1. Summary

Removes the `arm_ci` marker from `test_rendering_shadow_hand_kitless.py`. Since the test landed on arm-ci (2026-07-10, #5698) it has been implicated in 15 of 81 concluded arm-ci runs (~19%) and 15 of that job's 18 failures — including 3 failures on `develop` itself — typically stalling mid-file after several passing render cases until the per-file timeout kills the job. x86 coverage is unchanged: the file still runs in `rendering-correctness-kitless` with its full backend matrix.

## 2. Failure data (all concluded runs since 2026-07-10)

| Job | Concluded | Failures | Implicating this test |
|---|---|---|---|
| `arm-ci` (blocking on PRs) | 81 | 18 | 15 (3 on `develop`) |
| `rendering-correctness-kitless` x86 (continue-on-error on PRs) | 85 | 32 | 10 (3 timeouts, 7 file failures) |

The instability is not arm-exclusive — x86 hits the same file at roughly half the rate — but the x86 job is advisory on PRs while `arm-ci` is blocking, making this test the dominant source of spurious red arm-ci checks. `test_rendering_dexsuite_kuka_homo_kitless.py` shows the same signature on arm-ci at a much lower rate (2 of 18 failures) and stays enabled for now.

## 3. Test plan

- [x] Pre-commit clean (`./isaaclab.sh -f`)
- [x] arm-ci green on this PR with the file no longer collected

## 4. Out of scope

Root-causing the renderer stall (all observed hangs sit in the ovrtx segment of the parametrized cases, between per-case env create/teardown cycles); the two remaining `arm_ci`-marked rendering files (cartpole, kuka-homo) stay enabled.
