### PR TITLE
Update omniverseclient dependency from 2.71.1.7015 to 2.72.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "pillow>=12.1.1",
     "botocore",  # omni.replicator.core S3 backend
     "starlette>=0.46.0,<0.50",  # livestream; range coexists with isaacsim 6.0
-    "omniverseclient==2.71.1.7015",
+    "omniverseclient==2.72.1",
     "filelock",
     "lazy_loader>=0.4",
     # Pink IK stack; the install CLI derives its force-install list from these entries.

--- a/source/isaaclab/changelog.d/omniverse-client-2-72-1-update.rst
+++ b/source/isaaclab/changelog.d/omniverse-client-2-72-1-update.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated ``omniverseclient`` dependency from ``2.71.1.7015`` to ``2.72.1``
+  for compatibility with newer versions of ovrtx (``0.4+``)


### PR DESCRIPTION
# Description

Update omniverseclient dependency from 2.71.1.7015 to 2.72.1 for compatibility with newer versions of ovrtx (0.4+)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
