### PR TITLE
Pin Newton to v1.4.0 and override the Isaac Sim MuJoCo pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,8 +168,11 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.2+head.f62c22207c"
 ovrtx = ">=0.3.0,<0.4.0"
 # Newton git commit + matching warp-lang prerelease (upgraded together).
-newton = "c7ae7c7648cd0717df39e5c94b95d5a02c997320"
+newton = "v1.4.0"
 warp = "1.15.0.dev20260626"
+# MuJoCo stack required by the Newton pin; overrides isaacsim-core's exact 3.8 pin.
+mujoco_warp = ">=3.10.0.2,<3.11"
+mujoco = "~=3.10.0"
 
 [tool.ruff]
 line-length = 120
@@ -335,7 +338,9 @@ prerelease = "allow"
 # the CUDA indexes via [tool.uv.sources]. Values mirror [tool.isaaclab.versions] above.
 override-dependencies = [
     "numpy>=2",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@c7ae7c7648cd0717df39e5c94b95d5a02c997320",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.4.0",
+    "mujoco-warp>=3.10.0.2,<3.11",
+    "mujoco~=3.10.0",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.3.1",
     "torch==2.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.2+head.f62c22207c"
 ovrtx = ">=0.3.0,<0.4.0"
 # Newton git commit + matching warp-lang prerelease (upgraded together).
-newton = "v1.4.0"
+newton = "1.4.0"
 warp = "1.15.0.dev20260626"
 # MuJoCo stack required by the Newton pin; overrides isaacsim-core's exact 3.8 pin.
 mujoco_warp = ">=3.10.0.2,<3.11"
@@ -338,7 +338,7 @@ prerelease = "allow"
 # the CUDA indexes via [tool.uv.sources]. Values mirror [tool.isaaclab.versions] above.
 override-dependencies = [
     "numpy>=2",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@v1.4.0",
+    "newton[sim]==1.4.0",
     "mujoco-warp>=3.10.0.2,<3.11",
     "mujoco~=3.10.0",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -101,6 +101,10 @@ def test_version_single_source_matches_literal_pins():
     assert any(dep.endswith(f"newton.git@{versions['newton']}") for dep in overrides)
     assert f"warp-lang=={versions['warp']}" in dependencies
 
+    # MuJoCo-stack overrides mirror the table (they outrank isaacsim-core's exact pins).
+    assert f"mujoco-warp{versions['mujoco_warp']}" in overrides
+    assert f"mujoco{versions['mujoco']}" in overrides
+
 
 def test_uv_run_isaacsim_extra_is_conflict_forked():
     """Isaac Sim is an opt-in uv workspace extra, forked away from clashing extras.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -98,7 +98,7 @@ def test_version_single_source_matches_literal_pins():
         assert f"{package}=={versions[package]}" in overrides
 
     # Newton git commit is pinned via a uv override; warp-lang is a core dependency.
-    assert any(dep.endswith(f"newton.git@{versions['newton']}") for dep in overrides)
+    assert f"newton[sim]=={versions['newton']}" in overrides
     assert f"warp-lang=={versions['warp']}" in dependencies
 
     # MuJoCo-stack overrides mirror the table (they outrank isaacsim-core's exact pins).

--- a/source/isaaclab_newton/changelog.d/newton-pin-v140.minor.rst
+++ b/source/isaaclab_newton/changelog.d/newton-pin-v140.minor.rst
@@ -1,0 +1,14 @@
+Changed
+^^^^^^^
+
+* Changed the pinned Newton version to the v1.4.0 release (from a pre-1.4
+  development commit), adopting the MuJoCo 3.10 stack and the new margin/gap
+  semantics. Assets that author PhysX ``contactOffset`` / ``restOffset``
+  attributes keep their behavior through Newton's schema translation
+  (``margin == restOffset``, ``gap == contactOffset - restOffset``).
+
+Fixed
+^^^^^
+
+* Fixed custom-frequency USD traversal honoring ``ignore_paths`` via the
+  upstream Newton fix included in v1.4.0.

--- a/source/isaaclab_newton/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_contact_sensor.py
@@ -202,7 +202,8 @@ def test_horizontal_collision_detects_contact(device: str, use_mujoco_contacts: 
     if use_mujoco_contacts and shape_type == ShapeType.MESH_CAPSULE:
         pytest.xfail(
             "Newton >= 1.4 (mujoco-warp 3.10 margin/gap semantics) loses mesh-mesh collision response in the"
-            " MuJoCo contacts pipeline: objects tunnel with zero contact forces. Tracked upstream."
+            " MuJoCo contacts pipeline: objects tunnel with zero contact forces."
+            " Tracked upstream: https://github.com/newton-physics/newton/issues/3559"
         )
     """Test horizontal collision detection with varied velocities and separations.
 

--- a/source/isaaclab_newton/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_contact_sensor.py
@@ -199,6 +199,11 @@ def test_contact_lifecycle(device: str, use_mujoco_contacts: bool, shape_type: S
 @pytest.mark.parametrize("use_mujoco_contacts", COLLISION_PIPELINES)
 @pytest.mark.parametrize("shape_type", STABLE_SHAPES, ids=[shape_type_to_str(s) for s in STABLE_SHAPES])
 def test_horizontal_collision_detects_contact(device: str, use_mujoco_contacts: bool, shape_type: ShapeType):
+    if use_mujoco_contacts and shape_type == ShapeType.MESH_CAPSULE:
+        pytest.xfail(
+            "Newton >= 1.4 (mujoco-warp 3.10 margin/gap semantics) loses mesh-mesh collision response in the"
+            " MuJoCo contacts pipeline: objects tunnel with zero contact forces. Tracked upstream."
+        )
     """Test horizontal collision detection with varied velocities and separations.
 
     8 environments (2 groups x 4 envs) with different collision speeds.


### PR DESCRIPTION
## Summary

- Advances the Newton pin from a pre-1.4 development commit (`c7ae7c7648c`) to the **v1.4.0 release**, which contains the `ignore_paths` custom-frequency USD traversal fix ([newton#3406](https://github.com/newton-physics/newton/pull/3406), membership in the release verified) plus the 1.4 stabilization series — 50 commits newer than the previously targeted dev SHA.
- Newton 1.4 requires the MuJoCo 3.10 stack while `isaacsim-core 6.0.0.1` pins `mujoco-warp==3.8.0.3` exactly, so `mujoco-warp>=3.10.0.2,<3.11` and `mujoco~=3.10.0` join the `[tool.uv]` override-dependencies (the same mechanism already used to out-rank isaacsim's torch and newton pins; the 3.10.0.2 floor is what v1.4.0 declares). The version table and its single-source test carry the new entries.
- Extracted from #6411 so the approved runtime fixes there stay decoupled from the dependency advance: #6411's Multi-GPU CI failure bisects to this pin, not to its code.

## Problem: mesh-mesh contact regression in the MuJoCo pipeline (upstream)

The Newton range this pin crosses includes [newton#2980](https://github.com/newton-physics/newton/pull/2980) (MuJoCo 3.10 margin/gap semantics), which introduces a regression: **mesh-mesh shape pairs in the MuJoCo contacts pipeline lose collision response entirely** — bodies tunnel through each other with zero contact forces.

Bisect (via `test_horizontal_collision_detects_contact[mesh_capsule-mujoco_contacts]`):

| Newton ref | Result |
|---|---|
| `c7ae7c7648c` (current develop pin) | pass |
| `346121aaaca` = newton#2980 | **fail (first bad)** |
| `9af5a9f4181` (1.5.0.dev0) | fail |
| `v1.4.0` | fail |

- No older pin avoids it: the `ignore_paths` fix landed 31 commits **after** the regression, so every Newton commit containing the fix also contains the regression.
- `legacy_margin_gap=True` at USD import does not restore the behavior (the failure is contact-pair loss, not margin-value translation), and neither does raising the builder default gap.
- Scope: primitive pairs and mesh-vs-primitive pairs are unaffected (the dexterous task families train to full success rates under this pin).
- Tracked upstream as [newton#3559](https://github.com/newton-physics/newton/issues/3559); the affected test case is marked xfail referencing that issue and should be re-enabled when the upstream fix lands.

## Stacking

- Independent of the dexterous task-cleanup series (based on develop). If #6411 merges first, this PR picks up the removal of its now-redundant ignore_paths cloner workaround on rebase.