### PR TITLE
Document micro-benchmark workflows

### DIFF
--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -3,483 +3,506 @@
 Micro-Benchmarks for Performance Testing
 ========================================
 
-Isaac Lab provides micro-benchmarking tools to measure the performance of asset
-setter/writer methods and data property accessors without requiring Isaac Sim.
+Micro-benchmarks measure a narrow Isaac Lab operation while excluding as much
+unrelated work as possible. They answer questions such as:
 
-.. seealso::
+* Did an asset API change make a property read or state write slower?
+* How much host conversion or backend-binding overhead does an API call add?
+* How expensive is a production sensor update after physics has completed?
+* Is a regression in Isaac Lab code, a backend read, or the workload around it?
 
-   For full-simulation benchmarks (environment stepping, RL training), see
-   :ref:`testing_benchmarks`. This page covers method-level micro-benchmarks
-   that use mock interfaces.
+Isolation makes these benchmarks quick to repeat and easier to diagnose than a
+full training run. It also limits what they prove: micro-benchmarks do **not**
+predict end-to-end environment or training throughput. Use
+:ref:`testing_benchmarks` when the question includes environment logic, policy
+inference, learning, or application startup.
 
-Overview
---------
-
-The benchmarks use **mock interfaces** to simulate PhysX views, allowing performance
-measurement of Python-level overhead in isolation. This is useful for:
-
-- Comparing list vs tensor index performance
-- Identifying bottlenecks in hot code paths
-- Tracking performance regressions
-- Optimizing custom methods
-
-Quick Start
------------
-
-Run benchmarks using the Isaac Lab launcher:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
-
-      .. code-block:: bash
-
-         # Run Articulation method benchmarks
-         uv run python source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
-         uv run python source/isaaclab_newton/benchmark/assets/benchmark_articulation.py
-         uv run python source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
-
-         # With custom parameters
-         uv run python source/isaaclab_physx/benchmark/assets/benchmark_articulation.py \
-             --num_iterations 1000 \
-             --num_instances 64 \
-             --num_bodies 5 \
-             --num_joints 4
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         # Run Articulation method benchmarks
-         ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
-         ./isaaclab.sh -p source/isaaclab_newton/benchmark/assets/benchmark_articulation.py
-         ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
-
-         # With custom parameters
-         ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py \
-             --num_iterations 1000 \
-             --num_instances 64 \
-             --num_bodies 5 \
-             --num_joints 4
-
-Available Benchmarks
+Choosing a Benchmark
 --------------------
 
-Asset Method Benchmarks
-~~~~~~~~~~~~~~~~~~~~~~~
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
 
-These benchmark setter and writer methods on asset classes:
+   * - Question
+     - Use
+     - Deliberately excluded
+   * - How fast is one asset method or data property?
+     - Asset method/data micro-benchmark
+     - Scene creation, simulation, sensors, and environment logic
+   * - How fast is one production sensor update?
+     - Sensor update micro-benchmark
+     - Timed physics stepping, environment logic, and learning
+   * - How fast does an environment step or policy train?
+     - Runtime, play, or training benchmark
+     - Nothing required by that workflow
+
+Benchmark Families
+------------------
+
+Asset Method and Data Benchmarks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Asset benchmarks instantiate Isaac Lab asset classes against backend-specific
+**mock views**. The mocks reproduce relevant data shapes and binding behavior
+without running physics. Measurements isolate Python input handling,
+tensor/index conversion, Isaac Lab method logic, backend binding calls, and
+data-property computation.
+
+Equivalent sets exist under:
+
+* ``source/isaaclab_physx/benchmark/assets/``
+* ``source/isaaclab_newton/benchmark/assets/``
+* ``source/isaaclab_ovphysx/benchmark/assets/``
 
 .. list-table::
    :header-rows: 1
-   :widths: 35 25 40
+   :widths: 34 22 22 22
 
-   * - Benchmark File
-     - Asset Class
-     - Methods Covered
+   * - Benchmark file
+     - PhysX
+     - Newton
+     - OVPhysX
    * - ``benchmark_articulation.py``
-     - ``Articulation``
-     - 24 methods (root/joint state, mass props, forces)
-   * - ``benchmark_rigid_object.py``
-     - ``RigidObject``
-     - 13 methods (root state, mass props, forces)
-   * - ``benchmark_rigid_object_collection.py``
-     - ``RigidObjectCollection``
-     - 13 methods (body state, mass props, forces)
-
-Data Property Benchmarks
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-These benchmark property accessors on data classes:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 40 30 30
-
-   * - Benchmark File
-     - Data Class
-     - Properties
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_articulation_data.py``
-     - ``ArticulationData``
-     - 59 properties
+     - Yes
+     - Yes
+     - Yes
+   * - ``benchmark_rigid_object.py``
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_rigid_object_data.py``
-     - ``RigidObjectData``
-     - 40 properties
+     - Yes
+     - Yes
+     - Yes
+   * - ``benchmark_rigid_object_collection.py``
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_rigid_object_collection_data.py``
-     - ``RigidObjectCollectionData``
-     - 40 properties
+     - Yes
+     - Yes
+     - Yes
 
-All benchmarks are located in ``source/isaaclab_physx/benchmark/assets/``.
+Method benchmarks cover state writes, targets, forces, and material or mass
+properties supported by the asset. Data benchmarks time backend-supported
+cached and derived properties. Use the same file, dimensions, and mode when
+comparing backends or commits.
 
 Sensor Update Benchmarks
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The PhysX and OVPhysX sensor benchmarks build simulation scenes and measure sensor
-updates separately from physics stepping:
+Sensor benchmarks build **live simulation scenes** and exercise production
+sensor implementations. They step the selected backend so fresh source data
+exists, but place ``sim.step()`` outside the timed region. Reported latency
+therefore measures sensor update work rather than the solver.
+
+Equivalent workloads exist under each backend ``benchmark/sensors`` directory:
 
 .. list-table::
    :header-rows: 1
-   :widths: 40 60
+   :widths: 34 22 22 22
 
-   * - Benchmark File
-     - Sensor Path
+   * - Benchmark file
+     - PhysX
+     - Newton
+     - OVPhysX
    * - ``benchmark_contact_sensor.py``
-     - Contact force collection
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_frame_transformer.py``
-     - Source and target frame transforms
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_imu_pva.py``
-     - IMU or PVA state estimation
+     - IMU and PVA
+     - IMU and PVA
+     - IMU and PVA
    * - ``benchmark_joint_wrench.py``
-     - Incoming joint wrench transforms
+     - Yes
+     - Yes
+     - Yes
    * - ``benchmark_ray_caster.py``
-     - Rigid-body tracking and ray casting
+     - Yes
+     - Yes
+     - Yes
 
-They are located in the ``benchmark/sensors/`` directories of ``isaaclab_physx``
-and ``isaaclab_ovphysx``. Each script reports synchronized completion latency,
-host submission latency, and a synchronized no-op observer floor. OVPhysX scripts
-also isolate supported native reads and report the full-update-minus-read result
-as an estimate. Physics ``sim.step()`` calls occur outside all timed regions.
+Every sensor benchmark validates output after timing. A fast run with missing
+contacts, non-finite transforms, zero wrenches, or invalid ray hits fails instead
+of reporting a misleading performance result.
 
-The default ``summary`` formatter prints the aggregate results and writes a JSON
-file containing the mean, sample standard deviation, sample count, p50, and p95.
-The observer floor is reported but is not subtracted from the measurements.
+Prerequisites
+-------------
 
-For example:
+Run commands from the repository root through ``./isaaclab.sh -p``. The active
+Python environment must contain the backend being measured.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 41 41
+
+   * - Backend
+     - Asset benchmarks
+     - Sensor benchmarks
+   * - PhysX
+     - Launch Isaac Sim and use mocked PhysX views
+     - Launch Isaac Sim and build a live PhysX scene
+   * - Newton
+     - Launch Isaac Sim and use mocked Newton views
+     - Run kitless with the installed Newton runtime
+   * - OVPhysX
+     - Run kitless; require the optional ``ovphysx`` runtime wheel
+     - Run kitless; require the optional ``ovphysx`` runtime wheel
+
+Use a CUDA device for representative GPU numbers. CPU execution is useful for
+correctness or profiling, but is a different workload and must not be mixed with
+CUDA results.
+
+Running Asset Benchmarks
+------------------------
+
+Choose a backend by changing the package directory:
 
 .. code-block:: bash
 
-   ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py \
+   ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py \
+       --num_instances 4096 \
+       --num_bodies 12 \
+       --num_joints 11 \
+       --warmup_steps 10 \
+       --num_iterations 1000 \
+       --mode all \
+       --backend json \
+       --output_dir results/physx_articulation
+
+   ./isaaclab.sh -p source/isaaclab_newton/benchmark/assets/benchmark_articulation.py \
+       --num_instances 4096 --warmup_steps 10 --num_iterations 1000
+
+   ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py \
+       --num_instances 4096 --warmup_steps 10 --num_iterations 1000
+
+Replace ``benchmark_articulation.py`` with the corresponding rigid-object,
+collection, or ``*_data.py`` file to measure another API surface.
+
+Asset Arguments
+~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 18 57
+
+   * - Argument
+     - Default
+     - Meaning
+   * - ``--num_iterations``
+     - 1000
+     - Timed calls per method or property
+   * - ``--warmup_steps``
+     - 10
+     - Untimed calls used to compile and warm caches
+   * - ``--num_instances``
+     - 4096
+     - Asset instances represented by the mock view
+   * - ``--mode``
+     - ``all``
+     - Input/index modes to run; method benchmarks only
+   * - ``--backend``
+     - ``json``
+     - Output formatter: ``json``, ``osmo``, or ``omniperf``
+   * - ``--output_dir``
+     - current directory
+     - Directory for the timestamped result file
+   * - ``--no_shape_checks``
+     - false
+     - Disable method input shape checks when supported
+
+Asset-specific dimensions include ``--num_bodies`` and ``--num_joints``.
+Defaults differ by file; use ``--help`` before creating a comparison command.
+
+Asset Input Modes
+~~~~~~~~~~~~~~~~~
+
+``torch_list``
+   Pass selection IDs as Python lists. This includes list-to-tensor conversion
+   and represents common convenience-API usage.
+
+``torch_tensor``
+   Pass pre-allocated Torch tensors. This removes repeated list conversion and
+   represents the optimized Torch path.
+
+``warp_mask``
+   Pass pre-allocated Warp boolean masks. This mode is available for supported
+   Newton and OVPhysX mask APIs.
+
+Not every backend or method supports every mode. Compare a mode only when it has
+the same meaning on both sides.
+
+Running Sensor Benchmarks
+-------------------------
+
+Common sensor defaults are substantial enough to amortize timing noise: 4096
+environments, 50 warm-up updates, and 500 timed updates. Override them for a
+quick smoke test or scaling study.
+
+Contact examples are backend-specific because PhysX and Newton expose a cadence
+workload with decimation and history controls:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py \
        --num_envs 4096 --warmup_steps 50 --num_steps 500 \
-       --benchmark_formatter summary --output_path artifacts/micro_benchmarks
-
-Newton Sensor Update Benchmarks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The Newton sensor benchmarks measure sensor updates separately from physics
-stepping:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 40 60
-
-   * - Benchmark File
-     - Sensor Path
-   * - ``benchmark_contact_sensor.py``
-     - Contact force collection
-   * - ``benchmark_frame_transformer.py``
-     - Source and target frame transforms
-   * - ``benchmark_imu_pva.py``
-     - IMU or PVA state estimation
-   * - ``benchmark_joint_wrench.py``
-     - Incoming joint wrench transforms
-   * - ``benchmark_ray_caster.py``
-     - Rigid-body tracking and ray casting
-
-They are located in ``source/isaaclab_newton/benchmark/sensors/``. Each script
-reports synchronized completion latency, host submission latency, and a synchronized
-no-op observer floor. Physics ``sim.step()`` calls use the normal Newton configuration
-but occur outside all timed regions.
-
-For example:
-
-.. code-block:: bash
+       --decimation 4 --history_length 0
 
    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py \
        --num_envs 4096 --warmup_steps 50 --num_steps 500 \
-       --benchmark_formatter summary --output_path artifacts/micro_benchmarks
+       --decimation 4 --history_length 0
 
-Command Line Arguments
-----------------------
+   ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py \
+       --num_envs 4096 --warmup_steps 50 --num_steps 500
 
-Common Arguments
+For other sensors, set ``BACKEND`` to ``physx``, ``newton``, or ``ovphysx``:
+
+.. code-block:: bash
+
+   BACKEND=newton
+
+   ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_frame_transformer.py \
+       --num_envs 4096 --num_target_frames 4 --warmup_steps 50 --num_steps 500
+
+   ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_imu_pva.py \
+       --sensor imu --num_envs 4096 --warmup_steps 50 --num_steps 500
+
+   ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_imu_pva.py \
+       --sensor pva --num_envs 4096 --warmup_steps 50 --num_steps 500
+
+   ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_joint_wrench.py \
+       --num_envs 4096 --warmup_steps 50 --num_steps 500
+
+   ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_ray_caster.py \
+       --num_envs 4096 --grid_size 1.0 --grid_resolution 0.25 \
+       --warmup_steps 50 --num_steps 500
+
+Sensor Arguments
 ~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 15 65
+   :widths: 27 18 55
 
    * - Argument
      - Default
-     - Description
-   * - ``--num_iterations``
-     - 1000
-     - Number of timed iterations
-   * - ``--warmup_steps``
-     - 10
-     - Warmup iterations (not timed)
-   * - ``--num_instances``
+     - Meaning
+   * - ``--num_envs``
      - 4096
-     - Number of asset instances
+     - Number of live sensor instances
+   * - ``--num_steps``
+     - 500
+     - Timed sensor updates or contact cadences
+   * - ``--warmup_steps``
+     - 50
+     - Untimed simulation and sensor updates before measurement
    * - ``--device``
      - ``cuda:0``
-     - Device for tensors
-   * - ``--mode``
-     - ``all``
-     - ``all``, ``torch_list``, or ``torch_tensor``
-   * - ``--output``
-     - auto
-     - Output JSON filename
-   * - ``--no_csv``
-     - false
-     - Disable CSV output
+     - Simulation and sensor device
+   * - ``--label``
+     - ``current``
+     - Label printed by scripts that support it
+   * - ``--sensor``
+     - required
+     - Select ``imu`` or ``pva`` in ``benchmark_imu_pva.py``
+   * - ``--num_target_frames``
+     - 4
+     - Target frames per environment in the frame-transformer workload
+   * - ``--grid_size``
+     - 1.0
+     - Ray-grid width and length [m]
+   * - ``--grid_resolution``
+     - 0.25
+     - Ray-grid spacing [m]
 
-Asset-Specific Arguments
-~~~~~~~~~~~~~~~~~~~~~~~~
+PhysX scripts also expose ``--disable_graph`` or
+``--disable_recorded_launch`` where applicable. These are diagnostic controls
+for comparing production cached/graph paths with eager launches; leave them
+disabled when measuring default production behavior.
 
-**Articulation benchmarks:**
+Understanding the Outputs
+-------------------------
 
-- ``--num_bodies``: Number of links (default: 13)
-- ``--num_joints``: Number of DOFs (default: 12)
-
-**RigidObjectCollection benchmarks:**
-
-- ``--num_bodies``: Number of bodies in collection (default: 5)
-
-Benchmark Modes
----------------
-
-Each method is benchmarked under two input scenarios:
-
-**torch_list**
-   Environment/body IDs passed as Python lists. Measures the overhead of
-   list-to-tensor conversion, which is common in user code.
-
-**torch_tensor**
-   Environment/body IDs passed as pre-allocated tensors. Represents the
-   optimal baseline with minimal overhead.
-
-Example output:
-
-.. code-block:: text
-
-   [1/24] [TORCH_LIST] write_root_state_to_sim... 132.02 ± 6.79 µs
-   [1/24] [TORCH_TENSOR] write_root_state_to_sim... 65.44 ± 3.06 µs
-
-The comparison shows tensor indices are ~2x faster than list indices.
-
-Output Format
--------------
-
-Console Output
-~~~~~~~~~~~~~~
-
-.. code-block:: text
-
-   Benchmarking Articulation (PhysX) with 64 instances, 5 bodies, 4 joints...
-   Device: cuda:0
-   Iterations: 100, Warmup: 10
-
-   Benchmarking 24 methods...
-   [1/24] [TORCH_LIST] write_root_state_to_sim... 132.02 ± 6.79 µs
-   [1/24] [TORCH_TENSOR] write_root_state_to_sim... 65.44 ± 3.06 µs
-   ...
-
-   ================================================================================
-   COMPARISON: Torch_list vs Torch_tensor
-   ================================================================================
-   Method Name                         Torch_list   Torch_tensor   Speedup
-   ------------------------------------------------------------------------
-   write_root_state_to_sim               132.02        65.44        2.02x
-
-Export Files
+Asset Output
 ~~~~~~~~~~~~
 
-Results are automatically exported to:
+Asset scripts print mean and standard deviation for every method/mode pair in
+microseconds, followed by mode comparisons when applicable:
 
-- ``{benchmark_name}_{timestamp}.json`` - Full results with hardware info
-- ``{benchmark_name}_{timestamp}.csv`` - Tabular results for analysis
+.. code-block:: text
 
-JSON Structure
-~~~~~~~~~~~~~~
+   [1/24] [TORCH_LIST] write_root_state_to_sim... 132.02 +/- 6.79 us
+   [1/24] [TORCH_TENSOR] write_root_state_to_sim... 65.44 +/- 3.06 us
 
-.. code-block:: json
+They also write a timestamped JSON file to ``--output_dir`` by default. It
+contains benchmark configuration, hardware/software metadata, phase names, and
+recorded measurements. Select ``--backend osmo`` or ``--backend omniperf`` for
+those ingestion formats. The script prints the exact output path at completion.
 
-   {
-     "config": {
-       "num_iterations": 100,
-       "num_instances": 64,
-       "device": "cuda:0"
-     },
-     "hardware": {
-       "cpu": "Intel Core i9-13950HX",
-       "gpu": "NVIDIA RTX 5000",
-       "pytorch": "2.7.0",
-       "cuda": "12.8"
-     },
-     "results": [
-       {
-         "name": "write_root_state_to_sim",
-         "mode": "torch_list",
-         "mean_us": 132.02,
-         "std_us": 6.79,
-         "iterations": 100
-       }
-     ]
-   }
+Sensor Output
+~~~~~~~~~~~~~
+
+Sensor scripts currently report human-readable statistics to standard output:
+
+.. code-block:: text
+
+   synchronized mean      : 0.041 ms
+   synchronized p50       : 0.040 ms
+   synchronized p95       : 0.043 ms
+   submission mean        : 0.037 ms
+   finite target frames   : 16384 / 16384
+
+``synchronized`` latency
+   Wall-clock latency from immediately before ``sensor.update()`` until all
+   submitted device work completes. A device synchronization before the timer
+   prevents earlier simulation or policy kernels from being charged to the
+   sensor.
+
+``submission`` latency
+   Host time spent issuing ``sensor.update()`` before post-update device
+   synchronization. This is enqueue/dispatch cost, not pure GPU execution time.
+
+``p50`` and ``p95``
+   Median and 95th-percentile latency within one process. They expose jitter
+   that a mean can hide.
+   Most workloads report both; the PhysX/Newton contact cadence reports p50 and
+   minimum instead.
+
+``read-only`` latency
+   OVPhysX scripts also time the blocking backend fetch without sensor Warp
+   processing. Newton sensor inputs are already Warp arrays, and PhysX scripts
+   do not consistently expose an equivalent phase.
+
+``implied kernel tail``
+   OVPhysX reports ``synchronized mean - read-only mean`` as an estimate of
+   remaining processing. It derives from separately measured phases, so treat
+   small differences as noise rather than direct kernel timing.
+
+Validation counts
+   Final lines prove that the workload produced expected contacts, finite
+   frames, sensor outputs, nonzero wrenches, or ray hits. Never use a result
+   whose validation failed.
+
+Sensor scripts do not currently write a structured result file. Redirect stdout
+to retain raw runs:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py \
+       --num_envs 4096 --warmup_steps 50 --num_steps 500 \
+       > results/newton_ray_caster_run_1.log 2>&1
+
+Making Fair Comparisons
+-----------------------
+
+For a performance claim:
+
+1. Use the same workstation, GPU conditions, environment, device, benchmark
+   file, dimensions, warm-up count, and timed count.
+2. Run baseline and candidate configurations from separate clean processes.
+3. Use at least three repetitions per configuration and report the mean plus
+   between-run standard deviation.
+4. Check validation output and retain raw logs or JSON files.
+5. Compare the same metric. Do not compare asset microseconds with sensor
+   milliseconds, submission with synchronized latency, or sensor latency with
+   environment FPS.
+6. Treat startup separately. Compilation, scene creation, physics initialization,
+   and CUDA graph construction occur outside reported sensor update latency but
+   still affect total command duration.
+
+.. important::
+
+   Contact workloads are not yet identical across all backends. PhysX and
+   Newton measure a configurable cadence of ``--decimation`` physics steps plus
+   a data read. OVPhysX measures one forced update after each physics step. Use
+   contact results for within-backend regressions unless protocols are aligned.
 
 Architecture
 ------------
 
-The benchmarks use mock interfaces to simulate PhysX views without Isaac Sim:
+Asset benchmarks isolate method/data code with mocks:
 
 .. code-block:: text
 
-   ┌─────────────────────┐     ┌──────────────────────┐
-   │   Asset Class       │────>│   MockArticulationView│
-   │   (Articulation)    │     │   (mock_interfaces)   │
-   └─────────────────────┘     └──────────────────────┘
-            │
-            v
-   ┌───────────────────────────┐
-   │   MethodBenchmarkRunner   │
-   │   (extends BaseIsaacLab-  │
-   │    Benchmark)             │
-   └───────────────────────────┘
-            │
-            v
-   ┌───────────────────────────┐
-   │   Output Backends         │
-   │   (json, osmo, omniperf)  │
-   └───────────────────────────┘
+   generated inputs -> Isaac Lab asset method/property -> backend mock view
+                    -> MethodBenchmarkRunner -> console + metrics formatter
 
-Key Components
-~~~~~~~~~~~~~~
+Sensor benchmarks isolate a live sensor update from simulation:
 
-1. **Mock Views** (``isaaclab_physx/test/mock_interfaces/``)
+.. code-block:: text
 
-   - ``MockArticulationView`` - Mimics PhysX ArticulationView
-   - ``MockRigidBodyView`` - Mimics PhysX RigidBodyView
+   sim.step() [untimed]
+       -> synchronize [timing boundary]
+       -> sensor.update() [timed]
+       -> synchronize [timing boundary]
+       -> validate output [untimed]
 
-2. **Benchmark Framework** (``isaaclab/benchmark/``)
-
-   - :class:`~isaaclab.benchmark.MethodBenchmarkRunner` - Runner extending
-     :class:`~isaaclab.benchmark.BaseIsaacLabBenchmark` for method-level benchmarks
-   - :class:`~isaaclab.benchmark.MethodBenchmarkRunnerConfig` - Configuration dataclass
-   - :class:`~isaaclab.benchmark.MethodBenchmarkDefinition` - Benchmark definition
-   - Multiple output backends (JSON, Osmo, OmniPerf)
-
-3. **Module Mocking**
-
-   Each benchmark file mocks Isaac Sim dependencies (``isaacsim``, ``omni``, ``pxr``)
-   to allow the asset classes to be instantiated without simulation.
+The pre-boundary synchronization is intentional. GPU work is asynchronous; if
+the timer started while earlier work was pending, synchronized sensor latency
+could incorrectly include that work.
 
 Adding New Benchmarks
 ---------------------
 
-Adding a Method Benchmark
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding an Asset Method or Property
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Create input generator functions:
+Add input generators and a
+:class:`~isaaclab.test.benchmark.MethodBenchmarkDefinition` to the corresponding
+backend script. Allocate inputs before the timed call. For a data property, list
+prerequisite properties through ``derived_from`` so dependencies are populated
+before timing.
 
-.. code-block:: python
+Keep equivalent backends aligned where the API is shared, but do not register a
+mode or property that a backend cannot implement meaningfully.
 
-   from isaaclab.benchmark import MethodBenchmarkRunnerConfig
+Adding a Sensor Workload
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-   def gen_my_method_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
-       return {
-           "param1": torch.rand(config.num_instances, 3, device=config.device),
-           "env_ids": list(range(config.num_instances)),
-       }
-
-   def gen_my_method_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
-       return {
-           "param1": torch.rand(config.num_instances, 3, device=config.device),
-           "env_ids": torch.arange(config.num_instances, device=config.device),
-       }
-
-2. Add to the ``BENCHMARKS`` list:
-
-.. code-block:: python
-
-   from isaaclab.benchmark import MethodBenchmarkDefinition
-
-   MethodBenchmarkDefinition(
-       name="my_method",
-       method_name="my_method",
-       input_generators={
-           "torch_list": gen_my_method_torch_list,
-           "torch_tensor": gen_my_method_torch_tensor,
-       },
-       category="my_category",
-   ),
-
-Adding a Property Benchmark
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For data class properties, add to the ``PROPERTIES`` list:
-
-.. code-block:: python
-
-   ("my_property", {"derived_from": ["dependency1", "dependency2"]}),
-
-The ``derived_from`` key indicates dependencies that should be pre-computed
-before timing the property access.
-
-Performance Tips
-----------------
-
-Based on benchmark results:
-
-1. **Use tensor indices** instead of lists for 30-50% speedup
-2. **Pre-allocate index tensors** and reuse them across calls
-3. **Batch operations** where possible (e.g., set all joint positions at once)
-4. **Mass properties are CPU-bound** - PhysX requires CPU tensors for these
-
-Example optimization:
-
-.. code-block:: python
-
-   # Slow: Create new list each call
-   for _ in range(1000):
-       robot.write_joint_state_to_sim(state, env_ids=list(range(64)))
-
-   # Fast: Pre-allocate tensor and reuse
-   env_ids = torch.arange(64, device="cuda:0")
-   for _ in range(1000):
-       robot.write_joint_state_to_sim(state, env_ids=env_ids)
+1. Build the smallest live scene that exercises the production sensor path.
+2. Warm simulation and sensor updates before collecting samples.
+3. Keep ``sim.step()`` and validation outside the timed region.
+4. Synchronize the device immediately before and after ``sensor.update()``.
+5. Report synchronized and submission distributions with clear units.
+6. Fail when output shapes, finite values, or physical signals are invalid.
+7. Document every backend-specific timing phase or protocol difference.
 
 Troubleshooting
 ---------------
 
-Import Errors
-~~~~~~~~~~~~~
+Import or Backend Errors
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Ensure you're running through ``isaaclab.sh``:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
-
-      .. code-block:: bash
-
-         uv run python source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
+Confirm the backend is installed in the Python environment selected by
+``./isaaclab.sh -p``. OVPhysX requires its optional runtime wheel. PhysX
+benchmarks require Isaac Sim.
 
 CUDA Out of Memory
 ~~~~~~~~~~~~~~~~~~
 
-Reduce ``--num_instances``:
+Reduce ``--num_instances`` for assets or ``--num_envs`` for sensors. Record the
+reduced size because latency scaling changes with workload size.
 
-.. tab-set::
+Slow First Process
+~~~~~~~~~~~~~~~~~~
 
-   .. tab-item:: uv (Recommended)
+The command may compile Warp kernels, build a scene, initialize physics, or
+capture CUDA graphs before measurement. Warm-up excludes this work from reported
+operation latency, but not from total command duration.
 
-      .. code-block:: bash
+Noisy Results
+~~~~~~~~~~~~~
 
-         uv run python ... --num_instances 1024
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh -p ... --num_instances 1024
-
-Slow First Run
-~~~~~~~~~~~~~~
-
-The first run compiles Warp kernels. Subsequent runs will be faster.
+Ensure no other GPU workload is active. Increase timed iterations, repeat the
+command in independent processes, and report between-run variation. A difference
+smaller than normal variation is not evidence of a regression or improvement.

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -36,6 +36,8 @@ Run benchmarks using the Isaac Lab launcher:
 
          # Run Articulation method benchmarks
          uv run python source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
+         uv run python source/isaaclab_newton/benchmark/assets/benchmark_articulation.py
+         uv run python source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
 
          # With custom parameters
          uv run python source/isaaclab_physx/benchmark/assets/benchmark_articulation.py \
@@ -50,6 +52,8 @@ Run benchmarks using the Isaac Lab launcher:
 
          # Run Articulation method benchmarks
          ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py
+         ./isaaclab.sh -p source/isaaclab_newton/benchmark/assets/benchmark_articulation.py
+         ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
 
          # With custom parameters
          ./isaaclab.sh -p source/isaaclab_physx/benchmark/assets/benchmark_articulation.py \

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -281,7 +281,8 @@ For other sensors, set ``BACKEND`` to ``physx``, ``newton``, or ``ovphysx``:
        --sensor pva --num_envs 4096 --warmup_steps 50 --num_steps 500
 
    ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_joint_wrench.py \
-       --num_envs 4096 --warmup_steps 50 --num_steps 500
+       --num_envs 4096 --warmup_steps 50 --num_steps 500 \
+       --benchmark_formatter summary --output_path results/sensors
 
    ./isaaclab.sh -p source/isaaclab_${BACKEND}/benchmark/sensors/benchmark_ray_caster.py \
        --num_envs 4096 --grid_size 1.0 --grid_resolution 0.25 \
@@ -309,9 +310,15 @@ Sensor Arguments
    * - ``--device``
      - ``cuda:0``
      - Simulation and sensor device
+   * - ``--benchmark_formatter``
+     - ``summary``
+     - Output formatter: ``summary``, ``json``, ``osmo``, or ``omniperf``
+   * - ``--output_path``
+     - current directory
+     - Directory for timestamped result files
    * - ``--label``
      - ``current``
-     - Label printed by scripts that support it
+     - Run label stored in metadata by scripts that support it
    * - ``--sensor``
      - required
      - Select ``imu`` or ``pva`` in ``benchmark_imu_pva.py``
@@ -325,9 +332,11 @@ Sensor Arguments
      - 0.25
      - Ray-grid spacing [m]
 
+The default ``summary`` formatter prints a terminal report and writes JSON. Add
+``--output_path results/sensors`` to keep artifacts outside the repository root.
 PhysX scripts also expose ``--disable_graph`` or
 ``--disable_recorded_launch`` where applicable. These are diagnostic controls
-for comparing production cached/graph paths with eager launches; leave them
+for comparing production cached or graph paths with eager launches; leave them
 disabled when measuring default production behavior.
 
 Understanding the Outputs
@@ -352,73 +361,112 @@ those ingestion formats. The script prints the exact output path at completion.
 Sensor Output
 ~~~~~~~~~~~~~
 
-Sensor scripts currently report human-readable statistics to standard output:
+The default ``summary`` formatter prints the aggregate result and writes the
+same phases to a timestamped JSON file. An abbreviated report looks like:
 
 .. code-block:: text
 
-   synchronized mean      : 0.041 ms
-   synchronized p50       : 0.040 ms
-   synchronized p95       : 0.043 ms
-   submission mean        : 0.037 ms
-   finite target frames   : 16384 / 16384
+   Results written to: results/sensors/newton_joint_wrench_sensor_2026-07-20_16-09-38.json
+   +------------------------------------------------------------------------------------+
+   |                                   Summary Report                                   |
+   +------------------------------------------------------------------------------------+
+   | workflow_name: newton_joint_wrench_sensor                                         |
+   | num_envs: 4096                                                                    |
+   +------------------------------------------------------------------------------------+
+   | Phase: sensor_update                                                              |
+   | Synchronized Completion: 0.120 ms                                                 |
+   | Synchronized Completion p50: 0.118 ms                                             |
+   | Synchronized Completion p95: 0.126 ms                                             |
+   | Host Submission: 0.115 ms                                                         |
+   | Host Submission p50: 0.113 ms                                                     |
+   | Host Submission p95: 0.122 ms                                                     |
+   +------------------------------------------------------------------------------------+
+   | Phase: observer                                                                   |
+   | Synchronized Observer Floor: 0.002 ms                                             |
+   +------------------------------------------------------------------------------------+
+   | Phase: validation                                                                 |
+   | Finite Wrenches: 8192 count                                                       |
+   | Nonzero Wrenches: 8192 count                                                      |
+   +------------------------------------------------------------------------------------+
 
-``synchronized`` latency
-   Wall-clock latency from immediately before ``sensor.update()`` until all
-   submitted device work completes. A device synchronization before the timer
-   prevents earlier simulation or policy kernels from being charged to the
-   sensor.
+The numbers above illustrate the output shape; they are not reference
+performance values. Use the generated artifact for analysis. Its statistical
+measurements contain ``mean``, sample ``std``, ``n``, and ``unit`` fields, while
+p50 and p95 are separate measurements in the same phase. For example:
 
-``submission`` latency
-   Host time spent issuing ``sensor.update()`` before post-update device
-   synchronization. This is enqueue/dispatch cost, not pure GPU execution time.
+.. code-block:: json
+
+   {
+       "name": "newton_joint_wrench_sensor sensor_update Synchronized Completion",
+       "mean": 0.038223,
+       "std": 0.00010748023074035611,
+       "n": 2,
+       "unit": "ms",
+       "type": "statistical"
+   }
+
+``Synchronized Completion``
+   Wall-clock latency from immediately before the sensor operation until all
+   work it submitted completes. A device synchronization before the timer
+   excludes earlier simulation, policy, or unrelated kernels. The matching
+   post-boundary synchronization makes this the primary comparison metric.
+
+``Host Submission``
+   Host time until the sensor operation returns, before the post-boundary
+   synchronization. This measures enqueue and dispatch cost, not GPU execution.
+
+``Synchronized Observer Floor``
+   Cost of the same synchronized timing boundary around a no-op. It quantifies
+   measurement overhead and is never subtracted automatically. Contact cadence
+   reports an observer sample with the same ``decimation + 1`` boundaries as its
+   sensor sample.
 
 ``p50`` and ``p95``
-   Median and 95th-percentile latency within one process. They expose jitter
-   that a mean can hide.
-   Most workloads report both; the PhysX/Newton contact cadence reports p50 and
-   minimum instead.
+   Median and 95th-percentile latency within one process. They expose jitter that
+   a mean can hide. Use the JSON ``std`` to quantify within-process variation.
 
-``read-only`` latency
-   OVPhysX scripts also time the blocking backend fetch without sensor Warp
-   processing. Newton sensor inputs are already Warp arrays, and PhysX scripts
-   do not consistently expose an equivalent phase.
+``Synchronized Native Read``
+   OVPhysX scripts report this phase when the blocking backend read can be
+   isolated. A missing phase means that backend does not expose an equivalent
+   read, not that the read costs zero.
 
-``implied kernel tail``
-   OVPhysX reports ``synchronized mean - read-only mean`` as an estimate of
-   remaining processing. It derives from separately measured phases, so treat
-   small differences as noise rather than direct kernel timing.
+``Estimated Synchronized Non-read Time``
+   OVPhysX may report full synchronized update mean minus native-read mean. It is
+   derived from separately sampled phases and can be dominated by noise when the
+   values are close; it is not direct kernel timing.
 
-Validation counts
-   Final lines prove that the workload produced expected contacts, finite
-   frames, sensor outputs, nonzero wrenches, or ray hits. Never use a result
-   whose validation failed.
+``validation``
+   Counts prove that the workload produced expected contacts, finite frames,
+   sensor outputs, nonzero wrenches, or ray hits. The script exits with an error
+   instead of writing a valid-looking result when these checks fail.
 
-Sensor scripts do not currently write a structured result file. Redirect stdout
-to retain raw runs:
-
-.. code-block:: bash
-
-   ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py \
-       --num_envs 4096 --warmup_steps 50 --num_steps 500 \
-       > results/newton_ray_caster_run_1.log 2>&1
+Use ``--benchmark_formatter json`` for JSON without the terminal summary, or
+``osmo`` and ``omniperf`` for their ingestion formats.
 
 Making Fair Comparisons
 -----------------------
 
 For a performance claim:
 
-1. Use the same workstation, GPU conditions, environment, device, benchmark
-   file, dimensions, warm-up count, and timed count.
+1. Use the same workstation, GPU and CPU conditions, software environment,
+   device, benchmark file, dimensions, warm-up count, and timed count. CPU model,
+   frequency, and load still affect Python, dispatch, and synchronization costs
+   when the measured tensors live on the GPU.
 2. Run baseline and candidate configurations from separate clean processes.
 3. Use at least three repetitions per configuration and report the mean plus
    between-run standard deviation.
-4. Check validation output and retain raw logs or JSON files.
+4. Check validation output and retain the raw JSON files.
 5. Compare the same metric. Do not compare asset microseconds with sensor
    milliseconds, submission with synchronized latency, or sensor latency with
    environment FPS.
 6. Treat startup separately. Compilation, scene creation, physics initialization,
    and CUDA graph construction occur outside reported sensor update latency but
    still affect total command duration.
+
+Published Isaac Lab performance comparisons must be collected on the project
+designated benchmark workstation with complete hardware and run provenance.
+Local runs are appropriate for correctness checks and investigation, but should
+not be presented as official reference numbers.
 
 .. important::
 
@@ -442,14 +490,18 @@ Sensor benchmarks isolate a live sensor update from simulation:
 .. code-block:: text
 
    sim.step() [untimed]
-       -> synchronize [timing boundary]
-       -> sensor.update() [timed]
-       -> synchronize [timing boundary]
+       -> synchronize [exclude earlier device work]
+       -> start clock
+       -> sensor operation [record host-return time]
+       -> synchronize [wait for submitted device work]
+       -> stop clock
        -> validate output [untimed]
 
-The pre-boundary synchronization is intentional. GPU work is asynchronous; if
-the timer started while earlier work was pending, synchronized sensor latency
-could incorrectly include that work.
+The shared :func:`~isaaclab.benchmark.measure_latency` helper enforces both
+boundaries and returns paired host-submission and synchronized-completion times.
+The runner measures a synchronized no-op separately to expose observer cost.
+The pre-boundary synchronization is intentional: without it, pending simulation,
+policy, or unrelated kernels could be charged to the sensor sample.
 
 Adding New Benchmarks
 ---------------------
@@ -458,7 +510,7 @@ Adding an Asset Method or Property
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add input generators and a
-:class:`~isaaclab.test.benchmark.MethodBenchmarkDefinition` to the corresponding
+:class:`~isaaclab.benchmark.MethodBenchmarkDefinition` to the corresponding
 backend script. Allocate inputs before the timed call. For a data property, list
 prerequisite properties through ``derived_from`` so dependencies are populated
 before timing.
@@ -472,10 +524,15 @@ Adding a Sensor Workload
 1. Build the smallest live scene that exercises the production sensor path.
 2. Warm simulation and sensor updates before collecting samples.
 3. Keep ``sim.step()`` and validation outside the timed region.
-4. Synchronize the device immediately before and after ``sensor.update()``.
-5. Report synchronized and submission distributions with clear units.
-6. Fail when output shapes, finite values, or physical signals are invalid.
-7. Document every backend-specific timing phase or protocol difference.
+4. Collect samples with :func:`~isaaclab.benchmark.measure_latency`; do not
+   duplicate clock, synchronization, percentile, or unit-conversion logic.
+5. Publish the samples through
+   :class:`~isaaclab.benchmark.LatencyBenchmarkRunner` and include a matched
+   synchronized observer floor.
+6. Add workload dimensions and modes as metadata, and validation values as
+   measurements.
+7. Fail when output shapes, finite values, or physical signals are invalid.
+8. Document every backend-specific timing phase or protocol difference.
 
 Troubleshooting
 ---------------

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -111,6 +111,41 @@ These benchmark property accessors on data classes:
 
 All benchmarks are located in ``source/isaaclab_physx/benchmark/assets/``.
 
+Sensor Update Benchmarks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The OVPhysX sensor benchmarks build kitless simulation scenes and measure sensor
+updates separately from physics stepping:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Benchmark File
+     - Sensor Path
+   * - ``benchmark_contact_sensor.py``
+     - Contact force collection
+   * - ``benchmark_frame_transformer.py``
+     - Source and target frame transforms
+   * - ``benchmark_imu_pva.py``
+     - IMU or PVA state estimation
+   * - ``benchmark_joint_wrench.py``
+     - Incoming joint wrench transforms
+   * - ``benchmark_ray_caster.py``
+     - Rigid-body tracking and ray casting
+
+They are located in ``source/isaaclab_ovphysx/benchmark/sensors/``. Each script
+reports synchronized update latency, asynchronous submission latency, and the
+blocking backend read latency measured without sensor Warp processing.
+Physics ``sim.step()`` calls occur outside all timed regions.
+
+For example:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py \
+       --num_envs 4096 --warmup_steps 50 --num_steps 500
+
 Command Line Arguments
 ----------------------
 

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -176,16 +176,17 @@ stepping:
      - Rigid-body tracking and ray casting
 
 They are located in ``source/isaaclab_newton/benchmark/sensors/``. Each script
-reports synchronized sensor update latency and asynchronous host submission
-latency. Physics ``sim.step()`` calls use the normal Newton configuration but
-occur outside all timed regions.
+reports synchronized completion latency, host submission latency, and a synchronized
+no-op observer floor. Physics ``sim.step()`` calls use the normal Newton configuration
+but occur outside all timed regions.
 
 For example:
 
 .. code-block:: bash
 
    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py \
-       --num_envs 4096 --warmup_steps 50 --num_steps 500
+       --num_envs 4096 --warmup_steps 50 --num_steps 500 \
+       --benchmark_formatter summary --output_path artifacts/micro_benchmarks
 
 Command Line Arguments
 ----------------------

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -114,7 +114,7 @@ All benchmarks are located in ``source/isaaclab_physx/benchmark/assets/``.
 Sensor Update Benchmarks
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The OVPhysX sensor benchmarks build kitless simulation scenes and measure sensor
+The PhysX and OVPhysX sensor benchmarks build simulation scenes and measure sensor
 updates separately from physics stepping:
 
 .. list-table::
@@ -134,17 +134,23 @@ updates separately from physics stepping:
    * - ``benchmark_ray_caster.py``
      - Rigid-body tracking and ray casting
 
-They are located in ``source/isaaclab_ovphysx/benchmark/sensors/``. Each script
-reports synchronized update latency, asynchronous submission latency, and the
-blocking backend read latency measured without sensor Warp processing.
-Physics ``sim.step()`` calls occur outside all timed regions.
+They are located in the ``benchmark/sensors/`` directories of ``isaaclab_physx``
+and ``isaaclab_ovphysx``. Each script reports synchronized completion latency,
+host submission latency, and a synchronized no-op observer floor. OVPhysX scripts
+also isolate supported native reads and report the full-update-minus-read result
+as an estimate. Physics ``sim.step()`` calls occur outside all timed regions.
+
+The default ``summary`` formatter prints the aggregate results and writes a JSON
+file containing the mean, sample standard deviation, sample count, p50, and p95.
+The observer floor is reported but is not subtracted from the measurements.
 
 For example:
 
 .. code-block:: bash
 
    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py \
-       --num_envs 4096 --warmup_steps 50 --num_steps 500
+       --num_envs 4096 --warmup_steps 50 --num_steps 500 \
+       --benchmark_formatter summary --output_path artifacts/micro_benchmarks
 
 Command Line Arguments
 ----------------------

--- a/docs/source/testing/micro_benchmarks.rst
+++ b/docs/source/testing/micro_benchmarks.rst
@@ -152,6 +152,41 @@ For example:
        --num_envs 4096 --warmup_steps 50 --num_steps 500 \
        --benchmark_formatter summary --output_path artifacts/micro_benchmarks
 
+Newton Sensor Update Benchmarks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Newton sensor benchmarks measure sensor updates separately from physics
+stepping:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Benchmark File
+     - Sensor Path
+   * - ``benchmark_contact_sensor.py``
+     - Contact force collection
+   * - ``benchmark_frame_transformer.py``
+     - Source and target frame transforms
+   * - ``benchmark_imu_pva.py``
+     - IMU or PVA state estimation
+   * - ``benchmark_joint_wrench.py``
+     - Incoming joint wrench transforms
+   * - ``benchmark_ray_caster.py``
+     - Rigid-body tracking and ray casting
+
+They are located in ``source/isaaclab_newton/benchmark/sensors/``. Each script
+reports synchronized sensor update latency and asynchronous host submission
+latency. Physics ``sim.step()`` calls use the normal Newton configuration but
+occur outside all timed regions.
+
+For example:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py \
+       --num_envs 4096 --warmup_steps 50 --num_steps 500
+
 Command Line Arguments
 ----------------------
 

--- a/source/isaaclab/changelog.d/antoiner-sensor-latency-benchmark.minor.rst
+++ b/source/isaaclab/changelog.d/antoiner-sensor-latency-benchmark.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added shared synchronized latency sampling and structured reporting utilities
+  for micro-benchmarks.

--- a/source/isaaclab/isaaclab/benchmark/__init__.pyi
+++ b/source/isaaclab/isaaclab/benchmark/__init__.pyi
@@ -30,6 +30,12 @@ __all__ = [
     "MethodBenchmarkDefinition",
     "MethodBenchmarkRunner",
     "MethodBenchmarkRunnerConfig",
+    "LatencyBenchmarkRunner",
+    "LatencySample",
+    "LatencyStatistics",
+    "add_latency_measurements",
+    "measure_latency",
+    "summarize_latency",
     "BooleanMeasurement",
     "DictMeasurement",
     "DictMetadata",
@@ -96,6 +102,14 @@ from .method_benchmark import (
     MethodBenchmarkDefinition,
     MethodBenchmarkRunner,
     MethodBenchmarkRunnerConfig,
+)
+from .micro import (
+    LatencyBenchmarkRunner,
+    LatencySample,
+    LatencyStatistics,
+    add_latency_measurements,
+    measure_latency,
+    summarize_latency,
 )
 from .measurements import (
     BooleanMeasurement,

--- a/source/isaaclab/isaaclab/benchmark/micro.py
+++ b/source/isaaclab/isaaclab/benchmark/micro.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared latency sampling and reporting for micro-benchmarks."""
+
+from __future__ import annotations
+
+import statistics
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from .benchmark_core import BaseIsaacLabBenchmark
+from .measurements import Measurement, SingleMeasurement, StatisticalMeasurement
+
+
+class _MeasurementSink(Protocol):
+    """Benchmark object that accepts measurements grouped by phase."""
+
+    def add_measurement(self, phase_name: str, measurement: Measurement | Sequence[Measurement]) -> None:
+        """Add one or more measurements to a phase."""
+
+
+@dataclass(frozen=True)
+class LatencySample:
+    """One host-submission and device-synchronized latency sample.
+
+    Attributes:
+        submission_s: Time [s] until the operation returned to the host.
+        synchronized_s: Time [s] until all submitted device work completed.
+    """
+
+    submission_s: float
+    synchronized_s: float
+
+
+@dataclass(frozen=True)
+class LatencyStatistics:
+    """Aggregate statistics for a latency sample series.
+
+    Attributes:
+        mean_s: Arithmetic mean latency [s].
+        std_s: Sample standard deviation [s], or zero for one sample.
+        p50_s: Linearly interpolated 50th percentile latency [s].
+        p95_s: Linearly interpolated 95th percentile latency [s].
+        n: Number of samples.
+    """
+
+    mean_s: float
+    std_s: float
+    p50_s: float
+    p95_s: float
+    n: int
+
+
+def measure_latency(
+    operation: Callable[[], None],
+    synchronize: Callable[[], None],
+    *,
+    clock_ns: Callable[[], int] | None = None,
+) -> LatencySample:
+    """Measure host submission and synchronized completion latency.
+
+    The pre-boundary synchronization prevents asynchronous work submitted before
+    :paramref:`operation` from being charged to the sample. The post-boundary
+    synchronization includes all device work submitted by the operation.
+
+    Args:
+        operation: Workload to measure.
+        synchronize: Function that blocks until pending device work completes.
+        clock_ns: Monotonic nanosecond clock. Defaults to :func:`time.perf_counter_ns`.
+
+    Returns:
+        Host-submission and device-synchronized latency [s].
+    """
+    if clock_ns is None:
+        clock_ns = time.perf_counter_ns
+
+    synchronize()
+    start_ns = clock_ns()
+    operation()
+    submitted_ns = clock_ns()
+    synchronize()
+    finished_ns = clock_ns()
+    return LatencySample(
+        submission_s=(submitted_ns - start_ns) / 1e9,
+        synchronized_s=(finished_ns - start_ns) / 1e9,
+    )
+
+
+def summarize_latency(samples_s: Sequence[float]) -> LatencyStatistics:
+    """Summarize a non-empty latency sample series.
+
+    Args:
+        samples_s: Latency samples [s].
+
+    Returns:
+        Mean, sample standard deviation, and interpolated percentiles [s].
+
+    Raises:
+        ValueError: If :paramref:`samples_s` is empty.
+    """
+    if not samples_s:
+        raise ValueError("Latency statistics require at least one sample.")
+    return LatencyStatistics(
+        mean_s=statistics.mean(samples_s),
+        std_s=statistics.stdev(samples_s) if len(samples_s) > 1 else 0.0,
+        p50_s=_percentile(samples_s, 0.50),
+        p95_s=_percentile(samples_s, 0.95),
+        n=len(samples_s),
+    )
+
+
+def add_latency_measurements(
+    benchmark: _MeasurementSink,
+    phase_name: str,
+    name: str,
+    samples_s: Sequence[float],
+) -> LatencyStatistics:
+    """Add latency mean, standard deviation, and percentiles to a benchmark.
+
+    Args:
+        benchmark: Benchmark receiving the measurements.
+        phase_name: Phase that owns the measurements.
+        name: Base measurement name.
+        samples_s: Latency samples [s].
+
+    Returns:
+        Computed latency statistics [s].
+    """
+    stats = summarize_latency(samples_s)
+    benchmark.add_measurement(
+        phase_name,
+        measurement=StatisticalMeasurement(
+            name=name,
+            mean=stats.mean_s * 1000.0,
+            std=stats.std_s * 1000.0,
+            n=stats.n,
+            unit="ms",
+        ),
+    )
+    benchmark.add_measurement(
+        phase_name,
+        measurement=SingleMeasurement(name=f"{name} p50", value=stats.p50_s * 1000.0, unit="ms"),
+    )
+    benchmark.add_measurement(
+        phase_name,
+        measurement=SingleMeasurement(name=f"{name} p95", value=stats.p95_s * 1000.0, unit="ms"),
+    )
+    return stats
+
+
+def _percentile(samples: Sequence[float], fraction: float) -> float:
+    """Return a linearly interpolated percentile from a non-empty series."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (position - lower) * (ordered[upper] - ordered[lower])
+
+
+class LatencyBenchmarkRunner(BaseIsaacLabBenchmark):
+    """One-shot runner for latency micro-benchmarks.
+
+    Args:
+        benchmark_name: Name used in output metadata and filenames.
+        formatter_type: Formatter used to report results.
+        output_path: Directory for result files.
+        metadata: Workload metadata stored with the result.
+        use_recorders: Whether to collect hardware and version information.
+    """
+
+    def __init__(
+        self,
+        benchmark_name: str,
+        formatter_type: str,
+        output_path: str,
+        metadata: dict[str, str | int | float | dict] | None = None,
+        use_recorders: bool = True,
+    ) -> None:
+        workflow_metadata = {"metadata": [{"name": name, "data": value} for name, value in (metadata or {}).items()]}
+        super().__init__(
+            benchmark_name=benchmark_name,
+            formatter_type=formatter_type,
+            output_path=output_path,
+            output_prefix=benchmark_name,
+            workflow_metadata=workflow_metadata,
+            use_recorders=use_recorders,
+        )
+
+    def add_latency_samples(self, phase_name: str, samples: Sequence[LatencySample]) -> LatencyStatistics:
+        """Add synchronized completion and host submission latency series.
+
+        Args:
+            phase_name: Phase that owns the measurements.
+            samples: Paired host and synchronized latency samples [s].
+
+        Returns:
+            Synchronized completion latency statistics [s].
+        """
+        synchronized_stats = add_latency_measurements(
+            self, phase_name, "Synchronized Completion", [sample.synchronized_s for sample in samples]
+        )
+        add_latency_measurements(self, phase_name, "Host Submission", [sample.submission_s for sample in samples])
+        return synchronized_stats
+
+    def add_synchronized_samples(self, phase_name: str, name: str, samples_s: Sequence[float]) -> LatencyStatistics:
+        """Add a synchronized-only latency series.
+
+        Args:
+            phase_name: Phase that owns the measurements.
+            name: Measurement name.
+            samples_s: Synchronized latency samples [s].
+
+        Returns:
+            Synchronized latency statistics [s].
+        """
+        return add_latency_measurements(self, phase_name, name, samples_s)
+
+    def finalize(self) -> tuple[Path, ...]:
+        """Sample recorders and write results.
+
+        Returns:
+            Paths written by the selected formatters.
+        """
+        if self._use_recorders:
+            self.update_manual_recorders()
+        return super().finalize()

--- a/source/isaaclab/test/benchmark/test_micro.py
+++ b/source/isaaclab/test/benchmark/test_micro.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for shared micro-benchmark latency sampling."""
+
+from collections.abc import Callable
+
+import pytest
+
+from isaaclab.benchmark.micro import (
+    LatencyBenchmarkRunner,
+    add_latency_measurements,
+    measure_latency,
+    summarize_latency,
+)
+
+pytestmark = pytest.mark.benchmark
+
+
+class _MeasurementSink:
+    """Collect benchmark measurements without constructing formatter services."""
+
+    def __init__(self) -> None:
+        self.measurements = []
+
+    def add_measurement(self, phase_name: str, measurement) -> None:
+        self.measurements.append((phase_name, measurement))
+
+
+def _clock(values: list[int]) -> Callable[[], int]:
+    """Return a deterministic nanosecond clock."""
+    iterator = iter(values)
+    return lambda: next(iterator)
+
+
+def test_measure_latency_synchronizes_at_both_boundaries() -> None:
+    """Pending work must be drained before the operation and after its submission."""
+    events: list[str] = []
+
+    sample = measure_latency(
+        operation=lambda: events.append("operation"),
+        synchronize=lambda: events.append("synchronize"),
+        clock_ns=_clock([10, 30, 70]),
+    )
+
+    assert events == ["synchronize", "operation", "synchronize"]
+    assert sample.submission_s == pytest.approx(20e-9)
+    assert sample.synchronized_s == pytest.approx(60e-9)
+
+
+def test_measure_latency_excludes_pending_work_before_operation() -> None:
+    """The pre-boundary synchronization must not be charged to the operation."""
+    now_ns = 0
+    pending_ns = 100
+
+    def synchronize() -> None:
+        nonlocal now_ns, pending_ns
+        now_ns += pending_ns
+        pending_ns = 0
+
+    def operation() -> None:
+        nonlocal now_ns, pending_ns
+        now_ns += 20
+        pending_ns = 30
+
+    sample = measure_latency(operation=operation, synchronize=synchronize, clock_ns=lambda: now_ns)
+
+    assert sample.submission_s == pytest.approx(20e-9)
+    assert sample.synchronized_s == pytest.approx(50e-9)
+
+
+def test_measure_latency_propagates_operation_failure() -> None:
+    """A failed workload must abort instead of producing a partial sample."""
+
+    def operation() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        measure_latency(operation=operation, synchronize=lambda: None)
+
+
+def test_summarize_latency_rejects_empty_samples() -> None:
+    """Empty benchmark results have no meaningful latency statistics."""
+    with pytest.raises(ValueError, match="at least one"):
+        summarize_latency([])
+
+
+def test_summarize_latency_uses_zero_std_for_one_sample() -> None:
+    """A one-sample run should remain reportable without an undefined sample deviation."""
+    stats = summarize_latency([0.5])
+
+    assert stats.std_s == 0.0
+    assert stats.p50_s == 0.5
+    assert stats.p95_s == 0.5
+
+
+def test_summarize_latency_uses_sample_std_and_interpolated_percentiles() -> None:
+    """Latency summaries should match the regular benchmark statistical convention."""
+    stats = summarize_latency([1.0, 2.0, 4.0])
+
+    assert stats.mean_s == pytest.approx(7.0 / 3.0)
+    assert stats.std_s == pytest.approx(1.5275252316519468)
+    assert stats.p50_s == pytest.approx(2.0)
+    assert stats.p95_s == pytest.approx(3.8)
+    assert stats.n == 3
+
+
+def test_add_latency_measurements_converts_seconds_and_std_to_milliseconds() -> None:
+    """Structured results should publish all latency fields in milliseconds."""
+    sink = _MeasurementSink()
+
+    add_latency_measurements(sink, "sensor", "Synchronized Update", [0.001, 0.003, 0.005])
+
+    assert [phase for phase, _ in sink.measurements] == ["sensor", "sensor", "sensor"]
+    statistical = sink.measurements[0][1]
+    assert statistical.name == "Synchronized Update"
+    assert statistical.mean == pytest.approx(3.0)
+    assert statistical.std == pytest.approx(2.0)
+    assert statistical.n == 3
+    assert statistical.unit == "ms"
+    assert sink.measurements[1][1].value == pytest.approx(3.0)
+    assert sink.measurements[2][1].value == pytest.approx(4.8)
+
+
+def test_latency_runner_publishes_paired_samples() -> None:
+    """The runner should publish host and synchronized series with consistent names."""
+    sink = _MeasurementSink()
+    runner = object.__new__(LatencyBenchmarkRunner)
+    runner.add_measurement = sink.add_measurement
+    samples = [
+        measure_latency(lambda: None, lambda: None, clock_ns=_clock([0, 1, 3])),
+        measure_latency(lambda: None, lambda: None, clock_ns=_clock([0, 2, 6])),
+    ]
+
+    stats = runner.add_latency_samples("sensor", samples)
+
+    assert stats.mean_s == pytest.approx(4.5e-9)
+    assert sink.measurements[0][1].name == "Synchronized Completion"
+    assert sink.measurements[3][1].name == "Host Submission"
+
+
+def test_latency_runner_samples_recorders_before_finalize(monkeypatch) -> None:
+    """One-shot latency benchmarks should collect recorder data before writing results."""
+    events: list[str] = []
+    runner = object.__new__(LatencyBenchmarkRunner)
+    runner._use_recorders = True
+    runner.update_manual_recorders = lambda: events.append("recorders")
+    monkeypatch.setattr(
+        "isaaclab.benchmark.micro.BaseIsaacLabBenchmark.finalize",
+        lambda _self: events.append("finalize") or (),
+    )
+
+    assert runner.finalize() == ()
+    assert events == ["recorders", "finalize"]

--- a/source/isaaclab_newton/benchmark/assets/benchmark_articulation_data.py
+++ b/source/isaaclab_newton/benchmark/assets/benchmark_articulation_data.py
@@ -6,7 +6,7 @@
 """Micro-benchmarking framework for ArticulationData class (Newton backend).
 
 This module provides a benchmarking framework to measure the performance of all properties
-in the Newton ArticulationData class. Each property is run multiple times with randomized mock data,
+in the Newton ArticulationData class. Each property is run multiple times against preallocated mock data,
 and timing statistics (mean and standard deviation) are reported.
 
 Usage:
@@ -22,6 +22,7 @@ from __future__ import annotations
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import traceback
 
 from isaaclab.app import AppLauncher
 
@@ -51,8 +52,6 @@ simulation_app = app_launcher.app
 
 import warnings
 
-import numpy as np
-import warp as wp
 from isaaclab_newton.test.mock_interfaces import MockNewtonArticulationView, create_mock_newton_manager
 
 from isaaclab.benchmark import MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
@@ -68,6 +67,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 # List of deprecated properties - skip these
 DEPRECATED_PROPERTIES = {
+    "default_root_state",
     "root_pose_w",
     "root_pos_w",
     "root_quat_w",
@@ -118,6 +118,7 @@ NOT_IMPLEMENTED_PROPERTIES = {
     "spatial_tendon_limit_stiffness",
     "spatial_tendon_offset",
     "body_incoming_joint_wrench_b",
+    "gravity_compensation_forces",
 }
 
 # Removed default_* properties that raise RuntimeError
@@ -173,12 +174,12 @@ INTERNAL_PROPERTIES = {
 PROPERTY_DEPENDENCIES = {
     "root_link_lin_vel_w": ["root_link_vel_w"],
     "root_link_ang_vel_w": ["root_link_vel_w"],
-    "root_link_lin_vel_b": ["root_link_vel_b"],
-    "root_link_ang_vel_b": ["root_link_vel_b"],
+    "root_link_lin_vel_b": ["root_link_lin_vel_w", "root_link_quat_w"],
+    "root_link_ang_vel_b": ["root_link_ang_vel_w", "root_link_quat_w"],
     "root_com_pos_w": ["root_com_pose_w"],
     "root_com_quat_w": ["root_com_pose_w"],
-    "root_com_lin_vel_b": ["root_com_vel_b"],
-    "root_com_ang_vel_b": ["root_com_vel_b"],
+    "root_com_lin_vel_b": ["root_com_lin_vel_w", "root_link_quat_w"],
+    "root_com_ang_vel_b": ["root_com_ang_vel_w", "root_link_quat_w"],
     "root_com_lin_vel_w": ["root_com_vel_w"],
     "root_com_ang_vel_w": ["root_com_vel_w"],
     "root_link_pos_w": ["root_link_pose_w"],
@@ -255,63 +256,34 @@ def main():
         "isaaclab_newton.assets.articulation.articulation_data.SimulationManager",
         gravity=(0.0, 0.0, -9.81),
     ):
+        from isaaclab_newton.assets.articulation import articulation_data as articulation_data_module
+
+        model = articulation_data_module.SimulationManager.get_model()
+        model.articulation_count = config.num_instances
+        model.max_joints_per_articulation = config.num_bodies
+        model.max_dofs_per_articulation = config.num_joints + 6
+        model.joint_dof_count = config.num_instances * (config.num_joints + 6)
+        model.body_count = config.num_instances * config.num_bodies
+
         # Setup mock environment
         mock_view = setup_mock_environment(config)
         mock_view.set_random_mock_data()
-
-        # Import ArticulationData inside the patch context
-        from isaaclab_newton.assets.articulation.articulation_data import ArticulationData
+        # Stub solver evaluation so these samples isolate Isaac Lab accessor and gather overhead.
+        # End-to-end dynamics cost requires a backend-integrated benchmark.
+        mock_view.eval_jacobian = lambda state, *, J, joint_S_s: None
+        mock_view.eval_mass_matrix = lambda state, *, H, J, body_I_s, joint_S_s: None
 
         # Create ArticulationData instance
-        articulation_data = ArticulationData(mock_view, config.device)
+        articulation_data = articulation_data_module.ArticulationData(mock_view, config.device)
+        articulation_data._apply_ordering_maps_after_resolve()
 
         # Get list of properties to benchmark
         properties = get_benchmarkable_properties(articulation_data)
 
-        # Generator that updates mock data and invalidates timestamp
-        def gen_mock_data(cfg: MethodBenchmarkRunnerConfig) -> dict:
-            N, L, J = cfg.num_instances, cfg.num_bodies, cfg.num_joints
-            dev = cfg.device
-
-            # Update root transforms
-            root_tf_np = np.random.randn(N, 1, 7).astype(np.float32)
-            root_tf_np[..., 3:7] /= np.linalg.norm(root_tf_np[..., 3:7], axis=-1, keepdims=True)
-            mock_view.set_mock_root_transforms(wp.array(root_tf_np, dtype=wp.transformf, device=dev))
-
-            # Update root velocities
-            root_vel_np = np.random.randn(N, 1, 6).astype(np.float32)
-            mock_view.set_mock_root_velocities(wp.array(root_vel_np, dtype=wp.spatial_vectorf, device=dev))
-
-            # Update link transforms
-            link_tf_np = np.random.randn(N, 1, L, 7).astype(np.float32)
-            link_tf_np[..., 3:7] /= np.linalg.norm(link_tf_np[..., 3:7], axis=-1, keepdims=True)
-            mock_view.set_mock_link_transforms(wp.array(link_tf_np, dtype=wp.transformf, device=dev))
-
-            # Update link velocities
-            link_vel_np = np.random.randn(N, 1, L, 6).astype(np.float32)
-            mock_view.set_mock_link_velocities(wp.array(link_vel_np, dtype=wp.spatial_vectorf, device=dev))
-
-            # Update DOF state
-            mock_view.set_mock_dof_positions(
-                wp.array(np.random.randn(N, 1, J).astype(np.float32), dtype=wp.float32, device=dev)
-            )
-            mock_view.set_mock_dof_velocities(
-                wp.array(np.random.randn(N, 1, J).astype(np.float32), dtype=wp.float32, device=dev)
-            )
-
-            # Update body properties
-            mock_view.set_mock_coms(
-                wp.array(np.random.randn(N, 1, L, 3).astype(np.float32), dtype=wp.vec3f, device=dev)
-            )
-            mock_view.set_mock_inertias(
-                wp.array(np.random.randn(N, 1, L, 9).astype(np.float32), dtype=wp.mat33f, device=dev)
-            )
-            mock_view.set_mock_masses(
-                wp.array((np.random.rand(N, 1, L) * 10 + 0.1).astype(np.float32), dtype=wp.float32, device=dev)
-            )
-
-            # Invalidate timestamp to trigger recomputation
+        # Advance the simulated step without allocating replacement state buffers.
+        def gen_mock_data(_cfg: MethodBenchmarkRunnerConfig) -> dict:
             articulation_data._sim_timestamp += 1.0
+            articulation_data._fk_timestamp = articulation_data._sim_timestamp
             return {}
 
         # Create runner
@@ -334,9 +306,14 @@ def main():
 
         runner.finalize()
 
-    # Close the simulation app
-    simulation_app.close()
-
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the Newton contact sensor update.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
@@ -32,16 +33,33 @@ parser.add_argument("--decimation", type=int, default=4, help="Physics steps per
 parser.add_argument("--history_length", type=int, default=0, help="Number of contact history frames.")
 
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
+if args_cli.decimation <= 0:
+    parser.error("--decimation must be greater than zero")
+if args_cli.history_length < 0:
+    parser.error("--history_length must be non-negative")
 
 import warp as wp
 from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, LatencySample, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ContactSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -92,50 +110,59 @@ def main():
         wp.synchronize_device(sim.device)
 
         # Time only sensor work. Physics steps happen outside the timed regions.
-        cadence_times_ms = []
-        submit_times_ms = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        cadence_samples: list[LatencySample] = []
         for _ in range(args_cli.num_steps):
-            cadence_time_ms = 0.0
-            submit_time_ms = 0.0
+            cadence_synchronized = 0.0
+            cadence_submission = 0.0
             for _ in range(args_cli.decimation):
                 sim.step(render=False)
-                wp.synchronize_device(sim.device)
-                t_start = time.perf_counter()
-                sensor.update(sim_dt)
-                t_submit = time.perf_counter()
-                wp.synchronize_device(sim.device)
-                cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
-                submit_time_ms += (t_submit - t_start) * 1000.0
+                sample = measure_latency(operation=lambda: sensor.update(sim_dt), synchronize=synchronize)
+                cadence_synchronized += sample.synchronized_s
+                cadence_submission += sample.submission_s
 
-            wp.synchronize_device(sim.device)
-            t_start = time.perf_counter()
-            _ = sensor.data
-            t_submit = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
-            submit_time_ms += (t_submit - t_start) * 1000.0
-            cadence_times_ms.append(cadence_time_ms)
-            submit_times_ms.append(submit_time_ms)
+            sample = measure_latency(operation=lambda: getattr(sensor, "data"), synchronize=synchronize)
+            cadence_synchronized += sample.synchronized_s
+            cadence_submission += sample.submission_s
+            cadence_samples.append(LatencySample(submission_s=cadence_submission, synchronized_s=cadence_synchronized))
 
-        print("-" * 80)
-        print("Contact sensor cadence benchmark (Newton)")
-        print(f"  device                  : {sim.device}")
-        print(f"  num_envs                : {args_cli.num_envs}")
-        print(f"  num_steps               : {args_cli.num_steps}")
-        print(f"  decimation              : {args_cli.decimation}")
-        print(f"  history_length          : {args_cli.history_length}")
-        print(f"  cadence mean (sync)     : {statistics.mean(cadence_times_ms):.3f} ms")
-        print(f"  cadence p50  (sync)     : {statistics.median(cadence_times_ms):.3f} ms")
-        print(f"  cadence min  (sync)     : {min(cadence_times_ms):.3f} ms")
-        print(f"  cadence submit mean     : {statistics.mean(submit_times_ms):.3f} ms")
-        print("-" * 80)
+        observer_synchronized_s = [
+            sum(
+                measure_latency(operation=lambda: None, synchronize=synchronize).synchronized_s
+                for _ in range(args_cli.decimation + 1)
+            )
+            for _ in range(args_cli.num_steps)
+        ]
 
-        # sanity check: cubes rest on the ground, so every sensor must report an upward net force
+        # Cubes rest on the ground, so every sensor must report an upward net force.
         net_forces = sensor.data.net_forces_w.torch
         num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
         if num_in_contact != args_cli.num_envs:
             raise RuntimeError(f"Expected {args_cli.num_envs} contacting sensors, received {num_in_contact}.")
-        print(f"  sensors in contact      : {num_in_contact} / {args_cli.num_envs}")
+
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="newton_contact_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+                "decimation": args_cli.decimation,
+                "history_length": args_cli.history_length,
+            },
+        )
+        benchmark.add_latency_samples("sensor_cadence", cadence_samples)
+        benchmark.add_synchronized_samples("observer", "Synchronized Observer Floor", observer_synchronized_s)
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Sensors in Contact", value=num_in_contact, unit="count"),
+                SingleMeasurement(name="Expected Sensors", value=args_cli.num_envs, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the Newton contact sensor update cadence.
+
+Measures synchronized sensor work over one environment step while excluding physics simulation.
+Each timed cadence advances the sensor by --decimation physics steps and reads the data once.
+Use --history_length 0 for lazy on-read updates and a positive value for physics-step history
+updates.
+
+Usage:
+    # Lazy update once per environment step
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
+        --num_envs 4096 --history_length 0
+
+    # History update at each of four physics steps
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_contact_sensor.py
+        --num_envs 4096 --history_length 3 --decimation 4
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the Newton contact sensor update.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed simulation steps.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up steps.")
+parser.add_argument("--decimation", type=int, default=4, help="Physics steps per timed sensor cadence.")
+parser.add_argument("--history_length", type=int, default=0, help="Number of contact history frames.")
+
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class ContactSensorBenchmarkSceneCfg(InteractiveSceneCfg):
+    """Scene with one cube per environment and a contact sensor on the cube."""
+
+    terrain = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+
+    cube = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.5, 0.5, 0.5),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
+            activate_contact_sensors=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.3)),
+    )
+
+    contact_sensor = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        track_air_time=True,
+        update_period=0.0,
+        history_length=args_cli.history_length,
+    )
+
+
+def main():
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device, physics=NewtonCfg())
+    with sim_utils.build_simulation_context(sim_cfg=sim_cfg) as sim:
+        scene_cfg = ContactSensorBenchmarkSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, lazy_sensor_update=True)
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["contact_sensor"]
+        # Warm up the simulation before collecting timings.
+        for _ in range(args_cli.warmup_steps):
+            for _ in range(args_cli.decimation):
+                sim.step(render=False)
+                sensor.update(sim_dt)
+            _ = sensor.data
+        wp.synchronize_device(sim.device)
+
+        # Time only sensor work. Physics steps happen outside the timed regions.
+        cadence_times_ms = []
+        submit_times_ms = []
+        for _ in range(args_cli.num_steps):
+            cadence_time_ms = 0.0
+            submit_time_ms = 0.0
+            for _ in range(args_cli.decimation):
+                sim.step(render=False)
+                wp.synchronize_device(sim.device)
+                t_start = time.perf_counter()
+                sensor.update(sim_dt)
+                t_submit = time.perf_counter()
+                wp.synchronize_device(sim.device)
+                cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
+                submit_time_ms += (t_submit - t_start) * 1000.0
+
+            wp.synchronize_device(sim.device)
+            t_start = time.perf_counter()
+            _ = sensor.data
+            t_submit = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
+            submit_time_ms += (t_submit - t_start) * 1000.0
+            cadence_times_ms.append(cadence_time_ms)
+            submit_times_ms.append(submit_time_ms)
+
+        print("-" * 80)
+        print("Contact sensor cadence benchmark (Newton)")
+        print(f"  device                  : {sim.device}")
+        print(f"  num_envs                : {args_cli.num_envs}")
+        print(f"  num_steps               : {args_cli.num_steps}")
+        print(f"  decimation              : {args_cli.decimation}")
+        print(f"  history_length          : {args_cli.history_length}")
+        print(f"  cadence mean (sync)     : {statistics.mean(cadence_times_ms):.3f} ms")
+        print(f"  cadence p50  (sync)     : {statistics.median(cadence_times_ms):.3f} ms")
+        print(f"  cadence min  (sync)     : {min(cadence_times_ms):.3f} ms")
+        print(f"  cadence submit mean     : {statistics.mean(submit_times_ms):.3f} ms")
+        print("-" * 80)
+
+        # sanity check: cubes rest on the ground, so every sensor must report an upward net force
+        net_forces = sensor.data.net_forces_w.torch
+        num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
+        if num_in_contact != args_cli.num_envs:
+            raise RuntimeError(f"Expected {args_cli.num_envs} contacting sensors, received {num_in_contact}.")
+        print(f"  sensors in contact      : {num_in_contact} / {args_cli.num_envs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_frame_transformer.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_frame_transformer.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the Newton FrameTransformer update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
@@ -24,10 +25,23 @@ parser.add_argument("--num_steps", type=int, default=500, help="Number of timed 
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_target_frames <= 0:
+    parser.error("--num_target_frames must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
@@ -35,6 +49,8 @@ from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg, OffsetCfg
 from isaaclab.utils.configclass import configclass
@@ -65,16 +81,6 @@ class FrameTransformerBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.5)),
     )
     frame_transformer: FrameTransformerCfg = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -109,18 +115,20 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step(render=False)
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
+
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
 
         target_positions = sensor.data.target_pos_w.torch
         finite_frames = int(torch.isfinite(target_positions).all(dim=-1).sum().item())
@@ -128,21 +136,31 @@ def main() -> None:
         if finite_frames != expected_frames:
             raise RuntimeError(f"Expected {expected_frames} finite target frames, received {finite_frames}.")
 
-        print("-" * 80)
-        print("FrameTransformer update benchmark (Newton)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  target_frames_per_env  : {args_cli.num_target_frames}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print("-" * 80)
-        print(f"  finite target frames   : {finite_frames} / {expected_frames}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="newton_frame_transformer_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "target_frames_per_env": args_cli.num_target_frames,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        benchmark.add_latency_samples("sensor_update", samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [sample.synchronized_s for sample in observer_samples]
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Target Frames", value=finite_frames, unit="count"),
+                SingleMeasurement(name="Expected Target Frames", value=expected_frames, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_frame_transformer.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_frame_transformer.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the Newton FrameTransformer update path.
+
+Each environment contains a kinematic source body and target body. Multiple
+target frames share the target body with distinct offsets, exercising the
+FrameTransformer kernel without adding unnecessary physics bodies.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_frame_transformer.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the Newton FrameTransformer update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--num_target_frames", type=int, default=4, help="Number of target frames per environment.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import FrameTransformerCfg, OffsetCfg
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class FrameTransformerBenchmarkSceneCfg(InteractiveSceneCfg):
+    """Two kinematic rigid bodies and one FrameTransformer per environment."""
+
+    source = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Source",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.5)),
+    )
+    target = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Target",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.5)),
+    )
+    frame_transformer: FrameTransformerCfg = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device, physics=NewtonCfg(), gravity=(0.0, 0.0, 0.0))
+    with sim_utils.build_simulation_context(sim_cfg=sim_cfg) as sim:
+        scene_cfg = FrameTransformerBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=1.0,
+            lazy_sensor_update=True,
+        )
+        scene_cfg.frame_transformer = FrameTransformerCfg(
+            prim_path="{ENV_REGEX_NS}/Source",
+            target_frames=[
+                FrameTransformerCfg.FrameCfg(
+                    name=f"target_{index}",
+                    prim_path="{ENV_REGEX_NS}/Target",
+                    offset=OffsetCfg(pos=(0.0, 0.01 * index, 0.0)),
+                )
+                for index in range(args_cli.num_target_frames)
+            ],
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["frame_transformer"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step(render=False)
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step(render=False)
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        target_positions = sensor.data.target_pos_w.torch
+        finite_frames = int(torch.isfinite(target_positions).all(dim=-1).sum().item())
+        expected_frames = args_cli.num_envs * args_cli.num_target_frames
+        if finite_frames != expected_frames:
+            raise RuntimeError(f"Expected {expected_frames} finite target frames, received {finite_frames}.")
+
+        print("-" * 80)
+        print("FrameTransformer update benchmark (Newton)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  target_frames_per_env  : {args_cli.num_target_frames}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print("-" * 80)
+        print(f"  finite target frames   : {finite_frames} / {expected_frames}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark a Newton IMU or PVA sensor update path.")
 parser.add_argument("--sensor", choices=("imu", "pva"), required=True, help="Sensor update path to benchmark.")
@@ -23,10 +24,21 @@ parser.add_argument("--num_steps", type=int, default=500, help="Number of timed 
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
@@ -34,6 +46,8 @@ from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ImuCfg, PvaCfg
 from isaaclab.utils.configclass import configclass
@@ -55,16 +69,6 @@ class ImuPvaBenchmarkSceneCfg(InteractiveSceneCfg):
     )
     imu: ImuCfg | None = None
     pva: PvaCfg | None = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -92,39 +96,54 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step(render=False)
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
+
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
 
         lin_acc_b = sensor.data.lin_acc_b.torch
         ang_vel_b = sensor.data.ang_vel_b.torch
-        finite_instances = int((torch.isfinite(lin_acc_b).all(dim=-1) & torch.isfinite(ang_vel_b).all(dim=-1)).sum())
+        finite_instances = int(
+            (torch.isfinite(lin_acc_b).all(dim=-1) & torch.isfinite(ang_vel_b).all(dim=-1)).sum().item()
+        )
         if finite_instances != args_cli.num_envs:
             raise RuntimeError(f"Expected {args_cli.num_envs} finite sensor outputs, received {finite_instances}.")
 
-        print("-" * 80)
-        print(f"{args_cli.sensor.upper()} update benchmark (Newton)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print("-" * 80)
-        print(f"  finite sensor outputs  : {finite_instances} / {args_cli.num_envs}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name=f"newton_{args_cli.sensor}_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "sensor": args_cli.sensor,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        benchmark.add_latency_samples("sensor_update", samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [sample.synchronized_s for sample in observer_samples]
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Sensor Outputs", value=finite_instances, unit="count"),
+                SingleMeasurement(name="Expected Sensor Outputs", value=args_cli.num_envs, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the Newton IMU and PVA sensor update paths.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py \
+        --sensor imu --num_envs 4096
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_imu_pva.py \
+        --sensor pva --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark a Newton IMU or PVA sensor update path.")
+parser.add_argument("--sensor", choices=("imu", "pva"), required=True, help="Sensor update path to benchmark.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments and sensor instances.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import ImuCfg, PvaCfg
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class ImuPvaBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One kinematic rigid body and one selected sensor per environment."""
+
+    body = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Body",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.5)),
+    )
+    imu: ImuCfg | None = None
+    pva: PvaCfg | None = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the selected sensor benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device, physics=NewtonCfg(), gravity=(0.0, 0.0, -9.81))
+    with sim_utils.build_simulation_context(sim_cfg=sim_cfg) as sim:
+        scene_cfg = ImuPvaBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=1.0,
+            lazy_sensor_update=True,
+        )
+        if args_cli.sensor == "imu":
+            scene_cfg.imu = ImuCfg(prim_path="{ENV_REGEX_NS}/Body")
+        else:
+            scene_cfg.pva = PvaCfg(prim_path="{ENV_REGEX_NS}/Body")
+
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+        sensor = scene[args_cli.sensor]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step(render=False)
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step(render=False)
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        lin_acc_b = sensor.data.lin_acc_b.torch
+        ang_vel_b = sensor.data.ang_vel_b.torch
+        finite_instances = int((torch.isfinite(lin_acc_b).all(dim=-1) & torch.isfinite(ang_vel_b).all(dim=-1)).sum())
+        if finite_instances != args_cli.num_envs:
+            raise RuntimeError(f"Expected {args_cli.num_envs} finite sensor outputs, received {finite_instances}.")
+
+        print("-" * 80)
+        print(f"{args_cli.sensor.upper()} update benchmark (Newton)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print("-" * 80)
+        print(f"  finite sensor outputs  : {finite_instances} / {args_cli.num_envs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_joint_wrench.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_joint_wrench.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the Newton JointWrench sensor update path.
+
+Each environment contains one cartpole articulation. The sensor reads the
+incoming wrench for all three links and transforms it into each child-side
+joint frame.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_joint_wrench.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the Newton JointWrench sensor update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import JointWrenchSensorCfg
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_assets import CARTPOLE_CFG
+
+
+@configclass
+class JointWrenchBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One cartpole articulation and JointWrench sensor per environment."""
+
+    robot = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency and output sanity statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device, physics=NewtonCfg())
+    with sim_utils.build_simulation_context(sim_cfg=sim_cfg) as sim:
+        scene_cfg = JointWrenchBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=4.0,
+            lazy_sensor_update=True,
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["joint_wrench"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step(render=False)
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step(render=False)
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        force = sensor.data.force.torch
+        torque = sensor.data.torque.torch
+        finite_wrenches = int((torch.isfinite(force).all(dim=-1) & torch.isfinite(torque).all(dim=-1)).sum().item())
+        nonzero_wrenches = int(((force != 0.0).any(dim=-1) | (torque != 0.0).any(dim=-1)).sum().item())
+        expected_wrenches = args_cli.num_envs * len(sensor.body_names)
+        if finite_wrenches != expected_wrenches:
+            raise RuntimeError(f"Expected {expected_wrenches} finite wrenches, received {finite_wrenches}.")
+        if nonzero_wrenches == 0:
+            raise RuntimeError("Expected at least one nonzero wrench.")
+
+        print("-" * 80)
+        print("JointWrench sensor update benchmark (Newton)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  bodies_per_env         : {len(sensor.body_names)}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print("-" * 80)
+        print(f"  finite wrenches        : {finite_wrenches} / {expected_wrenches}")
+        print(f"  nonzero wrenches       : {nonzero_wrenches} / {expected_wrenches}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_joint_wrench.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_joint_wrench.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the Newton JointWrench sensor update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
@@ -23,16 +24,29 @@ parser.add_argument("--num_steps", type=int, default=500, help="Number of timed 
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
 from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.sim as sim_utils
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.utils.configclass import configclass
@@ -46,16 +60,6 @@ class JointWrenchBenchmarkSceneCfg(InteractiveSceneCfg):
 
     robot = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
     joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -79,18 +83,20 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step(render=False)
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
+
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
 
         force = sensor.data.force.torch
         torque = sensor.data.torque.torch
@@ -102,22 +108,32 @@ def main() -> None:
         if nonzero_wrenches == 0:
             raise RuntimeError("Expected at least one nonzero wrench.")
 
-        print("-" * 80)
-        print("JointWrench sensor update benchmark (Newton)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  bodies_per_env         : {len(sensor.body_names)}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print("-" * 80)
-        print(f"  finite wrenches        : {finite_wrenches} / {expected_wrenches}")
-        print(f"  nonzero wrenches       : {nonzero_wrenches} / {expected_wrenches}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="newton_joint_wrench_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "bodies_per_env": len(sensor.body_names),
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        benchmark.add_latency_samples("sensor_update", samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [sample.synchronized_s for sample in observer_samples]
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Wrenches", value=finite_wrenches, unit="count"),
+                SingleMeasurement(name="Nonzero Wrenches", value=nonzero_wrenches, unit="count"),
+                SingleMeasurement(name="Expected Wrenches", value=expected_wrenches, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the standard Newton RayCaster update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
@@ -24,10 +25,25 @@ parser.add_argument("--num_steps", type=int, default=500, help="Number of timed 
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.grid_size <= 0.0:
+    parser.error("--grid_size must be greater than zero")
+if args_cli.grid_resolution <= 0.0:
+    parser.error("--grid_resolution must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
@@ -35,6 +51,8 @@ from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.utils.configclass import configclass
@@ -56,16 +74,6 @@ class RayCasterBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
     )
     ray_caster: RayCasterCfg = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -99,18 +107,20 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step(render=False)
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
+
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
 
         ray_hits = sensor.data.ray_hits_w.torch
         finite_hits = int(torch.isfinite(ray_hits).all(dim=-1).sum().item())
@@ -125,22 +135,34 @@ def main() -> None:
                 f"received maximum |z| {max_hit_height} m."
             )
 
-        print("-" * 80)
-        print("RayCaster update benchmark (Newton)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  rays_per_env           : {sensor.num_rays}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print("-" * 80)
-        print(f"  finite ray hits        : {finite_hits} / {expected_hits}")
-        print(f"  maximum |hit z|        : {max_hit_height:.6f} m")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="newton_ray_caster_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "rays_per_env": sensor.num_rays,
+                "grid_size": args_cli.grid_size,
+                "grid_resolution": args_cli.grid_resolution,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        benchmark.add_latency_samples("sensor_update", samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [sample.synchronized_s for sample in observer_samples]
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Ray Hits", value=finite_hits, unit="count"),
+                SingleMeasurement(name="Expected Ray Hits", value=expected_hits, unit="count"),
+                SingleMeasurement(name="Maximum Absolute Hit Height", value=max_hit_height, unit="m"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py
+++ b/source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the standard Newton RayCaster update path.
+
+Each environment contains one kinematic body carrying a downward-facing grid
+sensor. All sensors cast against one shared ground plane.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_newton/benchmark/sensors/benchmark_ray_caster.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the standard Newton RayCaster update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--grid_size", type=float, default=1.0, help="Width and length [m] of each ray grid.")
+parser.add_argument("--grid_resolution", type=float, default=0.25, help="Ray-grid resolution [m].")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_newton.physics import NewtonCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import RayCasterCfg, patterns
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class RayCasterBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One kinematic sensor body per environment above a shared ground plane."""
+
+    ground = AssetBaseCfg(prim_path="/World/ground", spawn=sim_utils.GroundPlaneCfg())
+    sensor_body = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/SensorBody",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=False),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+    )
+    ray_caster: RayCasterCfg = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = sim_utils.SimulationCfg(dt=sim_dt, device=args_cli.device, physics=NewtonCfg(), gravity=(0.0, 0.0, 0.0))
+    with sim_utils.build_simulation_context(sim_cfg=sim_cfg) as sim:
+        scene_cfg = RayCasterBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=2.0,
+            lazy_sensor_update=True,
+        )
+        scene_cfg.ray_caster = RayCasterCfg(
+            prim_path="{ENV_REGEX_NS}/SensorBody",
+            mesh_prim_paths=["/World/ground"],
+            ray_alignment="world",
+            pattern_cfg=patterns.GridPatternCfg(
+                resolution=args_cli.grid_resolution,
+                size=(args_cli.grid_size, args_cli.grid_size),
+                direction=(0.0, 0.0, -1.0),
+            ),
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["ray_caster"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step(render=False)
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step(render=False)
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        ray_hits = sensor.data.ray_hits_w.torch
+        finite_hits = int(torch.isfinite(ray_hits).all(dim=-1).sum().item())
+        expected_hits = args_cli.num_envs * sensor.num_rays
+        if finite_hits != expected_hits:
+            raise RuntimeError(f"Expected {expected_hits} finite ray hits, received {finite_hits}.")
+        max_hit_height = float(torch.abs(ray_hits[..., 2]).max().item())
+        hit_height_tolerance = 1.0e-4
+        if max_hit_height > hit_height_tolerance:
+            raise RuntimeError(
+                f"Expected ray hits within {hit_height_tolerance} m of the z=0 plane, "
+                f"received maximum |z| {max_hit_height} m."
+            )
+
+        print("-" * 80)
+        print("RayCaster update benchmark (Newton)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  rays_per_env           : {sensor.num_rays}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print("-" * 80)
+        print(f"  finite ray hits        : {finite_hits} / {expected_hits}")
+        print(f"  maximum |hit z|        : {max_hit_height:.6f} m")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_newton/changelog.d/antoiner-articulation-micro-benchmarks.rst
+++ b/source/isaaclab_newton/changelog.d/antoiner-articulation-micro-benchmarks.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed articulation-data micro-benchmarks to initialize Newton dynamics buffers and exclude unsupported properties.

--- a/source/isaaclab_newton/changelog.d/antoiner-newton-sensor-micro-benchmarks.minor.rst
+++ b/source/isaaclab_newton/changelog.d/antoiner-newton-sensor-micro-benchmarks.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added update micro-benchmarks for contact, frame transformer, IMU, PVA,
+  joint wrench, and ray caster sensors.

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation.py
@@ -1,0 +1,1169 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for Articulation class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of setter and writer
+methods in the Articulation class. Each method is benchmarked under three scenarios:
+
+1. **Torch List**: Inputs are PyTorch tensors with list indices (via deprecated wrappers).
+2. **Torch Tensor**: Inputs are PyTorch tensors with tensor indices (via deprecated wrappers).
+3. **Warp Mask**: Inputs are warp arrays with boolean masks (via ``_mask`` methods).
+
+Usage:
+    python benchmark_articulation.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I] [--num_bodies B] [--num_joints J]
+
+Example:
+    python benchmark_articulation.py --num_iterations 1000 --warmup_steps 10
+    python benchmark_articulation.py --mode torch_list  # Only run list-based benchmarks
+    python benchmark_articulation.py --mode warp_mask   # Only run warp mask benchmarks
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Benchmark Articulation methods (OVPhysX backend).")
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--num_bodies", type=int, default=12, help="Number of bodies")
+parser.add_argument("--num_joints", type=int, default=11, help="Number of joints")
+parser.add_argument(
+    "--mode",
+    type=str,
+    default="all",
+    choices=["all", "torch_list", "torch_tensor", "warp_mask"],
+    help="Benchmark mode",
+)
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+parser.add_argument("--no_shape_checks", action="store_true", help="Disable shape/dtype assertions")
+
+args = parser.parse_args()
+
+
+import logging
+import warnings
+
+import torch
+import warp as wp
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet
+
+from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
+from isaaclab.benchmark import MethodBenchmarkDefinition, MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# Also suppress logging warnings
+logging.getLogger("isaaclab_ovphysx").setLevel(logging.ERROR)
+logging.getLogger("isaaclab").setLevel(logging.ERROR)
+
+
+# =============================================================================
+# Index Helpers
+# =============================================================================
+
+
+def make_tensor_env_ids(num_instances: int, device: str) -> torch.Tensor:
+    """Create a tensor of environment IDs."""
+    return torch.arange(num_instances, dtype=torch.int32, device=device)
+
+
+def make_tensor_joint_ids(num_joints: int, device: str) -> torch.Tensor:
+    """Create a tensor of joint IDs."""
+    return torch.arange(num_joints, dtype=torch.int32, device=device)
+
+
+def make_tensor_body_ids(num_bodies: int, device: str) -> torch.Tensor:
+    """Create a tensor of body IDs."""
+    return torch.arange(num_bodies, dtype=torch.int32, device=device)
+
+
+# =============================================================================
+# Test Articulation Factory
+# =============================================================================
+
+
+def create_test_articulation(
+    num_instances: int = 2,
+    num_joints: int = 6,
+    num_bodies: int = 7,
+    device: str = "cuda:0",
+):
+    """Create a test Articulation instance with mocked dependencies."""
+    from isaaclab_ovphysx.assets.articulation.articulation import Articulation
+    from isaaclab_ovphysx.assets.articulation.articulation_data import ArticulationData
+
+    joint_names = [f"joint_{i}" for i in range(num_joints)]
+    body_names = [f"body_{i}" for i in range(num_bodies)]
+    binding_set = MockOvPhysxBindingSet(
+        num_instances=num_instances,
+        num_joints=num_joints,
+        num_bodies=num_bodies,
+        joint_names=joint_names,
+        body_names=body_names,
+        benchmark_mode=True,
+    )
+    binding_set.set_random_data()
+    mock_view = binding_set.view
+
+    articulation = object.__new__(Articulation)
+    articulation.cfg = ArticulationCfg(
+        prim_path="/World/Robot",
+        soft_joint_pos_limit_factor=1.0,
+        actuators={},
+    )
+    object.__setattr__(articulation, "_initialize_handle", None)
+    object.__setattr__(articulation, "_invalidate_initialize_handle", None)
+    object.__setattr__(articulation, "_prim_deletion_handle", None)
+    object.__setattr__(articulation, "_debug_vis_handle", None)
+    object.__setattr__(articulation, "_root_view", mock_view)
+    object.__setattr__(articulation, "_device", device)
+    object.__setattr__(articulation, "_check_shapes", not args.no_shape_checks)
+    object.__setattr__(articulation, "_num_instances", num_instances)
+    object.__setattr__(articulation, "_num_bodies", num_bodies)
+    object.__setattr__(articulation, "_num_joints", num_joints)
+    object.__setattr__(articulation, "_num_fixed_tendons", 0)
+    object.__setattr__(articulation, "_num_spatial_tendons", 0)
+    object.__setattr__(articulation, "_is_fixed_base", False)
+    object.__setattr__(articulation, "_joint_names", joint_names)
+    object.__setattr__(articulation, "_body_names", body_names)
+    object.__setattr__(articulation, "_fixed_tendon_names", [])
+    object.__setattr__(articulation, "_spatial_tendon_names", [])
+
+    data = ArticulationData(mock_view, device)
+    data._apply_ordering_maps_after_resolve()
+    object.__setattr__(articulation, "_data", data)
+    object.__setattr__(articulation, "actuators", {})
+    object.__setattr__(articulation, "_has_implicit_actuators", False)
+    articulation._create_buffers()
+
+    return articulation, mock_view
+
+
+# Input Generators (Torch-only for OVPhysX backend)
+# =============================================================================
+
+
+# --- Root Link Pose ---
+def gen_root_link_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_link_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root COM Pose ---
+def gen_root_com_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_com_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root Link Velocity ---
+def gen_root_link_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_link_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root COM Velocity ---
+def gen_root_com_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_com_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root State (Deprecated) ---
+def gen_root_state_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_state_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root COM State (Deprecated) ---
+def gen_root_com_state_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_com_state_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root Link State (Deprecated) ---
+def gen_root_link_state_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_link_state_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_state": torch.rand(config.num_instances, 13, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Joint State ---
+def gen_joint_state_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_state_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Position ---
+def gen_joint_position_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_position_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Velocity ---
+def gen_joint_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Stiffness ---
+def gen_joint_stiffness_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "stiffness": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_stiffness_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "stiffness": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Damping ---
+def gen_joint_damping_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "damping": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_damping_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "damping": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Position Limit ---
+def gen_joint_position_limit_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    lower = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * -3.14
+    upper = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * 3.14
+    return {
+        "limits": torch.cat([lower, upper], dim=-1),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_position_limit_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    lower = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * -3.14
+    upper = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * 3.14
+    return {
+        "limits": torch.cat([lower, upper], dim=-1),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Velocity Limit ---
+def gen_joint_velocity_limit_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 10.0,
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_velocity_limit_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 10.0,
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Effort Limit ---
+def gen_joint_effort_limit_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 100.0
+        ),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_effort_limit_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 100.0
+        ),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Armature ---
+def gen_joint_armature_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "armature": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.1
+        ),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_armature_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "armature": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.1
+        ),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Joint Friction Coefficient ---
+def gen_joint_friction_coefficient_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "joint_friction_coeff": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.5
+        ),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_joint_friction_coefficient_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "joint_friction_coeff": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.5
+        ),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Set Joint Position Target ---
+def gen_set_joint_position_target_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_set_joint_position_target_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Set Joint Velocity Target ---
+def gen_set_joint_velocity_target_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_set_joint_velocity_target_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Set Joint Effort Target ---
+def gen_set_joint_effort_target_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "joint_ids": list(range(config.num_joints)),
+    }
+
+
+def gen_set_joint_effort_target_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "joint_ids": make_tensor_joint_ids(config.num_joints, config.device),
+    }
+
+
+# --- Set Masses ---
+def gen_set_masses_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_masses_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set CoMs ---
+def gen_set_coms_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_coms_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set Inertias ---
+def gen_set_inertias_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_inertias_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set External Force and Torque ---
+def gen_set_external_force_and_torque_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_set_external_force_and_torque_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# =============================================================================
+# Warp Mask Input Generators (for _mask methods)
+# =============================================================================
+
+
+def _env_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_instances,), dtype=wp.bool, device=config.device)
+
+
+def _joint_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_joints,), dtype=wp.bool, device=config.device)
+
+
+def _body_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_bodies,), dtype=wp.bool, device=config.device)
+
+
+# --- Root Link Pose (mask) ---
+def gen_root_link_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root COM Pose (mask) ---
+def gen_root_com_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root Link Velocity (mask) ---
+def gen_root_link_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root COM Velocity (mask) ---
+def gen_root_com_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint State (mask) ---
+def gen_joint_state_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Position (mask) ---
+def gen_joint_position_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "position": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Velocity (mask) ---
+def gen_joint_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "velocity": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Stiffness (mask) ---
+def gen_joint_stiffness_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "stiffness": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Damping (mask) ---
+def gen_joint_damping_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "damping": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Position Limit (mask) ---
+def gen_joint_position_limit_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    lower = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * -3.14
+    upper = torch.rand(config.num_instances, config.num_joints, 1, device=config.device, dtype=torch.float32) * 3.14
+    return {
+        "limits": torch.cat([lower, upper], dim=-1),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Velocity Limit (mask) ---
+def gen_joint_velocity_limit_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 10.0,
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Effort Limit (mask) ---
+def gen_joint_effort_limit_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "limits": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 100.0
+        ),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Armature (mask) ---
+def gen_joint_armature_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "armature": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.1
+        ),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Joint Friction Coefficient (mask) ---
+def gen_joint_friction_coefficient_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "joint_friction_coeff": (
+            torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32) * 0.5
+        ),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Joint Position Target (mask) ---
+def gen_set_joint_position_target_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Joint Velocity Target (mask) ---
+def gen_set_joint_velocity_target_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Joint Effort Target (mask) ---
+def gen_set_joint_effort_target_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "target": torch.rand(config.num_instances, config.num_joints, device=config.device, dtype=torch.float32),
+        "joint_mask": _joint_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Masses (mask) ---
+def gen_set_masses_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set CoMs (mask) ---
+def gen_set_coms_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Inertias (mask) ---
+def gen_set_inertias_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# =============================================================================
+# Benchmarks
+# =============================================================================
+
+BENCHMARKS = [
+    # --- Root State (Deprecated, no _mask equivalent) ---
+    MethodBenchmarkDefinition(
+        name="write_root_state_to_sim",
+        method_name="write_root_state_to_sim",
+        input_generators={
+            "torch_list": gen_root_state_torch_list,
+            "torch_tensor": gen_root_state_torch_tensor,
+        },
+        category="root_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_state_to_sim",
+        method_name="write_root_com_state_to_sim",
+        input_generators={
+            "torch_list": gen_root_com_state_torch_list,
+            "torch_tensor": gen_root_com_state_torch_tensor,
+        },
+        category="root_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_state_to_sim",
+        method_name="write_root_link_state_to_sim",
+        input_generators={
+            "torch_list": gen_root_link_state_torch_list,
+            "torch_tensor": gen_root_link_state_torch_tensor,
+        },
+        category="root_state",
+    ),
+    # --- Root Pose / Velocity ---
+    MethodBenchmarkDefinition(
+        name="write_root_link_pose_to_sim",
+        method_name="write_root_link_pose_to_sim",
+        input_generators={
+            "torch_list": gen_root_link_pose_torch_list,
+            "torch_tensor": gen_root_link_pose_torch_tensor,
+        },
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_pose_to_sim_mask",
+        method_name="write_root_link_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_root_link_pose_warp_mask},
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_pose_to_sim",
+        method_name="write_root_com_pose_to_sim",
+        input_generators={
+            "torch_list": gen_root_com_pose_torch_list,
+            "torch_tensor": gen_root_com_pose_torch_tensor,
+        },
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_pose_to_sim_mask",
+        method_name="write_root_com_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_root_com_pose_warp_mask},
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_velocity_to_sim",
+        method_name="write_root_link_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_root_link_velocity_torch_list,
+            "torch_tensor": gen_root_link_velocity_torch_tensor,
+        },
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_velocity_to_sim_mask",
+        method_name="write_root_link_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_root_link_velocity_warp_mask},
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_velocity_to_sim",
+        method_name="write_root_com_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_root_com_velocity_torch_list,
+            "torch_tensor": gen_root_com_velocity_torch_tensor,
+        },
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_velocity_to_sim_mask",
+        method_name="write_root_com_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_root_com_velocity_warp_mask},
+        category="root_velocity",
+    ),
+    # --- Joint State ---
+    MethodBenchmarkDefinition(
+        name="write_joint_state_to_sim",
+        method_name="write_joint_state_to_sim",
+        input_generators={
+            "torch_list": gen_joint_state_torch_list,
+            "torch_tensor": gen_joint_state_torch_tensor,
+        },
+        category="joint_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_state_to_sim_mask",
+        method_name="write_joint_state_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_state_warp_mask},
+        category="joint_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_position_to_sim",
+        method_name="write_joint_position_to_sim",
+        input_generators={
+            "torch_list": gen_joint_position_torch_list,
+            "torch_tensor": gen_joint_position_torch_tensor,
+        },
+        category="joint_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_position_to_sim_mask",
+        method_name="write_joint_position_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_position_warp_mask},
+        category="joint_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_velocity_to_sim",
+        method_name="write_joint_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_joint_velocity_torch_list,
+            "torch_tensor": gen_joint_velocity_torch_tensor,
+        },
+        category="joint_state",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_velocity_to_sim_mask",
+        method_name="write_joint_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_velocity_warp_mask},
+        category="joint_state",
+    ),
+    # --- Joint Params ---
+    MethodBenchmarkDefinition(
+        name="write_joint_stiffness_to_sim",
+        method_name="write_joint_stiffness_to_sim",
+        input_generators={
+            "torch_list": gen_joint_stiffness_torch_list,
+            "torch_tensor": gen_joint_stiffness_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_stiffness_to_sim_mask",
+        method_name="write_joint_stiffness_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_stiffness_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_damping_to_sim",
+        method_name="write_joint_damping_to_sim",
+        input_generators={
+            "torch_list": gen_joint_damping_torch_list,
+            "torch_tensor": gen_joint_damping_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_damping_to_sim_mask",
+        method_name="write_joint_damping_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_damping_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_position_limit_to_sim",
+        method_name="write_joint_position_limit_to_sim",
+        input_generators={
+            "torch_list": gen_joint_position_limit_torch_list,
+            "torch_tensor": gen_joint_position_limit_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_position_limit_to_sim_mask",
+        method_name="write_joint_position_limit_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_position_limit_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_velocity_limit_to_sim",
+        method_name="write_joint_velocity_limit_to_sim",
+        input_generators={
+            "torch_list": gen_joint_velocity_limit_torch_list,
+            "torch_tensor": gen_joint_velocity_limit_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_velocity_limit_to_sim_mask",
+        method_name="write_joint_velocity_limit_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_velocity_limit_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_effort_limit_to_sim",
+        method_name="write_joint_effort_limit_to_sim",
+        input_generators={
+            "torch_list": gen_joint_effort_limit_torch_list,
+            "torch_tensor": gen_joint_effort_limit_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_effort_limit_to_sim_mask",
+        method_name="write_joint_effort_limit_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_effort_limit_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_armature_to_sim",
+        method_name="write_joint_armature_to_sim",
+        input_generators={
+            "torch_list": gen_joint_armature_torch_list,
+            "torch_tensor": gen_joint_armature_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_armature_to_sim_mask",
+        method_name="write_joint_armature_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_armature_warp_mask},
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_friction_coefficient_to_sim",
+        method_name="write_joint_friction_coefficient_to_sim",
+        input_generators={
+            "torch_list": gen_joint_friction_coefficient_torch_list,
+            "torch_tensor": gen_joint_friction_coefficient_torch_tensor,
+        },
+        category="joint_params",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_joint_friction_coefficient_to_sim_mask",
+        method_name="write_joint_friction_coefficient_to_sim_mask",
+        input_generators={"warp_mask": gen_joint_friction_coefficient_warp_mask},
+        category="joint_params",
+    ),
+    # --- Joint Targets ---
+    MethodBenchmarkDefinition(
+        name="set_joint_position_target",
+        method_name="set_joint_position_target",
+        input_generators={
+            "torch_list": gen_set_joint_position_target_torch_list,
+            "torch_tensor": gen_set_joint_position_target_torch_tensor,
+        },
+        category="joint_targets",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_joint_position_target_mask",
+        method_name="set_joint_position_target_mask",
+        input_generators={"warp_mask": gen_set_joint_position_target_warp_mask},
+        category="joint_targets",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_joint_velocity_target",
+        method_name="set_joint_velocity_target",
+        input_generators={
+            "torch_list": gen_set_joint_velocity_target_torch_list,
+            "torch_tensor": gen_set_joint_velocity_target_torch_tensor,
+        },
+        category="joint_targets",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_joint_velocity_target_mask",
+        method_name="set_joint_velocity_target_mask",
+        input_generators={"warp_mask": gen_set_joint_velocity_target_warp_mask},
+        category="joint_targets",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_joint_effort_target",
+        method_name="set_joint_effort_target",
+        input_generators={
+            "torch_list": gen_set_joint_effort_target_torch_list,
+            "torch_tensor": gen_set_joint_effort_target_torch_tensor,
+        },
+        category="joint_targets",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_joint_effort_target_mask",
+        method_name="set_joint_effort_target_mask",
+        input_generators={"warp_mask": gen_set_joint_effort_target_warp_mask},
+        category="joint_targets",
+    ),
+    # --- Body Properties ---
+    MethodBenchmarkDefinition(
+        name="set_masses",
+        method_name="set_masses",
+        input_generators={
+            "torch_list": gen_set_masses_torch_list,
+            "torch_tensor": gen_set_masses_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_masses_mask",
+        method_name="set_masses_mask",
+        input_generators={"warp_mask": gen_set_masses_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms",
+        method_name="set_coms",
+        input_generators={
+            "torch_list": gen_set_coms_torch_list,
+            "torch_tensor": gen_set_coms_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms_mask",
+        method_name="set_coms_mask",
+        input_generators={"warp_mask": gen_set_coms_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias",
+        method_name="set_inertias",
+        input_generators={
+            "torch_list": gen_set_inertias_torch_list,
+            "torch_tensor": gen_set_inertias_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias_mask",
+        method_name="set_inertias_mask",
+        input_generators={"warp_mask": gen_set_inertias_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_external_force_and_torque",
+        method_name="set_external_force_and_torque",
+        input_generators={
+            "torch_list": gen_set_external_force_and_torque_torch_list,
+            "torch_tensor": gen_set_external_force_and_torque_torch_tensor,
+        },
+        category="external_wrench",
+    ),
+]
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=args.num_bodies,
+        num_joints=args.num_joints,
+        device=args.device,
+        mode=args.mode,
+    )
+
+    # Create the test articulation
+    articulation, _ = create_test_articulation(
+        num_instances=config.num_instances,
+        num_bodies=config.num_bodies,
+        num_joints=config.num_joints,
+        device=config.device,
+    )
+
+    print(
+        f"Benchmarking Articulation (OVPhysX) with {config.num_instances} instances, {config.num_bodies} bodies,"
+        f" {config.num_joints} joints..."
+    )
+
+    # Create runner and run benchmarks
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_articulation_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+
+    runner.run_benchmarks(BENCHMARKS, articulation)
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation_data.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_articulation_data.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for ArticulationData class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of all properties
+in the OVPhysX ArticulationData class. Each property is run multiple times after invalidating
+its cached data, and timing statistics (mean and standard deviation) are reported.
+
+Usage:
+    python benchmark_articulation_data.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I] [--num_bodies B] [--num_joints J]
+
+Example:
+    python benchmark_articulation_data.py --num_iterations 10000 --warmup_steps 10
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(
+    description="Micro-benchmarking framework for ArticulationData class (OVPhysX backend).",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--num_bodies", type=int, default=12, help="Number of bodies")
+parser.add_argument("--num_joints", type=int, default=11, help="Number of joints")
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+
+args = parser.parse_args()
+
+
+import warnings
+
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet, MockOvPhysxView
+
+from isaaclab.benchmark import MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+
+# =============================================================================
+# Skip Lists
+# =============================================================================
+
+# List of deprecated properties - skip these
+DEPRECATED_PROPERTIES = {
+    "default_root_state",
+    "root_pose_w",
+    "root_pos_w",
+    "root_quat_w",
+    "root_vel_w",
+    "root_lin_vel_w",
+    "root_ang_vel_w",
+    "root_lin_vel_b",
+    "root_ang_vel_b",
+    "body_pose_w",
+    "body_pos_w",
+    "body_quat_w",
+    "body_vel_w",
+    "body_lin_vel_w",
+    "body_ang_vel_w",
+    "body_acc_w",
+    "body_lin_acc_w",
+    "body_ang_acc_w",
+    "com_pos_b",
+    "com_quat_b",
+    "joint_limits",
+    "joint_friction",
+    "fixed_tendon_limit",
+    "applied_torque",
+    "computed_torque",
+    "joint_dynamic_friction",
+    "joint_effort_target",
+    "joint_viscous_friction",
+    "joint_velocity_limits",
+    # Combined state properties marked as deprecated
+    "root_state_w",
+    "root_link_state_w",
+    "root_com_state_w",
+    "body_state_w",
+    "body_link_state_w",
+    "body_com_state_w",
+}
+
+# List of properties that raise NotImplementedError - skip these
+NOT_IMPLEMENTED_PROPERTIES = {
+    "fixed_tendon_stiffness",
+    "fixed_tendon_damping",
+    "fixed_tendon_limit_stiffness",
+    "fixed_tendon_rest_length",
+    "fixed_tendon_offset",
+    "fixed_tendon_pos_limits",
+    "spatial_tendon_stiffness",
+    "spatial_tendon_damping",
+    "spatial_tendon_limit_stiffness",
+    "spatial_tendon_offset",
+    "body_incoming_joint_wrench_b",
+    "gravity_compensation_forces",
+}
+
+# Removed default_* properties that raise RuntimeError
+REMOVED_PROPERTIES = {
+    "default_fixed_tendon_damping",
+    "default_fixed_tendon_limit",
+    "default_fixed_tendon_limit_stiffness",
+    "default_fixed_tendon_offset",
+    "default_fixed_tendon_pos_limits",
+    "default_fixed_tendon_rest_length",
+    "default_fixed_tendon_stiffness",
+    "default_inertia",
+    "default_joint_armature",
+    "default_joint_damping",
+    "default_joint_dynamic_friction_coeff",
+    "default_joint_friction",
+    "default_joint_friction_coeff",
+    "default_joint_limits",
+    "default_joint_pos_limits",
+    "default_joint_stiffness",
+    "default_joint_viscous_friction_coeff",
+    "default_mass",
+    "default_spatial_tendon_damping",
+    "default_spatial_tendon_limit_stiffness",
+    "default_spatial_tendon_offset",
+    "default_spatial_tendon_stiffness",
+}
+
+# Private/internal properties and methods to skip
+INTERNAL_PROPERTIES = {
+    "_create_simulation_bindings",
+    "_create_buffers",
+    "update",
+    "is_primed",
+    "device",
+    "body_names",
+    "joint_names",
+    "fixed_tendon_names",
+    "spatial_tendon_names",
+    "GRAVITY_VEC_W",
+    "GRAVITY_VEC_W_TORCH",
+    "FORWARD_VEC_B",
+    "FORWARD_VEC_B_TORCH",
+    "ALL_ENV_MASK",
+    "ALL_BODY_MASK",
+    "ALL_JOINT_MASK",
+    "ENV_MASK",
+    "BODY_MASK",
+    "JOINT_MASK",
+    "has_body_ordering",
+    "has_joint_ordering",
+}
+
+# Dependency mapping for properties
+PROPERTY_DEPENDENCIES = {
+    "root_link_lin_vel_w": ["root_link_vel_w"],
+    "root_link_ang_vel_w": ["root_link_vel_w"],
+    "root_link_lin_vel_b": ["root_link_lin_vel_w", "root_link_quat_w"],
+    "root_link_ang_vel_b": ["root_link_ang_vel_w", "root_link_quat_w"],
+    "root_com_pos_w": ["root_com_pose_w"],
+    "root_com_quat_w": ["root_com_pose_w"],
+    "root_com_lin_vel_b": ["root_com_lin_vel_w", "root_link_quat_w"],
+    "root_com_ang_vel_b": ["root_com_ang_vel_w", "root_link_quat_w"],
+    "root_com_lin_vel_w": ["root_com_vel_w"],
+    "root_com_ang_vel_w": ["root_com_vel_w"],
+    "root_link_pos_w": ["root_link_pose_w"],
+    "root_link_quat_w": ["root_link_pose_w"],
+    "body_link_lin_vel_w": ["body_link_vel_w"],
+    "body_link_ang_vel_w": ["body_link_vel_w"],
+    "body_link_pos_w": ["body_link_pose_w"],
+    "body_link_quat_w": ["body_link_pose_w"],
+    "body_com_pos_w": ["body_com_pose_w"],
+    "body_com_quat_w": ["body_com_pose_w"],
+    "body_com_lin_vel_w": ["body_com_vel_w"],
+    "body_com_ang_vel_w": ["body_com_vel_w"],
+    "body_com_lin_acc_w": ["body_com_acc_w"],
+    "body_com_ang_acc_w": ["body_com_acc_w"],
+    "body_com_quat_b": ["body_com_pose_b"],
+}
+
+
+# =============================================================================
+# Benchmark Functions
+# =============================================================================
+
+
+def get_benchmarkable_properties(articulation_data) -> list[str]:
+    """Get list of properties that can be benchmarked."""
+    all_properties = []
+
+    for name in dir(articulation_data):
+        if name.startswith("_"):
+            continue
+        if name in DEPRECATED_PROPERTIES:
+            continue
+        if name in NOT_IMPLEMENTED_PROPERTIES:
+            continue
+        if name in REMOVED_PROPERTIES:
+            continue
+        if name in INTERNAL_PROPERTIES:
+            continue
+
+        attr = getattr(type(articulation_data), name, None)
+        if isinstance(attr, property):
+            try:
+                getattr(articulation_data, name)
+            except NotImplementedError:
+                continue
+            all_properties.append(name)
+
+    return sorted(all_properties)
+
+
+def setup_mock_environment(config: MethodBenchmarkRunnerConfig) -> MockOvPhysxView:
+    """Set up the mock environment for benchmarking."""
+    bindings = MockOvPhysxBindingSet(
+        num_instances=config.num_instances,
+        num_bodies=config.num_bodies,
+        num_joints=config.num_joints,
+        benchmark_mode=True,
+    )
+    bindings.set_random_data()
+    return bindings.view
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    from isaaclab_ovphysx.assets.articulation.articulation_data import ArticulationData
+
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=args.num_bodies,
+        num_joints=args.num_joints,
+        device=args.device,
+    )
+    mock_view = setup_mock_environment(config)
+    articulation_data = ArticulationData(mock_view, config.device)
+    articulation_data._apply_ordering_maps_after_resolve()
+    properties = get_benchmarkable_properties(articulation_data)
+
+    def gen_mock_data(_cfg: MethodBenchmarkRunnerConfig) -> dict:
+        articulation_data._sim_timestamp += 1.0
+        articulation_data._fk_timestamp = articulation_data._sim_timestamp
+        return {}
+
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_articulation_data_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+    runner.run_property_benchmarks(
+        target_data=articulation_data,
+        properties=properties,
+        gen_mock_data=gen_mock_data,
+        dependencies=PROPERTY_DEPENDENCIES,
+        category="property",
+    )
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for RigidObject class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of setter and writer
+methods in the RigidObject class. Each method is benchmarked under three scenarios:
+
+1. **Torch List**: Inputs are PyTorch tensors with list indices (via deprecated wrappers).
+2. **Torch Tensor**: Inputs are PyTorch tensors with tensor indices (via deprecated wrappers).
+3. **Warp Mask**: Inputs are warp arrays with boolean masks (via ``_mask`` methods).
+
+Usage:
+    python benchmark_rigid_object.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I] [--num_bodies B]
+
+Example:
+    python benchmark_rigid_object.py --num_iterations 1000 --warmup_steps 10
+    python benchmark_rigid_object.py --mode torch_list  # Only run list-based benchmarks
+    python benchmark_rigid_object.py --mode warp_mask   # Only run warp mask benchmarks
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Benchmark RigidObject methods (OVPhysX backend).")
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--num_bodies", type=int, default=1, help="Number of bodies")
+parser.add_argument(
+    "--mode",
+    type=str,
+    default="all",
+    choices=["all", "torch_list", "torch_tensor", "warp_mask"],
+    help="Benchmark mode",
+)
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+parser.add_argument("--no_shape_checks", action="store_true", help="Disable shape/dtype assertions")
+
+args = parser.parse_args()
+
+
+import logging
+import warnings
+
+import torch
+import warp as wp
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet
+
+from isaaclab.assets.rigid_object.rigid_object_cfg import RigidObjectCfg
+from isaaclab.benchmark import MethodBenchmarkDefinition, MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# Also suppress logging warnings
+logging.getLogger("isaaclab_ovphysx").setLevel(logging.ERROR)
+logging.getLogger("isaaclab").setLevel(logging.ERROR)
+
+
+# =============================================================================
+# Index Helpers
+# =============================================================================
+
+
+def make_tensor_env_ids(num_instances: int, device: str) -> torch.Tensor:
+    """Create a tensor of environment IDs."""
+    return torch.arange(num_instances, dtype=torch.int32, device=device)
+
+
+def make_tensor_body_ids(num_bodies: int, device: str) -> torch.Tensor:
+    """Create a tensor of body IDs."""
+    return torch.arange(num_bodies, dtype=torch.int32, device=device)
+
+
+# =============================================================================
+# Test RigidObject Factory
+# =============================================================================
+
+
+def create_test_rigid_object(
+    num_instances: int = 2,
+    num_bodies: int = 1,
+    device: str = "cuda:0",
+):
+    """Create a test RigidObject instance with mocked dependencies."""
+    from isaaclab_ovphysx.assets.rigid_object.rigid_object import RigidObject
+    from isaaclab_ovphysx.assets.rigid_object.rigid_object_data import RigidObjectData
+
+    if num_bodies != 1:
+        raise ValueError(f"RigidObject requires exactly one body, got {num_bodies}.")
+
+    binding_set = MockOvPhysxBindingSet(
+        num_instances=num_instances,
+        num_joints=0,
+        num_bodies=1,
+        body_names=["base_link"],
+        asset_kind="rigid_object",
+        benchmark_mode=True,
+    )
+    binding_set.set_random_data()
+    mock_view = binding_set.view
+
+    rigid_object = object.__new__(RigidObject)
+    rigid_object.cfg = RigidObjectCfg(prim_path="/World/Object")
+    object.__setattr__(rigid_object, "_initialize_handle", None)
+    object.__setattr__(rigid_object, "_invalidate_initialize_handle", None)
+    object.__setattr__(rigid_object, "_prim_deletion_handle", None)
+    object.__setattr__(rigid_object, "_debug_vis_handle", None)
+    object.__setattr__(rigid_object, "_root_view", mock_view)
+    object.__setattr__(rigid_object, "_device", device)
+    object.__setattr__(rigid_object, "_check_shapes", not args.no_shape_checks)
+    object.__setattr__(rigid_object, "_num_instances", num_instances)
+    object.__setattr__(rigid_object, "_num_bodies", 1)
+    object.__setattr__(rigid_object, "_body_names", ["base_link"])
+
+    data = RigidObjectData(mock_view, device, check_shapes=not args.no_shape_checks)
+    object.__setattr__(rigid_object, "_data", data)
+    rigid_object._create_buffers()
+
+    return rigid_object, mock_view
+
+
+# Input Generators (Torch-only for OVPhysX backend)
+# =============================================================================
+
+
+# --- Root Link Pose ---
+def gen_root_link_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_link_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root COM Pose ---
+def gen_root_com_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_com_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root Link Velocity ---
+def gen_root_link_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_link_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Root COM Velocity ---
+def gen_root_com_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_root_com_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# --- Set Masses ---
+def gen_set_masses_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_masses_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set CoMs ---
+def gen_set_coms_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_coms_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set Inertias ---
+def gen_set_inertias_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_inertias_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set External Force and Torque ---
+def gen_set_external_force_and_torque_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_set_external_force_and_torque_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# =============================================================================
+# Warp Mask Input Generators (for _mask methods)
+# =============================================================================
+
+
+def _env_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_instances,), dtype=wp.bool, device=config.device)
+
+
+def _body_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_bodies,), dtype=wp.bool, device=config.device)
+
+
+# --- Root Link Pose (mask) ---
+def gen_root_link_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root COM Pose (mask) ---
+def gen_root_com_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_pose": torch.rand(config.num_instances, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root Link Velocity (mask) ---
+def gen_root_link_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Root COM Velocity (mask) ---
+def gen_root_com_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "root_velocity": torch.rand(config.num_instances, 6, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Masses (mask) ---
+def gen_set_masses_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set CoMs (mask) ---
+def gen_set_coms_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Inertias (mask) ---
+def gen_set_inertias_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# =============================================================================
+# Benchmarks
+# =============================================================================
+
+BENCHMARKS = [
+    # --- Root Pose / Velocity ---
+    MethodBenchmarkDefinition(
+        name="write_root_link_pose_to_sim",
+        method_name="write_root_link_pose_to_sim",
+        input_generators={
+            "torch_list": gen_root_link_pose_torch_list,
+            "torch_tensor": gen_root_link_pose_torch_tensor,
+        },
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_pose_to_sim_mask",
+        method_name="write_root_link_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_root_link_pose_warp_mask},
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_pose_to_sim",
+        method_name="write_root_com_pose_to_sim",
+        input_generators={
+            "torch_list": gen_root_com_pose_torch_list,
+            "torch_tensor": gen_root_com_pose_torch_tensor,
+        },
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_pose_to_sim_mask",
+        method_name="write_root_com_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_root_com_pose_warp_mask},
+        category="root_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_velocity_to_sim",
+        method_name="write_root_link_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_root_link_velocity_torch_list,
+            "torch_tensor": gen_root_link_velocity_torch_tensor,
+        },
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_link_velocity_to_sim_mask",
+        method_name="write_root_link_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_root_link_velocity_warp_mask},
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_velocity_to_sim",
+        method_name="write_root_com_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_root_com_velocity_torch_list,
+            "torch_tensor": gen_root_com_velocity_torch_tensor,
+        },
+        category="root_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_root_com_velocity_to_sim_mask",
+        method_name="write_root_com_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_root_com_velocity_warp_mask},
+        category="root_velocity",
+    ),
+    # --- Body Properties ---
+    MethodBenchmarkDefinition(
+        name="set_masses",
+        method_name="set_masses",
+        input_generators={
+            "torch_list": gen_set_masses_torch_list,
+            "torch_tensor": gen_set_masses_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_masses_mask",
+        method_name="set_masses_mask",
+        input_generators={"warp_mask": gen_set_masses_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms",
+        method_name="set_coms",
+        input_generators={
+            "torch_list": gen_set_coms_torch_list,
+            "torch_tensor": gen_set_coms_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms_mask",
+        method_name="set_coms_mask",
+        input_generators={"warp_mask": gen_set_coms_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias",
+        method_name="set_inertias",
+        input_generators={
+            "torch_list": gen_set_inertias_torch_list,
+            "torch_tensor": gen_set_inertias_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias_mask",
+        method_name="set_inertias_mask",
+        input_generators={"warp_mask": gen_set_inertias_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_external_force_and_torque",
+        method_name="set_external_force_and_torque",
+        input_generators={
+            "torch_list": gen_set_external_force_and_torque_torch_list,
+            "torch_tensor": gen_set_external_force_and_torque_torch_tensor,
+        },
+        category="external_wrench",
+    ),
+]
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=args.num_bodies,
+        num_joints=0,
+        device=args.device,
+        mode=args.mode,
+    )
+
+    # Create the test rigid object
+    rigid_object, _ = create_test_rigid_object(
+        num_instances=config.num_instances,
+        num_bodies=config.num_bodies,
+        device=config.device,
+    )
+
+    print(f"Benchmarking RigidObject (OVPhysX) with {config.num_instances} instances, {config.num_bodies} bodies...")
+
+    # Create runner and run benchmarks
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_rigid_object_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+
+    runner.run_benchmarks(BENCHMARKS, rigid_object)
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_collection.py
@@ -1,0 +1,533 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for RigidObjectCollection class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of setter and writer
+methods in the RigidObjectCollection class. Each method is benchmarked under three scenarios:
+
+1. **Torch List**: Inputs are PyTorch tensors with list indices (via deprecated wrappers).
+2. **Torch Tensor**: Inputs are PyTorch tensors with tensor indices (via deprecated wrappers).
+3. **Warp Mask**: Inputs are warp arrays with boolean masks (via ``_mask`` methods).
+
+Usage:
+    python benchmark_rigid_object_collection.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I] [--num_bodies B]
+
+Example:
+    python benchmark_rigid_object_collection.py --num_iterations 1000 --warmup_steps 10
+    python benchmark_rigid_object_collection.py --mode torch_list  # Only run list-based benchmarks
+    python benchmark_rigid_object_collection.py --mode warp_mask   # Only run warp mask benchmarks
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Benchmark RigidObjectCollection methods (OVPhysX backend).")
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--num_bodies", type=int, default=3, help="Number of bodies (object types)")
+parser.add_argument(
+    "--mode",
+    type=str,
+    default="all",
+    choices=["all", "torch_list", "torch_tensor", "warp_mask"],
+    help="Benchmark mode",
+)
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+parser.add_argument("--no_shape_checks", action="store_true", help="Disable shape/dtype assertions")
+
+args = parser.parse_args()
+
+
+import logging
+import warnings
+
+import torch
+import warp as wp
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet
+
+from isaaclab.assets.rigid_object_collection.rigid_object_collection_cfg import RigidObjectCollectionCfg
+from isaaclab.benchmark import MethodBenchmarkDefinition, MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+# Also suppress logging warnings
+logging.getLogger("isaaclab_ovphysx").setLevel(logging.ERROR)
+logging.getLogger("isaaclab").setLevel(logging.ERROR)
+
+
+# =============================================================================
+# Index Helpers
+# =============================================================================
+
+
+def make_tensor_env_ids(num_instances: int, device: str) -> torch.Tensor:
+    """Create a tensor of environment IDs."""
+    return torch.arange(num_instances, dtype=torch.int32, device=device)
+
+
+def make_tensor_body_ids(num_bodies: int, device: str) -> torch.Tensor:
+    """Create a tensor of body IDs."""
+    return torch.arange(num_bodies, dtype=torch.int32, device=device)
+
+
+# =============================================================================
+# Test RigidObjectCollection Factory
+# =============================================================================
+
+
+def create_test_collection(
+    num_instances: int = 2,
+    num_bodies: int = 3,
+    device: str = "cuda:0",
+):
+    """Create a test RigidObjectCollection instance with mocked dependencies."""
+    from isaaclab_ovphysx.assets.rigid_object_collection.rigid_object_collection import RigidObjectCollection
+    from isaaclab_ovphysx.assets.rigid_object_collection.rigid_object_collection_data import RigidObjectCollectionData
+
+    from isaaclab.assets.rigid_object.rigid_object_cfg import RigidObjectCfg
+
+    object_names = [f"object_{i}" for i in range(num_bodies)]
+    binding_set = MockOvPhysxBindingSet(
+        num_instances=num_instances,
+        num_joints=0,
+        num_bodies=num_bodies,
+        body_names=object_names,
+        benchmark_mode=True,
+    )
+    binding_set.set_random_data()
+    mock_view = binding_set.view
+
+    collection = object.__new__(RigidObjectCollection)
+    rigid_objects = {name: RigidObjectCfg(prim_path=f"/World/{name}") for name in object_names}
+    collection.cfg = RigidObjectCollectionCfg(rigid_objects=rigid_objects)
+    object.__setattr__(collection, "_initialize_handle", None)
+    object.__setattr__(collection, "_invalidate_initialize_handle", None)
+    object.__setattr__(collection, "_prim_deletion_handle", None)
+    object.__setattr__(collection, "_debug_vis_handle", None)
+    object.__setattr__(collection, "_root_view", mock_view)
+    object.__setattr__(collection, "_device", device)
+    object.__setattr__(collection, "_check_shapes", not args.no_shape_checks)
+    object.__setattr__(collection, "_num_instances", num_instances)
+    object.__setattr__(collection, "_num_bodies", num_bodies)
+    object.__setattr__(collection, "_body_names_list", object_names)
+    object.__setattr__(collection, "_object_names", object_names)
+
+    data = RigidObjectCollectionData(mock_view, num_bodies, device)
+    object.__setattr__(collection, "_data", data)
+    collection._create_buffers()
+
+    return collection, mock_view
+
+
+# Input Generators (Torch-only for OVPhysX backend)
+# =============================================================================
+
+
+# --- Body Link Pose ---
+def gen_body_link_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_body_link_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Body COM Pose ---
+def gen_body_com_pose_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_body_com_pose_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Body Link Velocity ---
+def gen_body_link_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_body_link_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Body COM Velocity ---
+def gen_body_com_velocity_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_body_com_velocity_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set Masses ---
+def gen_set_masses_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_masses_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set CoMs ---
+def gen_set_coms_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_coms_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set Inertias ---
+def gen_set_inertias_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+        "body_ids": list(range(config.num_bodies)),
+    }
+
+
+def gen_set_inertias_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+        "body_ids": make_tensor_body_ids(config.num_bodies, config.device),
+    }
+
+
+# --- Set External Force and Torque ---
+def gen_set_external_force_and_torque_torch_list(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": list(range(config.num_instances)),
+    }
+
+
+def gen_set_external_force_and_torque_torch_tensor(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "forces": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "torques": torch.rand(config.num_instances, config.num_bodies, 3, device=config.device, dtype=torch.float32),
+        "env_ids": make_tensor_env_ids(config.num_instances, config.device),
+    }
+
+
+# =============================================================================
+# Warp Mask Input Generators (for _mask methods)
+# =============================================================================
+
+
+def _env_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_instances,), dtype=wp.bool, device=config.device)
+
+
+def _body_mask(config: MethodBenchmarkRunnerConfig) -> wp.array:
+    return wp.ones((config.num_bodies,), dtype=wp.bool, device=config.device)
+
+
+# --- Body Link Pose (mask) ---
+def gen_body_link_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Body COM Pose (mask) ---
+def gen_body_com_pose_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_poses": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Body Link Velocity (mask) ---
+def gen_body_link_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Body COM Velocity (mask) ---
+def gen_body_com_velocity_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "body_velocities": torch.rand(
+            config.num_instances, config.num_bodies, 6, device=config.device, dtype=torch.float32
+        ),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Masses (mask) ---
+def gen_set_masses_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "masses": torch.rand(config.num_instances, config.num_bodies, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set CoMs (mask) ---
+def gen_set_coms_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "coms": torch.rand(config.num_instances, config.num_bodies, 7, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# --- Set Inertias (mask) ---
+def gen_set_inertias_warp_mask(config: MethodBenchmarkRunnerConfig) -> dict:
+    return {
+        "inertias": torch.rand(config.num_instances, config.num_bodies, 9, device=config.device, dtype=torch.float32),
+        "body_mask": _body_mask(config),
+        "env_mask": _env_mask(config),
+    }
+
+
+# =============================================================================
+# Benchmarks
+# =============================================================================
+
+BENCHMARKS = [
+    # --- Body Link Pose ---
+    MethodBenchmarkDefinition(
+        name="write_body_link_pose_to_sim",
+        method_name="write_body_link_pose_to_sim",
+        input_generators={
+            "torch_list": gen_body_link_pose_torch_list,
+            "torch_tensor": gen_body_link_pose_torch_tensor,
+        },
+        category="body_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_body_link_pose_to_sim_mask",
+        method_name="write_body_link_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_body_link_pose_warp_mask},
+        category="body_pose",
+    ),
+    # --- Body COM Pose ---
+    MethodBenchmarkDefinition(
+        name="write_body_com_pose_to_sim",
+        method_name="write_body_com_pose_to_sim",
+        input_generators={
+            "torch_list": gen_body_com_pose_torch_list,
+            "torch_tensor": gen_body_com_pose_torch_tensor,
+        },
+        category="body_pose",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_body_com_pose_to_sim_mask",
+        method_name="write_body_com_pose_to_sim_mask",
+        input_generators={"warp_mask": gen_body_com_pose_warp_mask},
+        category="body_pose",
+    ),
+    # --- Body Link Velocity ---
+    MethodBenchmarkDefinition(
+        name="write_body_link_velocity_to_sim",
+        method_name="write_body_link_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_body_link_velocity_torch_list,
+            "torch_tensor": gen_body_link_velocity_torch_tensor,
+        },
+        category="body_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_body_link_velocity_to_sim_mask",
+        method_name="write_body_link_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_body_link_velocity_warp_mask},
+        category="body_velocity",
+    ),
+    # --- Body COM Velocity ---
+    MethodBenchmarkDefinition(
+        name="write_body_com_velocity_to_sim",
+        method_name="write_body_com_velocity_to_sim",
+        input_generators={
+            "torch_list": gen_body_com_velocity_torch_list,
+            "torch_tensor": gen_body_com_velocity_torch_tensor,
+        },
+        category="body_velocity",
+    ),
+    MethodBenchmarkDefinition(
+        name="write_body_com_velocity_to_sim_mask",
+        method_name="write_body_com_velocity_to_sim_mask",
+        input_generators={"warp_mask": gen_body_com_velocity_warp_mask},
+        category="body_velocity",
+    ),
+    # --- Body Properties ---
+    MethodBenchmarkDefinition(
+        name="set_masses",
+        method_name="set_masses",
+        input_generators={
+            "torch_list": gen_set_masses_torch_list,
+            "torch_tensor": gen_set_masses_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_masses_mask",
+        method_name="set_masses_mask",
+        input_generators={"warp_mask": gen_set_masses_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms",
+        method_name="set_coms",
+        input_generators={
+            "torch_list": gen_set_coms_torch_list,
+            "torch_tensor": gen_set_coms_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_coms_mask",
+        method_name="set_coms_mask",
+        input_generators={"warp_mask": gen_set_coms_warp_mask},
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias",
+        method_name="set_inertias",
+        input_generators={
+            "torch_list": gen_set_inertias_torch_list,
+            "torch_tensor": gen_set_inertias_torch_tensor,
+        },
+        category="body_props",
+    ),
+    MethodBenchmarkDefinition(
+        name="set_inertias_mask",
+        method_name="set_inertias_mask",
+        input_generators={"warp_mask": gen_set_inertias_warp_mask},
+        category="body_props",
+    ),
+    # --- External Force and Torque ---
+    MethodBenchmarkDefinition(
+        name="set_external_force_and_torque",
+        method_name="set_external_force_and_torque",
+        input_generators={
+            "torch_list": gen_set_external_force_and_torque_torch_list,
+            "torch_tensor": gen_set_external_force_and_torque_torch_tensor,
+        },
+        category="external_wrench",
+    ),
+]
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=args.num_bodies,
+        num_joints=0,
+        device=args.device,
+        mode=args.mode,
+    )
+
+    # Create the test collection
+    collection, _ = create_test_collection(
+        num_instances=config.num_instances,
+        num_bodies=config.num_bodies,
+        device=config.device,
+    )
+
+    print(
+        f"Benchmarking RigidObjectCollection (OVPhysX) with {config.num_instances} instances, "
+        f"{config.num_bodies} bodies..."
+    )
+
+    # Create runner and run benchmarks
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_rigid_object_collection_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+
+    runner.run_benchmarks(BENCHMARKS, collection)
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_collection_data.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_collection_data.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for RigidObjectCollectionData class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of all properties
+in the OVPhysX RigidObjectCollectionData class. Each property is run multiple times after
+invalidating its cached data, and timing statistics (mean and standard deviation) are reported.
+
+Usage:
+    python benchmark_rigid_object_collection_data.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I] [--num_bodies B]
+
+Example:
+    python benchmark_rigid_object_collection_data.py --num_iterations 10000 --warmup_steps 10
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(
+    description="Micro-benchmarking framework for RigidObjectCollectionData class (OVPhysX backend).",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--num_bodies", type=int, default=3, help="Number of bodies (object types)")
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+
+args = parser.parse_args()
+
+
+import warnings
+
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet, MockOvPhysxView
+
+from isaaclab.benchmark import MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+
+# =============================================================================
+# Skip Lists
+# =============================================================================
+
+# List of deprecated properties - skip these
+DEPRECATED_PROPERTIES = {
+    "default_body_state",
+    "body_state_w",
+    "body_link_state_w",
+    "body_com_state_w",
+}
+
+# List of properties that raise NotImplementedError - skip these
+NOT_IMPLEMENTED_PROPERTIES = set()
+
+# Removed default_* properties that raise RuntimeError
+REMOVED_PROPERTIES = {
+    "default_inertia",
+    "default_mass",
+}
+
+# Private/internal properties and methods to skip
+INTERNAL_PROPERTIES = {
+    "_create_simulation_bindings",
+    "_create_buffers",
+    "update",
+    "is_primed",
+    "device",
+    "body_names",
+    "object_names",
+    "GRAVITY_VEC_W",
+    "GRAVITY_VEC_W_TORCH",
+    "FORWARD_VEC_B",
+    "FORWARD_VEC_B_TORCH",
+    "ALL_ENV_MASK",
+    "ENV_MASK",
+    "ALL_OBJECT_MASK",
+    "OBJECT_MASK",
+    "num_bodies",
+    "num_instances",
+}
+
+# Dependency mapping for properties
+PROPERTY_DEPENDENCIES = {
+    "body_link_pos_w": ["body_link_pose_w"],
+    "body_link_quat_w": ["body_link_pose_w"],
+    "body_link_lin_vel_w": ["body_link_vel_w"],
+    "body_link_ang_vel_w": ["body_link_vel_w"],
+    "body_com_pos_w": ["body_com_pose_w"],
+    "body_com_quat_w": ["body_com_pose_w"],
+    "body_com_lin_vel_w": ["body_com_vel_w"],
+    "body_com_ang_vel_w": ["body_com_vel_w"],
+    "body_com_lin_acc_w": ["body_com_acc_w"],
+    "body_com_ang_acc_w": ["body_com_acc_w"],
+    "body_com_quat_b": ["body_com_pose_b"],
+}
+
+
+# =============================================================================
+# Benchmark Functions
+# =============================================================================
+
+
+def get_benchmarkable_properties(data) -> list[str]:
+    """Get list of properties that can be benchmarked."""
+    all_properties = []
+
+    for name in dir(data):
+        if name.startswith("_"):
+            continue
+        if name in DEPRECATED_PROPERTIES:
+            continue
+        if name in NOT_IMPLEMENTED_PROPERTIES:
+            continue
+        if name in REMOVED_PROPERTIES:
+            continue
+        if name in INTERNAL_PROPERTIES:
+            continue
+
+        attr = getattr(type(data), name, None)
+        if isinstance(attr, property):
+            try:
+                getattr(data, name)
+            except NotImplementedError:
+                continue
+            all_properties.append(name)
+
+    return sorted(all_properties)
+
+
+def setup_mock_environment(config: MethodBenchmarkRunnerConfig) -> MockOvPhysxView:
+    """Set up the mock environment for benchmarking."""
+    bindings = MockOvPhysxBindingSet(
+        num_instances=config.num_instances,
+        num_bodies=config.num_bodies,
+        num_joints=0,
+        benchmark_mode=True,
+    )
+    bindings.set_random_data()
+    return bindings.view
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    from isaaclab_ovphysx.assets.rigid_object_collection.rigid_object_collection_data import RigidObjectCollectionData
+
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=args.num_bodies,
+        num_joints=0,
+        device=args.device,
+    )
+    mock_view = setup_mock_environment(config)
+    data = RigidObjectCollectionData(mock_view, config.num_bodies, config.device)
+    properties = get_benchmarkable_properties(data)
+
+    def gen_mock_data(_cfg: MethodBenchmarkRunnerConfig) -> dict:
+        data._sim_timestamp += 1.0
+        return {}
+
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_rigid_object_collection_data_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+    runner.run_property_benchmarks(
+        target_data=data,
+        properties=properties,
+        gen_mock_data=gen_mock_data,
+        dependencies=PROPERTY_DEPENDENCIES,
+        category="property",
+    )
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_data.py
+++ b/source/isaaclab_ovphysx/benchmark/assets/benchmark_rigid_object_data.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Micro-benchmarking framework for RigidObjectData class (OVPhysX backend).
+
+This module provides a benchmarking framework to measure the performance of all properties
+in the OVPhysX RigidObjectData class. Each property is run multiple times after invalidating
+its cached data, and timing statistics (mean and standard deviation) are reported.
+
+Usage:
+    python benchmark_rigid_object_data.py [--num_iterations N] [--warmup_steps W]
+        [--num_instances I]
+
+Example:
+    python benchmark_rigid_object_data.py --num_iterations 10000 --warmup_steps 10
+"""
+
+from __future__ import annotations
+
+import argparse
+
+# add argparse arguments
+parser = argparse.ArgumentParser(
+    description="Micro-benchmarking framework for RigidObjectData class (OVPhysX backend).",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument("--num_iterations", type=int, default=1000, help="Number of iterations")
+parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warmup steps")
+parser.add_argument("--num_instances", type=int, default=4096, help="Number of instances")
+parser.add_argument("--device", type=str, default="cuda:0", help="Device for tensors")
+parser.add_argument(
+    "--output_path", "--output_dir", dest="output_path", type=str, default=".", help="Output directory for results"
+)
+parser.add_argument(
+    "--benchmark_formatter",
+    "--backend",
+    dest="benchmark_formatter",
+    type=str,
+    default="json",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Metrics formatter",
+)
+
+args = parser.parse_args()
+
+
+import warnings
+
+from isaaclab_ovphysx.test.mock_interfaces import MockOvPhysxBindingSet, MockOvPhysxView
+
+from isaaclab.benchmark import MethodBenchmarkRunner, MethodBenchmarkRunnerConfig
+
+# Suppress deprecation warnings during benchmarking
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+
+# =============================================================================
+# Skip Lists
+# =============================================================================
+
+# List of deprecated properties - skip these
+DEPRECATED_PROPERTIES = {
+    "default_root_state",
+    "root_pose_w",
+    "root_pos_w",
+    "root_quat_w",
+    "root_vel_w",
+    "root_lin_vel_w",
+    "root_ang_vel_w",
+    "root_lin_vel_b",
+    "root_ang_vel_b",
+    "body_pose_w",
+    "body_pos_w",
+    "body_quat_w",
+    "body_vel_w",
+    "body_lin_vel_w",
+    "body_ang_vel_w",
+    "body_acc_w",
+    "body_lin_acc_w",
+    "body_ang_acc_w",
+    "com_pos_b",
+    "com_quat_b",
+    # Combined state properties marked as deprecated
+    "root_state_w",
+    "root_link_state_w",
+    "root_com_state_w",
+    "body_state_w",
+    "body_link_state_w",
+    "body_com_state_w",
+}
+
+# List of properties that raise NotImplementedError - skip these
+NOT_IMPLEMENTED_PROPERTIES = set()
+
+# Removed default_* properties that raise RuntimeError
+REMOVED_PROPERTIES = {
+    "default_inertia",
+    "default_mass",
+}
+
+# Private/internal properties and methods to skip
+INTERNAL_PROPERTIES = {
+    "_create_simulation_bindings",
+    "_create_buffers",
+    "update",
+    "is_primed",
+    "device",
+    "body_names",
+    "GRAVITY_VEC_W",
+    "GRAVITY_VEC_W_TORCH",
+    "FORWARD_VEC_B",
+    "FORWARD_VEC_B_TORCH",
+    "ALL_ENV_MASK",
+    "ENV_MASK",
+}
+
+# Dependency mapping for properties
+PROPERTY_DEPENDENCIES = {
+    "root_link_lin_vel_w": ["root_link_vel_w"],
+    "root_link_ang_vel_w": ["root_link_vel_w"],
+    "root_link_lin_vel_b": ["root_link_lin_vel_w", "root_link_quat_w"],
+    "root_link_ang_vel_b": ["root_link_ang_vel_w", "root_link_quat_w"],
+    "root_com_pos_w": ["root_com_pose_w"],
+    "root_com_quat_w": ["root_com_pose_w"],
+    "root_com_lin_vel_b": ["root_com_lin_vel_w", "root_link_quat_w"],
+    "root_com_ang_vel_b": ["root_com_ang_vel_w", "root_link_quat_w"],
+    "root_com_lin_vel_w": ["root_com_vel_w"],
+    "root_com_ang_vel_w": ["root_com_vel_w"],
+    "root_link_pos_w": ["root_link_pose_w"],
+    "root_link_quat_w": ["root_link_pose_w"],
+    "body_link_lin_vel_w": ["body_link_vel_w"],
+    "body_link_ang_vel_w": ["body_link_vel_w"],
+    "body_link_pos_w": ["body_link_pose_w"],
+    "body_link_quat_w": ["body_link_pose_w"],
+    "body_com_pos_w": ["body_com_pose_w"],
+    "body_com_quat_w": ["body_com_pose_w"],
+    "body_com_lin_vel_w": ["body_com_vel_w"],
+    "body_com_ang_vel_w": ["body_com_vel_w"],
+    "body_com_lin_acc_w": ["body_com_acc_w"],
+    "body_com_ang_acc_w": ["body_com_acc_w"],
+    "body_com_quat_b": ["body_com_pose_b"],
+}
+
+
+# =============================================================================
+# Benchmark Functions
+# =============================================================================
+
+
+def get_benchmarkable_properties(rigid_object_data) -> list[str]:
+    """Get list of properties that can be benchmarked."""
+    all_properties = []
+
+    for name in dir(rigid_object_data):
+        if name.startswith("_"):
+            continue
+        if name in DEPRECATED_PROPERTIES:
+            continue
+        if name in NOT_IMPLEMENTED_PROPERTIES:
+            continue
+        if name in REMOVED_PROPERTIES:
+            continue
+        if name in INTERNAL_PROPERTIES:
+            continue
+
+        attr = getattr(type(rigid_object_data), name, None)
+        if isinstance(attr, property):
+            try:
+                getattr(rigid_object_data, name)
+            except NotImplementedError:
+                continue
+            all_properties.append(name)
+
+    return sorted(all_properties)
+
+
+def setup_mock_environment(config: MethodBenchmarkRunnerConfig) -> MockOvPhysxView:
+    """Set up the mock environment for benchmarking."""
+    bindings = MockOvPhysxBindingSet(
+        num_instances=config.num_instances,
+        num_bodies=1,
+        num_joints=0,
+        asset_kind="rigid_object",
+        benchmark_mode=True,
+    )
+    bindings.set_random_data()
+    return bindings.view
+
+
+def main():
+    """Main entry point for the benchmarking script."""
+    from isaaclab_ovphysx.assets.rigid_object.rigid_object_data import RigidObjectData
+
+    config = MethodBenchmarkRunnerConfig(
+        num_iterations=args.num_iterations,
+        warmup_steps=args.warmup_steps,
+        num_instances=args.num_instances,
+        num_bodies=1,
+        num_joints=0,
+        device=args.device,
+    )
+    mock_view = setup_mock_environment(config)
+    rigid_object_data = RigidObjectData(mock_view, config.device)
+    properties = get_benchmarkable_properties(rigid_object_data)
+
+    def gen_mock_data(_cfg: MethodBenchmarkRunnerConfig) -> dict:
+        rigid_object_data._sim_timestamp += 1.0
+        return {}
+
+    runner = MethodBenchmarkRunner(
+        benchmark_name="ovphysx_rigid_object_data_benchmark",
+        config=config,
+        backend_type=args.benchmark_formatter,
+        output_path=args.output_path,
+        use_recorders=True,
+    )
+    runner.run_property_benchmarks(
+        target_data=rigid_object_data,
+        properties=properties,
+        gen_mock_data=gen_mock_data,
+        dependencies=PROPERTY_DEPENDENCIES,
+        category="property",
+    )
+    runner.finalize()
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the OVPhysX contact sensor update path.
+
+Mirrors ``isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py`` but
+runs kitless against the OVPhysX backend. Also times the blocking native
+``read_net_forces`` fetch in isolation.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the OVPhysX contact sensor update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed simulation steps.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up steps.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import warp as wp
+from isaaclab_ovphysx.physics import OvPhysxCfg
+from isaaclab_ovphysx.sensors import ContactSensorCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils.configclass import configclass
+
+wp.init()
+
+
+@configclass
+class ContactSensorBenchmarkSceneCfg(InteractiveSceneCfg):
+    """Scene with one cube per environment and a contact sensor on the cube."""
+
+    terrain = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+
+    cube = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.5, 0.5, 0.5),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=False),
+            collision_props=sim_utils.CollisionPropertiesCfg(collision_enabled=True),
+            activate_contact_sensors=True,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.3)),
+    )
+
+    contact_sensor = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Cube",
+        track_air_time=True,
+        update_period=0.0,
+    )
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = SimulationCfg(dt=sim_dt, device=args_cli.device, physics=OvPhysxCfg(), gravity=(0.0, 0.0, -9.81))
+    with build_simulation_context(device=args_cli.device, sim_cfg=sim_cfg) as sim:
+        scene_cfg = ContactSensorBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs, env_spacing=2.0, lazy_sensor_update=False
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["contact_sensor"]
+
+        # warm-up: let the cubes settle on the ground
+        for _ in range(args_cli.warmup_steps):
+            sim.step()
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step()
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        # read-only phase: only the blocking native fetch, no warp kernel tail
+        read_only_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor._contact_binding.read_net_forces(sensor._net_forces_flat_buf)
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            read_only_ms.append((finished - start) * 1000.0)
+
+        net_forces = sensor.data.net_forces_w.torch
+        num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
+        if num_in_contact != args_cli.num_envs:
+            raise RuntimeError(f"Expected {args_cli.num_envs} contacting sensors, received {num_in_contact}.")
+
+        full_mean = statistics.mean(synchronized_ms)
+        read_mean = statistics.mean(read_only_ms)
+        print("-" * 80)
+        print("Contact sensor update benchmark (OVPhysX)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {full_mean:.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print(f"  read-only mean         : {read_mean:.3f} ms")
+        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
+        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
+        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
+        print("-" * 80)
+        print(f"  sensors in contact     : {num_in_contact} / {args_cli.num_envs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_contact_sensor.py
@@ -16,17 +16,29 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the OVPhysX contact sensor update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed simulation steps.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up steps.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import warp as wp
 from isaaclab_ovphysx.physics import OvPhysxCfg
@@ -34,6 +46,8 @@ from isaaclab_ovphysx.sensors import ContactSensorCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
 from isaaclab.terrains import TerrainImporterCfg
@@ -66,16 +80,6 @@ class ContactSensorBenchmarkSceneCfg(InteractiveSceneCfg):
     )
 
 
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
-
-
 def main() -> None:
     """Run the benchmark and print latency statistics."""
     sim_dt = 1.0 / 120.0
@@ -96,54 +100,68 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step()
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
 
-        # read-only phase: only the blocking native fetch, no warp kernel tail
-        read_only_ms: list[float] = []
-        for _ in range(args_cli.num_steps):
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor._contact_binding.read_net_forces(sensor._net_forces_flat_buf)
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            read_only_ms.append((finished - start) * 1000.0)
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
+
+        # Read-only phase: the blocking native fetch without the Warp kernel tail.
+        read_only_samples = [
+            measure_latency(
+                operation=lambda: sensor._contact_binding.read_net_forces(sensor._net_forces_flat_buf),
+                synchronize=synchronize,
+            )
+            for _ in range(args_cli.num_steps)
+        ]
 
         net_forces = sensor.data.net_forces_w.torch
         num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
         if num_in_contact != args_cli.num_envs:
             raise RuntimeError(f"Expected {args_cli.num_envs} contacting sensors, received {num_in_contact}.")
 
-        full_mean = statistics.mean(synchronized_ms)
-        read_mean = statistics.mean(read_only_ms)
-        print("-" * 80)
-        print("Contact sensor update benchmark (OVPhysX)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {full_mean:.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print(f"  read-only mean         : {read_mean:.3f} ms")
-        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
-        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
-        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
-        print("-" * 80)
-        print(f"  sensors in contact     : {num_in_contact} / {args_cli.num_envs}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="ovphysx_contact_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        full_stats = benchmark.add_latency_samples("sensor_update", samples)
+        read_stats = benchmark.add_latency_samples("native_read", read_only_samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+        )
+        benchmark.add_measurement(
+            "sensor_update",
+            measurement=SingleMeasurement(
+                name="Estimated Synchronized Non-read Time",
+                value=(full_stats.mean_s - read_stats.mean_s) * 1000.0,
+                unit="ms",
+            ),
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Sensors in Contact", value=num_in_contact, unit="count"),
+                SingleMeasurement(name="Expected Sensors", value=args_cli.num_envs, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_frame_transformer.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_frame_transformer.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the OVPhysX FrameTransformer update path.
+
+Mirrors ``isaaclab_physx/benchmark/sensors/benchmark_frame_transformer.py`` but
+runs kitless against the OVPhysX backend. Also times the per-body blocking
+``RIGID_BODY_POSE`` reads in isolation.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_frame_transformer.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the OVPhysX FrameTransformer update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--num_target_frames", type=int, default=4, help="Number of target frames per environment.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import isaaclab_ovphysx.tensor_types as TT
+import torch
+import warp as wp
+from isaaclab_ovphysx.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import FrameTransformerCfg, OffsetCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.utils.configclass import configclass
+
+wp.init()
+
+
+@configclass
+class FrameTransformerBenchmarkSceneCfg(InteractiveSceneCfg):
+    """Two kinematic rigid bodies and one FrameTransformer per environment."""
+
+    source = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Source",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True, disable_gravity=True),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.5)),
+    )
+    target = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Target",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True, disable_gravity=True),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.5)),
+    )
+    frame_transformer: FrameTransformerCfg | None = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = SimulationCfg(dt=sim_dt, device=args_cli.device, physics=OvPhysxCfg(), gravity=(0.0, 0.0, 0.0))
+    with build_simulation_context(device=args_cli.device, sim_cfg=sim_cfg) as sim:
+        scene_cfg = FrameTransformerBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=1.0,
+            lazy_sensor_update=True,
+        )
+        scene_cfg.frame_transformer = FrameTransformerCfg(
+            prim_path="{ENV_REGEX_NS}/Source",
+            target_frames=[
+                FrameTransformerCfg.FrameCfg(
+                    name=f"target_{index}",
+                    prim_path="{ENV_REGEX_NS}/Target",
+                    offset=OffsetCfg(pos=(0.0, 0.01 * index, 0.0)),
+                )
+                for index in range(args_cli.num_target_frames)
+            ],
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["frame_transformer"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step()
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step()
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        # read-only phase: only the blocking per-body native fetches, no warp kernels
+        read_only_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            for view, read_buf in zip(sensor._body_views, sensor._body_read_bufs):
+                view.read_into(TT.RIGID_BODY_POSE, read_buf)
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            read_only_ms.append((finished - start) * 1000.0)
+
+        target_positions = sensor.data.target_pos_w.torch
+        finite_frames = int(torch.isfinite(target_positions).all(dim=-1).sum().item())
+        expected_frames = args_cli.num_envs * args_cli.num_target_frames
+        if finite_frames != expected_frames:
+            raise RuntimeError(f"Expected {expected_frames} finite target frames, received {finite_frames}.")
+
+        full_mean = statistics.mean(synchronized_ms)
+        read_mean = statistics.mean(read_only_ms)
+        print("-" * 80)
+        print("FrameTransformer update benchmark (OVPhysX)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  target_frames_per_env  : {args_cli.num_target_frames}")
+        print(f"  tracked_body_views     : {len(sensor._body_views)}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {full_mean:.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print(f"  read-only mean         : {read_mean:.3f} ms")
+        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
+        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
+        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
+        print("-" * 80)
+        print(f"  finite target frames   : {finite_frames} / {expected_frames}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_frame_transformer.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_frame_transformer.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the OVPhysX FrameTransformer update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
@@ -23,11 +24,24 @@ parser.add_argument("--num_target_frames", type=int, default=4, help="Number of 
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_target_frames <= 0:
+    parser.error("--num_target_frames must be greater than zero")
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import isaaclab_ovphysx.tensor_types as TT
 import torch
@@ -36,6 +50,8 @@ from isaaclab_ovphysx.physics import OvPhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg, OffsetCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
@@ -65,16 +81,6 @@ class FrameTransformerBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.5)),
     )
     frame_transformer: FrameTransformerCfg | None = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -109,29 +115,29 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step()
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
 
-        # read-only phase: only the blocking per-body native fetches, no warp kernels
-        read_only_ms: list[float] = []
-        for _ in range(args_cli.num_steps):
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
+
+        # Read-only phase: the blocking per-body native fetches without Warp kernels.
+        def read_only() -> None:
             for view, read_buf in zip(sensor._body_views, sensor._body_read_bufs):
                 view.read_into(TT.RIGID_BODY_POSE, read_buf)
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            read_only_ms.append((finished - start) * 1000.0)
+
+        read_only_samples = [
+            measure_latency(operation=read_only, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
 
         target_positions = sensor.data.target_pos_w.torch
         finite_frames = int(torch.isfinite(target_positions).all(dim=-1).sum().item())
@@ -139,28 +145,41 @@ def main() -> None:
         if finite_frames != expected_frames:
             raise RuntimeError(f"Expected {expected_frames} finite target frames, received {finite_frames}.")
 
-        full_mean = statistics.mean(synchronized_ms)
-        read_mean = statistics.mean(read_only_ms)
-        print("-" * 80)
-        print("FrameTransformer update benchmark (OVPhysX)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  target_frames_per_env  : {args_cli.num_target_frames}")
-        print(f"  tracked_body_views     : {len(sensor._body_views)}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {full_mean:.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print(f"  read-only mean         : {read_mean:.3f} ms")
-        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
-        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
-        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
-        print("-" * 80)
-        print(f"  finite target frames   : {finite_frames} / {expected_frames}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="ovphysx_frame_transformer_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "target_frames_per_env": args_cli.num_target_frames,
+                "tracked_body_views": len(sensor._body_views),
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        full_stats = benchmark.add_latency_samples("sensor_update", samples)
+        read_stats = benchmark.add_latency_samples("native_read", read_only_samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+        )
+        benchmark.add_measurement(
+            "sensor_update",
+            measurement=SingleMeasurement(
+                name="Estimated Synchronized Non-read Time",
+                value=(full_stats.mean_s - read_stats.mean_s) * 1000.0,
+                unit="ms",
+            ),
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Target Frames", value=finite_frames, unit="count"),
+                SingleMeasurement(name="Expected Target Frames", value=expected_frames, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py
@@ -20,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark an OVPhysX IMU or PVA sensor update path.")
 parser.add_argument("--sensor", choices=("imu", "pva"), required=True, help="Sensor update path to benchmark.")
@@ -27,11 +28,22 @@ parser.add_argument("--num_envs", type=int, default=4096, help="Number of enviro
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
@@ -39,6 +51,8 @@ from isaaclab_ovphysx.physics import OvPhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ImuCfg, PvaCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
@@ -63,18 +77,8 @@ class ImuPvaBenchmarkSceneCfg(InteractiveSceneCfg):
     pva: PvaCfg | None = None
 
 
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
-
-
 def _read_only(sensor) -> None:
-    """Issue only the native OVPhysX reads performed by ``_update_buffers_impl``."""
+    """Issue only the native OVPhysX reads performed by the sensor update."""
     import isaaclab_ovphysx.tensor_types as TT
 
     sensor._root_view.read_into(TT.RIGID_BODY_POSE, sensor._transforms)
@@ -114,28 +118,26 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step()
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
 
-        # read-only phase: only the blocking native fetches, no warp kernel tail
-        read_only_ms: list[float] = []
-        for _ in range(args_cli.num_steps):
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            _read_only(sensor)
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            read_only_ms.append((finished - start) * 1000.0)
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
+
+        # Read-only phase: the blocking native fetches without the Warp kernel tail.
+        read_only_samples = [
+            measure_latency(operation=lambda: _read_only(sensor), synchronize=synchronize)
+            for _ in range(args_cli.num_steps)
+        ]
 
         lin_acc_b = sensor.data.lin_acc_b.torch
         ang_vel_b = sensor.data.ang_vel_b.torch
@@ -143,26 +145,41 @@ def main() -> None:
         if finite_instances != args_cli.num_envs:
             raise RuntimeError(f"Expected {args_cli.num_envs} finite sensor outputs, received {finite_instances}.")
 
-        full_mean = statistics.mean(synchronized_ms)
-        read_mean = statistics.mean(read_only_ms)
-        print("-" * 80)
-        print(f"{args_cli.sensor.upper()} update benchmark (OVPhysX)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {full_mean:.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print(f"  read-only mean         : {read_mean:.3f} ms")
-        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
-        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
-        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
-        print("-" * 80)
-        print(f"  finite sensor outputs  : {finite_instances} / {args_cli.num_envs}")
+        benchmark_name = f"ovphysx_{args_cli.sensor}_sensor"
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name=benchmark_name,
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "sensor": args_cli.sensor,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        full_stats = benchmark.add_latency_samples("sensor_update", samples)
+        read_stats = benchmark.add_latency_samples("native_read", read_only_samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+        )
+        benchmark.add_measurement(
+            "sensor_update",
+            measurement=SingleMeasurement(
+                name="Estimated Synchronized Non-read Time",
+                value=(full_stats.mean_s - read_stats.mean_s) * 1000.0,
+                unit="ms",
+            ),
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Sensor Outputs", value=finite_instances, unit="count"),
+                SingleMeasurement(name="Expected Sensor Outputs", value=args_cli.num_envs, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the OVPhysX IMU and PVA sensor update paths.
+
+Mirrors ``isaaclab_physx/benchmark/sensors/benchmark_imu_pva.py`` but runs
+kitless against the OVPhysX backend. In addition to the full-update timing it
+also times the blocking native reads and required staging copies so the derived
+processing share can be estimated.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py \
+        --sensor imu --num_envs 4096
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_imu_pva.py \
+        --sensor pva --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark an OVPhysX IMU or PVA sensor update path.")
+parser.add_argument("--sensor", choices=("imu", "pva"), required=True, help="Sensor update path to benchmark.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments and sensor instances.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_ovphysx.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import ImuCfg, PvaCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.utils.configclass import configclass
+
+wp.init()
+
+
+@configclass
+class ImuPvaBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One kinematic rigid body and one selected sensor per environment."""
+
+    body = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Body",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True, disable_gravity=True),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 0.5)),
+    )
+    imu: ImuCfg | None = None
+    pva: PvaCfg | None = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def _read_only(sensor) -> None:
+    """Issue only the native OVPhysX reads performed by ``_update_buffers_impl``."""
+    import isaaclab_ovphysx.tensor_types as TT
+
+    sensor._root_view.read_into(TT.RIGID_BODY_POSE, sensor._transforms)
+    sensor._root_view.read_into(TT.RIGID_BODY_VELOCITY, sensor._velocities)
+    if args_cli.sensor == "imu":
+        sensor._root_view.read_into(TT.RIGID_BODY_COM_POSE, sensor._coms_read_view)
+        if sensor._coms_read_view is not sensor._coms_gpu_view:
+            wp.copy(sensor._coms_gpu_view, sensor._coms_read_view)
+    else:
+        sensor._root_view.read_into(TT.RIGID_BODY_COM_POSE, sensor._coms_read_view)
+        if sensor._coms_read_view is not sensor._coms_buffer:
+            wp.copy(sensor._coms_buffer, sensor._coms_read_view)
+
+
+def main() -> None:
+    """Run the selected sensor benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = SimulationCfg(dt=sim_dt, device=args_cli.device, physics=OvPhysxCfg(), gravity=(0.0, 0.0, -9.81))
+    with build_simulation_context(device=args_cli.device, sim_cfg=sim_cfg) as sim:
+        scene_cfg = ImuPvaBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=1.0,
+            lazy_sensor_update=True,
+        )
+        if args_cli.sensor == "imu":
+            scene_cfg.imu = ImuCfg(prim_path="{ENV_REGEX_NS}/Body")
+        else:
+            scene_cfg.pva = PvaCfg(prim_path="{ENV_REGEX_NS}/Body")
+
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+        sensor = scene[args_cli.sensor]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step()
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step()
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        # read-only phase: only the blocking native fetches, no warp kernel tail
+        read_only_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            _read_only(sensor)
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            read_only_ms.append((finished - start) * 1000.0)
+
+        lin_acc_b = sensor.data.lin_acc_b.torch
+        ang_vel_b = sensor.data.ang_vel_b.torch
+        finite_instances = int((torch.isfinite(lin_acc_b).all(dim=-1) & torch.isfinite(ang_vel_b).all(dim=-1)).sum())
+        if finite_instances != args_cli.num_envs:
+            raise RuntimeError(f"Expected {args_cli.num_envs} finite sensor outputs, received {finite_instances}.")
+
+        full_mean = statistics.mean(synchronized_ms)
+        read_mean = statistics.mean(read_only_ms)
+        print("-" * 80)
+        print(f"{args_cli.sensor.upper()} update benchmark (OVPhysX)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {full_mean:.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print(f"  read-only mean         : {read_mean:.3f} ms")
+        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
+        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
+        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
+        print("-" * 80)
+        print(f"  finite sensor outputs  : {finite_instances} / {args_cli.num_envs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_joint_wrench.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_joint_wrench.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the OVPhysX JointWrench sensor update path.
+
+Mirrors ``isaaclab_physx/benchmark/sensors/benchmark_joint_wrench.py`` but runs
+kitless against the OVPhysX backend. Also times the blocking native
+``LINK_INCOMING_JOINT_FORCE`` read in isolation.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_joint_wrench.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the OVPhysX JointWrench sensor update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import isaaclab_ovphysx.tensor_types as TT
+import torch
+import warp as wp
+from isaaclab_ovphysx.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils  # noqa: F401
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import JointWrenchSensorCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_assets import CARTPOLE_CFG
+
+wp.init()
+
+
+@configclass
+class JointWrenchBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One cartpole articulation and JointWrench sensor per environment."""
+
+    robot = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency and output sanity statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = SimulationCfg(dt=sim_dt, device=args_cli.device, physics=OvPhysxCfg(), gravity=(0.0, 0.0, -9.81))
+    with build_simulation_context(device=args_cli.device, sim_cfg=sim_cfg) as sim:
+        scene_cfg = JointWrenchBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=4.0,
+            lazy_sensor_update=True,
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["joint_wrench"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step()
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step()
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        # read-only phase: only the blocking native fetch, no warp kernel tail
+        read_only_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor._root_view.read_into(TT.LINK_INCOMING_JOINT_FORCE, sensor._wrench_buf)
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            read_only_ms.append((finished - start) * 1000.0)
+
+        force = sensor.data.force.torch
+        torque = sensor.data.torque.torch
+        finite_wrenches = int((torch.isfinite(force).all(dim=-1) & torch.isfinite(torque).all(dim=-1)).sum().item())
+        nonzero_wrenches = int(((force != 0.0).any(dim=-1) | (torque != 0.0).any(dim=-1)).sum().item())
+        expected_wrenches = args_cli.num_envs * len(sensor.body_names)
+        if finite_wrenches != expected_wrenches:
+            raise RuntimeError(f"Expected {expected_wrenches} finite wrenches, received {finite_wrenches}.")
+        if nonzero_wrenches == 0:
+            raise RuntimeError("Expected at least one nonzero wrench.")
+
+        full_mean = statistics.mean(synchronized_ms)
+        read_mean = statistics.mean(read_only_ms)
+        print("-" * 80)
+        print("JointWrench sensor update benchmark (OVPhysX)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  bodies_per_env         : {len(sensor.body_names)}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {full_mean:.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print(f"  read-only mean         : {read_mean:.3f} ms")
+        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
+        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
+        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
+        print("-" * 80)
+        print(f"  finite wrenches        : {finite_wrenches} / {expected_wrenches}")
+        print(f"  nonzero wrenches       : {nonzero_wrenches} / {expected_wrenches}")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_joint_wrench.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_joint_wrench.py
@@ -16,17 +16,29 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the OVPhysX JointWrench sensor update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import isaaclab_ovphysx.tensor_types as TT
 import torch
@@ -34,6 +46,8 @@ import warp as wp
 from isaaclab_ovphysx.physics import OvPhysxCfg
 
 import isaaclab.sim as sim_utils  # noqa: F401
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.sim import SimulationCfg, build_simulation_context
@@ -50,16 +64,6 @@ class JointWrenchBenchmarkSceneCfg(InteractiveSceneCfg):
 
     robot = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
     joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -83,28 +87,29 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step()
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
 
-        # read-only phase: only the blocking native fetch, no warp kernel tail
-        read_only_ms: list[float] = []
-        for _ in range(args_cli.num_steps):
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor._root_view.read_into(TT.LINK_INCOMING_JOINT_FORCE, sensor._wrench_buf)
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            read_only_ms.append((finished - start) * 1000.0)
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
+
+        # Read-only phase: the blocking native fetch without the Warp kernel tail.
+        read_only_samples = [
+            measure_latency(
+                operation=lambda: sensor._root_view.read_into(TT.LINK_INCOMING_JOINT_FORCE, sensor._wrench_buf),
+                synchronize=synchronize,
+            )
+            for _ in range(args_cli.num_steps)
+        ]
 
         force = sensor.data.force.torch
         torque = sensor.data.torque.torch
@@ -116,28 +121,41 @@ def main() -> None:
         if nonzero_wrenches == 0:
             raise RuntimeError("Expected at least one nonzero wrench.")
 
-        full_mean = statistics.mean(synchronized_ms)
-        read_mean = statistics.mean(read_only_ms)
-        print("-" * 80)
-        print("JointWrench sensor update benchmark (OVPhysX)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  bodies_per_env         : {len(sensor.body_names)}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {full_mean:.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print(f"  read-only mean         : {read_mean:.3f} ms")
-        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
-        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
-        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
-        print("-" * 80)
-        print(f"  finite wrenches        : {finite_wrenches} / {expected_wrenches}")
-        print(f"  nonzero wrenches       : {nonzero_wrenches} / {expected_wrenches}")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="ovphysx_joint_wrench_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "bodies_per_env": len(sensor.body_names),
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        full_stats = benchmark.add_latency_samples("sensor_update", samples)
+        read_stats = benchmark.add_latency_samples("native_read", read_only_samples)
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+        )
+        benchmark.add_measurement(
+            "sensor_update",
+            measurement=SingleMeasurement(
+                name="Estimated Synchronized Non-read Time",
+                value=(full_stats.mean_s - read_stats.mean_s) * 1000.0,
+                unit="ms",
+            ),
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Wrenches", value=finite_wrenches, unit="count"),
+                SingleMeasurement(name="Nonzero Wrenches", value=nonzero_wrenches, unit="count"),
+                SingleMeasurement(name="Expected Wrenches", value=expected_wrenches, unit="count"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_ray_caster.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_ray_caster.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from functools import partial
 
 parser = argparse.ArgumentParser(description="Benchmark the OVPhysX RayCaster update path.")
 parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
@@ -24,11 +25,26 @@ parser.add_argument("--grid_resolution", type=float, default=0.25, help="Ray-gri
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
 args_cli = parser.parse_args()
-
-import statistics
-import time
+if args_cli.grid_size <= 0:
+    parser.error("--grid_size must be greater than zero")
+if args_cli.grid_resolution <= 0:
+    parser.error("--grid_resolution must be greater than zero")
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 import torch
 import warp as wp
@@ -36,6 +52,8 @@ from isaaclab_ovphysx.physics import OvPhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.sim import SimulationCfg, build_simulation_context
@@ -59,16 +77,6 @@ class RayCasterBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
     )
     ray_caster: RayCasterCfg | None = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -102,31 +110,31 @@ def main() -> None:
             sensor.update(sim_dt, force_recompute=True)
         wp.synchronize_device(sim.device)
 
-        synchronized_ms: list[float] = []
-        submission_ms: list[float] = []
+        synchronize = partial(wp.synchronize_device, sim.device)
+        samples = []
         for _ in range(args_cli.num_steps):
             sim.step()
-            wp.synchronize_device(sim.device)
-            start = time.perf_counter()
-            sensor.update(sim_dt, force_recompute=True)
-            submitted = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            finished = time.perf_counter()
-            synchronized_ms.append((finished - start) * 1000.0)
-            submission_ms.append((submitted - start) * 1000.0)
+            samples.append(
+                measure_latency(
+                    operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                    synchronize=synchronize,
+                )
+            )
 
-        # read-only phase: only the blocking native pose fetch, no raycast kernels
-        read_only_ms: list[float] = []
+        observer_samples = [
+            measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+        ]
+
+        # Read-only phase: the blocking native pose fetch without raycast kernels.
+        read_only_samples = []
         if sensor._ovphysx_body_view is not None:
-            for _ in range(args_cli.num_steps):
-                wp.synchronize_device(sim.device)
-                start = time.perf_counter()
-                sensor._ovphysx_body_view.read(sensor._pose_buf)
-                wp.synchronize_device(sim.device)
-                finished = time.perf_counter()
-                read_only_ms.append((finished - start) * 1000.0)
-        else:
-            read_only_ms = [0.0]
+            read_only_samples = [
+                measure_latency(
+                    operation=lambda: sensor._ovphysx_body_view.read(sensor._pose_buf),
+                    synchronize=synchronize,
+                )
+                for _ in range(args_cli.num_steps)
+            ]
 
         ray_hits = sensor.data.ray_hits_w.torch
         finite_hits = int(torch.isfinite(ray_hits).all(dim=-1).sum().item())
@@ -141,28 +149,42 @@ def main() -> None:
                 f"received maximum |z| {max_hit_height} m."
             )
 
-        full_mean = statistics.mean(synchronized_ms)
-        read_mean = statistics.mean(read_only_ms)
-        print("-" * 80)
-        print("RayCaster update benchmark (OVPhysX)")
-        print(f"  label                  : {args_cli.label}")
-        print(f"  device                 : {sim.device}")
-        print(f"  num_envs               : {args_cli.num_envs}")
-        print(f"  rays_per_env           : {sensor.num_rays}")
-        print(f"  num_steps              : {args_cli.num_steps}")
-        print(f"  synchronized mean      : {full_mean:.3f} ms")
-        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-        print(f"  read-only mean         : {read_mean:.3f} ms")
-        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
-        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
-        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
-        print("-" * 80)
-        print(f"  finite ray hits        : {finite_hits} / {expected_hits}")
-        print(f"  maximum |hit z|        : {max_hit_height:.6f} m")
+        benchmark = LatencyBenchmarkRunner(
+            benchmark_name="ovphysx_ray_caster_sensor",
+            formatter_type=args_cli.benchmark_formatter,
+            output_path=args_cli.output_path,
+            metadata={
+                "label": args_cli.label,
+                "device": str(sim.device),
+                "num_envs": args_cli.num_envs,
+                "rays_per_env": sensor.num_rays,
+                "num_steps": args_cli.num_steps,
+                "warmup_steps": args_cli.warmup_steps,
+            },
+        )
+        full_stats = benchmark.add_latency_samples("sensor_update", samples)
+        if read_only_samples:
+            read_stats = benchmark.add_latency_samples("native_read", read_only_samples)
+            benchmark.add_measurement(
+                "sensor_update",
+                measurement=SingleMeasurement(
+                    name="Estimated Synchronized Non-read Time",
+                    value=(full_stats.mean_s - read_stats.mean_s) * 1000.0,
+                    unit="ms",
+                ),
+            )
+        benchmark.add_synchronized_samples(
+            "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+        )
+        benchmark.add_measurement(
+            "validation",
+            measurement=[
+                SingleMeasurement(name="Finite Ray Hits", value=finite_hits, unit="count"),
+                SingleMeasurement(name="Expected Ray Hits", value=expected_hits, unit="count"),
+                SingleMeasurement(name="Maximum Absolute Hit Height", value=max_hit_height, unit="m"),
+            ],
+        )
+        benchmark.finalize()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_ovphysx/benchmark/sensors/benchmark_ray_caster.py
+++ b/source/isaaclab_ovphysx/benchmark/sensors/benchmark_ray_caster.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Benchmark the OVPhysX RayCaster update path.
+
+Mirrors ``isaaclab_physx/benchmark/sensors/benchmark_ray_caster.py`` but runs
+kitless against the OVPhysX backend. Also times the blocking native
+``RIGID_BODY_POSE`` binding read in isolation.
+
+Usage:
+    ./isaaclab.sh -p source/isaaclab_ovphysx/benchmark/sensors/benchmark_ray_caster.py --num_envs 4096
+"""
+
+from __future__ import annotations
+
+import argparse
+
+parser = argparse.ArgumentParser(description="Benchmark the OVPhysX RayCaster update path.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments.")
+parser.add_argument("--grid_size", type=float, default=1.0, help="Width and length [m] of each ray grid.")
+parser.add_argument("--grid_resolution", type=float, default=0.25, help="Ray-grid resolution [m].")
+parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
+parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
+parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--device", type=str, default="cuda:0", help="Simulation device.")
+args_cli = parser.parse_args()
+
+import statistics
+import time
+
+import torch
+import warp as wp
+from isaaclab_ovphysx.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import RayCasterCfg, patterns
+from isaaclab.sim import SimulationCfg, build_simulation_context
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils.configclass import configclass
+
+wp.init()
+
+
+@configclass
+class RayCasterBenchmarkSceneCfg(InteractiveSceneCfg):
+    """One kinematic sensor body per environment above a shared ground plane."""
+
+    ground = TerrainImporterCfg(prim_path="/World/ground", terrain_type="plane")
+    sensor_body = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/SensorBody",
+        spawn=sim_utils.CuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True, disable_gravity=True),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+    )
+    ray_caster: RayCasterCfg | None = None
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    """Return a linearly interpolated percentile for sorted scalar samples."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def main() -> None:
+    """Run the benchmark and print latency statistics."""
+    sim_dt = 1.0 / 120.0
+    sim_cfg = SimulationCfg(dt=sim_dt, device=args_cli.device, physics=OvPhysxCfg(), gravity=(0.0, 0.0, 0.0))
+    with build_simulation_context(device=args_cli.device, sim_cfg=sim_cfg) as sim:
+        scene_cfg = RayCasterBenchmarkSceneCfg(
+            num_envs=args_cli.num_envs,
+            env_spacing=2.0,
+            lazy_sensor_update=True,
+        )
+        scene_cfg.ray_caster = RayCasterCfg(
+            prim_path="{ENV_REGEX_NS}/SensorBody",
+            mesh_prim_paths=["/World/ground"],
+            ray_alignment="world",
+            pattern_cfg=patterns.GridPatternCfg(
+                resolution=args_cli.grid_resolution,
+                size=(args_cli.grid_size, args_cli.grid_size),
+                direction=(0.0, 0.0, -1.0),
+            ),
+        )
+        scene = InteractiveScene(scene_cfg)
+        sim.reset()
+        scene.reset()
+
+        sensor = scene["ray_caster"]
+
+        for _ in range(args_cli.warmup_steps):
+            sim.step()
+            sensor.update(sim_dt, force_recompute=True)
+        wp.synchronize_device(sim.device)
+
+        synchronized_ms: list[float] = []
+        submission_ms: list[float] = []
+        for _ in range(args_cli.num_steps):
+            sim.step()
+            wp.synchronize_device(sim.device)
+            start = time.perf_counter()
+            sensor.update(sim_dt, force_recompute=True)
+            submitted = time.perf_counter()
+            wp.synchronize_device(sim.device)
+            finished = time.perf_counter()
+            synchronized_ms.append((finished - start) * 1000.0)
+            submission_ms.append((submitted - start) * 1000.0)
+
+        # read-only phase: only the blocking native pose fetch, no raycast kernels
+        read_only_ms: list[float] = []
+        if sensor._ovphysx_body_view is not None:
+            for _ in range(args_cli.num_steps):
+                wp.synchronize_device(sim.device)
+                start = time.perf_counter()
+                sensor._ovphysx_body_view.read(sensor._pose_buf)
+                wp.synchronize_device(sim.device)
+                finished = time.perf_counter()
+                read_only_ms.append((finished - start) * 1000.0)
+        else:
+            read_only_ms = [0.0]
+
+        ray_hits = sensor.data.ray_hits_w.torch
+        finite_hits = int(torch.isfinite(ray_hits).all(dim=-1).sum().item())
+        expected_hits = args_cli.num_envs * sensor.num_rays
+        if finite_hits != expected_hits:
+            raise RuntimeError(f"Expected {expected_hits} finite ray hits, received {finite_hits}.")
+        max_hit_height = float(torch.abs(ray_hits[..., 2]).max().item())
+        hit_height_tolerance = 1.0e-4
+        if max_hit_height > hit_height_tolerance:
+            raise RuntimeError(
+                f"Expected ray hits within {hit_height_tolerance} m of the z=0 plane, "
+                f"received maximum |z| {max_hit_height} m."
+            )
+
+        full_mean = statistics.mean(synchronized_ms)
+        read_mean = statistics.mean(read_only_ms)
+        print("-" * 80)
+        print("RayCaster update benchmark (OVPhysX)")
+        print(f"  label                  : {args_cli.label}")
+        print(f"  device                 : {sim.device}")
+        print(f"  num_envs               : {args_cli.num_envs}")
+        print(f"  rays_per_env           : {sensor.num_rays}")
+        print(f"  num_steps              : {args_cli.num_steps}")
+        print(f"  synchronized mean      : {full_mean:.3f} ms")
+        print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
+        print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
+        print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
+        print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
+        print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
+        print(f"  read-only mean         : {read_mean:.3f} ms")
+        print(f"  read-only p50          : {_percentile(read_only_ms, 0.50):.3f} ms")
+        print(f"  read-only p95          : {_percentile(read_only_ms, 0.95):.3f} ms")
+        print(f"  implied kernel tail    : {full_mean - read_mean:.3f} ms")
+        print("-" * 80)
+        print(f"  finite ray hits        : {finite_hits} / {expected_hits}")
+        print(f"  maximum |hit z|        : {max_hit_height:.6f} m")
+
+
+if __name__ == "__main__":
+    main()

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-asset-micro-benchmarks.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-asset-micro-benchmarks.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added asset method and data property micro-benchmarks for the articulation,
+  rigid object, and rigid object collection classes.

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-sensor-micro-benchmarks.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-sensor-micro-benchmarks.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added update and backend-read micro-benchmarks for contact, frame transformer,
+  IMU, PVA, joint wrench, and ray caster sensors.

--- a/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-sensor-micro-benchmarks.minor.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-sensor-micro-benchmarks.minor.rst
@@ -1,5 +1,5 @@
 Added
 ^^^^^
 
-* Added update and backend-read micro-benchmarks for contact, frame transformer,
-  IMU, PVA, joint wrench, and ray caster sensors.
+* Added update and backend-read micro-benchmarks with structured results for
+  contact, frame transformer, IMU, PVA, joint wrench, and ray caster sensors.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/test/mock_interfaces/views/mock_ovphysx_bindings.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/test/mock_interfaces/views/mock_ovphysx_bindings.py
@@ -108,13 +108,20 @@ class MockTensorBinding:
             import warp as wp
 
             if isinstance(tensor, wp.array):
-                tmp = wp.from_numpy(self._data, dtype=wp.float32, device=tensor.device)
                 scalar = getattr(tensor.dtype, "_wp_scalar_type_", tensor.dtype)
                 if scalar is not wp.float32:
                     raise RuntimeError(
                         f"incompatible destination dtype: expected float32 scalar elements, got {tensor.dtype}"
                     )
                 destination = tensor if tensor.dtype == wp.float32 else tensor.view(wp.float32)
+                if self._benchmark_mode:
+                    key = (str(tensor.device), str(tensor.dtype))
+                    tmp = self._warp_sources.get(key)
+                    if tmp is None:
+                        tmp = wp.from_numpy(self._data, dtype=wp.float32, device=tensor.device)
+                        self._warp_sources[key] = tmp
+                else:
+                    tmp = wp.from_numpy(self._data, dtype=wp.float32, device=tensor.device)
                 wp.copy(destination, tmp)
                 return
         except ImportError:

--- a/source/isaaclab_ovphysx/test/assets/test_articulation_helpers.py
+++ b/source/isaaclab_ovphysx/test/assets/test_articulation_helpers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import warp as wp
 
@@ -137,3 +138,50 @@ def test_mock_binding_set_rigid_object_shapes():
     # Articulation-only bindings must be absent
     assert TT.DOF_POSITION not in bindings.bindings
     assert TT.LINK_WRENCH not in bindings.bindings
+
+
+def test_mock_binding_benchmark_mode_reuses_warp_source(monkeypatch):
+    """Benchmark reads should allocate their mock Warp source only once."""
+    from isaaclab_ovphysx import tensor_types as TT
+
+    bindings = MockOvPhysxBindingSet(num_instances=4, num_joints=1, num_bodies=2, benchmark_mode=True)
+    destination = wp.empty((4, 2), dtype=wp.spatial_vectorf, device="cpu")
+    from_numpy = wp.from_numpy
+    call_count = 0
+
+    def count_from_numpy(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return from_numpy(*args, **kwargs)
+
+    monkeypatch.setattr(wp, "from_numpy", count_from_numpy)
+    bindings.bindings[TT.LINK_VELOCITY].read(destination)
+    bindings.bindings[TT.LINK_VELOCITY].read(destination)
+
+    assert call_count == 1
+
+
+def test_mock_binding_benchmark_mode_skips_write_scatter():
+    """Benchmark writes should not include mock-only NumPy scatter work."""
+    from isaaclab_ovphysx import tensor_types as TT
+
+    bindings = MockOvPhysxBindingSet(num_instances=4, num_joints=1, num_bodies=2, benchmark_mode=True)
+    binding = bindings.bindings[TT.DOF_POSITION_TARGET]
+    initial_data = binding._data.copy()
+    values = wp.ones((4, 1), dtype=wp.float32, device="cpu")
+
+    binding.write(values)
+
+    np.testing.assert_array_equal(binding._data, initial_data)
+
+
+def test_mock_binding_read_preserves_structured_warp_dtype():
+    """Mock bindings should read flat component data into structured Warp arrays."""
+    from isaaclab_ovphysx import tensor_types as TT
+
+    bindings = MockOvPhysxBindingSet(num_instances=4, num_joints=1, num_bodies=2)
+    destination = wp.empty((4, 2), dtype=wp.spatial_vectorf, device="cpu")
+
+    bindings.bindings[TT.LINK_VELOCITY].read(destination)
+
+    assert destination.numpy().shape == (4, 2, 6)

--- a/source/isaaclab_physx/benchmark/assets/benchmark_articulation_data.py
+++ b/source/isaaclab_physx/benchmark/assets/benchmark_articulation_data.py
@@ -5,8 +5,8 @@
 
 """Micro-benchmarking framework for ArticulationData class.
 
-This module provides a benchmarking framework to measure the performance of all functions
-in the ArticulationData class. Each function is run multiple times with randomized mock data,
+This module provides a benchmarking framework to measure the performance of all properties
+in the ArticulationData class. Each property is run multiple times against preallocated mock data,
 and timing statistics (mean and standard deviation) are reported.
 
 Usage:
@@ -22,6 +22,7 @@ from __future__ import annotations
 """Launch Isaac Sim Simulator first."""
 
 import argparse
+import traceback
 
 from isaaclab.app import AppLauncher
 
@@ -51,8 +52,6 @@ simulation_app = app_launcher.app
 
 import warnings
 from unittest.mock import MagicMock
-
-import torch
 
 # Mock SimulationManager.get_physics_sim_view() to return a mock object with gravity
 # This is needed because the Data classes call SimulationManager.get_physics_sim_view().get_gravity()
@@ -186,12 +185,12 @@ INTERNAL_PROPERTIES = {
 PROPERTY_DEPENDENCIES = {
     "root_link_lin_vel_w": ["root_link_vel_w"],
     "root_link_ang_vel_w": ["root_link_vel_w"],
-    "root_link_lin_vel_b": ["root_link_vel_b"],
-    "root_link_ang_vel_b": ["root_link_vel_b"],
+    "root_link_lin_vel_b": ["root_link_lin_vel_w", "root_link_quat_w"],
+    "root_link_ang_vel_b": ["root_link_ang_vel_w", "root_link_quat_w"],
     "root_com_pos_w": ["root_com_pose_w"],
     "root_com_quat_w": ["root_com_pose_w"],
-    "root_com_lin_vel_b": ["root_com_vel_b"],
-    "root_com_ang_vel_b": ["root_com_vel_b"],
+    "root_com_lin_vel_b": ["root_com_lin_vel_w", "root_link_quat_w"],
+    "root_com_ang_vel_b": ["root_com_ang_vel_w", "root_link_quat_w"],
     "root_com_lin_vel_w": ["root_com_vel_w"],
     "root_com_ang_vel_w": ["root_com_vel_w"],
     "root_link_pos_w": ["root_link_pose_w"],
@@ -252,6 +251,38 @@ def setup_mock_environment(config: MethodBenchmarkRunnerConfig) -> MockArticulat
     return mock_view
 
 
+def configure_stable_state_views(mock_view: MockArticulationViewWarp) -> None:
+    """Configure zero-copy state getters matching the PhysX tensor API."""
+    mock_view.get_root_transforms = lambda: mock_view._as_structured(
+        mock_view._root_transforms, wp.transformf, (mock_view._count,)
+    )
+    mock_view.get_root_velocities = lambda: mock_view._as_structured(
+        mock_view._root_velocities, wp.spatial_vectorf, (mock_view._count,)
+    )
+    mock_view.get_link_transforms = lambda: mock_view._as_structured(
+        mock_view._link_transforms, wp.transformf, (mock_view._count, mock_view._num_links)
+    )
+    mock_view.get_link_velocities = lambda: mock_view._as_structured(
+        mock_view._link_velocities, wp.spatial_vectorf, (mock_view._count, mock_view._num_links)
+    )
+    mock_view.get_link_accelerations = lambda: mock_view._as_structured(
+        mock_view._link_accelerations, wp.spatial_vectorf, (mock_view._count, mock_view._num_links)
+    )
+    mock_view.get_dof_positions = lambda: mock_view._dof_positions
+    mock_view.get_dof_velocities = lambda: mock_view._dof_velocities
+
+
+def configure_dynamics_views(mock_view: MockArticulationViewWarp, config: MethodBenchmarkRunnerConfig) -> None:
+    """Configure stable buffers for solver-provided dynamics data."""
+    num_dofs = config.num_joints + 6
+    jacobians = wp.zeros((config.num_instances, config.num_bodies, 6, num_dofs), dtype=wp.float32, device=config.device)
+    mass_matrices = wp.zeros((config.num_instances, num_dofs, num_dofs), dtype=wp.float32, device=config.device)
+    gravity_forces = wp.zeros((config.num_instances, num_dofs), dtype=wp.float32, device=config.device)
+    mock_view.get_jacobians = lambda: jacobians
+    mock_view.get_generalized_mass_matrices = lambda: mass_matrices
+    mock_view.get_gravity_compensation_forces = lambda: gravity_forces
+
+
 def main():
     """Main entry point for the benchmarking script."""
     config = MethodBenchmarkRunnerConfig(
@@ -266,43 +297,20 @@ def main():
     # Setup mock environment
     mock_view = setup_mock_environment(config)
     mock_view.set_random_mock_data()
+    configure_stable_state_views(mock_view)
+    configure_dynamics_views(mock_view, config)
 
     # Create ArticulationData instance
     articulation_data = ArticulationData(mock_view, config.device)
+    articulation_data._apply_ordering_maps_after_resolve()
 
     # Get list of properties to benchmark
     properties = get_benchmarkable_properties(articulation_data)
 
-    # Generator that updates mock data and invalidates timestamp
-    def gen_mock_data(cfg: MethodBenchmarkRunnerConfig) -> dict:
-        mock_view.set_mock_coms(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_bodies, 7, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_inertias(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_bodies, 9, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_root_transforms(
-            wp.from_torch(torch.randn(cfg.num_instances, 7, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_root_velocities(
-            wp.from_torch(torch.randn(cfg.num_instances, 6, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_link_transforms(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_bodies, 7, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_link_velocities(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_bodies, 6, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_link_accelerations(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_bodies, 6, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_dof_positions(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_joints, device=cfg.device), dtype=wp.float32)
-        )
-        mock_view.set_mock_dof_velocities(
-            wp.from_torch(torch.randn(cfg.num_instances, cfg.num_joints, device=cfg.device), dtype=wp.float32)
-        )
+    # Advance the simulated step without allocating replacement state buffers.
+    def gen_mock_data(_cfg: MethodBenchmarkRunnerConfig) -> dict:
         articulation_data._sim_timestamp += 1.0
+        articulation_data._fk_timestamp = articulation_data._sim_timestamp
         return {}
 
     # Create runner
@@ -325,9 +333,14 @@ def main():
 
     runner.finalize()
 
-    # Close the simulation app
-    simulation_app.close()
-
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_contact_sensor.py
@@ -23,6 +23,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import traceback
+from functools import partial
 
 from isaaclab.app import AppLauncher
 
@@ -32,23 +34,40 @@ parser.add_argument("--num_steps", type=int, default=500, help="Number of timed 
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up steps.")
 parser.add_argument("--decimation", type=int, default=4, help="Physics steps per timed sensor cadence.")
 parser.add_argument("--history_length", type=int, default=0, help="Number of contact history frames.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument("--disable_graph", action="store_true", help="Disable CUDA graph capture of the sensor update.")
 
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
+if args_cli.decimation <= 0:
+    parser.error("--decimation must be greater than zero")
+if args_cli.history_length < 0:
+    parser.error("--history_length must be non-negative")
 
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""
 
-import statistics
-import time
-
 import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, LatencySample, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ContactSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -103,52 +122,71 @@ def main():
     wp.synchronize_device(sim.device)
 
     # Time only sensor work. Physics steps happen outside the timed regions.
-    cadence_times_ms = []
-    submit_times_ms = []
+    synchronize = partial(wp.synchronize_device, sim.device)
+    cadence_samples: list[LatencySample] = []
     for _ in range(args_cli.num_steps):
-        cadence_time_ms = 0.0
-        submit_time_ms = 0.0
+        cadence_synchronized = 0.0
+        cadence_submission = 0.0
         for _ in range(args_cli.decimation):
             sim.step(render=False)
-            wp.synchronize_device(sim.device)
-            t_start = time.perf_counter()
-            sensor.update(sim_dt)
-            t_submit = time.perf_counter()
-            wp.synchronize_device(sim.device)
-            cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
-            submit_time_ms += (t_submit - t_start) * 1000.0
+            sample = measure_latency(operation=lambda: sensor.update(sim_dt), synchronize=synchronize)
+            cadence_synchronized += sample.synchronized_s
+            cadence_submission += sample.submission_s
 
-        wp.synchronize_device(sim.device)
-        t_start = time.perf_counter()
-        _ = sensor.data
-        t_submit = time.perf_counter()
-        wp.synchronize_device(sim.device)
-        cadence_time_ms += (time.perf_counter() - t_start) * 1000.0
-        submit_time_ms += (t_submit - t_start) * 1000.0
-        cadence_times_ms.append(cadence_time_ms)
-        submit_times_ms.append(submit_time_ms)
+        sample = measure_latency(operation=lambda: getattr(sensor, "data"), synchronize=synchronize)
+        cadence_synchronized += sample.synchronized_s
+        cadence_submission += sample.submission_s
+        cadence_samples.append(LatencySample(submission_s=cadence_submission, synchronized_s=cadence_synchronized))
+
+    observer_synchronized_s = [
+        sum(
+            measure_latency(operation=lambda: None, synchronize=synchronize).synchronized_s
+            for _ in range(args_cli.decimation + 1)
+        )
+        for _ in range(args_cli.num_steps)
+    ]
 
     mode = "eager" if args_cli.disable_graph else "graph"
-    print("-" * 80)
-    print("Contact sensor cadence benchmark (PhysX)")
-    print(f"  mode                    : {mode}")
-    print(f"  device                  : {sim.device}")
-    print(f"  num_envs                : {args_cli.num_envs}")
-    print(f"  num_steps               : {args_cli.num_steps}")
-    print(f"  decimation              : {args_cli.decimation}")
-    print(f"  history_length          : {args_cli.history_length}")
-    print(f"  cadence mean (sync)     : {statistics.mean(cadence_times_ms):.3f} ms")
-    print(f"  cadence p50  (sync)     : {statistics.median(cadence_times_ms):.3f} ms")
-    print(f"  cadence min  (sync)     : {min(cadence_times_ms):.3f} ms")
-    print(f"  cadence submit mean     : {statistics.mean(submit_times_ms):.3f} ms")
-    print("-" * 80)
-
-    # sanity check: cubes rest on the ground, so every sensor must report an upward net force
+    # Cubes rest on the ground, so every sensor must report an upward net force.
     net_forces = sensor.data.net_forces_w.torch
     num_in_contact = int((net_forces.norm(dim=-1) > 0.1).sum().item())
-    print(f"  sensors in contact: {num_in_contact} / {args_cli.num_envs}")
+
+    if num_in_contact != args_cli.num_envs:
+        raise RuntimeError(f"Expected {args_cli.num_envs} contacting sensors, received {num_in_contact}.")
+
+    benchmark = LatencyBenchmarkRunner(
+        benchmark_name="physx_contact_sensor",
+        formatter_type=args_cli.benchmark_formatter,
+        output_path=args_cli.output_path,
+        metadata={
+            "mode": mode,
+            "device": str(sim.device),
+            "num_envs": args_cli.num_envs,
+            "num_steps": args_cli.num_steps,
+            "warmup_steps": args_cli.warmup_steps,
+            "decimation": args_cli.decimation,
+            "history_length": args_cli.history_length,
+        },
+    )
+    benchmark.add_latency_samples("sensor_cadence", cadence_samples)
+    benchmark.add_synchronized_samples("observer", "Synchronized Observer Floor", observer_synchronized_s)
+    benchmark.add_measurement(
+        "validation",
+        measurement=[
+            SingleMeasurement(name="Sensors in Contact", value=num_in_contact, unit="count"),
+            SingleMeasurement(name="Expected Sensors", value=args_cli.num_envs, unit="count"),
+        ],
+    )
+    benchmark.finalize()
 
 
 if __name__ == "__main__":
-    main()
-    simulation_app.close()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_frame_transformer.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_frame_transformer.py
@@ -16,6 +16,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import traceback
+from functools import partial
 
 from isaaclab.app import AppLauncher
 
@@ -25,6 +27,14 @@ parser.add_argument("--num_target_frames", type=int, default=4, help="Number of 
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument(
     "--disable_recorded_launch",
     action="store_true",
@@ -32,20 +42,27 @@ parser.add_argument(
 )
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
+if args_cli.num_target_frames <= 0:
+    parser.error("--num_target_frames must be greater than zero")
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Everything below follows application launch."""
 
-import statistics
-import time
-
 import torch
 import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg, OffsetCfg
 from isaaclab.utils.configclass import configclass
@@ -72,16 +89,6 @@ class FrameTransformerBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.5)),
     )
     frame_transformer: FrameTransformerCfg = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -119,40 +126,62 @@ def main() -> None:
         sensor.update(sim_dt, force_recompute=True)
     wp.synchronize_device(sim.device)
 
-    synchronized_ms: list[float] = []
-    submission_ms: list[float] = []
+    synchronize = partial(wp.synchronize_device, sim.device)
+    samples = []
     for _ in range(args_cli.num_steps):
         sim.step(render=False)
-        wp.synchronize_device(sim.device)
-        start = time.perf_counter()
-        sensor.update(sim_dt, force_recompute=True)
-        submitted = time.perf_counter()
-        wp.synchronize_device(sim.device)
-        finished = time.perf_counter()
-        synchronized_ms.append((finished - start) * 1000.0)
-        submission_ms.append((submitted - start) * 1000.0)
+        samples.append(
+            measure_latency(
+                operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                synchronize=synchronize,
+            )
+        )
+
+    observer_samples = [
+        measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+    ]
 
     target_positions = sensor.data.target_pos_w.torch
     finite_frames = int(torch.isfinite(target_positions).all(dim=-1).sum().item())
     expected_frames = args_cli.num_envs * args_cli.num_target_frames
 
-    print("-" * 80)
-    print("FrameTransformer update benchmark (PhysX)")
-    print(f"  label                  : {args_cli.label}")
-    print(f"  device                 : {sim.device}")
-    print(f"  num_envs               : {args_cli.num_envs}")
-    print(f"  target_frames_per_env  : {args_cli.num_target_frames}")
-    print(f"  num_steps              : {args_cli.num_steps}")
-    print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-    print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-    print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-    print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-    print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-    print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-    print("-" * 80)
-    print(f"  finite target frames   : {finite_frames} / {expected_frames}")
+    if finite_frames != expected_frames:
+        raise RuntimeError(f"Expected {expected_frames} finite target frames, received {finite_frames}.")
+
+    benchmark = LatencyBenchmarkRunner(
+        benchmark_name="physx_frame_transformer_sensor",
+        formatter_type=args_cli.benchmark_formatter,
+        output_path=args_cli.output_path,
+        metadata={
+            "label": args_cli.label,
+            "device": str(sim.device),
+            "num_envs": args_cli.num_envs,
+            "target_frames_per_env": args_cli.num_target_frames,
+            "num_steps": args_cli.num_steps,
+            "warmup_steps": args_cli.warmup_steps,
+        },
+    )
+    benchmark.add_latency_samples("sensor_update", samples)
+    benchmark.add_synchronized_samples(
+        "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+    )
+    benchmark.add_measurement(
+        "validation",
+        measurement=[
+            SingleMeasurement(name="Finite Target Frames", value=finite_frames, unit="count"),
+            SingleMeasurement(name="Expected Target Frames", value=expected_frames, unit="count"),
+        ],
+    )
+    benchmark.finalize()
 
 
 if __name__ == "__main__":
-    main()
-    simulation_app.close()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_imu_pva.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_imu_pva.py
@@ -15,6 +15,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import traceback
+from functools import partial
 
 from isaaclab.app import AppLauncher
 
@@ -24,6 +26,14 @@ parser.add_argument("--num_envs", type=int, default=4096, help="Number of enviro
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument(
     "--disable_recorded_launch",
     action="store_true",
@@ -31,20 +41,25 @@ parser.add_argument(
 )
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Everything below follows application launch."""
 
-import statistics
-import time
-
 import torch
 import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ImuCfg, PvaCfg
 from isaaclab.utils.configclass import configclass
@@ -64,16 +79,6 @@ class ImuPvaBenchmarkSceneCfg(InteractiveSceneCfg):
     )
     imu: ImuCfg | None = None
     pva: PvaCfg | None = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -104,39 +109,63 @@ def main() -> None:
         sensor.update(sim_dt, force_recompute=True)
     wp.synchronize_device(sim.device)
 
-    synchronized_ms: list[float] = []
-    submission_ms: list[float] = []
+    synchronize = partial(wp.synchronize_device, sim.device)
+    samples = []
     for _ in range(args_cli.num_steps):
         sim.step(render=False)
-        wp.synchronize_device(sim.device)
-        start = time.perf_counter()
-        sensor.update(sim_dt, force_recompute=True)
-        submitted = time.perf_counter()
-        wp.synchronize_device(sim.device)
-        finished = time.perf_counter()
-        synchronized_ms.append((finished - start) * 1000.0)
-        submission_ms.append((submitted - start) * 1000.0)
+        samples.append(
+            measure_latency(
+                operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                synchronize=synchronize,
+            )
+        )
+
+    observer_samples = [
+        measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+    ]
 
     lin_acc_b = sensor.data.lin_acc_b.torch
     ang_vel_b = sensor.data.ang_vel_b.torch
     finite_instances = int((torch.isfinite(lin_acc_b).all(dim=-1) & torch.isfinite(ang_vel_b).all(dim=-1)).sum())
 
-    print("-" * 80)
-    print(f"{args_cli.sensor.upper()} update benchmark (PhysX)")
-    print(f"  label                  : {args_cli.label}")
-    print(f"  device                 : {sim.device}")
-    print(f"  num_envs               : {args_cli.num_envs}")
-    print(f"  num_steps              : {args_cli.num_steps}")
-    print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-    print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-    print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-    print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-    print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-    print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-    print("-" * 80)
-    print(f"  finite sensor outputs  : {finite_instances} / {args_cli.num_envs}")
+    if finite_instances != args_cli.num_envs:
+        raise RuntimeError(f"Expected {args_cli.num_envs} finite sensor outputs, received {finite_instances}.")
+
+    benchmark_name = f"physx_{args_cli.sensor}_sensor"
+    benchmark = LatencyBenchmarkRunner(
+        benchmark_name=benchmark_name,
+        formatter_type=args_cli.benchmark_formatter,
+        output_path=args_cli.output_path,
+        metadata={
+            "label": args_cli.label,
+            "sensor": args_cli.sensor,
+            "device": str(sim.device),
+            "num_envs": args_cli.num_envs,
+            "num_steps": args_cli.num_steps,
+            "warmup_steps": args_cli.warmup_steps,
+        },
+    )
+    benchmark.add_latency_samples("sensor_update", samples)
+    benchmark.add_synchronized_samples(
+        "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+    )
+    benchmark.add_measurement(
+        "validation",
+        measurement=[
+            SingleMeasurement(name="Finite Sensor Outputs", value=finite_instances, unit="count"),
+            SingleMeasurement(name="Expected Sensor Outputs", value=args_cli.num_envs, unit="count"),
+        ],
+    )
+    benchmark.finalize()
 
 
 if __name__ == "__main__":
-    main()
-    simulation_app.close()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_joint_wrench.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_joint_wrench.py
@@ -16,6 +16,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import traceback
+from functools import partial
 
 from isaaclab.app import AppLauncher
 
@@ -24,6 +26,14 @@ parser.add_argument("--num_envs", type=int, default=4096, help="Number of enviro
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument(
     "--disable_recorded_launch",
     action="store_true",
@@ -31,20 +41,25 @@ parser.add_argument(
 )
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Everything below follows application launch."""
 
-import statistics
-import time
-
 import torch
 import warp as wp
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.utils.configclass import configclass
@@ -58,16 +73,6 @@ class JointWrenchBenchmarkSceneCfg(InteractiveSceneCfg):
 
     robot = CARTPOLE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
     joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -94,43 +99,66 @@ def main() -> None:
         sensor.update(sim_dt, force_recompute=True)
     wp.synchronize_device(sim.device)
 
-    synchronized_ms: list[float] = []
-    submission_ms: list[float] = []
+    synchronize = partial(wp.synchronize_device, sim.device)
+    samples = []
     for _ in range(args_cli.num_steps):
         sim.step(render=False)
-        wp.synchronize_device(sim.device)
-        start = time.perf_counter()
-        sensor.update(sim_dt, force_recompute=True)
-        submitted = time.perf_counter()
-        wp.synchronize_device(sim.device)
-        finished = time.perf_counter()
-        synchronized_ms.append((finished - start) * 1000.0)
-        submission_ms.append((submitted - start) * 1000.0)
+        samples.append(
+            measure_latency(
+                operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                synchronize=synchronize,
+            )
+        )
+
+    observer_samples = [
+        measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+    ]
 
     force = sensor.data.force.torch
     torque = sensor.data.torque.torch
     finite_wrenches = int((torch.isfinite(force).all(dim=-1) & torch.isfinite(torque).all(dim=-1)).sum().item())
     nonzero_wrenches = int(((force != 0.0).any(dim=-1) | (torque != 0.0).any(dim=-1)).sum().item())
     expected_wrenches = args_cli.num_envs * len(sensor.body_names)
+    if finite_wrenches != expected_wrenches:
+        raise RuntimeError(f"Expected {expected_wrenches} finite wrenches, received {finite_wrenches}.")
+    if nonzero_wrenches == 0:
+        raise RuntimeError("Expected at least one nonzero wrench.")
 
-    print("-" * 80)
-    print("JointWrench sensor update benchmark (PhysX)")
-    print(f"  label                  : {args_cli.label}")
-    print(f"  device                 : {sim.device}")
-    print(f"  num_envs               : {args_cli.num_envs}")
-    print(f"  bodies_per_env         : {len(sensor.body_names)}")
-    print(f"  num_steps              : {args_cli.num_steps}")
-    print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-    print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-    print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-    print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-    print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-    print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-    print("-" * 80)
-    print(f"  finite wrenches        : {finite_wrenches} / {expected_wrenches}")
-    print(f"  nonzero wrenches       : {nonzero_wrenches} / {expected_wrenches}")
+    benchmark = LatencyBenchmarkRunner(
+        benchmark_name="physx_joint_wrench_sensor",
+        formatter_type=args_cli.benchmark_formatter,
+        output_path=args_cli.output_path,
+        metadata={
+            "label": args_cli.label,
+            "device": str(sim.device),
+            "num_envs": args_cli.num_envs,
+            "bodies_per_env": len(sensor.body_names),
+            "num_steps": args_cli.num_steps,
+            "warmup_steps": args_cli.warmup_steps,
+        },
+    )
+    benchmark.add_latency_samples("sensor_update", samples)
+    benchmark.add_synchronized_samples(
+        "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+    )
+    benchmark.add_measurement(
+        "validation",
+        measurement=[
+            SingleMeasurement(name="Finite Wrenches", value=finite_wrenches, unit="count"),
+            SingleMeasurement(name="Nonzero Wrenches", value=nonzero_wrenches, unit="count"),
+            SingleMeasurement(name="Expected Wrenches", value=expected_wrenches, unit="count"),
+        ],
+    )
+    benchmark.finalize()
 
 
 if __name__ == "__main__":
-    main()
-    simulation_app.close()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/benchmark/sensors/benchmark_ray_caster.py
+++ b/source/isaaclab_physx/benchmark/sensors/benchmark_ray_caster.py
@@ -15,6 +15,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import traceback
+from functools import partial
 
 from isaaclab.app import AppLauncher
 
@@ -25,6 +27,14 @@ parser.add_argument("--grid_resolution", type=float, default=0.25, help="Ray-gri
 parser.add_argument("--num_steps", type=int, default=500, help="Number of timed updates.")
 parser.add_argument("--warmup_steps", type=int, default=50, help="Number of untimed warm-up updates.")
 parser.add_argument("--label", type=str, default="current", help="Label printed with the benchmark results.")
+parser.add_argument("--output_path", type=str, default=".", help="Output directory for benchmark results.")
+parser.add_argument(
+    "--benchmark_formatter",
+    type=str,
+    default="summary",
+    choices=["json", "osmo", "omniperf", "summary"],
+    help="Formatter used for benchmark results.",
+)
 parser.add_argument(
     "--disable_graph",
     action="store_true",
@@ -32,20 +42,29 @@ parser.add_argument(
 )
 AppLauncher.add_app_launcher_args(parser)
 args_cli = parser.parse_args()
+if args_cli.grid_size <= 0:
+    parser.error("--grid_size must be greater than zero")
+if args_cli.grid_resolution <= 0:
+    parser.error("--grid_resolution must be greater than zero")
+if args_cli.num_envs <= 0:
+    parser.error("--num_envs must be greater than zero")
+if args_cli.num_steps <= 0:
+    parser.error("--num_steps must be greater than zero")
+if args_cli.warmup_steps < 0:
+    parser.error("--warmup_steps must be non-negative")
 
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
 """Everything below follows application launch."""
 
-import statistics
-import time
-
 import torch
 import warp as wp
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
+from isaaclab.benchmark import LatencyBenchmarkRunner, SingleMeasurement
+from isaaclab.benchmark.micro import measure_latency
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import RayCasterCfg, patterns
 from isaaclab.utils.configclass import configclass
@@ -65,16 +84,6 @@ class RayCasterBenchmarkSceneCfg(InteractiveSceneCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
     )
     ray_caster: RayCasterCfg = None
-
-
-def _percentile(samples: list[float], percentile: float) -> float:
-    """Return a linearly interpolated percentile for sorted scalar samples."""
-    ordered = sorted(samples)
-    position = (len(ordered) - 1) * percentile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
 
 
 def main() -> None:
@@ -111,18 +120,20 @@ def main() -> None:
         sensor.update(sim_dt, force_recompute=True)
     wp.synchronize_device(sim.device)
 
-    synchronized_ms: list[float] = []
-    submission_ms: list[float] = []
+    synchronize = partial(wp.synchronize_device, sim.device)
+    samples = []
     for _ in range(args_cli.num_steps):
         sim.step(render=False)
-        wp.synchronize_device(sim.device)
-        start = time.perf_counter()
-        sensor.update(sim_dt, force_recompute=True)
-        submitted = time.perf_counter()
-        wp.synchronize_device(sim.device)
-        finished = time.perf_counter()
-        synchronized_ms.append((finished - start) * 1000.0)
-        submission_ms.append((submitted - start) * 1000.0)
+        samples.append(
+            measure_latency(
+                operation=lambda: sensor.update(sim_dt, force_recompute=True),
+                synchronize=synchronize,
+            )
+        )
+
+    observer_samples = [
+        measure_latency(operation=lambda: None, synchronize=synchronize) for _ in range(args_cli.num_steps)
+    ]
 
     ray_hits = sensor.data.ray_hits_w.torch
     finite_hits = int(torch.isfinite(ray_hits).all(dim=-1).sum().item())
@@ -137,24 +148,41 @@ def main() -> None:
             f"received maximum |z| {max_hit_height} m."
         )
 
-    print("-" * 80)
-    print("RayCaster update benchmark (PhysX)")
-    print(f"  label                  : {args_cli.label}")
-    print(f"  device                 : {sim.device}")
-    print(f"  num_envs               : {args_cli.num_envs}")
-    print(f"  rays_per_env           : {sensor.num_rays}")
-    print(f"  num_steps              : {args_cli.num_steps}")
-    print(f"  synchronized mean      : {statistics.mean(synchronized_ms):.3f} ms")
-    print(f"  synchronized p50       : {_percentile(synchronized_ms, 0.50):.3f} ms")
-    print(f"  synchronized p95       : {_percentile(synchronized_ms, 0.95):.3f} ms")
-    print(f"  submission mean        : {statistics.mean(submission_ms):.3f} ms")
-    print(f"  submission p50         : {_percentile(submission_ms, 0.50):.3f} ms")
-    print(f"  submission p95         : {_percentile(submission_ms, 0.95):.3f} ms")
-    print("-" * 80)
-    print(f"  finite ray hits        : {finite_hits} / {expected_hits}")
-    print(f"  maximum |hit z|        : {max_hit_height:.6f} m")
+    benchmark = LatencyBenchmarkRunner(
+        benchmark_name="physx_ray_caster_sensor",
+        formatter_type=args_cli.benchmark_formatter,
+        output_path=args_cli.output_path,
+        metadata={
+            "label": args_cli.label,
+            "device": str(sim.device),
+            "num_envs": args_cli.num_envs,
+            "rays_per_env": sensor.num_rays,
+            "num_steps": args_cli.num_steps,
+            "warmup_steps": args_cli.warmup_steps,
+        },
+    )
+    benchmark.add_latency_samples("sensor_update", samples)
+    benchmark.add_synchronized_samples(
+        "observer", "Synchronized Observer Floor", [s.synchronized_s for s in observer_samples]
+    )
+    benchmark.add_measurement(
+        "validation",
+        measurement=[
+            SingleMeasurement(name="Finite Ray Hits", value=finite_hits, unit="count"),
+            SingleMeasurement(name="Expected Ray Hits", value=expected_hits, unit="count"),
+            SingleMeasurement(name="Maximum Absolute Hit Height", value=max_hit_height, unit="m"),
+        ],
+    )
+    benchmark.finalize()
 
 
 if __name__ == "__main__":
-    main()
-    simulation_app.close()
+    try:
+        main()
+    except BaseException:
+        if simulation_app.config.get("fast_shutdown", False):
+            traceback.print_exc()
+        simulation_app.close(exit_code=1)
+        raise
+    else:
+        simulation_app.close()

--- a/source/isaaclab_physx/changelog.d/antoiner-articulation-micro-benchmarks.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-articulation-micro-benchmarks.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed articulation-data micro-benchmarks to use stable PhysX state, mass-property, and dynamics buffers.

--- a/source/isaaclab_physx/changelog.d/antoiner-sensor-latency-benchmark.rst
+++ b/source/isaaclab_physx/changelog.d/antoiner-sensor-latency-benchmark.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added structured summary and JSON output to PhysX sensor micro-benchmarks.

--- a/source/isaaclab_physx/isaaclab_physx/test/mock_interfaces/views/mock_articulation_view_warp.py
+++ b/source/isaaclab_physx/isaaclab_physx/test/mock_interfaces/views/mock_articulation_view_warp.py
@@ -400,7 +400,7 @@ class MockArticulationViewWarp:
         """
         if self._masses is None:
             self._masses = wp.ones((self._count, self._num_links), dtype=wp.float32, device="cpu")
-        return wp.clone(self._masses)
+        return self._masses
 
     def get_coms(self) -> wp.array:
         """Get centers of mass of all links.
@@ -426,7 +426,7 @@ class MockArticulationViewWarp:
                 inputs=[self._inertias],
                 device="cpu",
             )
-        return wp.clone(self._inertias)
+        return self._inertias
 
     def get_jacobians(self) -> wp.array:
         """Get COM-referenced geometric Jacobians of all links."""

--- a/source/isaaclab_physx/test/test_mock_interfaces/test_mock_articulation_view_warp.py
+++ b/source/isaaclab_physx/test/test_mock_interfaces/test_mock_articulation_view_warp.py
@@ -230,6 +230,13 @@ class TestMockArticulationViewWarpMassGetters:
         assert inertias.shape == (4, 13, 9)
         assert inertias.dtype == wp.float32
 
+    @pytest.mark.parametrize("getter_name", ["get_masses", "get_inertias"])
+    def test_get_mass_properties_returns_stable_view(self, view, getter_name):
+        """Test mass-property getters alias their stable PhysX-style buffers."""
+        getter = getattr(view, getter_name)
+
+        assert getter().ptr == getter().ptr
+
 
 class TestMockArticulationViewWarpSetters:
     """Tests for MockArticulationViewWarp setter methods."""


### PR DESCRIPTION
# Description

Documents why isolated asset and sensor micro-benchmarks exist, when to use them, and what they do not measure.

The guide covers:

- backend and workload coverage;
- prerequisites and commands;
- warm-up, sample-count, formatter, and output options;
- terminal summaries and structured JSON artifacts;
- synchronized completion, host submission, observer-floor, and native-read timing semantics;
- validation requirements and fair comparison rules;
- the distinction between mock-based asset benchmarks and live sensor scenes;
- guidance for extending and troubleshooting micro-benchmarks.

Published performance comparisons must use the designated benchmark workstation and record complete hardware and run provenance. Local runs remain appropriate for correctness and investigation.

## Dependencies

- Direct dependency: #6568.
- Transitive dependencies: #6474, #6564, #6565, #6566, and #6567.
- Satisfied prerequisite: #6553 is already merged.

This is the documentation tip of the micro-benchmark implementation stack.

## Type of change

- Documentation update

## Validation

- `./isaaclab.sh -p -m pytest source/isaaclab/test/benchmark` (184 passed on the integrated stack).
- `./isaaclab.sh -f`
- `./isaaclab.sh -d` (warning-free).
- `git diff --check`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] Existing benchmark tests cover the documented APIs
- [x] A changelog fragment is not required for this documentation-only PR
- [x] My name already exists in `CONTRIBUTORS.md`
