### PR TITLE
Update Newton FPGS non-WIP pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.2+head.f62c22207c"
 ovrtx = ">=0.3.0,<0.4.0"
 # FeatherPGS Newton fork commit + matching warp-lang prerelease (upgraded together).
-newton = "186502cec5db4b80a4cc235c9a6f5e4266ee2c07"
+newton = "aae676fee7b08c945aa2746f673fb924f2e12c22"
 warp = "1.15.0.dev20260626"
 
 [tool.ruff]
@@ -334,7 +334,7 @@ prerelease = "allow"
 # the CUDA indexes via [tool.uv.sources]. Values mirror [tool.isaaclab.versions] above.
 override-dependencies = [
     "numpy>=2",
-    "newton[sim] @ git+https://github.com/ooctipus/newton.git@186502cec5db4b80a4cc235c9a6f5e4266ee2c07",
+    "newton[sim] @ git+https://github.com/ooctipus/newton.git@aae676fee7b08c945aa2746f673fb924f2e12c22",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.3.1",
     "torch==2.11.0",


### PR DESCRIPTION
# Description

Updates the root Newton pin from 186502cec5db4b80a4cc235c9a6f5e4266ee2c07 to the public aae676fee7b08c945aa2746f673fb924f2e12c22 integration. The new commit brings Dylan Turpin’s June 19 non-WIP FPGS line onto the current Newton base while retaining the newer Newton APIs required by IsaacLab.

The dependency remains pinned to the public ooctipus/newton commit; this does not add a local path override. The imported matrix-free warm-start remains disabled by default and is not enabled by IsaacLab presets.

## Type of change

- Bug fix (non-breaking dependency update)

## Validation

- Newton pre-commit: all hooks passed
- Newton serial FeatherPGS suite: 25 passed
- IsaacLab test_uv_run_pyproject.py: 6 passed
- All applicable pre-commit hooks for pyproject.toml: passed
- Full IsaacLab all-files pre-commit was also run; code and style hooks passed, while the existing fpgs-dev golden-image Git LFS pointer gate reported unrelated baseline files

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the relevant pre-commit checks
- [x] My changes generate no new warnings
- [x] Existing focused tests cover this dependency-pin change
- [x] No package changelog fragment is needed for this root dependency-pin-only change
- [x] My name already exists in CONTRIBUTORS.md