### PR TITLE
Step Newton with one program and one capture policy

### DIFF
--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -495,9 +495,9 @@ class PhysicsManager(ABC):
         """Inform the physics backend how many substeps the environment runs per policy step.
 
         Backends that can fold the full decimation loop into a single
-        :meth:`step` call (e.g. Newton with all-graphable actuators) use this
-        to size their internal loop / CUDA graph.  The default implementation
-        is a no-op.
+        :meth:`step` call (e.g. Newton with the Newton actuator path active)
+        use this to size their internal loop / CUDA graph.  The default
+        implementation is a no-op.
 
         Args:
             decimation: Number of physics steps per environment step.

--- a/source/isaaclab_contrib/changelog.d/zhengyuz-fix-deferred-graph-capture.rst
+++ b/source/isaaclab_contrib/changelog.d/zhengyuz-fix-deferred-graph-capture.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the VBD deformable managers to hook their per-step BVH rebuild into
+  ``_simulate`` (the unified Newton step program) instead of the removed
+  ``_simulate_physics_only``.

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_featherstone_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_featherstone_vbd_manager.py
@@ -108,11 +108,11 @@ class NewtonCoupledFeatherstoneVBDManager(NewtonVBDManager):
             )
 
     @classmethod
-    def _simulate_physics_only(cls) -> None:
+    def _simulate(cls) -> None:
         # Rebuild BVH once per step for solvers that require it (e.g. VBD cloth).
         if hasattr(cls._soft_solver, "rebuild_bvh"):
             cls._soft_solver.rebuild_bvh(cls._state_0)
-        super()._simulate_physics_only()
+        super()._simulate()
 
     @classmethod
     def _step_kinematic(cls, state_in: State, state_out: State, control: Control, dt: float) -> None:

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_mjwarp_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/coupled_mjwarp_vbd_manager.py
@@ -92,11 +92,11 @@ class NewtonCoupledMJWarpVBDManager(NewtonVBDManager):
             raise ValueError(f"Unknown coupling_mode={cls._coupling_mode!r}; expected one of {{'one_way', 'two_way'}}.")
 
     @classmethod
-    def _simulate_physics_only(cls) -> None:
+    def _simulate(cls) -> None:
         # Rebuild BVH once per step for solvers that require it (e.g. VBD cloth).
         if hasattr(cls._soft_solver, "rebuild_bvh"):
             cls._soft_solver.rebuild_bvh(cls._state_0)
-        super()._simulate_physics_only()
+        super()._simulate()
 
     @classmethod
     def _step_one_way(cls, state_in: State, state_out: State, control: Control, dt: float) -> None:

--- a/source/isaaclab_contrib/isaaclab_contrib/deformable/vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/deformable/vbd_manager.py
@@ -251,8 +251,8 @@ class NewtonVBDManager(NewtonManager):
         NewtonManager._needs_collision_pipeline = True
 
     @classmethod
-    def _simulate_physics_only(cls) -> None:
+    def _simulate(cls) -> None:
         # Rebuild BVH once per step for solvers that require it (e.g. VBD cloth).
         if hasattr(cls._solver, "rebuild_bvh"):
             cls._solver.rebuild_bvh(cls._state_0)
-        super()._simulate_physics_only()
+        super()._simulate()

--- a/source/isaaclab_newton/changelog.d/zhengyuz-fix-deferred-graph-capture.minor.rst
+++ b/source/isaaclab_newton/changelog.d/zhengyuz-fix-deferred-graph-capture.minor.rst
@@ -1,0 +1,31 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_newton.physics.NewtonManager` to step through a
+  single program with per-stage toggles instead of two parallel step routines.
+  The private ``_simulate_full`` and ``_simulate_physics_only`` methods were
+  removed; subclasses that overrode them should override ``_simulate``
+  instead.
+* Changed :meth:`~isaaclab_newton.physics.NewtonManager.handles_decimation` to
+  return ``True`` whenever the Newton actuator path is active, including mixed
+  scenes with non-graph-safe actuators (previously only when every actuator
+  was CUDA-graph-safe). Environments now fold the decimation loop into one
+  :meth:`~isaaclab_newton.physics.NewtonManager.step` call for such scenes;
+  callers that stepped mixed scenes one sub-step at a time should gate on
+  ``handles_decimation()`` as the environments do.
+* Changed CUDA graph capture in
+  :class:`~isaaclab_newton.physics.NewtonManager` to a single deferral policy:
+  decision sites (solver initialization, decimation changes, hard resets) only
+  invalidate the graph, and the first
+  :meth:`~isaaclab_newton.physics.NewtonManager.step` afterwards captures it,
+  with the capture warmup counting as that step's physics advance. Exactly one
+  capture occurs per invalidation.
+
+Fixed
+^^^^^
+
+* Fixed the initial CUDA graph capture being skipped instead of deferred when
+  the Newton actuator fast path is active (``use_newton_actuators=True``):
+  callers that never set a decimation — plain
+  :class:`~isaaclab.sim.SimulationContext` loops — silently ran eager forever
+  despite requesting ``use_cuda_graph=True``.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -306,18 +306,23 @@ class NewtonManager(PhysicsManager):
 
     # Newton actuator adapter (owns actuators and double-buffered states)
     _adapter: NewtonActuatorAdapter | None = None
-    # In-graph hooks invoked after the actuator step and before the solver
-    # substeps, in registration order. Multiple articulations register their
+    # Per-iteration hooks invoked after the actuator stage and before the
+    # solver substeps, in registration order (captured into whichever CUDA
+    # graph records the iteration). Multiple articulations register their
     # implicit-DOF telemetry / FF-routing kernels here.
     _post_actuator_callbacks: list[Callable[[], None]] = []
-    # In-graph hooks invoked after the last solver substep and before sensors,
-    # in registration order. Articulations with non-identity ordering register
-    # their backend-to-user state republish kernels here so the reorders are
-    # recorded into every captured graph.
+    # Per-step tail hooks invoked after the last solver substep and before
+    # sensors, in registration order. Articulations with non-identity ordering
+    # register their backend-to-user state republish kernels here; the tail is
+    # captured into the whole-program graph when all actuators are graph-safe.
     _post_step_callbacks: list[Callable[[], None]] = []
 
     # CUDA graphing
+    # Whole-step graph: the full _simulate() program (all actuators graph-safe).
     _graph = None
+    # Per-iteration graph: one decimation iteration without the actuator stage,
+    # replayed by _simulate() when some actuator must be stepped eagerly.
+    _iteration_graph = None
     _graph_capture_pending: bool = False
 
     # USD/Fabric sync
@@ -424,8 +429,7 @@ class NewtonManager(PhysicsManager):
         if not soft:
             # Release the cached collision pipeline, contacts and CUDA graph;
             # they point at the old model's freed buffers (CUDA 700 on next step).
-            NewtonManager._graph = None
-            NewtonManager._graph_capture_pending = False
+            cls._invalidate_graph()
             NewtonManager._collision_pipeline = None
             NewtonManager._contacts = None
 
@@ -684,7 +688,7 @@ class NewtonManager(PhysicsManager):
         """Flag that all physics state has changed and Fabric needs re-sync.
 
         Convenience method that marks both transforms and particles dirty.
-        Called by :meth:`_simulate` after stepping.
+        Called by :meth:`step` after stepping.
         """
         cls._mark_transforms_dirty()
         cls._mark_particles_dirty()
@@ -716,27 +720,27 @@ class NewtonManager(PhysicsManager):
     def step(cls) -> None:
         """Step the physics simulation.
 
-        The stepping logic follows one of two paths depending on whether
-        **all** actuators are CUDA-graph-safe:
+        One program (:meth:`_simulate`) serves every scene; per-stage toggles
+        select its shape:
 
-        **All-graphable path** (:meth:`_simulate_full`):
+        * **Loop ownership**: when :meth:`handles_decimation` is ``True`` one
+          call runs the env's full ``decimation`` loop, otherwise the env
+          drives the loop and one call covers exactly one sub-step.
+        * **Actuator stage**: graph-safe actuators run inside the iteration;
+          otherwise the adapter is stepped eagerly before each iteration,
+          outside any captured span.
+        * **Execution**: all-graphable scenes replay the whole program from a
+          single CUDA graph; mixed scenes replay a per-iteration graph from
+          inside the eager loop; without CUDA graphs everything runs eagerly.
 
-        Actuators and solver substeps are captured together in a single
-        CUDA graph containing the full
-        ``decimation x (actuators + solver substeps)`` loop.
+        The sequence within one iteration is::
 
-        **Eager-actuator path** (fallback, some actuators not graph-safe):
-
-        Actuators are stepped eagerly on the CPU timeline (outside the
-        graph), then a graph containing only the solver substeps is
-        launched via :meth:`_simulate_physics_only`.
-
-        In both paths the sequence within one physics step is::
-
-            zero actuated DOFs in control.joint_f
-            -> actuator.step (computes effort, writes to control.joint_f)
+            collision collide
+            -> actuator.step (zeroes actuated DOFs, writes efforts to control.joint_f)
+            -> post-actuator hooks
             -> solver.step x num_substeps (integrates, reads control.joint_f)
-            -> sensors.update
+
+        followed once per call by the post-step hooks and sensor updates.
         """
         sim = PhysicsManager._sim
         if sim is None or not sim.is_playing():
@@ -751,50 +755,59 @@ class NewtonManager(PhysicsManager):
                     cls._solver.notify_model_changed(change)
                 NewtonManager._model_changes = set()
 
-        # Lazy CUDA graph capture
+        # Sole CUDA graph capture site: decision sites (initialize_solver,
+        # set_decimation, hard reset) only invalidate via _invalidate_graph;
+        # the first step after an invalidation consumes the pending flag here.
         cfg = PhysicsManager._cfg
         device = PhysicsManager._device
-        if cls._graph_capture_pending and cfg is not None and cfg.use_cuda_graph and "cuda" in device:  # type: ignore[union-attr]
+        stepped_via_warmup = False
+        if (
+            cls._graph_capture_pending
+            and cfg is not None
+            and cfg.use_cuda_graph
+            and "cuda" in device
+            and _cudart is not None  # no libcudart: capture is impossible AND the
+            # warmup never runs, so this tick must execute normally below
+        ):
             NewtonManager._graph_capture_pending = False
-            NewtonManager._graph = cls._capture_relaxed_graph(device)
-            if cls._graph is not None:
-                # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                # first step() inside graph capture. Replay once to pin those
-                # memory-pool addresses before any eager solver.reset() call.
-                if isinstance(cls._solver, SolverKamino):
-                    wp.capture_launch(cls._graph)
-                logger.info("Newton CUDA graph captured (deferred relaxed mode, RTX-compatible)")
+            if cls._is_all_graphable():
+                # Whole program (decimation loop + tail) in one graph.
+                captured = NewtonManager._graph = cls._capture_relaxed_graph(
+                    device, warmup=cls._simulate, capture=cls._simulate
+                )
+            else:
+                # Some actuator must stay eager: capture one iteration without
+                # the actuator stage; _simulate() replays it per iteration.
+                physics_dt = cls._solver_dt * cls._num_substeps
+                contacts = cls._contacts if cls._needs_collision_pipeline else None
+                captured = NewtonManager._iteration_graph = cls._capture_relaxed_graph(
+                    device,
+                    warmup=cls._simulate,
+                    capture=lambda: cls._iteration_stages(physics_dt, contacts, include_actuator_stage=False),
+                )
+            # The capture warmup ran _simulate() eagerly and already advanced
+            # physics: it counts as this tick's step, so the execute branch
+            # below is skipped (running it again would double-advance).
+            stepped_via_warmup = True
+            if captured is not None:
+                logger.info("Newton CUDA graph captured on first step after invalidation")
             else:
                 logger.warning("Newton deferred CUDA graph capture failed; using eager execution")
 
-        # Reconcile authored state after any mutating graph warmup and before the requested physics step.
+        # Reconcile authored state: after the mutating capture warmup on a
+        # capture tick, before the physics step on every other tick.
         cls.forward()
 
         physics_dt = cls._solver_dt * cls._num_substeps
         use_graph = cfg is not None and cfg.use_cuda_graph and cls._graph is not None and "cuda" in device  # type: ignore[union-attr]
 
-        if cls._is_all_graphable():
-            # --- All actuators are graph-safe: actuators + solver in one graph ---
-            if use_graph:
+        if not stepped_via_warmup:
+            if use_graph and cls._is_all_graphable():
                 wp.capture_launch(cls._graph)
             else:
                 with wp.ScopedDevice(device):
-                    cls._simulate_full()
-            PhysicsManager._sim_time += physics_dt * cls._decimation
-        else:
-            # --- Some actuators not graph-safe: step them eagerly, graph solver only ---
-            if cls._adapter is not None:
-                cls._adapter.step(cls._state_0, cls._control, physics_dt)
-            for cb in cls._post_actuator_callbacks:
-                cb()
-
-            if use_graph:
-                wp.capture_launch(cls._graph)
-            else:
-                with wp.ScopedDevice(device):
-                    cls._simulate_physics_only()
-            PhysicsManager._sim_time += physics_dt
+                    cls._simulate()
+        PhysicsManager._sim_time += physics_dt * (cls._decimation if cls.handles_decimation() else 1)
 
         if cls._usdrt_stage is not None:
             cls._mark_state_dirty()
@@ -873,15 +886,17 @@ class NewtonManager(PhysicsManager):
         NewtonManager._post_actuator_callbacks = []
         NewtonManager._post_step_callbacks = []
         # Set by an articulation that took the ``use_newton_actuators=True``
-        # branch in ``_process_actuators_cfg``.  Together with the adapter
-        # check, this gates whether the decimation loop can be captured into
-        # a CUDA graph (see :meth:`_is_all_graphable`).
+        # branch in ``_process_actuators_cfg``.  Makes the manager own the
+        # decimation loop (see :meth:`handles_decimation`); together with the
+        # adapter check it also gates whole-program graph capture
+        # (see :meth:`_is_all_graphable`).
         NewtonManager._use_newton_actuators_active = False
         NewtonManager._decimation = 1
         # Per-world reset masks
         NewtonManager._world_reset_mask = None
         NewtonManager._fk_reset_mask = None
         NewtonManager._graph = None
+        NewtonManager._iteration_graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._newton_stage_path = None
         NewtonManager._usdrt_stage = None
@@ -1597,15 +1612,8 @@ class NewtonManager(PhysicsManager):
         Thin orchestrator: delegates solver construction to
         :meth:`_build_solver` (overridden by each solver subclass), allocates
         the collision pipeline (when applicable) via
-        :meth:`_initialize_contacts`, then sets up cubric bindings and either
-        captures the CUDA graph immediately or defers capture until the
-        first :meth:`step` call (RTX-active path).
-
-        .. warning::
-            When using a CUDA-enabled device, the simulation is graphed.
-            This means the function steps the simulation once to capture the
-            graph, so it should only be called after everything else in the
-            simulation is initialized.
+        :meth:`_initialize_contacts`, then sets up cubric bindings and
+        invalidates the CUDA graph so the first :meth:`step` captures it.
         """
         cfg = PhysicsManager._cfg
         if cfg is None:
@@ -1634,24 +1642,16 @@ class NewtonManager(PhysicsManager):
 
         # Establish the initial kinematically-consistent body state through the
         # solver-specialized FK delegate, now that the solver and the delegate both exist.
-        # Runs before graph capture below so the capture warmup sees a valid body_q.
+        # Runs before the first step() so its capture warmup sees a valid body_q.
         cls._eval_fk(None, None)
 
         if cls._usdrt_stage is not None:
             cls._setup_cubric_bindings()
 
-        # Skip the initial graph capture when the Newton actuator fast path is
-        # active. Capturing here would use ``cls._decimation`` (still its default
-        # of 1, because the env's ``set_decimation`` hasn't run yet); a second
-        # capture from ``set_decimation`` then triggers an illegal-memory-access
-        # CUDA fault inside the captured ``_simulate_full`` graph (back-to-back
-        # captures of the contact + actuator pipeline don't survive re-capture
-        # — root cause is in Newton's collision/actuator buffer handling, not
-        # Lab code). For non-Newton-actuator paths this branch is unaffected:
-        # ``set_decimation`` is a no-op for them (``_is_all_graphable`` is False),
-        # so we still need the start-time capture below.
-        if not cls._use_newton_actuators_active:
-            cls._capture_or_defer_graph()
+        # A capture here would bake in stale settings (e.g. the env's
+        # decimation is not known yet); invalidate instead and let the first
+        # step() capture.
+        cls._invalidate_graph()
 
     @classmethod
     def _setup_cubric_bindings(cls) -> None:
@@ -1672,59 +1672,30 @@ class NewtonManager(PhysicsManager):
             logger.warning("cubric bindings init failed; falling back to update_world_xforms()")
 
     @classmethod
-    def _capture_or_defer_graph(cls) -> None:
-        """Capture (or schedule deferred capture of) the CUDA graph.
+    def _invalidate_graph(cls) -> None:
+        """Drop the captured CUDA graphs and owe a re-capture to the next :meth:`step`.
 
-        Called by :meth:`start_simulation` and :meth:`set_decimation`
-        whenever the graph needs to be (re-)captured.
-
-        * **No USDRT / headless**: captures immediately via
-          ``wp.ScopedCapture``.
-        * **RTX active**: defers capture to the first :meth:`step` call
-          via :meth:`_capture_relaxed_graph`, because RTX background
-          streams are not yet idle during initialisation.
-        * **CUDA graphs disabled**: clears the graph reference.
+        This is the single deferral policy behind every decision site
+        (:meth:`initialize_solver`, :meth:`set_decimation`, hard
+        :meth:`reset`): decision sites never capture, they only invalidate.
+        The pending flag is consumed by the sole capture site in
+        :meth:`step`, which captures via :meth:`_capture_relaxed_graph`.
+        One capture per invalidation makes back-to-back captures — which
+        CUDA-fault inside the contact + actuator pipeline — structurally
+        impossible.
         """
         cfg = PhysicsManager._cfg
         device = PhysicsManager._device
-        if cfg is None or device is None:
-            return
-
-        use_cuda_graph = cfg.use_cuda_graph and "cuda" in device
+        use_cuda_graph = cfg is not None and device is not None and cfg.use_cuda_graph and "cuda" in device
         if use_cuda_graph and not cls._supports_cuda_graph_capture():
-            NewtonManager._graph = None
-            NewtonManager._graph_capture_pending = False
+            use_cuda_graph = False
             logger.warning(
                 "%s does not support CUDA graph capture for the current solver configuration; using eager execution.",
                 cls.__name__,
             )
-            return
-
-        if use_cuda_graph:
-            with Timer(name="newton_cuda_graph", msg="CUDA graph took:"):
-                if cls._usdrt_stage is None:
-                    simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
-                    with _paused_gc(), wp.ScopedCapture(device=device) as capture:
-                        simulate()
-                    NewtonManager._graph = capture.graph
-                    logger.info("Newton CUDA graph captured (standard Warp mode)")
-
-                    # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
-                    # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
-                    # first step() inside graph capture. Replay once to pin those
-                    # memory-pool addresses before any eager solver.reset() call.
-                    if isinstance(cls._solver, SolverKamino):
-                        wp.capture_launch(cls._graph)
-                else:
-                    # RTX is active during initialization — cudaImportExternalMemory and other
-                    # non-capturable RTX ops run on background CUDA streams right now.
-                    # Defer capture to the first step() call, after RTX is fully initialized
-                    # and idle between render frames (clean capture window).
-                    NewtonManager._graph = None
-                    NewtonManager._graph_capture_pending = True
-                    logger.info("Newton CUDA graph capture deferred until first step() (RTX active)")
-        else:
-            NewtonManager._graph = None
+        NewtonManager._graph = None
+        NewtonManager._iteration_graph = None
+        NewtonManager._graph_capture_pending = use_cuda_graph
 
     @classmethod
     def _supports_cuda_graph_capture(cls) -> bool:
@@ -1732,8 +1703,15 @@ class NewtonManager(PhysicsManager):
         return True
 
     @classmethod
-    def _capture_relaxed_graph(cls, device: str):
-        """Capture Newton physics (only) as a CUDA graph, RTX-compatible.
+    def _capture_relaxed_graph(cls, device: str, warmup: Callable[[], None], capture: Callable[[], None]):
+        """Capture ``capture`` as a CUDA graph. The sole capture routine.
+
+        Valid both headless and with RTX active. ``warmup`` — always
+        :meth:`_simulate`, of which ``capture`` records the whole program or
+        one iteration — runs eagerly first: it pre-allocates every scratch
+        buffer the capture will touch and advances physics by one true step,
+        so the calling tick must count the warmup as its step (see the
+        consume block in :meth:`step`).
 
         Uses a hybrid approach to work around two conflicting requirements:
 
@@ -1778,9 +1756,8 @@ class NewtonManager(PhysicsManager):
 
         # Warmup: pre-allocate all solver scratch buffers so the capture window has
         # no new cudaMalloc calls (which are forbidden inside graph capture).
-        simulate = cls._simulate_full if cls._is_all_graphable() else cls._simulate_physics_only
         with wp.ScopedDevice(device):
-            simulate()
+            warmup()
         wp.synchronize_stream(wp.get_stream(device))
 
         # Create a non-blocking stream (cudaStreamNonBlocking = 0x01).
@@ -1814,7 +1791,7 @@ class NewtonManager(PhysicsManager):
             err_during_capture = None
             with wp.ScopedStream(fresh_stream, sync_enter=False):
                 try:
-                    simulate()
+                    capture()
                 except Exception as exc:
                     err_during_capture = exc
 
@@ -1852,10 +1829,17 @@ class NewtonManager(PhysicsManager):
         # the next capture_launch.  Replace with public API when available.
         graph.graph = raw_graph
         graph.graph_exec = None
+
+        # Kamino: StateKamino.from_newton() lazily allocates body_f_total,
+        # joint_q_prev, and joint_lambdas via wp.clone/wp.zeros during the
+        # first step() inside graph capture. Replay once to pin those
+        # memory-pool addresses before any eager solver.reset() call.
+        if isinstance(cls._solver, SolverKamino):
+            wp.capture_launch(graph)
         return graph
 
     # ------------------------------------------------------------------
-    # Building blocks — used by _simulate_full / _simulate_physics_only
+    # Building blocks — used by _simulate
     # ------------------------------------------------------------------
 
     @classmethod
@@ -1901,51 +1885,62 @@ class NewtonManager(PhysicsManager):
                 sensor.update(cls._state_0, eval_contacts)
 
     # ------------------------------------------------------------------
-    # Composite stepping routines
+    # The step program
     # ------------------------------------------------------------------
 
     @classmethod
-    def _simulate_full(cls) -> None:
-        """Run ``decimation x (actuators + solver substeps)``, then sensors.
+    def _iteration_stages(cls, physics_dt: float, contacts, include_actuator_stage: bool) -> None:
+        """Run one decimation iteration: collide, actuators, post-actuator hooks, substeps.
 
-        Works for any decimation count (including 1).  All actuators must be
-        graph-safe so the entire loop can be captured as a single CUDA graph.
+        Args:
+            physics_dt: Duration of one physics step [s].
+            contacts: Contact buffer to feed the solver, or ``None``.
+            include_actuator_stage: Run :meth:`NewtonActuatorAdapter.step` inside
+                the iteration. ``False`` when the adapter is stepped eagerly
+                outside a captured span (see :meth:`_simulate`).
         """
-        physics_dt = cls._solver_dt * cls._num_substeps
-        contacts = cls._contacts if cls._needs_collision_pipeline else None
+        if cls._needs_collision_pipeline:
+            cls._collision_pipeline.collide(cls._state_0, cls._contacts)
+        if include_actuator_stage and cls._adapter is not None:
+            cls._adapter.step(cls._state_0, cls._control, physics_dt)
+        for cb in cls._post_actuator_callbacks:
+            cb()
+        cls._run_solver_substeps(contacts)
 
-        for _ in range(cls._decimation):
-            if cls._needs_collision_pipeline:
-                cls._collision_pipeline.collide(cls._state_0, cls._contacts)
-
-            if cls._adapter is not None:
-                cls._adapter.step(cls._state_0, cls._control, physics_dt)
-            for cb in cls._post_actuator_callbacks:
-                cb()
-
-            cls._run_solver_substeps(contacts)
-
+    @classmethod
+    def _tail_stages(cls, contacts) -> None:
+        """Run the per-step tail: post-step hooks, then sensor updates."""
         for cb in cls._post_step_callbacks:
             cb()
         cls._update_sensors(contacts)
 
     @classmethod
-    def _simulate_physics_only(cls) -> None:
-        """Collision + solver substeps + sensors (no actuators, no USD sync).
+    def _simulate(cls) -> None:
+        """The step program: ``steps x (collide + actuators + substeps)``, then the tail.
 
-        Used when actuators are stepped eagerly outside the graph, or when
-        there are no actuators at all.
+        One program serves every scene; per-stage toggles select its shape:
+
+        * ``steps`` is the decimation count when this manager owns the
+          decimation loop (:meth:`handles_decimation`), else 1 (the env drives
+          the loop and one call covers exactly one sub-step).
+        * Graph-safe scenes run the actuator stage inside the iteration; mixed
+          scenes step the adapter eagerly before it, outside any captured span.
+        * When a per-iteration graph exists (mixed scenes), the iteration is
+          replayed from it; otherwise its stages run eagerly.
         """
-        if cls._needs_collision_pipeline:
-            cls._collision_pipeline.collide(cls._state_0, cls._contacts)
-            contacts = cls._contacts
-        else:
-            contacts = None
+        physics_dt = cls._solver_dt * cls._num_substeps
+        contacts = cls._contacts if cls._needs_collision_pipeline else None
+        all_graphable = cls._is_all_graphable()
+        steps = cls._decimation if cls.handles_decimation() else 1
 
-        cls._run_solver_substeps(contacts)
-        for cb in cls._post_step_callbacks:
-            cb()
-        cls._update_sensors(contacts)
+        for _ in range(steps):
+            if not all_graphable and cls._adapter is not None:
+                cls._adapter.step(cls._state_0, cls._control, physics_dt)
+            if cls._iteration_graph is not None:
+                wp.capture_launch(cls._iteration_graph)
+            else:
+                cls._iteration_stages(physics_dt, contacts, include_actuator_stage=all_graphable)
+        cls._tail_stages(contacts)
 
     # State accessors (used extensively by articulation/rigid object data)
     @classmethod
@@ -2214,15 +2209,17 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def register_post_actuator_callback(cls, callback: Callable[[], None]) -> None:
-        """Append a hook to the list invoked after the actuator step on every iteration.
+        """Append a hook to the list invoked after the actuator stage on every iteration.
 
-        Each callback runs inside the captured CUDA graph (when
-        :meth:`_is_all_graphable` is ``True``) right after
+        Each callback runs inside the decimation iteration
+        (:meth:`_iteration_stages`) right after
         :meth:`NewtonActuatorAdapter.step` and before the solver substeps,
         so kernel writes to ``state``/``control`` are visible to the
-        integrator on the same iteration. Multiple articulations register
-        their own implicit-DOF telemetry / FF-routing kernels here; all
-        registered callbacks fire in registration order each step.
+        integrator on the same iteration. When CUDA graphs are active the
+        iteration is captured, so callbacks must be graph-safe and registered
+        before capture. Multiple articulations register their own implicit-DOF
+        telemetry / FF-routing kernels here; all registered callbacks fire in
+        registration order each iteration.
         """
         cls._post_actuator_callbacks.append(callback)
 
@@ -2230,15 +2227,14 @@ class NewtonManager(PhysicsManager):
     def register_post_step_callback(cls, callback: Callable[[], None]) -> None:
         """Append a hook to the list invoked after the last solver substep on every step.
 
-        Each callback runs inside the stepped (and, when
-        :meth:`_is_all_graphable` is ``True``, captured) region right after the
-        final solver substep of the decimation loop and before
-        :meth:`_update_sensors`, so the launches it issues are recorded into
-        every captured CUDA graph and replayed on each tick. Callbacks must be
-        graph-safe (fixed shapes, no host branching on device data) and must be
-        registered before capture. Articulations with non-identity ordering
-        register their backend-to-user state republish here; all registered
-        callbacks fire in registration order each step.
+        Each callback runs in the per-step tail (:meth:`_tail_stages`), after
+        the final solver substep of the decimation loop and before
+        :meth:`_update_sensors`. When all actuators are graph-safe the tail is
+        captured into the whole-program CUDA graph and replayed on each tick,
+        so callbacks must be graph-safe (fixed shapes, no host branching on
+        device data) and registered before capture. Articulations with
+        non-identity ordering register their backend-to-user state republish
+        here; all registered callbacks fire in registration order each step.
         """
         cls._post_step_callbacks.append(callback)
 
@@ -2258,31 +2254,27 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def set_decimation(cls, decimation: int) -> None:
-        """Set the decimation count and re-capture the CUDA graph.
+        """Set the decimation count and invalidate the CUDA graph.
 
-        When all actuators are graphable the entire decimation loop
-        (actuators + solver substeps, repeated *decimation* times)
-        is captured as a single CUDA graph.
-
-        If a CUDA graph was previously captured, it is automatically
-        re-captured with the new decimation count using the same
-        strategy as :meth:`start_simulation`: standard
-        ``wp.ScopedCapture`` when no USDRT stage is active, or
-        deferred relaxed capture when RTX is running.
+        When all actuators are graphable the captured graph contains the
+        entire decimation loop (actuators + solver substeps, repeated
+        *decimation* times), so a decimation change invalidates any
+        captured graph; the next :meth:`step` re-captures.
         """
         cls._decimation = max(1, decimation)
-        if cls._is_all_graphable():
-            cls._capture_or_defer_graph()
+        cls._invalidate_graph()
 
     @classmethod
     def handles_decimation(cls) -> bool:
         """``True`` when :meth:`step` executes the full decimation loop internally.
 
-        This is the case when all Newton actuators are CUDA-graph-safe.
-        The full decimation loop (including the trivial ``decimation=1`` case)
-        is folded into a single :meth:`step` call.
+        Loop ownership follows the Newton actuator fast path: whenever an
+        articulation activated it (including mixed scenes whose non-graph-safe
+        actuators are stepped eagerly), one :meth:`step` call runs the env's
+        full decimation loop. On the standard Lab actuator path the env drives
+        the loop and one call covers exactly one sub-step.
         """
-        return cls._is_all_graphable()
+        return cls._use_newton_actuators_active
 
     @classmethod
     def add_contact_sensor(

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -3262,8 +3262,8 @@ def test_body_q_consistent_after_root_write(num_articulations, device, articulat
     reset because eval_fk was not called between write_root_pose and collide.
 
     Uses ``use_mujoco_contacts=False`` so the Newton collision pipeline is
-    active, then patches ``_simulate_physics_only`` to capture body_q at
-    the moment collide() is called and asserts it matches joint_q.
+    active, then patches ``_simulate`` to capture body_q at the moment
+    collide() is called and asserts it matches joint_q.
     """
     from unittest.mock import patch
 
@@ -3304,9 +3304,9 @@ def test_body_q_consistent_after_root_write(num_articulations, device, articulat
             env_ids=torch.tensor([0], device=device, dtype=torch.int32),
         )
 
-        # Patch _simulate_physics_only to capture body_q before collide runs
+        # Patch _simulate to capture body_q before collide runs
         captured = {}
-        original_simulate = SimulationManager._simulate_physics_only.__func__
+        original_simulate = SimulationManager._simulate.__func__
 
         @classmethod  # type: ignore[misc]
         def _patched_simulate(cls):
@@ -3319,7 +3319,7 @@ def test_body_q_consistent_after_root_write(num_articulations, device, articulat
                 captured["jq_root"] = jq[jc0 : jc0 + 3].clone()
             original_simulate(cls)
 
-        with patch.object(SimulationManager, "_simulate_physics_only", _patched_simulate):
+        with patch.object(SimulationManager, "_simulate", _patched_simulate):
             sim.step()
         articulation.update(sim.cfg.dt)
 

--- a/source/isaaclab_newton/test/assets/test_newton_actuators_newton.py
+++ b/source/isaaclab_newton/test/assets/test_newton_actuators_newton.py
@@ -140,9 +140,9 @@ def _run_simulation(
         dt: Physics timestep [s].
         newton_cfg: Newton physics configuration.
         num_steps: Number of policy-level steps.
-        decimation: Actuator steps per policy step (Newton's CUDA-graph
-            d-loop is used when all-graphable; otherwise an explicit Python
-            inner loop).
+        decimation: Actuator steps per policy step (the manager's internal
+            d-loop is used when it owns the decimation loop; otherwise an
+            explicit Python inner loop).
         feedforward: When not ``None``, set a constant per-DOF feedforward
             effort target. Used by the implicit-FF equivalence test.
         joint_ordering: Optional explicit public joint-name order.
@@ -175,12 +175,9 @@ def _run_simulation(
         if use_newton_actuators and decimation > 1:
             SimulationManager.set_decimation(decimation)
 
-        handles_dec = (
-            use_newton_actuators
-            and decimation > 1
-            and SimulationManager._is_all_graphable()
-            and SimulationManager._decimation > 1
-        )
+        # Mirror the env gate: fold the decimation loop into one step() call
+        # whenever the manager owns it (Newton actuator path active).
+        handles_dec = SimulationManager.handles_decimation() and SimulationManager._decimation > 1
 
         joint_names = tuple(articulation.joint_names)
         backend_joint_names = tuple(articulation.backend_joint_names)

--- a/source/isaaclab_newton/test/physics/test_deferred_graph_capture.py
+++ b/source/isaaclab_newton/test/physics/test_deferred_graph_capture.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression test for the deferred CUDA-graph capture policy.
+
+Decision sites (``initialize_solver``, ``set_decimation``, hard reset) never
+capture the CUDA graph — they invalidate it and arm a pending flag that the
+first ``step()`` consumes by capturing. Callers that never set a decimation —
+plain :class:`~isaaclab.sim.SimulationContext` loops — must still get their
+graph from that first step.
+
+Regression: on the Newton-actuator path the initial capture was skipped
+outright instead of deferred, so such scenes ran eager forever (measured
+5.06 ms vs 0.91 ms per tick for the identical workload).
+"""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True).app
+
+import warp as wp
+from isaaclab_newton.assets import Articulation
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import NewtonManager as SimulationManager
+
+import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+
+from isaaclab_assets import ANYMAL_C_CFG
+
+NEWTON_CFG = NewtonCfg(solver_cfg=MJWarpSolverCfg(), use_cuda_graph=True)
+
+IMPLICIT_ACTUATORS = {
+    "legs": ImplicitActuatorCfg(
+        joint_names_expr=[".*"],
+        stiffness=80.0,
+        damping=2.0,
+        effort_limit_sim=80.0,
+        velocity_limit_sim=7.5,
+    )
+}
+
+
+def test_first_step_captures_deferred_graph():
+    """A fast-path scene that never sets a decimation gets its graph on the first step."""
+    sim_cfg = SimulationCfg(dt=1.0 / 120.0, physics=NEWTON_CFG, use_newton_actuators=True)
+    with build_simulation_context(
+        device="cuda:0",
+        gravity_enabled=True,
+        add_ground_plane=True,
+        sim_cfg=sim_cfg,
+    ) as sim:
+        sim._app_control_on_stop_handle = None
+        sim_utils.create_prim("/World/Env_0", "Xform", translation=(0.0, 0.0, 0.0))
+        art_cfg = ANYMAL_C_CFG.replace(actuators=IMPLICIT_ACTUATORS, prim_path="/World/Env_0/Robot")
+        articulation = Articulation(art_cfg)
+        sim.reset()
+        assert articulation.is_initialized
+
+        # No set_decimation call anywhere: the flag armed by initialize_solver
+        # must survive untouched until the first step consumes it.
+        assert SimulationManager._graph_capture_pending, "initialize_solver must arm the deferred capture"
+        assert SimulationManager._graph is None
+
+        articulation.write_data_to_sim()
+        sim.step()
+
+        assert not SimulationManager._graph_capture_pending, "first step must consume the pending capture"
+        assert SimulationManager._graph is not None, "first step must capture the CUDA graph (not run eager forever)"
+
+        # The captured graph must actually be the step vehicle: stepping again
+        # keeps the state finite and does not re-arm the flag.
+        articulation.write_data_to_sim()
+        sim.step()
+        assert not SimulationManager._graph_capture_pending
+        joint_pos = wp.to_torch(articulation.data.joint_pos)
+        assert bool(joint_pos.isfinite().all()), "post-capture step produced non-finite joint state"

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -423,7 +423,7 @@ def test_mpm_cuda_graph_capture_supports_only_fixed_grid(monkeypatch, grid_type,
 
 
 def test_mpm_unsupported_cuda_graph_capture_uses_eager_execution(monkeypatch):
-    """Sparse/dense MPM should not enter a CUDA graph capture window."""
+    """Sparse/dense MPM invalidation must not arm a CUDA graph capture."""
     from isaaclab.physics import PhysicsManager
 
     monkeypatch.setattr(
@@ -437,42 +437,58 @@ def test_mpm_unsupported_cuda_graph_capture_uses_eager_execution(monkeypatch):
     monkeypatch.setattr(NewtonManager, "_graph", object(), raising=False)
     monkeypatch.setattr(NewtonManager, "_graph_capture_pending", True, raising=False)
 
-    NewtonMPMManager._capture_or_defer_graph()
+    NewtonMPMManager._invalidate_graph()
 
     assert NewtonManager._graph is None
     assert NewtonManager._graph_capture_pending is False
 
 
 def test_cuda_graph_capture_uses_simulation_device(monkeypatch):
-    """CUDA graph capture should use the simulation device instead of Warp's default device."""
+    """The capture site in step() uses the simulation device, and its warmup counts as the step."""
     from isaaclab.physics import PhysicsManager
 
     captured_devices = []
     captured_graph = object()
+    launches = []
 
-    class FakeScopedCapture:
-        def __init__(self, device=None):
-            captured_devices.append(device)
-            self.graph = captured_graph
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc_value, traceback):
-            return False
-
+    monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(is_playing=lambda: True), raising=False)
     monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=True), raising=False)
     monkeypatch.setattr(PhysicsManager, "_device", "cuda:1", raising=False)
+    monkeypatch.setattr(PhysicsManager, "_sim_time", 0.0, raising=False)
+    monkeypatch.setattr(NewtonManager, "_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_iteration_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_graph_capture_pending", True, raising=False)
+    monkeypatch.setattr(NewtonManager, "_model_changes", set(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_world_reset_mask", None, raising=False)
     monkeypatch.setattr(NewtonManager, "_usdrt_stage", None, raising=False)
-    monkeypatch.setattr(NewtonManager, "_solver", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_particle_visual_prims", {}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_needs_collision_pipeline", False, raising=False)
+    monkeypatch.setattr(NewtonManager, "_use_newton_actuators_active", False, raising=False)
+    monkeypatch.setattr(NewtonManager, "_solver_dt", 0.005, raising=False)
+    monkeypatch.setattr(NewtonManager, "_num_substeps", 2, raising=False)
+    monkeypatch.setattr(NewtonManager, "_reset_solver_internals", classmethod(lambda cls, mask: None))
+    monkeypatch.setattr(NewtonManager, "forward", classmethod(lambda cls: None))
     monkeypatch.setattr(NewtonManager, "_is_all_graphable", classmethod(lambda cls: False))
-    monkeypatch.setattr(NewtonManager, "_simulate_physics_only", classmethod(lambda cls: None))
-    monkeypatch.setattr(wp, "ScopedCapture", FakeScopedCapture)
+    monkeypatch.setattr(NewtonManager, "_log_solver_debug", classmethod(lambda cls: None))
+    monkeypatch.setattr(
+        NewtonManager,
+        "_capture_relaxed_graph",
+        classmethod(lambda cls, device, warmup, capture: (captured_devices.append(device), captured_graph)[1]),
+    )
+    monkeypatch.setattr(wp, "capture_launch", lambda graph: launches.append(graph))
 
-    NewtonManager._capture_or_defer_graph()
+    NewtonManager.step()
 
     assert captured_devices == ["cuda:1"]
-    assert NewtonManager._graph is captured_graph
+    # Mixed scene (not all-graphable): the capture lands in the per-iteration slot.
+    assert NewtonManager._iteration_graph is captured_graph
+    assert NewtonManager._graph is None
+    assert NewtonManager._graph_capture_pending is False
+    # The capture warmup already advanced physics: the capturing tick must not
+    # also replay the fresh graph (double-advance), yet sim time advances by
+    # one sub-step (loop not owned: _use_newton_actuators_active is False).
+    assert launches == []
+    assert PhysicsManager._sim_time == pytest.approx(0.005 * 2)
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab_newton/test/physics/test_newton_solver_reset.py
+++ b/source/isaaclab_newton/test/physics/test_newton_solver_reset.py
@@ -117,10 +117,7 @@ def test_env_reset_clears_selected_mjwarp_solver_internals(device):
         warm_start[1].fill_(29.0)
         wp.synchronize_device(device)
 
-        with (
-            patch.object(SimulationManager, "_simulate_full", classmethod(lambda cls: None)),
-            patch.object(SimulationManager, "_simulate_physics_only", classmethod(lambda cls: None)),
-        ):
+        with patch.object(SimulationManager, "_simulate", classmethod(lambda cls: None)):
             sim.step(render=False)
         wp.synchronize_device(device)
 


### PR DESCRIPTION
## What

One step program and one capture policy for the Newton physics manager.

- `_simulate_full` / `_simulate_physics_only` are replaced by ONE program: `_simulate()` runs `steps x (collide -> actuator stage -> post-actuator hooks -> solver substeps)` and a tail (post-step hooks, sensors). `steps` is `decimation` when the manager owns the loop and `1` when the environment does — loop ownership is data, not a second code path.
- The CUDA graph machinery reduces to ONE deferral policy and ONE capture routine: every site that decides "the graph is stale but cannot be captured right now" (solver init, `set_decimation`, hard reset) calls `_invalidate_graph()`; the first `step()` afterwards captures. The init-time `ScopedCapture` branch, the RTX-vs-headless selector, `set_decimation`'s inline recapture, and the duplicated Kamino pin-replay are deleted.
- The capture warmup executes one true full step of the program, so the capturing step counts as a physics step (no double-advance). `handles_decimation()` reports loop ownership instead of aliasing kernel graph-safety.

## Why

Scenes whose callers never set a decimation (plain `SimulationContext` loops) previously never got their CUDA graph and ran eager forever; fixing that minimally would have added a third arm to an already-forked capture decision. With one program and one policy, both historical failure modes — never-captured and back-to-back re-capture faults — are structurally unrepresentable: there is exactly one capture per invalidation and exactly one program to capture.

## Evidence

- Regression test (`test_deferred_graph_capture.py`): a fast-path scene that never sets a decimation gets its graph on the first step; verified to fail on the old code.
- Newton manager abstraction suite: 80 passed on this branch (includes rewritten graph-flow tests asserting the capture tick does not double-advance).
- No-regression check with the repository benchmark, identical command on base and branch (`runtime.py --task Isaac-Velocity-Flat-AnymalD --num_envs 1024 --num_frames 300 --seed 7`, RTX 5090): base 12.70 ms/iter, this PR 12.86 ms/iter (within run noise).

## Test plan

```
./isaaclab.sh -p -m pytest source/isaaclab_newton/test/physics/test_deferred_graph_capture.py
./isaaclab.sh -p -m pytest source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
./isaaclab.sh -p -m pytest source/isaaclab_newton/test/physics/test_newton_solver_reset.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
