### PR TITLE
Step environments with one loop on every backend

### DIFF
--- a/source/isaaclab/changelog.d/decouple-ladder-env-loop.rst
+++ b/source/isaaclab/changelog.d/decouple-ladder-env-loop.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed environment physics stepping to one loop on every backend: the
+  backend's decimation ownership is expressed as the number of sub-steps one
+  ``sim.step()`` covers instead of a second stepping branch. Behavior is
+  identical on both paths.

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -441,33 +441,26 @@ class DirectMARLEnv(gym.Env):
         # note: uses cached property to avoid settings lookup every step
         is_rendering = self.sim.is_rendering
 
-        # perform physics stepping
-        if self._physics_handles_decimation:
-            self._sim_step_counter += self.cfg.decimation
+        # perform physics stepping — ONE loop on every backend: when the
+        # physics manager owns the decimation internally, one sim.step() covers
+        # all sub-steps and the loop runs once; otherwise it runs per sub-step.
+        # The backend difference is a number, never a second code path.
+        steps_per_call = self.cfg.decimation if self._physics_handles_decimation else 1
+        for _ in range(self.cfg.decimation // steps_per_call):
+            self._sim_step_counter += steps_per_call
+            # set actions into buffers
             self._apply_action()
+            # set actions into simulator
             self.scene.write_data_to_sim()
+            # simulate
             self.sim.step(render=False)
-            # render only when a render_interval boundary falls within this decimation block,
-            # mirroring the per-sub-step check in the else branch.
+            # render when a render_interval boundary falls inside this call.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
                 self.sim.render(skip_app_pumping=not self.render_enabled)
-            self.scene.update(dt=self.step_dt)
-        else:
-            for _ in range(self.cfg.decimation):
-                self._sim_step_counter += 1
-                # set actions into buffers
-                self._apply_action()
-                # set actions into simulator
-                self.scene.write_data_to_sim()
-                # simulate
-                self.sim.step(render=False)
-                # render between steps only if the GUI or an RTX sensor needs it.
-                # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
-                # but standalone visualizers (Newton, Rerun, Viser) still update.
-                if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                    self.sim.render(skip_app_pumping=not self.render_enabled)
-                # update buffers at sim dt
-                self.scene.update(dt=self.physics_dt)
+            # update buffers at the covered dt
+            self.scene.update(dt=self.physics_dt * steps_per_call)
 
         # post-step:
         # -- update env counters (used for curriculum generation)

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -432,33 +432,26 @@ class DirectRLEnv(gym.Env):
         # note: uses cached property to avoid settings lookup every step
         is_rendering = self.sim.is_rendering
 
-        # perform physics stepping
-        if self._physics_handles_decimation:
-            self._sim_step_counter += self.cfg.decimation
+        # perform physics stepping — ONE loop on every backend: when the
+        # physics manager owns the decimation internally, one sim.step() covers
+        # all sub-steps and the loop runs once; otherwise it runs per sub-step.
+        # The backend difference is a number, never a second code path.
+        steps_per_call = self.cfg.decimation if self._physics_handles_decimation else 1
+        for _ in range(self.cfg.decimation // steps_per_call):
+            self._sim_step_counter += steps_per_call
+            # set actions into buffers
             self._apply_action()
+            # set actions into simulator
             self.scene.write_data_to_sim()
+            # simulate
             self.sim.step(render=False)
-            # render only when a render_interval boundary falls within this decimation block,
-            # mirroring the per-sub-step check in the else branch.
+            # render when a render_interval boundary falls inside this call.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
                 self.sim.render(skip_app_pumping=not self.render_enabled)
-            self.scene.update(dt=self.step_dt)
-        else:
-            for _ in range(self.cfg.decimation):
-                self._sim_step_counter += 1
-                # set actions into buffers
-                self._apply_action()
-                # set actions into simulator
-                self.scene.write_data_to_sim()
-                # simulate
-                self.sim.step(render=False)
-                # render between steps only if the GUI or an RTX sensor needs it.
-                # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
-                # but standalone visualizers (Newton, Rerun, Viser) still update.
-                if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                    self.sim.render(skip_app_pumping=not self.render_enabled)
-                # update buffers at sim dt
-                self.scene.update(dt=self.physics_dt)
+            # update buffers at the covered dt
+            self.scene.update(dt=self.physics_dt * steps_per_call)
 
         # post-step:
         # -- update env counters (used for curriculum generation)

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -537,33 +537,26 @@ class ManagerBasedEnv:
         # note: uses cached property to avoid settings lookup every step
         is_rendering = self.sim.is_rendering
 
-        # perform physics stepping
-        if self._physics_handles_decimation:
-            self._sim_step_counter += self.cfg.decimation
+        # perform physics stepping — ONE loop on every backend: when the
+        # physics manager owns the decimation internally, one sim.step() covers
+        # all sub-steps and the loop runs once; otherwise it runs per sub-step.
+        # The backend difference is a number, never a second code path.
+        steps_per_call = self.cfg.decimation if self._physics_handles_decimation else 1
+        for _ in range(self.cfg.decimation // steps_per_call):
+            self._sim_step_counter += steps_per_call
+            # set actions into buffers
             self.action_manager.apply_action()
+            # set actions into simulator
             self.scene.write_data_to_sim()
+            # simulate
             self.sim.step(render=False)
-            # render only when a render_interval boundary falls within this decimation block,
-            # mirroring the per-sub-step check in the else branch.
+            # render when a render_interval boundary falls inside this call.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
                 self.sim.render(skip_app_pumping=not self.render_enabled)
-            self.scene.update(dt=self.step_dt)
-        else:
-            for _ in range(self.cfg.decimation):
-                self._sim_step_counter += 1
-                # set actions into buffers
-                self.action_manager.apply_action()
-                # set actions into simulator
-                self.scene.write_data_to_sim()
-                # simulate
-                self.sim.step(render=False)
-                # render between steps only if the GUI or an RTX sensor needs it.
-                # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
-                # but standalone visualizers (Newton, Rerun, Viser) still update.
-                if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                    self.sim.render(skip_app_pumping=not self.render_enabled)
-                # update buffers at sim dt
-                self.scene.update(dt=self.physics_dt)
+            # update buffers at the covered dt
+            self.scene.update(dt=self.physics_dt * steps_per_call)
 
         # post-step: step interval event
         if "interval" in self.event_manager.available_modes:

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -199,35 +199,27 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # note: uses cached property to avoid settings lookup every step
         is_rendering = self.sim.is_rendering
 
-        # perform physics stepping
-        if self._physics_handles_decimation:
-            self._sim_step_counter += self.cfg.decimation
+        # perform physics stepping — ONE loop on every backend: when the
+        # physics manager owns the decimation internally, one sim.step() covers
+        # all sub-steps and the loop runs once; otherwise it runs per sub-step.
+        # The backend difference is a number, never a second code path.
+        steps_per_call = self.cfg.decimation if self._physics_handles_decimation else 1
+        for _ in range(self.cfg.decimation // steps_per_call):
+            self._sim_step_counter += steps_per_call
+            # set actions into buffers
             self.action_manager.apply_action()
+            # set actions into simulator
             self.scene.write_data_to_sim()
+            # simulate
             self.sim.step(render=False)
             self.recorder_manager.record_post_physics_decimation_step()
-            # render only when a render_interval boundary falls within this decimation block,
-            # mirroring the per-sub-step check in the else branch.
+            # render when a render_interval boundary falls inside this call.
+            # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
+            # but standalone visualizers (Newton, Rerun, Viser) still update.
             if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
                 self.sim.render(skip_app_pumping=not self.render_enabled)
-            self.scene.update(dt=self.step_dt)
-        else:
-            for _ in range(self.cfg.decimation):
-                self._sim_step_counter += 1
-                # set actions into buffers
-                self.action_manager.apply_action()
-                # set actions into simulator
-                self.scene.write_data_to_sim()
-                # simulate
-                self.sim.step(render=False)
-                self.recorder_manager.record_post_physics_decimation_step()
-                # render between steps only if the GUI or an RTX sensor needs it.
-                # When render_enabled is False, Kit visualizer (camera/GUI) is skipped
-                # but standalone visualizers (Newton, Rerun, Viser) still update.
-                if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
-                    self.sim.render(skip_app_pumping=not self.render_enabled)
-                # update buffers at sim dt
-                self.scene.update(dt=self.physics_dt)
+            # update buffers at the covered dt
+            self.scene.update(dt=self.physics_dt * steps_per_call)
 
         # post-step:
         # -- update env counters (used for curriculum generation)


### PR DESCRIPTION
# Step environments with one loop on every backend

## What

Behavior-preserving refactor of the physics-stepping section in the four
environment classes (`ManagerBasedEnv`, `ManagerBasedRLEnv`, `DirectRLEnv`,
`DirectMARLEnv`). Each class previously carried two stepping branches selected
by `physics_manager.handles_decimation()`:

- manager-owned decimation: one `sim.step()` covers all sub-steps, single
  block with `scene.update(dt=self.step_dt)`;
- env-owned decimation: one `sim.step()` per sub-step, `for` loop with
  `scene.update(dt=self.physics_dt)`.

The two branches collapse into one loop parameterized by how many sub-steps a
single `sim.step()` call covers:

```python
steps_per_call = self.cfg.decimation if self._physics_handles_decimation else 1
for _ in range(self.cfg.decimation // steps_per_call):
    self._sim_step_counter += steps_per_call
    ...
    self.scene.update(dt=self.physics_dt * steps_per_call)
```

Changelog fragments are included for both touched packages
(`source/isaaclab/changelog.d/decouple-ladder-env-loop.rst`,
`source/isaaclab_newton/changelog.d/decouple-ladder.minor.rst`).

## Why

The backend difference is a number, not a program. Keeping two mirrored code
paths per env class (eight stepping programs across the four classes) meant
every change to the stepping sequence — render checks, recorder hooks, buffer
updates — had to be applied twice and kept in sync by comment. With one loop,
the render check, the recorder hook, and the `scene.update` call each exist
once per class, and both backends execute the identical program. No
performance claim is made — identical behavior on both paths is the point.

## Test plan

This is a behavior-preserving refactor: both prior branches execute the same
operations in the same order for their respective backends; the loop count and
per-call dt are now data (`steps_per_call`) instead of a second code path.
Covered by the existing environment stepping tests; no functional change is
intended, and none is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
