### PR TITLE
Restore flatdict docs mock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,7 @@ autodoc_mock_imports = [
     "pink",
     "pinocchio",
     "qpsolvers",
+    "flatdict",
     "filelock",
     "IPython",
     "cv2",


### PR DESCRIPTION
# Description

Restore `flatdict` to Sphinx's `autodoc_mock_imports` list.

The current package no longer depends on `flatdict`, but the multi-version documentation build still renders historical versions that import it. Without the mock, autosummary fails while rendering `v2.1.0` and the scheduled documentation deployment exits with status 2.

Failing job: https://github.com/isaac-sim/IsaacLab/actions/runs/29671271072/job/88150584588

No runtime dependency is added; this only restores the documentation import mock.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Screenshots

Not applicable.

## Validation

- Confirmed `flatdict` appears exactly once in `autodoc_mock_imports`.
- Ran `./isaaclab.bat -f` twice; all pre-commit checks passed.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made the corresponding documentation configuration change
- [x] My change introduces no new warnings
- [x] No package changelog fragment is required because no `source/<package>/` code is changed
- [x] My name already exists in `CONTRIBUTORS.md`
