### PR TITLE
Fix OVRTX GPU transform default

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@ Guidelines for modifications:
 * Cameron Upright
 * Cathy Y. Li
 * Cheng-Rong Lai
+* Chenyu Cao
 * Chenyu Yang
 * Connor Smith
 * CY (Chien-Ying) Chen

--- a/source/isaaclab_ov/changelog.d/codex-fix-newton-ovrtx-transforms.rst
+++ b/source/isaaclab_ov/changelog.d/codex-fix-newton-ovrtx-transforms.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed intermittent loss of dynamic geometry in OVRTX camera output by disabling GPU transform reads by default.
+  Set ``ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS=1`` to opt back into the previous behavior.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -119,7 +119,10 @@ def _raise_missing_ppisp_error(exc: ModuleNotFoundError) -> NoReturn:
 
 def _read_gpu_transforms_enabled() -> bool:
     """Return whether OVRTX should read GPU transforms from its internal transform cache."""
-    value = os.environ.get(_READ_GPU_TRANSFORMS_ENV, "1").strip()
+    # RTX geometry streaming can drop dynamic geometry when Fabric transform reads are enabled. Keep the safe
+    # CPU-read path as the default until that renderer-side incompatibility is resolved, while preserving an
+    # explicit opt-in for workloads that have validated the GPU path.
+    value = os.environ.get(_READ_GPU_TRANSFORMS_ENV, "0").strip()
     if value not in {"0", "1"}:
         raise ValueError(
             f"Invalid value for environment variable `{_READ_GPU_TRANSFORMS_ENV}`: {value}. Expected 0 or 1."

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -28,11 +28,16 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
-    from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderData, OVRTXRenderer  # noqa: E402
+    from isaaclab_ov.renderers.ovrtx_renderer import (  # noqa: E402
+        OVRTXRenderData,
+        OVRTXRenderer,
+        _read_gpu_transforms_enabled,
+    )
 else:
     OVRTXRenderData = None
     OVRTXRenderer = None
     OVRTXRendererCfg = None
+    _read_gpu_transforms_enabled = None
 
 _SPAWN = PinholeCameraCfg(
     focal_length=24.0,
@@ -67,6 +72,20 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     renderer = OVRTXRenderer.__new__(OVRTXRenderer)
     renderer.cfg = OVRTXRendererCfg()
     return renderer
+
+
+def test_ovrtx_gpu_transform_reads_default_to_disabled(monkeypatch):
+    """OVRTX avoids the unsafe Fabric transform and geometry streaming combination by default."""
+    monkeypatch.delenv("ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS", raising=False)
+
+    assert not _read_gpu_transforms_enabled()
+
+
+def test_ovrtx_gpu_transform_reads_allow_explicit_opt_in(monkeypatch):
+    """OVRTX preserves an explicit opt-in for validated GPU transform workloads."""
+    monkeypatch.setenv("ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS", "1")
+
+    assert _read_gpu_transforms_enabled()
 
 
 def test_ovrtx_supported_output_types_key_set():


### PR DESCRIPTION
# Description

Default OVRTX's environment-controlled `read_gpu_transforms` setting to the safe CPU-read path. OVRTX warns that enabling Fabric transform reads together with geometry streaming can prevent dynamic geometry from streaming correctly; in Newton workloads this intermittently appears as missing robot links in OVRTX camera output.

The existing `ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS=1` override remains available as an explicit opt-in for workloads that have validated the previous GPU path. No dependency changes are required.

A standalone four-environment differential reproducer found:

| Configuration | Missing-link reproductions |
|---|---:|
| OVRTX 0.3, current GPU-transform default | 2 / 3 |
| OVRTX 0.3, GPU transform reads disabled | 0 / 10 |
| OVRTX 0.4, current GPU-transform default | 1 / 5 |
| OVRTX 0.4, GPU transform reads disabled | 0 / 4 completed runs |

The Newton viewer-disabled control reproduced 0 / 3 times. USD visibility stayed unchanged and Newton body/joint states stayed finite and synchronized during captured failures.

Fixes #6625

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable to the adapter default itself. Issue #6625 describes the captured missing-link evidence and standalone reproducer.

## Validation

- Regression test was added first and failed against the previous default.
- `pytest source/isaaclab_ov/test/test_ovrtx_renderer_contract.py -q`: 14 passed.
- `./isaaclab.sh -p tools/changelog/cli.py check develop`: passed.
- `./isaaclab.sh -f`: passed before commit and again before push.
- Standalone MRE: OVRTX 0.3 safe path completed 10 / 10 runs without the symptom; OVRTX 0.4 safe path completed 4 / 4 runs without it.

Current-`develop` end-to-end validation used its exact Newton pin (`newton 1.4.0.dev0`, `warp-lang 1.15.0.dev20260626`) with OVRTX 0.3: the standalone Newton-viewer MRE completed 1,000 steps across four environments with `reproduced=False`, finite/synchronized state, and no unsafe transform/geometry-streaming warning. A separate RTX/MDL shutdown segfault occurred only after the result and final capture were written.

## Risk

The CPU transform-read path may have different renderer performance characteristics. Explicit opt-in to the previous behavior is preserved with `ISAAC_LAB_OVRTX_READ_GPU_TRANSFORMS=1`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (changelog fragment)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

