### PR TITLE
Fix AppLauncher exception exit status

### DIFF
--- a/source/isaaclab/changelog.d/nblauch-fix-applauncher-exit-code.rst
+++ b/source/isaaclab/changelog.d/nblauch-fix-applauncher-exit-code.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.app.AppLauncher` shutdown masking unhandled exceptions
+  with a successful process exit status.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -326,7 +326,11 @@ class AppLauncher:
         # and can leave GPU resources in a bad state for the next test).
         def _atexit_close(app=self._app):
             with contextlib.suppress(Exception):
-                app.close()
+                # Kit's fast shutdown replaces Python's pending exit status unless
+                # close() receives a nonzero code. The interpreter sets
+                # sys.last_type before atexit callbacks run for an unhandled exception.
+                exit_code = 1 if getattr(sys, "last_type", None) is not None else 0
+                app.close(exit_code=exit_code)
 
         atexit.register(_atexit_close)
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -328,8 +328,8 @@ class AppLauncher:
             with contextlib.suppress(Exception):
                 # Kit's fast shutdown replaces Python's pending exit status unless
                 # close() receives a nonzero code. The interpreter sets
-                # sys.last_type before atexit callbacks run for an unhandled exception.
-                exit_code = 1 if getattr(sys, "last_type", None) is not None else 0
+                # sys.last_exc before atexit callbacks run for an unhandled exception.
+                exit_code = 1 if getattr(sys, "last_exc", None) is not None else 0
                 app.close(exit_code=exit_code)
 
         atexit.register(_atexit_close)

--- a/source/isaaclab/test/app/test_app_launcher_exit_code.py
+++ b/source/isaaclab/test/app/test_app_launcher_exit_code.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Verify that AppLauncher preserves the exit status of unhandled exceptions."""
+
+import subprocess
+import sys
+
+import pytest
+
+_TRIGGER_UNHANDLED_EXCEPTION = "--trigger-unhandled-exception"
+
+
+def _raise_after_app_launcher_initialization() -> None:
+    from isaaclab.app import AppLauncher
+
+    AppLauncher(headless=True, device="cpu")
+    raise RuntimeError("intentional AppLauncher failure")
+
+
+@pytest.mark.integration
+def test_unhandled_exception_exits_with_failure():
+    """Verify that AppLauncher shutdown does not replace an exception's exit status with zero."""
+    result = subprocess.run(
+        [sys.executable, __file__, _TRIGGER_UNHANDLED_EXCEPTION],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "RuntimeError: intentional AppLauncher failure" in result.stderr
+
+
+if __name__ == "__main__" and _TRIGGER_UNHANDLED_EXCEPTION in sys.argv:
+    _raise_after_app_launcher_initialization()


### PR DESCRIPTION
# Description

`AppLauncher` registers an `atexit` callback that closes `SimulationApp`. With
Kit fast shutdown enabled, calling `close()` with its default zero exit code can
replace Python's pending nonzero status after an unhandled exception.

This change detects the unhandled exception state exposed by the interpreter
and passes exit code 1 to `SimulationApp.close()`. Normal interpreter shutdown
continues to pass exit code 0.

The new integration test launches a real headless CPU `AppLauncher` in a child
process, raises an unhandled `RuntimeError`, and verifies both the traceback and
exit status 1.

Fixes #6573

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Before the fix, the regression test failed because the child returned 0.
- After the fix, running the trigger script directly reports exit status 1.
- `python -m pytest source/isaaclab/test/app/test_app_launcher_exit_code.py source/isaaclab/test/app/test_kwarg_launch.py::test_launch_simulation_preserves_failure_exit_code -q` (2 passed)
- `./isaaclab.sh -f` (all hooks passed)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`.
- [x] Documentation is not required for this internal shutdown correction.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`.
- [x] My name is already present in `CONTRIBUTORS.md`.
