### PR TITLE
Fix fragment writers to reach nested rigid-body and mass prims

### DIFF
--- a/source/isaaclab/changelog.d/vidurv-descend-nested-fragments.rst
+++ b/source/isaaclab/changelog.d/vidurv-descend-nested-fragments.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.sim.schemas.apply_rigid_body_properties` and
+  :func:`~isaaclab.sim.schemas.apply_mass_properties` stopping at the outermost schema-bearing
+  prim on each branch. On assets with nested rigid-body hierarchies (child links authored under
+  their parent link prims, as produced by the URDF importer in Isaac Sim 6.0 and later), only
+  the outermost link received the fragment properties. The writers now modify every carrier in
+  the subtree, matching the legacy writers' full-subtree traversal.

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -552,15 +552,17 @@ def _resolve_fragment_targets(
     api_type,
     stage: Usd.Stage,
     apply_fresh: bool,
+    stop_at_carrier: bool,
 ) -> tuple[list, bool]:
     """Resolve the prims that a fragment family writer should author on.
 
     This mirrors the legacy nested writers: prims under ``prim_path`` that already carry
-    ``api_type`` are modified in place, and the search does not descend past a match, since
-    nested applications of the same physics schema are not allowed. Only when the subtree
-    carries no such prim is the defining API applied freshly to ``prim_path`` itself -- the
-    bare-prim case used by the shape and mesh spawners. Instanced prims cannot be edited, so
-    they are skipped with a warning.
+    ``api_type`` are modified in place. Rigid-body and mass carriers legitimately nest -- the
+    URDF importer authors child links under their parent link prims -- so those families search
+    the entire subtree; collision keeps the legacy stop-at-carrier traversal. Only when the
+    subtree carries no such prim is the defining API applied freshly to ``prim_path`` itself --
+    the bare-prim case used by the shape and mesh spawners. Instanced prims cannot be edited,
+    so they are skipped with a warning.
 
     Args:
         prim_path: The prim path whose subtree is searched.
@@ -568,6 +570,9 @@ def _resolve_fragment_targets(
         stage: The stage containing the prim.
         apply_fresh: Whether to apply ``api_type`` to ``prim_path`` when the subtree contains
             no carrier of it.
+        stop_at_carrier: Whether to skip the descendants of a found carrier instead of also
+            collecting nested carriers, mirroring :paramref:`~isaaclab.sim.utils.apply_nested.stop_on_success`
+            of the corresponding legacy writer.
 
     Returns:
         A tuple ``(targets, any_skipped)`` holding the writable target prims and whether any
@@ -579,11 +584,9 @@ def _resolve_fragment_targets(
     prim = stage.GetPrimAtPath(prim_path)
     if not prim.IsValid():
         raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # breadth-first search that stops descending at the first carrier on each branch, like the
-    # legacy nested writers: nested applications of the same physics schema are not allowed, so
-    # nothing below a carrier is ever a target. This keeps the search linear in the subtree size
-    # instead of collecting every carrier and pruning afterwards. Carriers on instanced prims are
-    # read-only and collected separately so they can be reported.
+    # breadth-first search over the subtree. Carriers on instanced prims are read-only and
+    # collected separately so they can be reported. With ``stop_at_carrier`` the search does not
+    # descend past a found carrier, matching the legacy writer's stop-on-success traversal.
     targets = []
     skipped = []
     prims_queue = [prim]
@@ -596,7 +599,8 @@ def _resolve_fragment_targets(
                 skipped.append(candidate)
             else:
                 targets.append(candidate)
-            continue
+            if stop_at_carrier:
+                continue
         prims_queue += candidate.GetFilteredChildren(Usd.TraverseInstanceProxies())
     if not targets and not skipped and apply_fresh:
         if prim.IsInstance() or prim.IsInstanceProxy():
@@ -624,13 +628,15 @@ def apply_rigid_body_properties(
     """Apply a list of rigid-body fragments to the rigid bodies under a prim.
 
     Existing rigid bodies in the subtree are modified in place, matching the legacy nested
-    writer. Real assets author ``UsdPhysics.RigidBodyAPI`` on their link prims, so anchoring a
-    fresh rigid body on the spawn prim instead would nest those links under a new body and the
-    PhysX parser would drop the articulation's joint graph. Only when the subtree carries no
-    rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path`` itself -- the bare-prim
-    case used by the shape and mesh spawners. Each fragment is dispatched to every resolved
-    target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry
-    backend-specific funcs, so core never imports a backend.
+    writer. This includes nested bodies: the URDF importer authors child links under their
+    parent link prims, so every carrier in the subtree is a target. Real assets author
+    ``UsdPhysics.RigidBodyAPI`` on their link prims, so anchoring a fresh rigid body on the
+    spawn prim instead would invent a body the asset's joints never reference. Only when the
+    subtree carries no rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path``
+    itself -- the bare-prim case used by the shape and mesh spawners. Each fragment is
+    dispatched to every resolved target via its
+    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry backend-specific
+    funcs, so core never imports a backend.
 
     Args:
         prim_path: The prim path whose subtree is searched for rigid bodies.
@@ -648,7 +654,7 @@ def apply_rigid_body_properties(
     if stage is None:
         stage = get_current_stage()
     targets, any_skipped = _resolve_fragment_targets(
-        prim_path, UsdPhysics.RigidBodyAPI, stage, apply_fresh=bool(fragments)
+        prim_path, UsdPhysics.RigidBodyAPI, stage, apply_fresh=bool(fragments), stop_at_carrier=False
     )
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
@@ -858,7 +864,8 @@ def apply_collision_properties(
 ) -> bool:
     """Apply a list of collision fragments to the colliders under a prim.
 
-    Existing colliders in the subtree are modified in place, matching the legacy nested writer.
+    Existing colliders in the subtree are modified in place, and the search does not descend
+    below a found collider, matching the legacy nested writer's stop-on-success traversal.
     Real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, so anchoring a fresh
     collider on the spawn prim would change the scene's collision geometry. Only when the
     subtree carries no collider is ``UsdPhysics.CollisionAPI`` applied to ``prim_path`` itself
@@ -882,7 +889,7 @@ def apply_collision_properties(
     if stage is None:
         stage = get_current_stage()
     targets, any_skipped = _resolve_fragment_targets(
-        prim_path, UsdPhysics.CollisionAPI, stage, apply_fresh=bool(fragments)
+        prim_path, UsdPhysics.CollisionAPI, stage, apply_fresh=bool(fragments), stop_at_carrier=True
     )
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
@@ -993,10 +1000,12 @@ def apply_mass_properties(
     """Apply a list of mass fragments to the mass-bearing prims under a prim.
 
     Existing mass-bearing prims in the subtree are modified in place, matching the legacy nested
-    writer, since real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the
-    subtree carries none is ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself -- the
-    bare-prim case used by the shape and mesh spawners. Each fragment is dispatched to every
-    resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
+    writer, since real assets author ``UsdPhysics.MassAPI`` on their link prims. This includes
+    nested carriers: the URDF importer authors child links under their parent link prims, so
+    every carrier in the subtree is a target. Only when the subtree carries none is
+    ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself -- the bare-prim case used by the
+    shape and mesh spawners. Each fragment is dispatched to every resolved target via its
+    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
 
     Args:
         prim_path: The prim path whose subtree is searched for mass-bearing prims.
@@ -1013,7 +1022,9 @@ def apply_mass_properties(
     fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    targets, any_skipped = _resolve_fragment_targets(prim_path, UsdPhysics.MassAPI, stage, apply_fresh=bool(fragments))
+    targets, any_skipped = _resolve_fragment_targets(
+        prim_path, UsdPhysics.MassAPI, stage, apply_fresh=bool(fragments), stop_at_carrier=False
+    )
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
     for target in targets:

--- a/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
+++ b/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
@@ -26,18 +26,23 @@ from isaaclab.sim.schemas import MassCfg
 pytestmark = pytest.mark.integration
 
 
+LINK_REL_PATHS = ("link1", "link2", "link2/link3")
+"""Link prim paths relative to the robot root; ``link2/link3`` is a nested child link."""
+
+
 def _author_robot_usd(path: str) -> None:
     """Author a minimal articulated-robot USD layout.
 
     Mirrors how real robot assets are structured: the default (spawn) prim carries
     ``ArticulationRootAPI``, the link prims carry ``RigidBodyAPI`` and ``MassAPI``, and the
     collider prims under the links carry ``CollisionAPI``. The spawn prim itself carries no
-    rigid-body, collision, or mass schema.
+    rigid-body, collision, or mass schema. ``link3`` is authored under ``link2`` the way the
+    URDF importer nests child links under their parent link.
     """
     stage = Usd.Stage.CreateNew(path)
     robot = UsdGeom.Xform.Define(stage, "/Robot")
     UsdPhysics.ArticulationRootAPI.Apply(robot.GetPrim())
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         link = UsdGeom.Xform.Define(stage, f"/Robot/{link_name}").GetPrim()
         UsdPhysics.RigidBodyAPI.Apply(link)
         UsdPhysics.MassAPI.Apply(link)
@@ -70,10 +75,10 @@ def _spawn_robot(tmp_path, prim_path: str, **cfg_kwargs):
 def test_rigid_body_fragments_target_existing_bodies_on_usd_asset(tmp_path):
     """Fragment ``rigid_props`` on a USD robot must modify the existing link bodies in place.
 
-    Force-applying ``RigidBodyAPI`` on the spawn prim (which already carries the articulation
-    root) turns the asset's links into nested rigid bodies, and the PhysX parser then drops the
-    articulation's joints. The fragment path must match the legacy nested writer: author onto the
-    prims that already carry the API and leave the spawn prim untouched.
+    Force-applying ``RigidBodyAPI`` on the spawn prim would invent a body the asset's joints
+    never reference and change the asset's dynamics. The fragment path must match the legacy
+    nested writer: author onto the prims that already carry the API and leave the spawn prim
+    untouched.
     """
     stage = _spawn_robot(
         tmp_path,
@@ -85,11 +90,11 @@ def test_rigid_body_fragments_target_existing_bodies_on_usd_asset(tmp_path):
     assert spawn_prim.HasAPI(UsdPhysics.ArticulationRootAPI)
     assert not spawn_prim.HasAPI(UsdPhysics.RigidBodyAPI)
     assert not spawn_prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
-    # every existing link body received the fragment's attribute
-    for link_name in ("link1", "link2"):
+    # every existing link body received the fragment's attribute, including the nested one
+    for link_name in LINK_REL_PATHS:
         link = stage.GetPrimAtPath(f"/World/RobotA/{link_name}")
         assert link.HasAPI(UsdPhysics.RigidBodyAPI)
-        assert link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+        assert link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0), link_name
 
 
 def test_collision_fragments_target_existing_colliders_on_usd_asset(tmp_path):
@@ -102,10 +107,10 @@ def test_collision_fragments_target_existing_colliders_on_usd_asset(tmp_path):
     spawn_prim = stage.GetPrimAtPath("/World/RobotB")
     assert not spawn_prim.HasAPI(UsdPhysics.CollisionAPI)
     assert not spawn_prim.GetAttribute("physxCollision:contactOffset").HasAuthoredValue()
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         collider = stage.GetPrimAtPath(f"/World/RobotB/{link_name}/collider")
         assert collider.HasAPI(UsdPhysics.CollisionAPI)
-        assert collider.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02)
+        assert collider.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02), link_name
 
 
 def test_mass_fragments_target_existing_mass_prims_on_usd_asset(tmp_path):
@@ -118,9 +123,9 @@ def test_mass_fragments_target_existing_mass_prims_on_usd_asset(tmp_path):
     spawn_prim = stage.GetPrimAtPath("/World/RobotC")
     assert not spawn_prim.HasAPI(UsdPhysics.MassAPI)
     assert not spawn_prim.GetAttribute("physics:mass").HasAuthoredValue()
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         link = stage.GetPrimAtPath(f"/World/RobotC/{link_name}")
-        assert link.GetAttribute("physics:mass").Get() == pytest.approx(2.0)
+        assert link.GetAttribute("physics:mass").Get() == pytest.approx(2.0), link_name
 
 
 def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path):
@@ -159,8 +164,8 @@ def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path)
 
 
 # -------------------------------------------------------------------------------------
-# Preserved behavior: bare prims (shape/mesh spawners) still get a fresh anchor,
-# and traversal does not descend past an existing schema-bearing prim.
+# Preserved behavior: bare prims (shape/mesh spawners) still get a fresh anchor, and
+# nested rigid-body trees (URDF-importer layouts) have every body modified.
 # -------------------------------------------------------------------------------------
 
 
@@ -179,26 +184,36 @@ def test_rigid_body_fragments_define_fresh_on_bare_prim():
     assert prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(3.0)
 
 
-def test_rigid_body_fragments_do_not_descend_past_existing_body():
-    """Traversal stops at the first schema-bearing prim on each branch (nested bodies are
-    illegal in physics), matching the legacy nested writer's stop-on-success behavior."""
-    from isaaclab.sim.schemas import apply_rigid_body_properties
+def test_rigid_body_and_mass_fragments_modify_nested_bodies():
+    """Every body in a nested rigid-body tree is modified, not just the outermost one.
+
+    The URDF importer authors child links under their parent link prims, so carriers of
+    ``RigidBodyAPI`` (and ``MassAPI``) legitimately nest. The fragment writers must reach all
+    of them, matching the legacy writers' full-subtree traversal for these families.
+    """
+    from isaaclab.sim.schemas import apply_mass_properties, apply_rigid_body_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
-    UsdGeom.Xform.Define(stage, "/World/Top")
-    outer = UsdGeom.Xform.Define(stage, "/World/Top/outer").GetPrim()
-    inner = UsdGeom.Xform.Define(stage, "/World/Top/outer/inner").GetPrim()
-    UsdPhysics.RigidBodyAPI.Apply(outer)
-    UsdPhysics.RigidBodyAPI.Apply(inner)  # ill-formed nesting in the source asset
+    body_paths = ["/World/Robot/pelvis", "/World/Robot/pelvis/hip", "/World/Robot/pelvis/hip/knee"]
+    UsdGeom.Xform.Define(stage, "/World/Robot")
+    for body_path in body_paths:
+        body = UsdGeom.Xform.Define(stage, body_path).GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(body)
+        UsdPhysics.MassAPI.Apply(body)
 
-    result = apply_rigid_body_properties("/World/Top", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage)
+    rigid_result = apply_rigid_body_properties(
+        "/World/Robot", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage
+    )
+    mass_result = apply_mass_properties("/World/Robot", [MassCfg(mass=2.5)], stage)
 
-    assert result is True
-    assert outer.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0)
-    # the nested body is not modified: legacy stops descending once a prim succeeds
-    assert not inner.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+    assert rigid_result is True
+    assert mass_result is True
+    for body_path in body_paths:
+        body = stage.GetPrimAtPath(body_path)
+        assert body.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0), body_path
+        assert body.GetAttribute("physics:mass").Get() == pytest.approx(2.5), body_path
 
 
 def test_rigid_body_fragments_skip_instanced_carriers(caplog):


### PR DESCRIPTION
# Description

Follow-up reconciling the fragment writers with #6377, which merged the same day as #6501.

#6377 established that nested rigid-body hierarchies are legitimate asset topology: the URDF importer in Isaac Sim 6.0 and later authors child links under their parent link prims. It fixed the legacy `modify_rigid_body_properties` / `modify_mass_properties` path via `apply_nested(stop_on_success=False)` so every link is reached. The fragment target resolver introduced in #6501 still stops descending at the first schema-bearing prim on each branch, so on such assets the fragment path modifies only the outermost link — silently reproducing the exact 1-of-N-links bug #6377 fixed on the legacy path.

This PR restores legacy parity:

- `_resolve_fragment_targets` gains a `stop_at_carrier` flag mirroring `apply_nested`'s `stop_on_success`. The rigid-body and mass fragment writers now collect every carrier in the subtree; the collision writer keeps stop-at-carrier traversal, matching the legacy collision writer, which #6377 left on the default.
- Docstrings no longer claim nested applications of the same physics schema are not allowed.
- The nested-target regression tests author a nested child link in the test asset, so the spawn-path tests, the fragment-vs-legacy parity test, and a new direct-writer test all cover the nested topology. Without the fix, four of them fail (nested link untouched by the fragment path while legacy reaches it); with it, all pass, and the legacy schema tests still pass (41/41).

Fixes the fragment-path counterpart of #6377.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
