### PR TITLE
Cast torch tensors in ID resolvers to int32 before giving to warp kernel

### DIFF
--- a/source/isaaclab_physx/changelog.d/angehu-torch-int64-to-32.rst
+++ b/source/isaaclab_physx/changelog.d/angehu-torch-int64-to-32.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the :class:`~isaaclab_physx.assets.Articulation` joint, body, and tendon index resolvers to accept
+  ``torch.int64`` ID tensors by converting them to Warp ``int32`` arrays, matching the environment-ID resolver
+  and the Newton backend. Previously, passing a default-dtype (``int64``) torch tensor of joint, body, or tendon
+  indices to a write API raised a Warp kernel dtype error on the PhysX backend while the same call succeeded on Newton.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -4887,7 +4887,9 @@ class Articulation(BaseArticulation):
         """Resolve joint indices to a warp array or tensor.
 
         .. note::
-            We do not need to convert torch tensors to warp arrays since they never get passed to the TensorAPI views.
+            Torch tensors are converted to warp ``int32`` arrays here. Torch defaults integer
+            tensors to ``int64``, but the warp kernels that consume joint indices require
+            ``int32``. This matches :meth:`_resolve_env_ids` and the Newton backend.
 
         Args:
             joint_ids: Joint indices. If None, then all indices are used.
@@ -4895,9 +4897,17 @@ class Articulation(BaseArticulation):
         Returns:
             A warp array of joint indices or a tensor of joint indices.
         """
+        if joint_ids is None:
+            return self._ALL_JOINT_INDICES
+        if isinstance(joint_ids, torch.Tensor):
+            if joint_ids.dtype == torch.int64:
+                joint_ids = joint_ids.to(torch.int32)
+            return wp.from_torch(joint_ids, dtype=wp.int32)
         if isinstance(joint_ids, list):
             return wp.array(joint_ids, dtype=wp.int32, device=self.device)
-        if (joint_ids is None) or (joint_ids == slice(None)):
+        if isinstance(joint_ids, wp.array):
+            return joint_ids
+        if joint_ids == slice(None):
             return self._ALL_JOINT_INDICES
         return joint_ids
 
@@ -4927,9 +4937,17 @@ class Articulation(BaseArticulation):
         Returns:
             A warp array of body indices or a tensor of body indices.
         """
+        if body_ids is None:
+            return self._ALL_BODY_INDICES
+        if isinstance(body_ids, torch.Tensor):
+            if body_ids.dtype == torch.int64:
+                body_ids = body_ids.to(torch.int32)
+            return wp.from_torch(body_ids, dtype=wp.int32)
         if isinstance(body_ids, list):
             return wp.array(body_ids, dtype=wp.int32, device=self.device)
-        if (body_ids is None) or (body_ids == slice(None)):
+        if isinstance(body_ids, wp.array):
+            return body_ids
+        if body_ids == slice(None):
             return self._ALL_BODY_INDICES
         return body_ids
 
@@ -4961,9 +4979,17 @@ class Articulation(BaseArticulation):
         Returns:
             A warp array of tendon indices or a tensor of tendon indices.
         """
+        if tendon_ids is None:
+            return self._ALL_FIXED_TENDON_INDICES
+        if isinstance(tendon_ids, torch.Tensor):
+            if tendon_ids.dtype == torch.int64:
+                tendon_ids = tendon_ids.to(torch.int32)
+            return wp.from_torch(tendon_ids, dtype=wp.int32)
         if isinstance(tendon_ids, list):
             return wp.array(tendon_ids, dtype=wp.int32, device=self.device)
-        if (tendon_ids is None) or (tendon_ids == slice(None)):
+        if isinstance(tendon_ids, wp.array):
+            return tendon_ids
+        if tendon_ids == slice(None):
             return self._ALL_FIXED_TENDON_INDICES
         return tendon_ids
 
@@ -4995,9 +5021,17 @@ class Articulation(BaseArticulation):
         Returns:
             A warp array of spatial tendon indices or a tensor of spatial tendon indices.
         """
+        if spatial_tendon_ids is None:
+            return self._ALL_SPATIAL_TENDON_INDICES
+        if isinstance(spatial_tendon_ids, torch.Tensor):
+            if spatial_tendon_ids.dtype == torch.int64:
+                spatial_tendon_ids = spatial_tendon_ids.to(torch.int32)
+            return wp.from_torch(spatial_tendon_ids, dtype=wp.int32)
         if isinstance(spatial_tendon_ids, list):
             return wp.array(spatial_tendon_ids, dtype=wp.int32, device=self.device)
-        if (spatial_tendon_ids is None) or (spatial_tendon_ids == slice(None)):
+        if isinstance(spatial_tendon_ids, wp.array):
+            return spatial_tendon_ids
+        if spatial_tendon_ids == slice(None):
             return self._ALL_SPATIAL_TENDON_INDICES
         return spatial_tendon_ids
 


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
