### PR TITLE
Set PXR_WORK_THREAD_LIMIT=1 for kitless rendering correctness tests

### DIFF
--- a/source/isaaclab_tasks/changelog.d/mataylor-kitless-pxr-thread-limit-one.skip
+++ b/source/isaaclab_tasks/changelog.d/mataylor-kitless-pxr-thread-limit-one.skip
@@ -1,0 +1,2 @@
+Test-only: set PXR_WORK_THREAD_LIMIT=1 for all kitless rendering correctness tests to improve
+USD work-thread determinism during golden-image comparisons. No user-facing API change.

--- a/source/isaaclab_tasks/changelog.d/mataylor-kitless-pxr-thread-limit-one.skip
+++ b/source/isaaclab_tasks/changelog.d/mataylor-kitless-pxr-thread-limit-one.skip
@@ -1,2 +1,2 @@
-Test-only: set PXR_WORK_THREAD_LIMIT=1 for all kitless rendering correctness tests to improve
-USD work-thread determinism during golden-image comparisons. No user-facing API change.
+Test-only: set PXR_WORK_THREAD_LIMIT=1 for all kitless rendering correctness tests to avoid
+USD work-thread race condition

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -732,6 +732,7 @@ def make_require_ovlibs_install_fixture():
 
     @pytest.fixture(autouse=True)
     def _require_ovlibs_install(request, monkeypatch: pytest.MonkeyPatch):
+        # TODO: Remove once usd-core>=26.5 is the minimum - that release fixes the race condition.
         # Limit OpenUSD's work-thread pool to one thread to avoid race condition in usd-core<26.5
         monkeypatch.setenv("PXR_WORK_THREAD_LIMIT", "1")
 

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -732,10 +732,7 @@ def make_require_ovlibs_install_fixture():
 
     @pytest.fixture(autouse=True)
     def _require_ovlibs_install(request, monkeypatch: pytest.MonkeyPatch):
-        # Limit OpenUSD's work-thread pool to one thread so that USD stage traversal and
-        # hydra delegate dispatch are serialized. Multi-threaded USD work produces
-        # non-deterministic draw-call ordering that causes pixel-level differences between
-        # runs, causing golden-image comparisons to fail.
+        # Limit OpenUSD's work-thread pool to one thread to avoid race condition in usd-core<26.5
         monkeypatch.setenv("PXR_WORK_THREAD_LIMIT", "1")
 
         callspec = getattr(request.node, "callspec", None)

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -732,6 +732,8 @@ def make_require_ovlibs_install_fixture():
 
     @pytest.fixture(autouse=True)
     def _require_ovlibs_install(request, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("PXR_WORK_THREAD_LIMIT", "1")
+
         callspec = getattr(request.node, "callspec", None)
         if callspec is None:
             return

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -732,6 +732,10 @@ def make_require_ovlibs_install_fixture():
 
     @pytest.fixture(autouse=True)
     def _require_ovlibs_install(request, monkeypatch: pytest.MonkeyPatch):
+        # Limit OpenUSD's work-thread pool to one thread so that USD stage traversal and
+        # hydra delegate dispatch are serialized. Multi-threaded USD work produces
+        # non-deterministic draw-call ordering that causes pixel-level differences between
+        # runs, causing golden-image comparisons to fail.
         monkeypatch.setenv("PXR_WORK_THREAD_LIMIT", "1")
 
         callspec = getattr(request.node, "callspec", None)


### PR DESCRIPTION
Limits OpenUSD's work-thread pool to a single thread for all kitless rendering tests to improve determinism in golden-image comparisons.

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
