### PR TITLE
Refresh Franka Soft golden images for the PhysX and Newton renderer combination

### DIFF
--- a/source/isaaclab_tasks/changelog.d/newton-golden-image-update.skip
+++ b/source/isaaclab_tasks/changelog.d/newton-golden-image-update.skip
@@ -1,0 +1,1 @@
+Test-only: refreshed Franka soft Newton renderer golden images. No user-facing change.

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-depth.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-depth.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cf6819fa3d05929ef6d8fc267bff29d366f31e26e86ddacafe3ee4474c921a7
-size 2368
+oid sha256:0f2c9ae64fa0cd8a6d4031d5da83bb72463e07c1c66b8d2c1ab1137c9bb6ffa1
+size 5982

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-distance_to_camera.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-distance_to_camera.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22b7afabb5d6da8722c81996dd4ac1ba2c2e4d436f2331c6865d824f2ddc56ec
+size 8499

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-distance_to_image_plane.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-distance_to_image_plane.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7f3c92f33b4a1ed53894fed00d6abd96ced569e789b83a0ce22374dea8035b8
+size 6008

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-normals.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-normals.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d021921d154cae66638b871490d930eb6420d8e0b155d0ab9181a2a6f8fdef92
-size 9308
+oid sha256:85eeb47516a15f13cb591f23e403c61baa699da2db048ec2f16be053d774297a
+size 9414

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-rgb.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-rgb.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8378cb69e6c68e390e0a6cbce0ef7df59b705bb3fd5706412f09d4165b049189
-size 8849
+oid sha256:c378b1303c53de6c4855f7d1ccdde8c7a3982998b58d55b8c11ac0192c5b80ed
+size 8959

--- a/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-rgba.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_soft/physx-newton_renderer-rgba.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d61d95f56dca0d4ee653b0f1bd3c503105eb9ce1e807c8ca1aa2fa7dfb1b6901
-size 9596
+oid sha256:189e22c6b758492670c11119b6d180e6b126a3d011491c0ad347b1bcbc822ee1
+size 9678

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1674,14 +1674,11 @@ def rendering_test_franka_soft(
     data_type: str,
     comparison_scores: list[dict],
 ) -> None:
-    if renderer == "isaacsim_rtx_renderer":
-        pytest.skip("The test cases will be enabled after OMPE-101977 is fixed.")
+    if physics_backend == "physx" or renderer == "isaacsim_rtx_renderer":
+        pytest.skip("Random teardown hangs in the kit-based combinations (OMPE-101977).")
 
     if renderer == "ovrtx_renderer" and data_type == "instance_segmentation_fast":
         pytest.skip("instance_segmentation_fast crashes with the OVRTX renderer on franka_soft (NVBUG#6463802).")
-
-    if physics_backend == "physx" and renderer == "newton_renderer":
-        pytest.skip("The test cases will be enabled after Newton Github Issue#3228 is fixed.")
 
     if renderer == "isaacsim_rtx_renderer" and data_type == "motion_vectors":
         pytest.skip("The test cases will be enabled after NVBUG#6418121 is fixed.")


### PR DESCRIPTION
# Description

Refresh Franka Soft golden images for the PhysX and Newton renderer combination.

The test case still needs to be disabled until we solve the random hang on teardown of Kit-based combinations (OMPE-101977).

## Type of change

- Test data update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
