### PR TITLE
Fix Warp import ordering for Newton renderer

### DIFF
--- a/source/isaaclab/isaaclab/__init__.py
+++ b/source/isaaclab/isaaclab/__init__.py
@@ -51,32 +51,47 @@ def _deprioritize_prebundle_paths():
                 return True
         return False
 
-    # Partition: keep non-conflicting in place, collect conflicting.
-    clean = []
-    demoted = []
-    for p in sys.path:
-        if _should_demote(p):
-            demoted.append(p)
-        else:
-            clean.append(p)
-
-    if not demoted:
-        return
+    def _demote_paths(paths):
+        # Partition: keep non-conflicting in place, collect conflicting.
+        clean = []
+        demoted = []
+        for p in paths:
+            if _should_demote(p):
+                demoted.append(p)
+            else:
+                clean.append(p)
+        return clean + demoted, bool(demoted)
 
     # Rebuild sys.path: originals first, then demoted at the very end.
-    sys.path[:] = clean + demoted
+    sys.path[:], _ = _demote_paths(sys.path)
 
     # Rewrite PYTHONPATH with the same ordering for subprocesses.
     if "PYTHONPATH" in os.environ:
         parts = os.environ["PYTHONPATH"].split(os.pathsep)
-        env_clean = []
-        env_demoted = []
-        for p in parts:
-            if _should_demote(p):
-                env_demoted.append(p)
-            else:
-                env_clean.append(p)
-        os.environ["PYTHONPATH"] = os.pathsep.join(env_clean + env_demoted)
+        os.environ["PYTHONPATH"] = os.pathsep.join(_demote_paths(parts)[0])
+
+    # Kit can mutate a loaded package's search path directly.  If ``warp`` is
+    # already imported and an older ``omni.warp.core`` path is appended to
+    # ``warp.__path__``, a later ``import warp.fem`` can still mix the extension
+    # package with Isaac Lab's pip-installed Warp even when ``sys.path`` is
+    # clean.  Reorder loaded package paths with the same policy.
+    for module in tuple(sys.modules.values()):
+        package_path = getattr(module, "__path__", None)
+        if package_path is None:
+            continue
+        try:
+            reordered, changed = _demote_paths(list(package_path))
+        except TypeError:
+            continue
+        if not changed:
+            continue
+        try:
+            package_path[:] = reordered
+        except TypeError:
+            try:
+                module.__path__ = reordered
+            except Exception:
+                pass
 
 
 _deprioritize_prebundle_paths()

--- a/source/isaaclab/isaaclab/utils/backend_utils.py
+++ b/source/isaaclab/isaaclab/utils/backend_utils.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_import_paths() -> None:
+    """Re-apply Isaac Lab import path ordering before dynamic backend imports."""
+    try:
+        from isaaclab import _deprioritize_prebundle_paths
+    except (AttributeError, ImportError):
+        return
+    _deprioritize_prebundle_paths()
+
+
 def get_default_renderer_cfg() -> RendererCfg:
     """Return the default :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` for cameras.
 
@@ -114,8 +123,10 @@ class FactoryBase:
             # Construct the module name from the backend and the determined subpath.
             module_name = cls._get_module_name(backend)
             try:
+                _sanitize_import_paths()
                 module = importlib.import_module(module_name)
                 class_name = getattr(cls, "_backend_class_names", {}).get(backend, cls.__name__)
+                _sanitize_import_paths()
                 module_class = getattr(module, class_name)
                 # Manually register the class
                 cls.register(backend, module_class)

--- a/source/isaaclab/test/test_import_path_sanitization.py
+++ b/source/isaaclab/test/test_import_path_sanitization.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Isaac Sim prebundle/import-path sanitization."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+import isaaclab
+from isaaclab.utils.backend_utils import FactoryBase
+
+pytestmark = pytest.mark.unit
+
+
+def test_deprioritize_prebundle_paths_demotes_loaded_package_paths(monkeypatch):
+    good_sys_path = "/workspace/isaaclab/_isaac_sim/kit/python/lib/python3.12/site-packages"
+    bad_sys_path = "/isaac-sim/extscache/omni.warp.core-1.13.0+lx64"
+    good_package_path = f"{good_sys_path}/warp"
+    bad_package_path = f"{bad_sys_path}/warp"
+
+    fake_package = types.ModuleType("_fake_warp_package")
+    fake_package.__path__ = [bad_package_path, good_package_path]
+
+    monkeypatch.setattr(sys, "path", [bad_sys_path, good_sys_path])
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([bad_sys_path, good_sys_path]))
+    monkeypatch.setitem(sys.modules, fake_package.__name__, fake_package)
+
+    isaaclab._deprioritize_prebundle_paths()
+
+    assert sys.path == [good_sys_path, bad_sys_path]
+    assert os.environ["PYTHONPATH"] == os.pathsep.join([good_sys_path, bad_sys_path])
+    assert fake_package.__path__ == [good_package_path, bad_package_path]
+
+
+def test_factory_sanitizes_paths_before_dynamic_backend_import(monkeypatch):
+    calls = []
+    backend_module = types.ModuleType("_fake_backend_module")
+
+    class DummyFactoryImpl:
+        pass
+
+    backend_module.DummyFactory = DummyFactoryImpl
+
+    class DummyFactory(FactoryBase):
+        __module__ = "isaaclab.fake.factory"
+
+        @classmethod
+        def _get_backend(cls, *args, **kwargs):
+            return "dummy"
+
+        @classmethod
+        def _get_module_name(cls, backend: str) -> str:
+            return backend_module.__name__
+
+    def fake_sanitize():
+        calls.append("sanitize")
+
+    def fake_import_module(name):
+        assert calls == ["sanitize"]
+        return backend_module
+
+    def lazy_getattr(name):
+        assert calls == ["sanitize", "sanitize"]
+        return DummyFactoryImpl
+
+    backend_module.__getattr__ = lazy_getattr
+
+    monkeypatch.setattr(isaaclab, "_deprioritize_prebundle_paths", fake_sanitize)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    assert DummyFactory.resolve_class() is DummyFactoryImpl

--- a/source/isaaclab_newton/isaaclab_newton/__init__.py
+++ b/source/isaaclab_newton/isaaclab_newton/__init__.py
@@ -7,6 +7,31 @@
 
 import importlib.metadata
 
+
+def _prepare_warp_imports() -> None:
+    """Keep Newton imports bound to Isaac Lab's pip-installed Warp package."""
+    try:
+        from isaaclab import _deprioritize_prebundle_paths
+    except (AttributeError, ImportError):
+        def _deprioritize_prebundle_paths() -> None:
+            return
+
+    _deprioritize_prebundle_paths()
+    try:
+        import warp  # noqa: F401
+
+        _deprioritize_prebundle_paths()
+        import warp.fem  # noqa: F401
+    except ImportError:
+        # Let the concrete Newton import site surface dependency errors with
+        # its normal context. This hook only corrects path ordering when Warp is
+        # available.
+        return
+
+
+_prepare_warp_imports()
+
+
 try:
     __version__ = importlib.metadata.version("isaaclab_newton")
 except importlib.metadata.PackageNotFoundError:

--- a/source/isaaclab_newton/test/test_warp_import_sanitization.py
+++ b/source/isaaclab_newton/test/test_warp_import_sanitization.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Newton/Warp import path preparation."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_prepare_warp_imports_sanitizes_before_loading_warp_fem(monkeypatch):
+    calls = []
+    warp_module = types.ModuleType("warp")
+    warp_module.__path__ = ["/isaac-sim/extscache/omni.warp.core-1.13.0+lx64/warp", "/pip/site-packages/warp"]
+    warp_fem_module = types.ModuleType("warp.fem")
+
+    def fake_sanitize():
+        calls.append("sanitize")
+        warp_module.__path__ = ["/pip/site-packages/warp", "/isaac-sim/extscache/omni.warp.core-1.13.0+lx64/warp"]
+
+    isaaclab_module = types.ModuleType("isaaclab")
+    isaaclab_module._deprioritize_prebundle_paths = fake_sanitize
+
+    def fake_import_module(name, package=None):
+        if name == "isaaclab":
+            return isaaclab_module
+        if name == "warp":
+            return warp_module
+        if name == "warp.fem":
+            assert calls == ["sanitize", "sanitize"]
+            assert warp_module.__path__[0] == "/pip/site-packages/warp"
+            return warp_fem_module
+        raise AssertionError(f"unexpected import: {name}")
+
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and name in {"isaaclab", "warp"}:
+            return fake_import_module(name)
+        if level == 0 and name == "warp.fem":
+            return fake_import_module(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setitem(sys.modules, "isaaclab", isaaclab_module)
+    monkeypatch.setitem(sys.modules, "warp", warp_module)
+
+    from isaaclab_newton import _prepare_warp_imports
+
+    calls.clear()
+    warp_module.__path__ = ["/isaac-sim/extscache/omni.warp.core-1.13.0+lx64/warp", "/pip/site-packages/warp"]
+    _prepare_warp_imports()
+
+    assert calls == ["sanitize", "sanitize"]

--- a/tools/wheel_builder/res/__init__.py
+++ b/tools/wheel_builder/res/__init__.py
@@ -56,32 +56,47 @@ def _deprioritize_prebundle_paths():
                 return True
         return False
 
-    # Partition: keep non-conflicting in place, collect conflicting.
-    clean = []
-    demoted = []
-    for p in sys.path:
-        if _should_demote(p):
-            demoted.append(p)
-        else:
-            clean.append(p)
-
-    if not demoted:
-        return
+    def _demote_paths(paths):
+        # Partition: keep non-conflicting in place, collect conflicting.
+        clean = []
+        demoted = []
+        for p in paths:
+            if _should_demote(p):
+                demoted.append(p)
+            else:
+                clean.append(p)
+        return clean + demoted, bool(demoted)
 
     # Rebuild sys.path: originals first, then demoted at the very end.
-    sys.path[:] = clean + demoted
+    sys.path[:], _ = _demote_paths(sys.path)
 
     # Rewrite PYTHONPATH with the same ordering for subprocesses.
     if "PYTHONPATH" in os.environ:
         parts = os.environ["PYTHONPATH"].split(os.pathsep)
-        env_clean = []
-        env_demoted = []
-        for p in parts:
-            if _should_demote(p):
-                env_demoted.append(p)
-            else:
-                env_clean.append(p)
-        os.environ["PYTHONPATH"] = os.pathsep.join(env_clean + env_demoted)
+        os.environ["PYTHONPATH"] = os.pathsep.join(_demote_paths(parts)[0])
+
+    # Kit can mutate a loaded package's search path directly.  If ``warp`` is
+    # already imported and an older ``omni.warp.core`` path is appended to
+    # ``warp.__path__``, a later ``import warp.fem`` can still mix the extension
+    # package with Isaac Lab's pip-installed Warp even when ``sys.path`` is
+    # clean.  Reorder loaded package paths with the same policy.
+    for module in tuple(sys.modules.values()):
+        package_path = getattr(module, "__path__", None)
+        if package_path is None:
+            continue
+        try:
+            reordered, changed = _demote_paths(list(package_path))
+        except TypeError:
+            continue
+        if not changed:
+            continue
+        try:
+            package_path[:] = reordered
+        except TypeError:
+            try:
+                module.__path__ = reordered
+            except Exception:
+                pass
 
 
 _deprioritize_prebundle_paths()


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
