### PR TITLE
Ignore PyTetWild tracked-surface artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ docker/.container.cfg
 **/.neptune/*
 docker/artifacts/
 *.tmp
+**/__tracked_surface.stl
 
 # Doc Outputs
 **/docs/_build/*


### PR DESCRIPTION
# Description

PyTetWild writes `__tracked_surface.stl` into the current working directory while tetrahedralizing meshes used by the deformables demo. This generated artifact can dirty the repository when the demo is launched from the repository root.

This change adds the exact recursive pattern `**/__tracked_surface.stl` to `.gitignore`. The narrow pattern ignores the generated file at any depth while leaving unrelated STL files and underscore-prefixed Python files visible. No runtime behavior or dependencies change.

Fixes [NVBug 6450931](https://nvbugspro.nvidia.com/bug/6450931/1) 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- Verified root-level and nested `__tracked_surface.stl` paths are ignored.
- Verified unrelated STL files and `__init__.py` remain visible to Git.
- Ran `./isaaclab.sh --format` from a fresh isolated uv environment.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] Documentation is not required for this `.gitignore`-only change
- [x] My changes generate no new warnings
- [x] I have validated that the ignore rule is effective and narrowly scoped
- [x] A changelog fragment is not required because no package was touched
- [x] My name already exists in `CONTRIBUTORS.md`
