### PR TITLE
Fix first-frame RTX synchronization after tensor pose writes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -192,6 +192,7 @@ Guidelines for modifications:
 * Song Yi
 * Stefan Van de Mosselaer
 * Stephan Pleines
+* StriverAlex
 * Tiffany Chen
 * Trushant Adeshara
 * Tsz Ki GAO

--- a/source/isaaclab/changelog.d/striveralex-fix-physx-forward-sync.minor.rst
+++ b/source/isaaclab/changelog.d/striveralex-fix-physx-forward-sync.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab.physics.PhysicsManager.before_kit_app_update` so physics backends can defer
+  synchronization until a Kit frame consumes it.

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -409,6 +409,20 @@ class PhysicsManager(ABC):
         pass
 
     @classmethod
+    def before_kit_app_update(cls) -> bool:
+        """Sync deferred backend state immediately before a frame-producing Kit update.
+
+        The default implementation is a no-op. Backends should override this only when
+        synchronization is required specifically for Kit/RTX rendering, rather than for
+        standalone visualizers handled by :meth:`pre_render`.
+
+        Returns:
+            True when synchronization changed physics state that must be forwarded to the
+            rendering backend before the Kit update; otherwise False.
+        """
+        return False
+
+    @classmethod
     def after_visualizers_render(cls) -> None:
         """Hook after visualizers have stepped during :meth:`~isaaclab.sim.SimulationContext.render`.
 

--- a/source/isaaclab/test/assets/test_physx_tensor_pose_write_barrier.py
+++ b/source/isaaclab/test/assets/test_physx_tensor_pose_write_barrier.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for the PhysX tensor-pose write barrier."""
+
+from unittest.mock import patch
+
+import pytest
+import warp as wp
+from _articulation_iface_test_utils import BACKENDS as ARTICULATION_BACKENDS
+from _articulation_iface_test_utils import get_articulation
+from _rigid_object_collection_iface_test_utils import BACKENDS as COLLECTION_BACKENDS
+from _rigid_object_collection_iface_test_utils import get_rigid_object_collection
+from _rigid_object_iface_test_utils import BACKENDS as RIGID_OBJECT_BACKENDS
+from _rigid_object_iface_test_utils import get_rigid_object
+from isaaclab_physx.assets.articulation import articulation as articulation_module
+from isaaclab_physx.assets.rigid_object import rigid_object as rigid_object_module
+from isaaclab_physx.assets.rigid_object_collection import rigid_object_collection as collection_module
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            "physx" in backends for backends in (RIGID_OBJECT_BACKENDS, COLLECTION_BACKENDS, ARTICULATION_BACKENDS)
+        ),
+        reason="PhysX backend is unavailable",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("asset_kind", "method_name"),
+    [
+        ("rigid_object", "write_root_link_pose_to_sim_index"),
+        ("rigid_object", "write_root_com_pose_to_sim_index"),
+        ("collection", "write_body_link_pose_to_sim_index"),
+        ("collection", "write_body_com_pose_to_sim_index"),
+        ("articulation", "write_root_link_pose_to_sim_index"),
+        ("articulation", "write_root_com_pose_to_sim_index"),
+    ],
+)
+def test_pose_writer_notifies_tensor_pose_write(asset_kind: str, method_name: str):
+    if asset_kind == "rigid_object":
+        asset, _ = get_rigid_object("physx", num_instances=2, device="cpu")
+        module = rigid_object_module
+        argument_name = "root_pose"
+        pose = wp.zeros((asset.num_instances,), dtype=wp.transformf, device="cpu")
+    elif asset_kind == "collection":
+        asset, _ = get_rigid_object_collection("physx", num_instances=2, num_bodies=3, device="cpu")
+        module = collection_module
+        argument_name = "body_poses"
+        pose = wp.zeros((asset.num_instances, asset.num_bodies), dtype=wp.transformf, device="cpu")
+    else:
+        asset, _ = get_articulation("physx", num_instances=2, num_joints=3, num_bodies=4, device="cpu")
+        module = articulation_module
+        argument_name = "root_pose"
+        pose = wp.zeros((asset.num_instances,), dtype=wp.transformf, device="cpu")
+
+    with patch.object(module.SimulationManager, "notify_tensor_pose_write") as notify:
+        getattr(asset, method_name)(**{argument_name: pose})
+
+    notify.assert_called_once_with()

--- a/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
+++ b/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
@@ -12,9 +12,13 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 
 """Rest everything follows."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import pytest
 import torch
 from isaaclab_physx.sim.schemas import PhysxCollisionPropertiesCfg, PhysxRigidBodyPropertiesCfg
+from isaaclab_visualizers.kit import KitVisualizerCfg
 
 import omni.replicator.core as rep
 
@@ -22,6 +26,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.sensors.camera import Camera, CameraCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.visualizers import VisualizerCfg
 
 pytestmark = [pytest.mark.integration, pytest.mark.rendering]
 
@@ -57,40 +62,55 @@ def _is_grey(mean_rgb: torch.Tensor) -> bool:
     return bool(channels_equal and all_low)
 
 
+@contextmanager
+def _simulation_context(
+    device: str,
+    gravity: tuple[float, float, float] = (0.0, 0.0, -9.81),
+    visualizer_cfg: VisualizerCfg | None = None,
+) -> Iterator[tuple[sim_utils.SimulationContext, float]]:
+    """Create and reliably tear down a simulation context for rendering tests."""
+    sim_utils.create_new_stage()
+    dt = 0.01
+    sim = sim_utils.SimulationContext(
+        sim_utils.SimulationCfg(
+            dt=dt,
+            device=device,
+            gravity=gravity,
+            visualizer_cfgs=[] if visualizer_cfg is None else visualizer_cfg,
+        )
+    )
+    try:
+        yield sim, dt
+    finally:
+        rep.vp_manager.destroy_hydra_textures("Replicator")
+        sim.stop()
+        sim.clear_instance()
+
+
 @pytest.fixture(scope="function")
-def setup_sim(device):
+def setup_sim(device: str) -> Iterator[tuple[sim_utils.SimulationContext, float]]:
     """Fixture to set up and tear down the textured rendering test environment."""
-    # Create a new stage
-    sim_utils.create_new_stage()
-    # Simulation time-step
-    dt = 0.01
-    # Load kit helper
-    sim_cfg = sim_utils.SimulationCfg(dt=dt, device=device)
-    sim = sim_utils.SimulationContext(sim_cfg)
-    # populate scene
-    _populate_scene()
-    # load stage
-    sim_utils.update_stage()
-    yield sim, dt
-    # Teardown
-    rep.vp_manager.destroy_hydra_textures("Replicator")
-    sim.stop()
-    sim.clear_instance()
+    with _simulation_context(device) as (sim, dt):
+        _populate_scene()
+        sim_utils.update_stage()
+        yield sim, dt
 
 
 @pytest.fixture(scope="function")
-def setup_pose_sim(device):
-    """Set up a local-only RTX scene for the tensor-pose regression test."""
-    sim_utils.create_new_stage()
-    dt = 0.01
-    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=dt, device=device, gravity=(0.0, 0.0, 0.0)))
-    light_cfg = sim_utils.DomeLightCfg(intensity=DOME_LIGHT_INTENSITY, color=(1.0, 1.0, 1.0))
-    light_cfg.func("/World/Light", light_cfg)
-    sim_utils.update_stage()
-    yield sim, dt
-    rep.vp_manager.destroy_hydra_textures("Replicator")
-    sim.stop()
-    sim.clear_instance()
+def setup_pose_sim(device: str) -> Iterator[tuple[sim_utils.SimulationContext, float]]:
+    """Set up a local-only RTX scene with a Kit visualizer for the tensor-pose regression test."""
+    visualizer_cfg = KitVisualizerCfg(
+        window_width=WIDTH,
+        window_height=HEIGHT,
+        eye=(1.5, -1.5, 1.0),
+        lookat=(0.5, 0.0, 0.2),
+        randomly_sample_visible_envs=False,
+    )
+    with _simulation_context(device, gravity=(0.0, 0.0, 0.0), visualizer_cfg=visualizer_cfg) as (sim, dt):
+        light_cfg = sim_utils.DomeLightCfg(intensity=DOME_LIGHT_INTENSITY, color=(1.0, 1.0, 1.0))
+        light_cfg.func("/World/Light", light_cfg)
+        sim_utils.update_stage()
+        yield sim, dt
 
 
 def _assert_first_frame_textured(first_frame: torch.Tensor, stable_frame: torch.Tensor):
@@ -118,7 +138,7 @@ def _assert_first_frame_textured(first_frame: torch.Tensor, stable_frame: torch.
 
 @pytest.mark.parametrize("device", ["cuda:0"])
 @pytest.mark.isaacsim_ci
-def test_first_frame_is_textured_camera(setup_sim, device):
+def test_first_frame_is_textured_camera(setup_sim: tuple[sim_utils.SimulationContext, float], device: str):
     """First RTX frame from a USD Camera must show loaded textures, not a grey placeholder."""
     sim, dt = setup_sim
     camera_cfg = CameraCfg(
@@ -158,9 +178,11 @@ def test_first_frame_is_textured_camera(setup_sim, device):
 
 @pytest.mark.parametrize("device", ["cuda:0"])
 @pytest.mark.isaacsim_ci
-def test_tensor_pose_is_visible_in_first_camera_frame(setup_pose_sim, device):
-    """A tensor pose write after reset must be visible without a public physics step."""
-    sim, dt = setup_pose_sim
+def test_tensor_pose_is_visible_in_first_kit_frame(
+    setup_pose_sim: tuple[sim_utils.SimulationContext, float], device: str
+):
+    """A tensor pose write after reset must be visible in the first Kit visualizer frame."""
+    sim, _ = setup_pose_sim
     cube = RigidObject(
         RigidObjectCfg(
             prim_path="/World/Objects/MovingCube",
@@ -174,37 +196,21 @@ def test_tensor_pose_is_visible_in_first_camera_frame(setup_pose_sim, device):
             init_state=RigidObjectCfg.InitialStateCfg(pos=(5.0, 0.0, 0.2)),
         )
     )
-    camera = Camera(
-        CameraCfg(
-            height=HEIGHT,
-            width=WIDTH,
-            offset=CameraCfg.OffsetCfg(pos=(0.5, 0.0, 2.0), rot=(0.0, 1.0, 0.0, 0.0), convention="ros"),
-            prim_path="/World/PoseCamera",
-            update_period=0,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=24.0,
-                focus_distance=400.0,
-                horizontal_aperture=20.955,
-                clipping_range=(0.1, 1.0e5),
-            ),
-        )
-    )
 
     sim.reset()
+
+    visualizer = sim.visualizers[0]
+    visualizer.render_rgb_array()  # Initialise the viewport before the pose write under test.
 
     root_pose = cube.data.default_root_pose.torch.clone()
     root_pose[:, :3] = torch.tensor((0.5, 0.0, 0.2), device=sim.device)
     cube.write_root_pose_to_sim_index(root_pose=root_pose)
-    sim.render()
 
-    camera.update(dt)
-    first_frame = camera.data.output["rgb"].torch[0].clone().to(dtype=torch.float32)
+    first_frame = torch.from_numpy(visualizer.render_rgb_array()).to(dtype=torch.float32)
     first_frame_step = sim.get_physics_step_count()
 
     sim.step()
-    camera.update(dt)
-    stable_frame = camera.data.output["rgb"].torch[0].clone().to(dtype=torch.float32)
+    stable_frame = torch.from_numpy(visualizer.render_rgb_array()).to(dtype=torch.float32)
 
     def red_fraction(frame: torch.Tensor) -> float:
         red, green, blue = frame.unbind(dim=-1)
@@ -221,7 +227,6 @@ def test_tensor_pose_is_visible_in_first_camera_frame(setup_pose_sim, device):
         f"stable red fraction={stable_red_fraction:.6f}."
     )
 
-    del camera
     del cube
 
 

--- a/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
+++ b/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
@@ -14,10 +14,12 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 
 import pytest
 import torch
+from isaaclab_physx.sim.schemas import PhysxCollisionPropertiesCfg, PhysxRigidBodyPropertiesCfg
 
 import omni.replicator.core as rep
 
 import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.sensors.camera import Camera, CameraCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
@@ -71,6 +73,21 @@ def setup_sim(device):
     sim_utils.update_stage()
     yield sim, dt
     # Teardown
+    rep.vp_manager.destroy_hydra_textures("Replicator")
+    sim.stop()
+    sim.clear_instance()
+
+
+@pytest.fixture(scope="function")
+def setup_pose_sim(device):
+    """Set up a local-only RTX scene for the tensor-pose regression test."""
+    sim_utils.create_new_stage()
+    dt = 0.01
+    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=dt, device=device, gravity=(0.0, 0.0, 0.0)))
+    light_cfg = sim_utils.DomeLightCfg(intensity=DOME_LIGHT_INTENSITY, color=(1.0, 1.0, 1.0))
+    light_cfg.func("/World/Light", light_cfg)
+    sim_utils.update_stage()
+    yield sim, dt
     rep.vp_manager.destroy_hydra_textures("Replicator")
     sim.stop()
     sim.clear_instance()
@@ -137,6 +154,75 @@ def test_first_frame_is_textured_camera(setup_sim, device):
     del camera
 
     _assert_first_frame_textured(first_frame, stable_frame)
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+@pytest.mark.isaacsim_ci
+def test_tensor_pose_is_visible_in_first_camera_frame(setup_pose_sim, device):
+    """A tensor pose write after reset must be visible without a public physics step."""
+    sim, dt = setup_pose_sim
+    cube = RigidObject(
+        RigidObjectCfg(
+            prim_path="/World/Objects/MovingCube",
+            spawn=sim_utils.CuboidCfg(
+                size=(0.2, 0.2, 0.2),
+                rigid_props=PhysxRigidBodyPropertiesCfg(),
+                mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+                collision_props=PhysxCollisionPropertiesCfg(),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),
+            ),
+            init_state=RigidObjectCfg.InitialStateCfg(pos=(5.0, 0.0, 0.2)),
+        )
+    )
+    camera = Camera(
+        CameraCfg(
+            height=HEIGHT,
+            width=WIDTH,
+            offset=CameraCfg.OffsetCfg(pos=(0.5, 0.0, 2.0), rot=(0.0, 1.0, 0.0, 0.0), convention="ros"),
+            prim_path="/World/PoseCamera",
+            update_period=0,
+            data_types=["rgb"],
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0,
+                focus_distance=400.0,
+                horizontal_aperture=20.955,
+                clipping_range=(0.1, 1.0e5),
+            ),
+        )
+    )
+
+    sim.reset()
+
+    root_pose = cube.data.default_root_pose.torch.clone()
+    root_pose[:, :3] = torch.tensor((0.5, 0.0, 0.2), device=sim.device)
+    cube.write_root_pose_to_sim_index(root_pose=root_pose)
+    sim.forward()
+
+    camera.update(dt)
+    first_frame = camera.data.output["rgb"].torch[0].clone().to(dtype=torch.float32)
+    first_frame_step = sim.get_physics_step_count()
+
+    sim.step()
+    camera.update(dt)
+    stable_frame = camera.data.output["rgb"].torch[0].clone().to(dtype=torch.float32)
+
+    def red_fraction(frame: torch.Tensor) -> float:
+        red, green, blue = frame.unbind(dim=-1)
+        red_pixels = (red > 40.0) & (red > 1.5 * green) & (red > 1.5 * blue)
+        return red_pixels.float().mean().item()
+
+    first_red_fraction = red_fraction(first_frame)
+    stable_red_fraction = red_fraction(stable_frame)
+
+    assert first_frame_step == 0
+    assert stable_red_fraction > 0.005, "The moved red cube is not visible in the stable reference frame."
+    assert first_red_fraction > 0.5 * stable_red_fraction, (
+        f"The tensor pose is stale in the first frame: first red fraction={first_red_fraction:.6f}, "
+        f"stable red fraction={stable_red_fraction:.6f}."
+    )
+
+    del camera
+    del cube
 
 
 """

--- a/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
+++ b/source/isaaclab/test/sensors/test_first_frame_textured_rendering.py
@@ -196,7 +196,7 @@ def test_tensor_pose_is_visible_in_first_camera_frame(setup_pose_sim, device):
     root_pose = cube.data.default_root_pose.torch.clone()
     root_pose[:, :3] = torch.tensor((0.5, 0.0, 0.2), device=sim.device)
     cube.write_root_pose_to_sim_index(root_pose=root_pose)
-    sim.forward()
+    sim.render()
 
     camera.update(dt)
     first_frame = camera.data.output["rgb"].torch[0].clone().to(dtype=torch.float32)

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -14,6 +14,8 @@ simulation_app = AppLauncher(headless=True, device=resolve_test_sim_device()).ap
 """Rest everything follows."""
 
 import weakref
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import numpy as np
 import pytest
@@ -917,6 +919,28 @@ def test_isaac_event_triggered_on_reset(event_type):
 def test_forward_and_clean_render_do_not_emit_native_step_callbacks():
     """Forward and clean renders must not emit native physics-step callbacks."""
     sim = SimulationContext(SimulationCfg(dt=0.01))
+    sim.reset()
+
+    with (
+        _temporary_bool_setting(sim, "/isaaclab/video/enabled", False),
+        _native_step_callback_counts() as callback_counts,
+    ):
+        sim.forward()
+        sim.render()
+
+        assert sim.get_physics_step_count() == 0
+        assert callback_counts == {"pre": 0, "post": 0}
+
+        sim.step(render=False)
+
+        assert sim.get_physics_step_count() == 1
+        assert callback_counts == {"pre": 1, "post": 1}
+
+
+@pytest.mark.isaacsim_ci
+def test_render_sync_only_runs_for_kit_rtx_frames():
+    """Pending rigid poses must sync only when a Kit/RTX frame will consume them."""
+    sim = SimulationContext(SimulationCfg(dt=0.01))
     cube = RigidObject(
         RigidObjectCfg(
             prim_path="/World/Cube",
@@ -929,30 +953,33 @@ def test_forward_and_clean_render_do_not_emit_native_step_callbacks():
     )
     sim.reset()
 
-    callback_counts = {"pre": 0, "post": 0}
+    with (
+        _temporary_bool_setting(sim, "/isaaclab/video/enabled", False),
+        _temporary_bool_setting(sim, "/isaaclab/render/rtx_sensors", False),
+        _native_step_callback_counts() as callback_counts,
+    ):
+        root_pose = cube.data.default_root_pose.torch.clone()
+        root_pose[:, 0] += 0.1
+        cube.write_root_pose_to_sim_index(root_pose=root_pose)
+        root_pose[:, 0] += 0.1
+        cube.write_root_pose_to_sim_index(root_pose=root_pose)
 
-    def on_pre_step(_dt):
-        callback_counts["pre"] += 1
-
-    def on_post_step(_dt):
-        callback_counts["post"] += 1
-
-    physx_interface = omni.physx.get_physx_interface()
-    subscriptions = [
-        physx_interface.subscribe_physics_on_step_events(on_pre_step, pre_step=True, order=0),
-        physx_interface.subscribe_physics_on_step_events(on_post_step, pre_step=False, order=0),
-    ]
-
-    try:
-        sim.forward()
-        sim.render()
+        # Multiple writes coalesce, and an RTX sensor can be active while per-step
+        # camera/Kit rendering is disabled.
+        sim.set_setting("/isaaclab/render/rtx_sensors", True)
+        sim.render(skip_app_pumping=True)
 
         assert sim.get_physics_step_count() == 0
         assert callback_counts == {"pre": 0, "post": 0}
 
-        root_pose = cube.data.default_root_pose.torch.clone()
-        root_pose[:, 0] += 0.1
-        cube.write_root_pose_to_sim_index(root_pose=root_pose)
+        # A render with no Kit/RTX consumer must also keep the pending sync intact.
+        sim.set_setting("/isaaclab/render/rtx_sensors", False)
+        sim.render()
+
+        assert callback_counts == {"pre": 0, "post": 0}
+
+        # The next real RTX render consumes the pending sync exactly once.
+        sim.set_setting("/isaaclab/video/enabled", True)
         sim.render()
 
         assert sim.get_physics_step_count() == 0
@@ -973,6 +1000,38 @@ def test_forward_and_clean_render_do_not_emit_native_step_callbacks():
 
         assert sim.get_physics_step_count() == 2
         assert callback_counts == {"pre": 3, "post": 3}
+
+
+@contextmanager
+def _temporary_bool_setting(sim: SimulationContext, path: str, value: bool) -> Iterator[None]:
+    """Temporarily override a process-global simulation setting."""
+    previous_value = bool(sim.get_setting(path))
+    sim.set_setting(path, value)
+    try:
+        yield
+    finally:
+        sim.set_setting(path, previous_value)
+
+
+@contextmanager
+def _native_step_callback_counts() -> Iterator[dict[str, int]]:
+    """Count callbacks emitted directly by the native PhysX interface."""
+    callback_counts = {"pre": 0, "post": 0}
+
+    def on_pre_step(_dt: float):
+        callback_counts["pre"] += 1
+
+    def on_post_step(_dt: float):
+        callback_counts["post"] += 1
+
+    physx_interface = omni.physx.get_physx_interface()
+    subscriptions = [
+        physx_interface.subscribe_physics_on_step_events(on_pre_step, pre_step=True, order=0),
+        physx_interface.subscribe_physics_on_step_events(on_post_step, pre_step=False, order=0),
+    ]
+
+    try:
+        yield callback_counts
     finally:
         subscriptions.clear()
 

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import IsaacEvents, PhysxCfg, PhysxManager
+from isaaclab_physx.sim.schemas import PhysxCollisionPropertiesCfg, PhysxRigidBodyPropertiesCfg
 
 import omni.timeline
 
@@ -908,6 +909,50 @@ def test_isaac_event_triggered_on_reset(event_type):
         # cleanup callback
         if callback_id is not None:
             PhysxManager.deregister_callback(callback_id)
+
+
+@pytest.mark.isaacsim_ci
+def test_forward_updates_without_step_callbacks():
+    """Forward updates must not have public physics-step semantics."""
+    sim = SimulationContext(SimulationCfg(dt=0.01))
+    cube_cfg = sim_utils.CuboidCfg(
+        size=(0.1, 0.1, 0.1),
+        rigid_props=PhysxRigidBodyPropertiesCfg(),
+        collision_props=PhysxCollisionPropertiesCfg(),
+    )
+    cube_cfg.func("/World/Cube", cube_cfg)
+
+    callback_counts = {"pre": 0, "post": 0}
+
+    def on_pre_step(_dt):
+        callback_counts["pre"] += 1
+
+    def on_post_step(_dt):
+        callback_counts["post"] += 1
+
+    pre_handle = PhysxManager.register_callback(on_pre_step, event=IsaacEvents.PRE_PHYSICS_STEP)
+    post_handle = PhysxManager.register_callback(on_post_step, event=IsaacEvents.POST_PHYSICS_STEP)
+
+    try:
+        sim.reset()
+
+        assert sim.get_physics_step_count() == 0
+        assert callback_counts == {"pre": 0, "post": 0}
+
+        sim.forward()
+
+        assert sim.get_physics_step_count() == 0
+        assert callback_counts == {"pre": 0, "post": 0}
+
+        sim.step(render=False)
+
+        assert sim.get_physics_step_count() == 1
+        assert callback_counts == {"pre": 1, "post": 1}
+    finally:
+        if pre_handle is not None:
+            PhysxManager.deregister_callback(pre_handle)
+        if post_handle is not None:
+            PhysxManager.deregister_callback(post_handle)
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -21,9 +21,11 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import IsaacEvents, PhysxCfg, PhysxManager
 from isaaclab_physx.sim.schemas import PhysxCollisionPropertiesCfg, PhysxRigidBodyPropertiesCfg
 
+import omni.physx
 import omni.timeline
 
 import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim import SimulationCfg, SimulationContext
 
@@ -912,15 +914,20 @@ def test_isaac_event_triggered_on_reset(event_type):
 
 
 @pytest.mark.isaacsim_ci
-def test_forward_updates_without_step_callbacks():
-    """Forward updates must not have public physics-step semantics."""
+def test_forward_and_clean_render_do_not_emit_native_step_callbacks():
+    """Forward and clean renders must not emit native physics-step callbacks."""
     sim = SimulationContext(SimulationCfg(dt=0.01))
-    cube_cfg = sim_utils.CuboidCfg(
-        size=(0.1, 0.1, 0.1),
-        rigid_props=PhysxRigidBodyPropertiesCfg(),
-        collision_props=PhysxCollisionPropertiesCfg(),
+    cube = RigidObject(
+        RigidObjectCfg(
+            prim_path="/World/Cube",
+            spawn=sim_utils.CuboidCfg(
+                size=(0.1, 0.1, 0.1),
+                rigid_props=PhysxRigidBodyPropertiesCfg(),
+                collision_props=PhysxCollisionPropertiesCfg(),
+            ),
+        )
     )
-    cube_cfg.func("/World/Cube", cube_cfg)
+    sim.reset()
 
     callback_counts = {"pre": 0, "post": 0}
 
@@ -930,29 +937,44 @@ def test_forward_updates_without_step_callbacks():
     def on_post_step(_dt):
         callback_counts["post"] += 1
 
-    pre_handle = PhysxManager.register_callback(on_pre_step, event=IsaacEvents.PRE_PHYSICS_STEP)
-    post_handle = PhysxManager.register_callback(on_post_step, event=IsaacEvents.POST_PHYSICS_STEP)
+    physx_interface = omni.physx.get_physx_interface()
+    subscriptions = [
+        physx_interface.subscribe_physics_on_step_events(on_pre_step, pre_step=True, order=0),
+        physx_interface.subscribe_physics_on_step_events(on_post_step, pre_step=False, order=0),
+    ]
 
     try:
-        sim.reset()
-
-        assert sim.get_physics_step_count() == 0
-        assert callback_counts == {"pre": 0, "post": 0}
-
         sim.forward()
+        sim.render()
 
         assert sim.get_physics_step_count() == 0
         assert callback_counts == {"pre": 0, "post": 0}
+
+        root_pose = cube.data.default_root_pose.torch.clone()
+        root_pose[:, 0] += 0.1
+        cube.write_root_pose_to_sim_index(root_pose=root_pose)
+        sim.render()
+
+        assert sim.get_physics_step_count() == 0
+        assert callback_counts == {"pre": 1, "post": 1}
+
+        sim.render()
+
+        assert callback_counts == {"pre": 1, "post": 1}
 
         sim.step(render=False)
 
         assert sim.get_physics_step_count() == 1
-        assert callback_counts == {"pre": 1, "post": 1}
+        assert callback_counts == {"pre": 2, "post": 2}
+
+        root_pose[:, 0] += 0.1
+        cube.write_root_pose_to_sim_index(root_pose=root_pose)
+        sim.step(render=True)
+
+        assert sim.get_physics_step_count() == 2
+        assert callback_counts == {"pre": 3, "post": 3}
     finally:
-        if pre_handle is not None:
-            PhysxManager.deregister_callback(pre_handle)
-        if post_handle is not None:
-            PhysxManager.deregister_callback(post_handle)
+        subscriptions.clear()
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
+++ b/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
@@ -1,6 +1,5 @@
 Fixed
 ^^^^^
 
-* Fixed :meth:`~isaaclab_physx.physics.PhysxManager.forward` so rigid-body
-  poses written through tensor APIs are visible to RTX cameras before the
-  next physics step.
+* Fixed RTX rendering of rigid-object poses written through tensor APIs before
+  the next physics step, while preserving the lightweight forward path.

--- a/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
+++ b/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_physx.physics.PhysxManager.forward` so rigid-body
+  poses written through tensor APIs are visible to RTX cameras before the
+  next physics step.

--- a/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
+++ b/source/isaaclab_physx/changelog.d/striveralex-fix-physx-forward-sync.rst
@@ -1,5 +1,5 @@
 Fixed
 ^^^^^
 
-* Fixed RTX rendering of rigid-object poses written through tensor APIs before
+* Fixed RTX rendering of rigid-object and articulation poses written through tensor APIs before
   the next physics step, while preserving the lightweight forward path.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -616,6 +616,7 @@ class Articulation(BaseArticulation):
             self.data._reset_pose()
         # set into simulation
         self.root_view.set_root_transforms(self.data._root_link_pose_w.data.view(wp.float32), indices=sim_env_ids)
+        SimulationManager.notify_tensor_pose_write()
 
     def write_root_link_pose_to_sim_mask(
         self,
@@ -713,6 +714,7 @@ class Articulation(BaseArticulation):
             self.data._reset_pose(from_link=False)
         # set into simulation
         self.root_view.set_root_transforms(self.data._root_link_pose_w.data.view(wp.float32), indices=sim_env_ids)
+        SimulationManager.notify_tensor_pose_write()
 
     def write_root_com_pose_to_sim_mask(
         self,

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -375,7 +375,7 @@ class RigidObject(BaseRigidObject):
             self.data._reset_pose()
         # set into simulation
         self.root_view.set_transforms(self._get_root_link_pose_w_f32(), indices=sim_env_ids)
-        SimulationManager._mark_render_sync_required()
+        SimulationManager.notify_tensor_pose_write()
 
     def write_root_link_pose_to_sim_mask(
         self,
@@ -468,7 +468,7 @@ class RigidObject(BaseRigidObject):
             self.data._reset_pose(from_link=False)
         # set into simulation
         self.root_view.set_transforms(self._get_root_link_pose_w_f32(), indices=sim_env_ids)
-        SimulationManager._mark_render_sync_required()
+        SimulationManager.notify_tensor_pose_write()
 
     def write_root_com_pose_to_sim_mask(
         self,

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -375,6 +375,7 @@ class RigidObject(BaseRigidObject):
             self.data._reset_pose()
         # set into simulation
         self.root_view.set_transforms(self._get_root_link_pose_w_f32(), indices=sim_env_ids)
+        SimulationManager._mark_render_sync_required()
 
     def write_root_link_pose_to_sim_mask(
         self,
@@ -467,6 +468,7 @@ class RigidObject(BaseRigidObject):
             self.data._reset_pose(from_link=False)
         # set into simulation
         self.root_view.set_transforms(self._get_root_link_pose_w_f32(), indices=sim_env_ids)
+        SimulationManager._mark_render_sync_required()
 
     def write_root_com_pose_to_sim_mask(
         self,

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -479,6 +479,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             self.reshape_data_to_view_2d(self.data._body_link_pose_w.data, device=self.device).view(wp.float32),
             indices=view_ids,
         )
+        SimulationManager.notify_tensor_pose_write()
 
     def write_body_link_pose_to_sim_mask(
         self,
@@ -589,6 +590,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             self.reshape_data_to_view_2d(self.data._body_link_pose_w.data, device=self.device).view(wp.float32),
             indices=view_ids,
         )
+        SimulationManager.notify_tensor_pose_write()
 
     def write_body_com_pose_to_sim_mask(
         self,

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -390,7 +390,7 @@ class PhysxManager(PhysicsManager):
     _stage_id: ClassVar[int] = -1
     _subscriptions: ClassVar[dict[str, Any]] = {}
     _fabric: ClassVar[Any] = None
-    _suppress_step_callbacks: ClassVar[bool] = False
+    _render_sync_step_count: ClassVar[int | None] = None
     _update_fabric: ClassVar[Callable[[float, float], None] | None] = None
     _anim_recorder: ClassVar[AnimationRecorder | None] = None
     _callback_exception: ClassVar[Exception | None] = None
@@ -489,18 +489,36 @@ class PhysxManager(PhysicsManager):
 
     @classmethod
     def forward(cls) -> None:
-        """Update tensor state and fabric without advancing simulation time."""
+        """Update articulation kinematics and fabric for rendering."""
         sim = PhysicsManager._sim
-        suppress_step_callbacks = cls._suppress_step_callbacks
-        cls._suppress_step_callbacks = True
-        try:
-            omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
-        finally:
-            cls._suppress_step_callbacks = suppress_step_callbacks
         if cls._fabric is not None and cls._update_fabric is not None:
             if cls._view is not None and sim is not None and sim.is_playing():
                 cls._view.update_articulations_kinematic()
             cls._update_fabric(0.0, 0.0)
+
+    @classmethod
+    def pre_render(cls) -> None:
+        """Synchronize pending rigid-object tensor pose writes before rendering."""
+        dirty_step_count = cls._render_sync_step_count
+        if dirty_step_count is None or not cls._view_created:
+            return
+        sim = PhysicsManager._sim
+        cls._render_sync_step_count = None
+        if sim is None or sim.get_physics_step_count() != dirty_step_count:
+            return
+        try:
+            omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
+        except Exception:
+            if cls._render_sync_step_count is None:
+                cls._render_sync_step_count = dirty_step_count
+            raise
+
+    @classmethod
+    def _mark_render_sync_required(cls) -> None:
+        """Request a render sync after a rigid-object tensor pose write."""
+        sim = PhysicsManager._sim
+        if sim is not None:
+            cls._render_sync_step_count = sim.get_physics_step_count()
 
     @classmethod
     def get_scene_data_backend(cls) -> SceneDataBackend:
@@ -687,7 +705,7 @@ class PhysxManager(PhysicsManager):
 
         def guarded(cb: Callable) -> Callable:
             def wrapper(dt: float) -> Any:
-                return cb(dt) if cls._view_created and not cls._suppress_step_callbacks else None
+                return cb(dt) if cls._view_created else None
 
             return wrapper
 
@@ -958,6 +976,7 @@ class PhysxManager(PhysicsManager):
         physx.start_simulation()
         physx.update_simulation(cls.get_physics_dt(), 0.0)
         physx_sim.fetch_results()
+        cls._render_sync_step_count = None
         cls._event_bus.dispatch_event(IsaacEvents.PHYSICS_WARMUP.value, payload={})
         cls._warmup_needed = False
 
@@ -991,6 +1010,7 @@ class PhysxManager(PhysicsManager):
         cls._view = None
         cls._view_warp = None
         cls._view_created = False
+        cls._render_sync_step_count = None
 
     @classmethod
     def _on_play(cls, event: Any) -> None:

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -390,6 +390,7 @@ class PhysxManager(PhysicsManager):
     _stage_id: ClassVar[int] = -1
     _subscriptions: ClassVar[dict[str, Any]] = {}
     _fabric: ClassVar[Any] = None
+    _suppress_step_callbacks: ClassVar[bool] = False
     _update_fabric: ClassVar[Callable[[float, float], None] | None] = None
     _anim_recorder: ClassVar[AnimationRecorder | None] = None
     _callback_exception: ClassVar[Exception | None] = None
@@ -488,8 +489,14 @@ class PhysxManager(PhysicsManager):
 
     @classmethod
     def forward(cls) -> None:
-        """Update articulation kinematics and fabric for rendering."""
+        """Update tensor state and fabric without advancing simulation time."""
         sim = PhysicsManager._sim
+        suppress_step_callbacks = cls._suppress_step_callbacks
+        cls._suppress_step_callbacks = True
+        try:
+            omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
+        finally:
+            cls._suppress_step_callbacks = suppress_step_callbacks
         if cls._fabric is not None and cls._update_fabric is not None:
             if cls._view is not None and sim is not None and sim.is_playing():
                 cls._view.update_articulations_kinematic()
@@ -680,7 +687,7 @@ class PhysxManager(PhysicsManager):
 
         def guarded(cb: Callable) -> Callable:
             def wrapper(dt: float) -> Any:
-                return cb(dt) if cls._view_created else None
+                return cb(dt) if cls._view_created and not cls._suppress_step_callbacks else None
 
             return wrapper
 

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -390,7 +390,7 @@ class PhysxManager(PhysicsManager):
     _stage_id: ClassVar[int] = -1
     _subscriptions: ClassVar[dict[str, Any]] = {}
     _fabric: ClassVar[Any] = None
-    _render_sync_step_count: ClassVar[int | None] = None
+    _pending_tensor_pose_write_step: ClassVar[int | None] = None
     _update_fabric: ClassVar[Callable[[float, float], None] | None] = None
     _anim_recorder: ClassVar[AnimationRecorder | None] = None
     _callback_exception: ClassVar[Exception | None] = None
@@ -497,28 +497,29 @@ class PhysxManager(PhysicsManager):
             cls._update_fabric(0.0, 0.0)
 
     @classmethod
-    def pre_render(cls) -> None:
-        """Synchronize pending rigid-object tensor pose writes before rendering."""
-        dirty_step_count = cls._render_sync_step_count
-        if dirty_step_count is None or not cls._view_created:
-            return
+    def notify_tensor_pose_write(cls) -> None:
+        """Record a PhysX tensor pose write that may need forwarding before the next Kit frame."""
         sim = PhysicsManager._sim
-        cls._render_sync_step_count = None
-        if sim is None or sim.get_physics_step_count() != dirty_step_count:
-            return
+        if sim is not None:
+            cls._pending_tensor_pose_write_step = sim.get_physics_step_count()
+
+    @classmethod
+    def before_kit_app_update(cls) -> bool:
+        """Forward pending PhysX tensor pose writes before a Kit/RTX frame."""
+        pending_write_step = cls._pending_tensor_pose_write_step
+        if pending_write_step is None or not cls._view_created:
+            return False
+        sim = PhysicsManager._sim
+        cls._pending_tensor_pose_write_step = None
+        if sim is None or sim.get_physics_step_count() != pending_write_step:
+            return False
         try:
             omni.physx.get_physx_interface().update_simulation(cls.get_physics_dt(), 0.0)
         except Exception:
-            if cls._render_sync_step_count is None:
-                cls._render_sync_step_count = dirty_step_count
+            if cls._pending_tensor_pose_write_step is None:
+                cls._pending_tensor_pose_write_step = pending_write_step
             raise
-
-    @classmethod
-    def _mark_render_sync_required(cls) -> None:
-        """Request a render sync after a rigid-object tensor pose write."""
-        sim = PhysicsManager._sim
-        if sim is not None:
-            cls._render_sync_step_count = sim.get_physics_step_count()
+        return True
 
     @classmethod
     def get_scene_data_backend(cls) -> SceneDataBackend:
@@ -976,7 +977,7 @@ class PhysxManager(PhysicsManager):
         physx.start_simulation()
         physx.update_simulation(cls.get_physics_dt(), 0.0)
         physx_sim.fetch_results()
-        cls._render_sync_step_count = None
+        cls._pending_tensor_pose_write_step = None
         cls._event_bus.dispatch_event(IsaacEvents.PHYSICS_WARMUP.value, payload={})
         cls._warmup_needed = False
 
@@ -1010,7 +1011,7 @@ class PhysxManager(PhysicsManager):
         cls._view = None
         cls._view_warp = None
         cls._view_created = False
-        cls._render_sync_step_count = None
+        cls._pending_tensor_pose_write_step = None
 
     @classmethod
     def _on_play(cls, event: Any) -> None:

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_utils.py
@@ -52,6 +52,7 @@ _RTX_FIELD_TO_SETTING = {
 _last_render_update_key: tuple[int, int, int] = (0, -1, -1)
 
 _STREAMING_WAIT_TIMEOUT_S: float = 30.0
+_PLAY_SIMULATIONS_SETTING = "/app/player/playSimulations"
 
 
 def _setting_path_from_key(key: str) -> str:
@@ -239,6 +240,9 @@ def ensure_isaac_rtx_render_update(force: bool = False) -> None:
     if not force and not sim.is_rendering:
         return
 
+    # Flush tensor pose writes before the frame consumes PhysX/Fabric transforms.
+    sim.physics_manager.before_kit_app_update()
+
     # Sync physics results → Fabric so RTX sees updated positions.
     # physics_manager.step() only runs simulate()/fetch_results() and does NOT
     # call _update_fabric(), so without this the render would lag one frame behind.
@@ -246,13 +250,15 @@ def ensure_isaac_rtx_render_update(force: bool = False) -> None:
 
     import omni.kit.app
 
-    sim.set_setting("/app/player/playSimulations", False)
-    omni.kit.app.get_app().update()
+    play_flag = sim.get_setting(_PLAY_SIMULATIONS_SETTING)
+    sim.set_setting(_PLAY_SIMULATIONS_SETTING, False)
+    try:
+        omni.kit.app.get_app().update()
 
-    if _get_stage_streaming_busy():
-        _wait_for_streaming_complete()
-
-    sim.set_setting("/app/player/playSimulations", True)
+        if _get_stage_streaming_busy():
+            _wait_for_streaming_complete()
+    finally:
+        sim.set_setting(_PLAY_SIMULATIONS_SETTING, bool(play_flag) if play_flag is not None else True)
 
     _last_render_update_key = key
 

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_utils.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import sys
 import time
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 # Stub ``omni`` / ``omni.usd`` in ``sys.modules`` before importing the module
 # under test so its top-level ``import omni.usd`` succeeds outside a running
@@ -262,6 +262,7 @@ class TestEnsureIsaacRtxRenderUpdate:
         ):
             rtx_utils.ensure_isaac_rtx_render_update()
 
+        mock_sim.physics_manager.before_kit_app_update.assert_called_once_with()
         mock_app.update.assert_called_once()
 
     def test_second_call_with_visualizer_skips_pump(
@@ -283,6 +284,7 @@ class TestEnsureIsaacRtxRenderUpdate:
             mock_sim._physics_step_count = 1
             rtx_utils.ensure_isaac_rtx_render_update()
 
+        mock_sim.physics_manager.before_kit_app_update.assert_called_once_with()
         mock_app.update.assert_not_called()
 
     def test_no_sim_is_noop(self, mock_sim_context, mock_omni_kit_app):
@@ -310,6 +312,7 @@ class TestEnsureIsaacRtxRenderUpdate:
 
             rtx_utils.ensure_isaac_rtx_render_update()
 
+        mock_sim.physics_manager.before_kit_app_update.assert_called_once_with()
         mock_app.update.assert_not_called()
 
     def test_not_rendering_skips(self, mock_sim, mock_sim_context, mock_omni_kit_app):
@@ -321,4 +324,21 @@ class TestEnsureIsaacRtxRenderUpdate:
 
         rtx_utils.ensure_isaac_rtx_render_update()
 
+        mock_sim.physics_manager.before_kit_app_update.assert_not_called()
         mock_app.update.assert_not_called()
+
+    def test_restores_play_state_when_app_update_fails(self, mock_sim, mock_sim_context, mock_omni_kit_app):
+        """An app-update failure must not leak a changed Kit playback state."""
+        mock_sim.get_setting.return_value = False
+        mock_app = MagicMock()
+        mock_app.update.side_effect = RuntimeError("update failed")
+        mock_omni_kit_app.get_app.return_value = mock_app
+        mock_sim_context.instance.return_value = mock_sim
+
+        with pytest.raises(RuntimeError, match="update failed"):
+            rtx_utils.ensure_isaac_rtx_render_update()
+
+        assert mock_sim.set_setting.call_args_list == [
+            call(rtx_utils._PLAY_SIMULATIONS_SETTING, False),
+            call(rtx_utils._PLAY_SIMULATIONS_SETTING, False),
+        ]

--- a/source/isaaclab_visualizers/changelog.d/striveralex-fix-physx-forward-sync.rst
+++ b/source/isaaclab_visualizers/changelog.d/striveralex-fix-physx-forward-sync.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed on-demand Kit frame updates to preserve the previous simulation playback state.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 
 _DEFAULT_VIEWPORT_NAME = "Visualizer Viewport"
 _DEFAULT_VIEWPORT_CAMERA_PATH = "/OmniverseKit_Persp"
+_PLAY_SIMULATIONS_SETTING = "/app/player/playSimulations"
 
 _BACKEND_DISPLAY_NAMES = {
     "physx": "PhysX",
@@ -212,10 +213,7 @@ class KitVisualizer(BaseVisualizer):
                 if app is not None and app.is_running():
                     # Keep app pumping for viewport/UI updates only; physics is owned by SimulationContext.
                     # Disable playSimulations around app.update() so Kit does not advance its own physics here.
-                    settings = get_settings_manager()
-                    settings.set_bool("/app/player/playSimulations", False)
-                    app.update()
-                    settings.set_bool("/app/player/playSimulations", True)
+                    self._update_kit_app(app)
                     self._app_pumped_this_step = True
             except (ImportError, AttributeError) as exc:
                 logger.debug("[KitVisualizer] App update skipped: %s", exc)
@@ -291,11 +289,7 @@ class KitVisualizer(BaseVisualizer):
                 self._rgb_render_product.resume()
 
         if not self._app_pumped_this_step:
-            settings = get_settings_manager()
-            play_flag = settings.get("/app/player/playSimulations")
-            settings.set_bool("/app/player/playSimulations", False)
-            omni.kit.app.get_app().update()
-            settings.set_bool("/app/player/playSimulations", bool(play_flag))
+            self._update_kit_app(omni.kit.app.get_app())
 
         raw = self._rgb_annotator.get_data()
         if isinstance(raw, dict):
@@ -866,6 +860,24 @@ class KitVisualizer(BaseVisualizer):
         image = np.ascontiguousarray(image)
         self._camera_image_provider.set_bytes_data(image.flatten().data, [image.shape[1], image.shape[0]])
 
+    def _update_kit_app(self, app: Any) -> None:
+        """Pump one Kit frame without letting Kit advance physics independently."""
+        from isaaclab.sim import SimulationContext
+
+        settings = get_settings_manager()
+        play_flag = settings.get(_PLAY_SIMULATIONS_SETTING)
+        settings.set_bool(_PLAY_SIMULATIONS_SETTING, False)
+        try:
+            sim = SimulationContext.instance()
+            if sim is not None:
+                physics_manager = sim.physics_manager
+                requires_reforward = physics_manager.before_kit_app_update()
+                if requires_reforward:
+                    physics_manager.forward()
+            app.update()
+        finally:
+            settings.set_bool(_PLAY_SIMULATIONS_SETTING, bool(play_flag) if play_flag is not None else True)
+
     def _sync_camera_pose_updates_to_kit(self) -> None:
         """Flush generated camera pose writes before camera RGB is sampled."""
         try:
@@ -874,12 +886,7 @@ class KitVisualizer(BaseVisualizer):
             app = omni.kit.app.get_app()
             if app is None or not app.is_running():
                 return
-            settings = get_settings_manager()
-            play_flag = settings.get("/app/player/playSimulations")
-            settings.set_bool("/app/player/playSimulations", False)
-            app.update()
-            if play_flag is not None:
-                settings.set_bool("/app/player/playSimulations", bool(play_flag))
+            self._update_kit_app(app)
         except Exception as exc:
             logger.debug("[KitVisualizer] Camera pose Kit sync skipped: %s", exc)
 

--- a/source/isaaclab_visualizers/test/test_kit_visualizer.py
+++ b/source/isaaclab_visualizers/test/test_kit_visualizer.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for Kit frame-boundary physics synchronization."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import Mock, call, patch
+
+import numpy as np
+import pytest
+from isaaclab_visualizers.kit import KitVisualizer, KitVisualizerCfg
+from isaaclab_visualizers.kit import kit_visualizer as kit_visualizer_module
+
+import omni
+
+from isaaclab.sim import SimulationContext
+
+_PLAY_SIMULATIONS_SETTING = "/app/player/playSimulations"
+
+
+def _make_visualizer() -> KitVisualizer:
+    visualizer = KitVisualizer(KitVisualizerCfg(window_width=2, window_height=1))
+    visualizer._is_initialized = True
+    visualizer._update_camera_image_panel = Mock()
+    visualizer._refresh_partial_viz_point_instancers_if_needed = Mock()
+    visualizer.is_training_paused = Mock(return_value=False)
+    return visualizer
+
+
+@contextmanager
+def _mock_kit_app(app: Mock) -> Iterator[None]:
+    kit_module = ModuleType("omni.kit")
+    kit_module.__path__ = []
+    app_module = ModuleType("omni.kit.app")
+    app_module.get_app = Mock(return_value=app)
+    kit_module.app = app_module
+    with (
+        patch.object(omni, "kit", kit_module, create=True),
+        patch.dict(sys.modules, {"omni.kit": kit_module, "omni.kit.app": app_module}),
+    ):
+        yield
+
+
+def test_step_prepares_physics_immediately_before_app_update():
+    visualizer = _make_visualizer()
+    events = []
+    sim = Mock()
+    sim.physics_manager.before_kit_app_update.side_effect = lambda: events.append("prepare") or True
+    sim.physics_manager.forward.side_effect = lambda: events.append("forward")
+    app = Mock()
+    app.is_running.return_value = True
+    app.update.side_effect = lambda: events.append("update")
+    settings = Mock()
+    settings.get.return_value = True
+
+    with (
+        patch.object(SimulationContext, "instance", return_value=sim),
+        patch.object(kit_visualizer_module, "get_settings_manager", return_value=settings),
+        _mock_kit_app(app),
+    ):
+        visualizer.step(0.01)
+
+    assert events == ["prepare", "forward", "update"]
+    assert visualizer._app_pumped_this_step is True
+    settings.set_bool.assert_has_calls([call(_PLAY_SIMULATIONS_SETTING, False), call(_PLAY_SIMULATIONS_SETTING, True)])
+
+
+def test_render_rgb_array_prepares_physics_for_on_demand_update():
+    visualizer = _make_visualizer()
+    visualizer._app_pumped_this_step = False
+    visualizer._rgb_annotator = Mock()
+    visualizer._rgb_annotator.get_data.return_value = np.full((1, 2, 4), 255, dtype=np.uint8)
+    events = []
+    sim = Mock()
+    sim.physics_manager.before_kit_app_update.side_effect = lambda: events.append("prepare") or True
+    sim.physics_manager.forward.side_effect = lambda: events.append("forward")
+    app = Mock()
+    app.update.side_effect = lambda: events.append("update")
+    settings = Mock()
+    settings.get.return_value = True
+    replicator_module = ModuleType("omni.replicator")
+    replicator_core_module = ModuleType("omni.replicator.core")
+    replicator_module.core = replicator_core_module
+
+    with (
+        patch.object(SimulationContext, "instance", return_value=sim),
+        patch.object(kit_visualizer_module, "get_settings_manager", return_value=settings),
+        _mock_kit_app(app),
+        patch.dict(
+            sys.modules,
+            {"omni.replicator": replicator_module, "omni.replicator.core": replicator_core_module},
+        ),
+    ):
+        image = visualizer.render_rgb_array()
+
+    assert events == ["prepare", "forward", "update"]
+    assert image.shape == (1, 2, 3)
+    settings.set_bool.assert_has_calls([call(_PLAY_SIMULATIONS_SETTING, False), call(_PLAY_SIMULATIONS_SETTING, True)])
+
+
+def test_kit_app_update_does_not_repeat_forward_after_clean_prepare():
+    visualizer = _make_visualizer()
+    sim = Mock()
+    sim.physics_manager.before_kit_app_update.return_value = False
+    app = Mock()
+    settings = Mock()
+    settings.get.return_value = True
+
+    with (
+        patch.object(SimulationContext, "instance", return_value=sim),
+        patch.object(kit_visualizer_module, "get_settings_manager", return_value=settings),
+    ):
+        visualizer._update_kit_app(app)
+
+    sim.physics_manager.before_kit_app_update.assert_called_once_with()
+    sim.physics_manager.forward.assert_not_called()
+    app.update.assert_called_once_with()
+
+
+def test_camera_pose_sync_does_not_consume_request_without_running_app():
+    visualizer = _make_visualizer()
+    sim = Mock()
+    app = Mock()
+    app.is_running.return_value = False
+
+    with patch.object(SimulationContext, "instance", return_value=sim), _mock_kit_app(app):
+        visualizer._sync_camera_pose_updates_to_kit()
+
+    sim.physics_manager.before_kit_app_update.assert_not_called()
+
+
+def test_kit_app_update_restores_play_state_on_failure():
+    visualizer = _make_visualizer()
+    sim = Mock()
+    sim.physics_manager.before_kit_app_update.return_value = False
+    app = Mock()
+    app.update.side_effect = RuntimeError("update failed")
+    settings = Mock()
+    settings.get.return_value = False
+
+    with (
+        patch.object(SimulationContext, "instance", return_value=sim),
+        patch.object(kit_visualizer_module, "get_settings_manager", return_value=settings),
+        pytest.raises(RuntimeError, match="update failed"),
+    ):
+        visualizer._update_kit_app(app)
+
+    sim.physics_manager.before_kit_app_update.assert_called_once_with()
+    sim.physics_manager.forward.assert_not_called()
+    assert settings.set_bool.call_args_list == [
+        call(_PLAY_SIMULATIONS_SETTING, False),
+        call(_PLAY_SIMULATIONS_SETTING, False),
+    ]


### PR DESCRIPTION
# Description

PhysX tensor pose writers can change simulation state without advancing the public physics step. RTX/Fabric may therefore render the previous transform in the first frame after a write.

This change keeps the normal physics and clean rendering paths lightweight. It introduces a step-stamped tensor-pose write barrier that is consumed only at an actual Kit/RTX frame boundary.

Fixes #6394.

## Root cause and design

- Native tensor pose writes bypass the propagation needed for the next RTX frame.
- `PhysicsManager.before_kit_app_update() -> bool` provides a backend-neutral frame-boundary hook. The default implementation is a no-op.
- `PhysxManager` records a private pending token only after a tensor pose mutation succeeds.
- At the next Kit update, the PhysX backend drops a stale token if a real physics step already consumed the change; otherwise it runs one native `update_simulation()` and consumes the token.
- Multiple writes in the same public physics step coalesce into one synchronization.
- A failed native synchronization is requeued so a transient failure does not silently lose the pending write.
- The boolean result tells the frame owner whether one final Fabric `forward()` is required before `app.update()`.
- Kit simulation playback state is disabled only around this synchronization and restored with `try/finally`.

The resulting invariants are:

- `SimulationContext.forward()` does not call native `update_simulation()`.
- A clean Kit update performs no additional Fabric forward.
- A dirty Kit update performs one native synchronization followed by one final Fabric forward.
- The renderer utility retains its existing single unconditional Fabric forward on both clean and dirty frames.
- Normal physics steps and clean frames do not inspect or clear generic dirty state on their hot paths.

## Tensor writer coverage

The barrier is notified by all six native tensor pose implementations:

- rigid object root-link pose
- rigid object root center-of-mass pose
- rigid object collection root-link pose
- rigid object collection root center-of-mass pose
- articulation root-link pose
- articulation root center-of-mass pose

Root-pose, indexed, and mask-based public APIs are covered through their existing delegation to these implementations.

## Review concerns addressed

The previously reviewed performance regression came from placing the full native PhysX update in `forward()`, which taxed every call. This revision removes that behavior entirely. Synchronization is local to the PhysX backend, causally tied to a successful tensor pose write, keyed to the public physics-step epoch, and consumed only by a frame-producing Kit update.

This is deliberately not a general-purpose manager dirty flag: the state models one backend-specific synchronization obligation and remains private to `PhysxManager`.

## Validation

Rebased onto current `develop` at `3b736feb04a98f708bb69ed1f69eb0f8e81b2adf`.

- 25 writer, renderer, and Kit visualizer regression tests passed.
- 2 native PhysX callback and coalescing integration tests passed.
- 4 CUDA articulation and rigid-object-collection writer cases passed.
- Real Kit RTX first-frame pixel regression passed on the candidate.
- The same regression mounted over clean `develop` failed as expected: first-frame red fraction `0.000000`, stable red fraction `0.010468`.
- Ruff lint passed for all 12 changed Python files; all 12 were already correctly formatted.
- Standards review: 0 findings.
- Specification review: 0 findings.
- Full repository suite was not run.

The local Git LFS pre-push hook was skipped because its SSH authentication helper hung in the validation environment. The 16 PR files are ordinary text files and contain no LFS pointers.

## Performance regression check

The same Isaac Sim container command was run in develop-candidate-develop order with `Isaac-Cartpole-Direct`, 4096 environments, 500 measured steps, 100 warmup steps, and the Kit visualizer.

| Run | FPS | Iteration time |
| --- | ---: | ---: |
| develop before | 169,223.41 | 24.2047 ms |
| candidate | 159,664.78 | 25.6537 ms |
| develop after | 150,679.47 | 27.1835 ms |

The two develop endpoints differed by 11.59%, showing monotonic host drift during the run. The candidate landed essentially at the midpoint: `-0.18%` FPS and `-0.16%` iteration time versus the arithmetic mean of the bracketing develop runs. This does not reproduce a candidate-specific `+11%` regression. An earlier, more stable ABA run likewise placed the candidate at `+1.13%` FPS versus the develop mean with only `1.30%` baseline spread.

## Type of change

- Bug fix with targeted regression coverage

## Checklist

- [x] Rebased onto current develop.
- [x] Preserved clean `forward()` and normal physics-step behavior.
- [x] Covered all PhysX tensor root-pose writer implementations.
- [x] Added changelog fragments.
- [x] Added real first-frame RTX regression coverage.
- [x] Reproduced the failure on clean develop.
- [x] Ran targeted functional, callback, CUDA, lint, and performance checks.
- [x] Added the contributor entry.
- [ ] Full repository test suite run.
