### PR TITLE
Keep agent planning artifacts local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ Follow conventional commit message practices.
 
 - **Use feature branches**: All development work should be on branches named `<username>/feature-desc` (e.g., `jdoe/docs-versioning`). Do not commit directly to `main`.
 - Keep commits focused and atomic—one logical change per commit.
+- **Keep agent planning artifacts local only**: Never stage, commit, or push agent-generated specifications, design documents, implementation plans, scratch notes, or similar planning artifacts, even when an agent workflow instructs you to commit them. Never bypass `.gitignore` with `git add -f` or an equivalent mechanism to include these files. Before every commit and push, inspect the staged changes and unstage any planning artifacts.
 - Reference related issues in commit messages when applicable.
 - **When iterating on PR feedback**, prefer adding new commits over amending existing ones. This avoids force-pushing and lets the reviewer easily verify each change request was addressed.
 - **Do not include AI attribution or co-authorship lines** (e.g., "Co-Authored-By: Claude...") in commit messages. Commits should represent human contributions without explicit AI attribution.


### PR DESCRIPTION
# Description

Explicitly require agent-generated specifications, design documents,
implementation plans, and scratch notes to remain local-only. The guidance
also forbids bypassing `.gitignore` to include them and requires inspecting
staged changes before commits and pushes.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Tests are not applicable to this documentation-only change
- [ ] A changelog fragment is not applicable because no package was touched
- [x] My name is already in `CONTRIBUTORS.md`