### PR TITLE
Add particle rendering support for OVRTX

### DIFF
--- a/source/isaaclab_ov/changelog.d/huidongc-ovrtx-particle-rendering.rst
+++ b/source/isaaclab_ov/changelog.d/huidongc-ovrtx-particle-rendering.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added OVRTX rendering to stream Newton MPM particle positions into registered
+  ``UsdGeom.Points`` prims, so kitless cameras can visualize MPM particle clouds.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -451,7 +451,7 @@ class OVRTXRenderer(BaseRenderer):
 
         self._setup_xform_bindings()
         self._setup_deformable_bindings(num_envs)
-        self._setup_particle_bindings(num_envs)
+        self._setup_particle_bindings()
 
     def _clone_sources_in_ovrtx(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan`."""
@@ -682,21 +682,17 @@ class OVRTXRenderer(BaseRenderer):
         if self._deformable_points_binding is None:
             raise RuntimeError("Failed to create OVRTX deformable body bindings")
 
-    def _setup_particle_bindings(self, num_envs: int) -> None:
-        """Setup OVRTX bindings for Newton MPM ``UsdGeom.Points`` particle clouds.
-
-        Args:
-            num_envs: Number of environments.
-        """
+    def _setup_particle_bindings(self) -> None:
+        """Setup OVRTX bindings for Newton particle clouds."""
         try:
             from isaaclab_newton.physics import NewtonManager
         except ImportError:
-            logger.debug("NewtonManager not available, skipping MPM particle point bindings")
+            logger.debug("NewtonManager not available, skipping particle point bindings")
             return
 
         particle_visual_prims = NewtonManager._particle_visual_prims
         if not particle_visual_prims:
-            logger.debug("No MPM particle visual prims registered, skipping particle point bindings")
+            logger.debug("No particle visual prims registered, skipping particle point bindings")
             return
 
         self._particle_visual_offsets = []
@@ -817,7 +813,7 @@ class OVRTXRenderer(BaseRenderer):
         if newton_state is None:
             raise RuntimeError("Newton state should not be None")
 
-        # particle_q is the world-space particle positions for all deformable bodies and MPM
+        # particle_q is the world-space particle positions for all deformable bodies and
         # particle clouds. A non-None geometry binding means entries were registered, so Newton
         # must expose particle state; a missing particle_q here is an inconsistent state.
         particle_q = getattr(newton_state, "particle_q", None)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -303,6 +303,10 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_points_binding = None
         self._deformable_particle_offsets: list[int] = []
         self._deformable_particle_counts: list[int] = []
+        self._particle_points_binding = None
+        self._particle_visual_offsets: list[int] = []
+        self._particle_visual_counts: list[int] = []
+        self._particle_workaround_applied = False
         self._initialized_scene = False
         self._exported_usd_string: str | None = None
         self._camera_rel_path: str | None = None
@@ -447,6 +451,7 @@ class OVRTXRenderer(BaseRenderer):
 
         self._setup_xform_bindings()
         self._setup_deformable_bindings(num_envs)
+        self._setup_particle_bindings(num_envs)
 
     def _clone_sources_in_ovrtx(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan`."""
@@ -677,6 +682,61 @@ class OVRTXRenderer(BaseRenderer):
         if self._deformable_points_binding is None:
             raise RuntimeError("Failed to create OVRTX deformable body bindings")
 
+    def _setup_particle_bindings(self, num_envs: int) -> None:
+        """Setup OVRTX bindings for Newton MPM ``UsdGeom.Points`` particle clouds.
+
+        Args:
+            num_envs: Number of environments.
+        """
+        try:
+            from isaaclab_newton.physics import NewtonManager
+        except ImportError:
+            logger.debug("NewtonManager not available, skipping MPM particle point bindings")
+            return
+
+        particle_visual_prims = NewtonManager._particle_visual_prims
+        if not particle_visual_prims:
+            logger.debug("No MPM particle visual prims registered, skipping particle point bindings")
+            return
+
+        self._particle_visual_offsets = []
+        self._particle_visual_counts = []
+        points_prim_paths: list[str] = []
+
+        for prim_path, record in particle_visual_prims.items():
+            points_prim_paths.append(prim_path)
+            self._particle_visual_offsets.append(record.offset)
+            self._particle_visual_counts.append(record.count)
+
+        prim_count = len(points_prim_paths)
+
+        # World-space particle_q is written directly into points. Reset the xform stack
+        # and pin identity omni:xform so inherited env/asset transforms are not applied twice.
+        self._renderer.write_attribute(
+            prim_paths=points_prim_paths,
+            attribute_name="omni:resetXformStack",
+            tensor=np.full(prim_count, True, dtype=np.bool_),
+            prim_mode=PrimMode.MUST_EXIST,
+        )
+        self._renderer.write_attribute(
+            prim_paths=points_prim_paths,
+            attribute_name="omni:xform",
+            tensor=np.tile(np.eye(4, dtype=np.float64), (prim_count, 1, 1)),
+            semantic=Semantic.XFORM_MAT4x4,
+            prim_mode=PrimMode.MUST_EXIST,
+        )
+
+        self._particle_points_binding = self._renderer.bind_array_attribute(
+            prim_paths=points_prim_paths,
+            attribute_name="points",
+            dtype=np.float32,
+            shape=(3,),
+            prim_mode=PrimMode.MUST_EXIST,
+            flags=BindingFlag.OPTIMIZE,
+        )
+
+        self._particle_workaround_applied = False
+
     def create_render_data(self, spec: CameraRenderSpec) -> OVRTXRenderData:
         """Create OVRTX-specific RenderData with GPU buffers.
 
@@ -747,7 +807,7 @@ class OVRTXRenderer(BaseRenderer):
 
     def update_geometries(self) -> None:
         """Sync geometries to OVRTX."""
-        if self._deformable_points_binding is None:
+        if self._deformable_points_binding is None and self._particle_points_binding is None:
             return
 
         # If self._deformable_points_binding is not None, then Newton's the current physics backend
@@ -757,24 +817,51 @@ class OVRTXRenderer(BaseRenderer):
         if newton_state is None:
             raise RuntimeError("Newton state should not be None")
 
-        # particle_q is the world-space particle positions for all deformable bodies. A non-None
-        # deformable points binding means deformable entries were registered, so Newton must
-        # expose particle state; a missing particle_q here is an inconsistent state.
+        # particle_q is the world-space particle positions for all deformable bodies and MPM
+        # particle clouds. A non-None geometry binding means entries were registered, so Newton
+        # must expose particle state; a missing particle_q here is an inconsistent state.
         particle_q = getattr(newton_state, "particle_q", None)
         if particle_q is None:
-            raise RuntimeError("Newton state has no particle_q but deformable bindings exist")
+            raise RuntimeError("Newton state has no particle_q but geometry bindings exist")
 
-        # OVRTX ``write()`` needs one DLPack tensor per mesh prim, not one flat
-        # ``particle_q`` plus offsets. Warp slices are zero-copy views with
-        # distinct base pointers, so this list satisfies that contract without
-        # staging buffers or ``wp.copy`` calls.
-        particle_slices = [
-            particle_q[particle_offset : particle_offset + particle_count]
-            for particle_offset, particle_count in zip(
+        if self._deformable_points_binding is not None:
+            self._write_particle_q_slices(
+                self._deformable_points_binding,
+                particle_q,
                 self._deformable_particle_offsets,
                 self._deformable_particle_counts,
-                strict=True,
             )
+
+        if self._particle_points_binding is not None:
+            if not self._particle_workaround_applied:
+                self._apply_particle_workaround(particle_q)
+                self._particle_workaround_applied = True
+            else:
+                self._write_particle_q_slices(
+                    self._particle_points_binding,
+                    particle_q,
+                    self._particle_visual_offsets,
+                    self._particle_visual_counts,
+                )
+
+    def _write_particle_q_slices(
+        self,
+        binding: Any,
+        particle_q: wp.array,
+        particle_offsets: list[int],
+        particle_counts: list[int],
+    ) -> None:
+        """Write world-space ``particle_q`` slices into one OVRTX array-attribute binding.
+
+        Args:
+            binding: OVRTX array-attribute binding for the ``points`` attribute.
+            particle_q: Flat world-space particle positions [m], shape ``[total_particles]``.
+            particle_offsets: Start index of each prim's slice into :paramref:`particle_q`.
+            particle_counts: Number of particles in each prim's slice.
+        """
+        particle_slices = [
+            particle_q[particle_offset : particle_offset + particle_count]
+            for particle_offset, particle_count in zip(particle_offsets, particle_counts, strict=True)
         ]
 
         # Array attributes cannot use ``binding.map()`` like rigid-body xforms, and
@@ -785,11 +872,29 @@ class OVRTXRenderer(BaseRenderer):
         # GPU-side wait (a cross-stream dependency) before its read, instead of us
         # forcing a host-side ``wp.synchronize_device()`` that would stall the CPU.
         cuda_stream = wp.get_stream(self._device).cuda_stream
-        self._deformable_points_binding.write(
+        binding.write(
             cast(Any, particle_slices),
             data_access=DataAccess.ASYNC,
             cuda_stream=cuda_stream,
         )
+
+    def _apply_particle_workaround(self, particle_q: wp.array) -> None:
+        """Host-SYNC seed ``UsdGeom.Points`` so later GPU ASYNC writes can work correctly.
+
+        OVRTX does not initialize UsdGeom.Points prims from a GPU ASYNC ``points`` write as expected.
+        A host SYNC write + a renderer step call are needed to finish initialization; later frames
+        can then use zero-copy GPU ASYNC write with the same binding.
+
+        TODO: The workaround will be removed when OVRTX fixes the issue (OMPE-102610).
+        """
+        particle_q_host = particle_q.numpy()
+        host_slices = [
+            particle_q_host[particle_offset : particle_offset + particle_count]
+            for particle_offset, particle_count in zip(
+                self._particle_visual_offsets, self._particle_visual_counts, strict=True
+            )
+        ]
+        self._particle_points_binding.write(cast(Any, host_slices), data_access=DataAccess.SYNC)
 
     def update_camera(
         self,
@@ -1222,9 +1327,14 @@ class OVRTXRenderer(BaseRenderer):
         self._object_xform_binding = None
         _safe_unbind(self._deformable_points_binding, "deformable points")
         self._deformable_points_binding = None
+        _safe_unbind(self._particle_points_binding, "particle points")
+        self._particle_points_binding = None
 
         self._deformable_particle_offsets = []
         self._deformable_particle_counts = []
+        self._particle_visual_offsets = []
+        self._particle_visual_counts = []
+        self._particle_workaround_applied = False
 
         if self._renderer:
             try:

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -89,9 +89,6 @@ class _FakeOVRTXBackend:
     def write_attribute(self, **kwargs):
         self.writes.append(kwargs)
 
-    def write_array_attribute(self, **kwargs):
-        self.writes.append(kwargs)
-
 
 def _make_renderer_without_backend(device: str = "cpu") -> tuple[OVRTXRenderer, _FakeOVRTXBackend]:
     renderer = OVRTXRenderer.__new__(OVRTXRenderer)
@@ -337,7 +334,7 @@ def test_setup_particle_points_bindings_binds_mpm_visual_prims(monkeypatch: pyte
 
     monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
 
-    renderer._setup_particle_bindings(num_envs=2)
+    renderer._setup_particle_bindings()
 
     assert len(backend.calls) == 1
     assert backend.calls[0]["prim_paths"] == [
@@ -367,7 +364,7 @@ def test_setup_particle_points_bindings_binds_multiple_mpm_assets(monkeypatch: p
 
     monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
 
-    renderer._setup_particle_bindings(num_envs=2)
+    renderer._setup_particle_bindings()
 
     # Binding order follows dict insertion order (no path sort).
     assert backend.calls[0]["prim_paths"] == [

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -30,12 +30,14 @@ if not _MISSING_MODULES:
     from isaaclab_newton.physics import NewtonManager  # noqa: E402
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer  # noqa: E402
-    from ovrtx import DataAccess  # noqa: E402
+    from ovrtx import BindingFlag, DataAccess  # noqa: E402
 else:
     NewtonManager = None
     OVRTXRenderer = None
     OVRTXRendererCfg = None
     ovrtx_renderer_module = None
+    BindingFlag = None
+    DataAccess = None
 
 
 class _FakePointsBinding:
@@ -87,6 +89,9 @@ class _FakeOVRTXBackend:
     def write_attribute(self, **kwargs):
         self.writes.append(kwargs)
 
+    def write_array_attribute(self, **kwargs):
+        self.writes.append(kwargs)
+
 
 def _make_renderer_without_backend(device: str = "cpu") -> tuple[OVRTXRenderer, _FakeOVRTXBackend]:
     renderer = OVRTXRenderer.__new__(OVRTXRenderer)
@@ -97,6 +102,10 @@ def _make_renderer_without_backend(device: str = "cpu") -> tuple[OVRTXRenderer, 
     renderer._deformable_points_binding = None
     renderer._deformable_particle_offsets = []
     renderer._deformable_particle_counts = []
+    renderer._particle_points_binding = None
+    renderer._particle_visual_offsets = []
+    renderer._particle_visual_counts = []
+    renderer._particle_workaround_applied = False
     return renderer, renderer._renderer
 
 
@@ -316,3 +325,159 @@ def test_update_geometries_rejects_inconsistent_deformable_mapping(monkeypatch: 
 
     with pytest.raises(ValueError, match="zip"):
         renderer.update_geometries()
+
+
+def test_setup_particle_points_bindings_binds_mpm_visual_prims(monkeypatch: pytest.MonkeyPatch):
+    """MPM particle visual prims create an OPTIMIZE ``points`` array binding."""
+    renderer, backend = _make_renderer_without_backend()
+    particle_visual_prims = {
+        "/World/envs/env_0/Media/Particles": SimpleNamespace(offset=10, count=5),
+        "/World/envs/env_1/Media/Particles": SimpleNamespace(offset=15, count=5),
+    }
+
+    monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
+
+    renderer._setup_particle_bindings(num_envs=2)
+
+    assert len(backend.calls) == 1
+    assert backend.calls[0]["prim_paths"] == [
+        "/World/envs/env_0/Media/Particles",
+        "/World/envs/env_1/Media/Particles",
+    ]
+    assert backend.calls[0]["attribute_name"] == "points"
+    assert backend.calls[0]["flags"] is BindingFlag.OPTIMIZE
+    assert renderer._particle_points_binding is backend.bindings["points"]
+    assert renderer._particle_workaround_applied is False
+    assert renderer._particle_visual_offsets == [10, 15]
+    assert renderer._particle_visual_counts == [5, 5]
+    assert len(backend.writes) == 2
+    assert backend.writes[0]["attribute_name"] == "omni:resetXformStack"
+    assert backend.writes[1]["attribute_name"] == "omni:xform"
+
+
+def test_setup_particle_points_bindings_binds_multiple_mpm_assets(monkeypatch: pytest.MonkeyPatch):
+    """Multiple MPM assets bind as ``num_assets * num_envs`` points prims, like deformables."""
+    renderer, backend = _make_renderer_without_backend()
+    particle_visual_prims = {
+        "/World/envs/env_0/Media/Particles": SimpleNamespace(offset=0, count=5),
+        "/World/envs/env_1/Media/Particles": SimpleNamespace(offset=5, count=5),
+        "/World/envs/env_0/Foam/Particles": SimpleNamespace(offset=10, count=3),
+        "/World/envs/env_1/Foam/Particles": SimpleNamespace(offset=13, count=3),
+    }
+
+    monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
+
+    renderer._setup_particle_bindings(num_envs=2)
+
+    # Binding order follows dict insertion order (no path sort).
+    assert backend.calls[0]["prim_paths"] == [
+        "/World/envs/env_0/Media/Particles",
+        "/World/envs/env_1/Media/Particles",
+        "/World/envs/env_0/Foam/Particles",
+        "/World/envs/env_1/Foam/Particles",
+    ]
+    assert renderer._particle_visual_offsets == [0, 5, 10, 13]
+    assert renderer._particle_visual_counts == [5, 5, 3, 3]
+
+
+def test_update_particle_points_primes_with_host_sync_then_gpu_async(monkeypatch: pytest.MonkeyPatch):
+    """First MPM ``points`` update host-SYNC primes via binding; later frames use GPU ASYNC."""
+    renderer, backend = _make_renderer_without_backend()
+    renderer._particle_points_binding = _FakePointsBinding("points")
+    renderer._particle_visual_offsets = [2]
+    renderer._particle_visual_counts = [2]
+    renderer._particle_workaround_applied = False
+    particle_q = wp.array(
+        [
+            wp.vec3f(0.0, 0.0, 0.0),
+            wp.vec3f(1.0, 0.0, 0.0),
+            wp.vec3f(2.0, 3.0, 4.0),
+            wp.vec3f(5.0, 6.0, 7.0),
+        ],
+        dtype=wp.vec3f,
+        device="cpu",
+    )
+    monkeypatch.setattr(NewtonManager, "get_state", classmethod(lambda cls: SimpleNamespace(particle_q=particle_q)))
+
+    class _FakeStream:
+        cuda_stream = 42
+
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: _FakeStream())  # noqa: ARG005
+
+    renderer.update_geometries()
+
+    assert renderer._particle_workaround_applied is True
+    assert len(backend.writes) == 0
+    written = renderer._particle_points_binding.written
+    assert written is not None
+    assert len(written) == 1
+    assert isinstance(written[0], np.ndarray)
+    assert written[0].tolist() == [
+        [2.0, 3.0, 4.0],
+        [5.0, 6.0, 7.0],
+    ]
+    assert renderer._particle_points_binding.write_kwargs["data_access"] is DataAccess.SYNC
+    assert "cuda_stream" not in renderer._particle_points_binding.write_kwargs
+
+    renderer.update_geometries()
+
+    written = renderer._particle_points_binding.written
+    assert written is not None
+    assert len(written) == 1
+    assert written[0].ptr == particle_q[2:4].ptr
+    assert renderer._particle_points_binding.write_kwargs["data_access"] is DataAccess.ASYNC
+    assert renderer._particle_points_binding.write_kwargs["cuda_stream"] == 42
+    assert len(backend.writes) == 0
+
+
+def test_update_geometries_writes_deformable_and_mpm_bindings(monkeypatch: pytest.MonkeyPatch):
+    """Deformable mesh stays GPU ASYNC; MPM primes once with host SYNC then switches to ASYNC."""
+    renderer, backend = _make_renderer_without_backend()
+    renderer._deformable_points_binding = _FakePointsBinding("deformable_points")
+    renderer._deformable_particle_offsets = [0]
+    renderer._deformable_particle_counts = [2]
+    renderer._particle_points_binding = _FakePointsBinding("points")
+    renderer._particle_visual_offsets = [2]
+    renderer._particle_visual_counts = [2]
+    renderer._particle_workaround_applied = False
+    particle_q = wp.array(
+        [
+            wp.vec3f(0.0, 0.0, 0.0),
+            wp.vec3f(1.0, 0.0, 0.0),
+            wp.vec3f(2.0, 3.0, 4.0),
+            wp.vec3f(5.0, 6.0, 7.0),
+        ],
+        dtype=wp.vec3f,
+        device="cpu",
+    )
+    monkeypatch.setattr(NewtonManager, "get_state", classmethod(lambda cls: SimpleNamespace(particle_q=particle_q)))
+
+    class _FakeStream:
+        cuda_stream = 42
+
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: _FakeStream())  # noqa: ARG005
+
+    renderer.update_geometries()
+
+    deformable_written = renderer._deformable_points_binding.written
+    assert deformable_written is not None
+    assert len(deformable_written) == 1
+    assert deformable_written[0].ptr == particle_q[0:2].ptr
+    assert renderer._deformable_points_binding.write_kwargs["data_access"] is DataAccess.ASYNC
+
+    assert renderer._particle_workaround_applied is True
+    assert len(backend.writes) == 0
+    mpm_written = renderer._particle_points_binding.written
+    assert mpm_written is not None
+    assert isinstance(mpm_written[0], np.ndarray)
+    assert mpm_written[0].tolist() == [[2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]
+    assert renderer._particle_points_binding.write_kwargs["data_access"] is DataAccess.SYNC
+
+    renderer.update_geometries()
+
+    mpm_written = renderer._particle_points_binding.written
+    assert mpm_written is not None
+    assert len(mpm_written) == 1
+    assert mpm_written[0].ptr == particle_q[2:4].ptr
+    assert renderer._particle_points_binding.write_kwargs["data_access"] is DataAccess.ASYNC
+    assert len(backend.writes) == 0


### PR DESCRIPTION
# Description

- Bind registered particle clouds to OVRTX and stream their positions from Newton state.
- As a workaround, prime point bindings synchronously before switching to asynchronous GPU updates (OMPE-102610).
- Rendering test will be added later, after particle spawner/solver and the corresponding training envs are added (OMPE-102396).

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
