### PR TITLE
Add PhysX support for DR Legs

### DIFF
--- a/source/isaaclab_assets/changelog.d/antoiner-dr-legs-velocity-limit.rst
+++ b/source/isaaclab_assets/changelog.d/antoiner-dr-legs-velocity-limit.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed excessive simulation joint velocity limits in the DR Legs asset.

--- a/source/isaaclab_assets/isaaclab_assets/robots/dr_legs.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/dr_legs.py
@@ -101,6 +101,7 @@ DR_LEGS_IMPLICIT_PD_CFG = ArticulationCfg(
             stiffness=5.0,
             damping=0.2,
             effort_limit_sim=3.1,
+            velocity_limit_sim=100.0,
         ),
         # Linkage DOFs are undriven: explicit zeros so the solver ignores USD drive defaults.
         "passive_joints": ImplicitActuatorCfg(
@@ -110,6 +111,7 @@ DR_LEGS_IMPLICIT_PD_CFG = ArticulationCfg(
             armature=0.0,
             friction=0.0,
             effort_limit_sim=400.0,
+            velocity_limit_sim=100.0,
         ),
     },
 )

--- a/source/isaaclab_tasks/changelog.d/antoiner-dr-legs-physx.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-dr-legs-physx.minor.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added PhysX support to the DR Legs hold-pose and walking environments.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Hold-pose environment for the Disney DR Legs closed-loop biped (Kamino solver).
+"""Hold-pose environment for the Disney DR Legs closed-loop biped.
 
 The robot must keep its pelvis upright at a target height.
 """
 
 from isaaclab_newton.physics import KaminoSolverCfg, NewtonCfg, NewtonShapeCfg
+from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg
@@ -76,10 +77,11 @@ def _kamino_newton_cfg() -> NewtonCfg:
 
 @configclass
 class DrLegsPhysicsCfg(PresetCfg):
-    """Physics backend preset (DR Legs runs only under the Kamino solver)."""
+    """Physics backend presets for DR Legs."""
 
     default: NewtonCfg = _kamino_newton_cfg()
     newton_kamino: NewtonCfg = _kamino_newton_cfg()
+    physx: PhysxCfg = PhysxCfg()
 
 
 ##
@@ -116,6 +118,22 @@ class ActionsCfg:
         scale=0.3,
         use_default_offset=True,
     )
+
+
+def _physx_actions_cfg() -> ActionsCfg:
+    """Return the reduced PhysX joint-target action profile."""
+    cfg = ActionsCfg()
+    cfg.joint_pos.scale = 0.1
+    return cfg
+
+
+@configclass
+class DrLegsActionsCfg(PresetCfg):
+    """Backend-specific DR Legs action presets."""
+
+    default: ActionsCfg = ActionsCfg()
+    newton_kamino: ActionsCfg = ActionsCfg()
+    physx: ActionsCfg = _physx_actions_cfg()
 
 
 @configclass
@@ -221,6 +239,23 @@ class EventCfg:
     )
 
 
+def _physx_event_cfg() -> EventCfg:
+    """Return the PhysX reset profile with assembled joint coordinates."""
+    cfg = EventCfg()
+    cfg.reset_robot_joints.params["position_range"] = (0.0, 0.0)
+    cfg.reset_robot_joints.params["velocity_range"] = (0.0, 0.0)
+    return cfg
+
+
+@configclass
+class DrLegsEventCfg(PresetCfg):
+    """Backend-specific DR Legs event presets."""
+
+    default: EventCfg = EventCfg()
+    newton_kamino: EventCfg = EventCfg()
+    physx: EventCfg = _physx_event_cfg()
+
+
 @configclass
 class RewardsCfg:
     alive = RewTerm(func=mdp.is_alive, weight=5.0)
@@ -256,12 +291,12 @@ class TerminationsCfg:
 
 @configclass
 class DrLegsHoldPoseEnvCfg(ManagerBasedRLEnvCfg):
-    """DR Legs hold-pose environment (Newton/Kamino backend)."""
+    """DR Legs hold-pose environment."""
 
     scene: HoldPoseSceneCfg = HoldPoseSceneCfg(num_envs=_NUM_ENVS, env_spacing=2.0)
     observations: ObservationsCfg = ObservationsCfg()
-    actions: ActionsCfg = ActionsCfg()
-    events: EventCfg = EventCfg()
+    actions: DrLegsActionsCfg = DrLegsActionsCfg()
+    events: DrLegsEventCfg = DrLegsEventCfg()
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
     sim: SimulationCfg = SimulationCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Velocity-tracking walk environment for the Disney DR Legs closed-loop biped (Kamino).
+"""Velocity-tracking walk environment for the Disney DR Legs closed-loop biped.
 
 Extends the hold-pose task with a base-velocity command, a gait-phase clock, a foot
 contact sensor, and gait / contact / foot-clearance rewards.
@@ -12,6 +12,7 @@ contact sensor, and gait / contact / foot-clearance rewards.
 import math
 
 from isaaclab_newton.sensors import ContactSensorCfg as NewtonContactSensorCfg
+from isaaclab_physx.sensors import ContactSensorCfg as PhysXContactSensorCfg
 
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
@@ -19,6 +20,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.utils.configclass import configclass
 
 import isaaclab_tasks.contrib.dr_legs.mdp as mdp
+from isaaclab_tasks.utils import PresetCfg
 
 from isaaclab_assets.robots.dr_legs import DR_LEGS_ACTUATED_JOINTS
 
@@ -40,12 +42,25 @@ _FOOT_SENSOR_CFG = SceneEntityCfg("contact_forces", body_names=["foot_l", "foot_
 
 
 @configclass
-class WalkSceneCfg(HoldPoseSceneCfg):
-    contact_forces = NewtonContactSensorCfg(
+class DrLegsContactSensorCfg(PresetCfg):
+    """Backend-specific foot contact sensor configuration."""
+
+    default = NewtonContactSensorCfg(
         prim_path="{ENV_REGEX_NS}/Robot/foot_.*",
         history_length=3,
         track_air_time=True,
     )
+    newton_kamino = default
+    physx = PhysXContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/foot_.*",
+        history_length=3,
+        track_air_time=True,
+    )
+
+
+@configclass
+class WalkSceneCfg(HoldPoseSceneCfg):
+    contact_forces = DrLegsContactSensorCfg()
 
 
 @configclass
@@ -143,7 +158,7 @@ class WalkRewardsCfg:
 
 @configclass
 class DrLegsWalkEnvCfg(DrLegsHoldPoseEnvCfg):
-    """DR Legs velocity-tracking walk environment (Newton/Kamino backend)."""
+    """DR Legs velocity-tracking walk environment."""
 
     scene: WalkSceneCfg = WalkSceneCfg(num_envs=4096, env_spacing=2.0)
     observations: WalkObservationsCfg = WalkObservationsCfg()

--- a/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
+++ b/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the DR Legs physics presets."""
+
+from isaaclab_newton.physics import KaminoSolverCfg, NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+from isaaclab_physx.sensors import ContactSensorCfg as PhysXContactSensorCfg
+
+from isaaclab_tasks.contrib.dr_legs.hold_pose_env_cfg import DrLegsHoldPoseEnvCfg, DrLegsPhysicsCfg
+from isaaclab_tasks.contrib.dr_legs.walk_env_cfg import DrLegsWalkEnvCfg
+from isaaclab_tasks.utils.hydra import resolve_presets
+
+from isaaclab_assets.robots.dr_legs import DR_LEGS_IMPLICIT_PD_CFG
+
+
+def test_dr_legs_physx_uses_assembled_joint_reset_without_changing_the_asset() -> None:
+    """PhysX must preserve the asset and random base reset while assembling joints."""
+    env_cfg = resolve_presets(DrLegsWalkEnvCfg(), selected=("physx",))
+
+    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.scene.contact_forces, PhysXContactSensorCfg)
+    assert env_cfg.actions.joint_pos.scale == 0.1
+    assert env_cfg.scene.robot == DR_LEGS_IMPLICIT_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    assert env_cfg.events.reset_robot_joints.params["position_range"] == (0.0, 0.0)
+    assert env_cfg.events.reset_robot_joints.params["velocity_range"] == (0.0, 0.0)
+    assert env_cfg.events.reset_base.params["pose_range"]["x"] == (-0.05, 0.05)
+    assert env_cfg.events.reset_base.params["velocity_range"]["x"] == (-0.2, 0.2)
+    assert env_cfg.events.randomize_joint_params is not None
+
+
+def test_dr_legs_kamino_presets_remain_unchanged() -> None:
+    """PhysX support must not change the existing Kamino task distribution."""
+    physics = DrLegsPhysicsCfg()
+    env_cfg = resolve_presets(DrLegsHoldPoseEnvCfg(), selected=("newton_kamino",))
+
+    assert isinstance(physics.default, NewtonCfg)
+    assert isinstance(physics.newton_kamino.solver_cfg, KaminoSolverCfg)
+    assert env_cfg.events.reset_base.params["pose_range"]["x"] == (-0.05, 0.05)
+    assert env_cfg.events.reset_robot_joints.params["position_range"] == (-0.1, 0.1)
+    assert env_cfg.events.reset_robot_joints.params["velocity_range"] == (-0.05, 0.05)
+    assert env_cfg.actions.joint_pos.scale == 0.3

--- a/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
+++ b/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
@@ -16,14 +16,16 @@ from isaaclab_tasks.utils.hydra import resolve_presets
 from isaaclab_assets.robots.dr_legs import DR_LEGS_IMPLICIT_PD_CFG
 
 
-def test_dr_legs_physx_uses_assembled_joint_reset_without_changing_the_asset() -> None:
-    """PhysX must preserve the asset and random base reset while assembling joints."""
+def test_dr_legs_physx_uses_assembled_joint_reset_and_bounded_joint_velocity() -> None:
+    """PhysX must assemble the joints and apply the asset's solver velocity limit."""
     env_cfg = resolve_presets(DrLegsWalkEnvCfg(), selected=("physx",))
 
     assert isinstance(env_cfg.sim.physics, PhysxCfg)
     assert isinstance(env_cfg.scene.contact_forces, PhysXContactSensorCfg)
     assert env_cfg.actions.joint_pos.scale == 0.1
     assert env_cfg.scene.robot == DR_LEGS_IMPLICIT_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    assert env_cfg.scene.robot.actuators["driven_joints"].velocity_limit_sim == 100.0
+    assert env_cfg.scene.robot.actuators["passive_joints"].velocity_limit_sim == 100.0
     assert env_cfg.events.reset_robot_joints.params["position_range"] == (0.0, 0.0)
     assert env_cfg.events.reset_robot_joints.params["velocity_range"] == (0.0, 0.0)
     assert env_cfg.events.reset_base.params["pose_range"]["x"] == (-0.05, 0.05)


### PR DESCRIPTION
## Summary

- Add a PhysX physics preset for the DR Legs hold-pose and walking environments.
- Select the PhysX contact sensor and an assembled-joint reset profile for PhysX.
- Bound driven and passive joint simulation velocities at 100 rad/s instead of inheriting the USD limit of about 17,000 rad/s.
- Keep the PhysX-only 0.1 action scale because it provides the best velocity-tracking success, while preserving the existing Kamino solver and task presets.

## Testing

- `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py -q` (`2 passed`)
- `./isaaclab.sh -f`
- Final configuration smoke: RSL-RL, `IsaacContrib-DrLegs-Walk`, `presets=physx`, 4096 environments, seed 42, 5 iterations; completed and reported 100 rad/s for all 30 joints.
- Action-scale experiments at 4096 environments, seed 42, 300 iterations:
  - 0.3 without the limit: value loss became `inf` at iteration 1 and observations became NaN at iteration 3.
  - 0.3 with the 100 rad/s limit: completed without NaNs. Final-20 reward 326.16, episode length 494.20, success rate 0%, XY error 0.276 m/s, yaw error 0.829 rad/s.
  - 0.2 with the limit: completed without NaNs. Final-20 reward 356.03, episode length 496.36, success rate 51.95%, XY error 0.232 m/s, yaw error 0.423 rad/s; mean throughput 49.8k FPS.
  - 0.1 baseline: completed without NaNs. Final-20 reward 342.15, episode length 492.11, success rate 94.21%, XY error 0.237 m/s, yaw error 0.318 rad/s.
- The solver clamp fixes numerical stability at larger scales. Scale 0.2 maximizes aggregate reward and slightly improves XY error, but scale 0.1 remains substantially better for yaw tracking and overall success.