### PR TITLE
Add backend selection to standalone scripts

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -118,6 +118,15 @@ a {
     width: min(100%, 480px);
 }
 
+/* Keep each showroom demo visually grouped with its options, commands, and image. */
+.showroom-demo-list > li {
+    margin-bottom: 4rem;
+}
+
+.showroom-demo-list > li:last-child {
+    margin-bottom: 0;
+}
+
 .nurec-gif-grid,
 .nurec-gif-grid td {
     border: none;

--- a/docs/source/overview/core-concepts/sensors/camera.rst
+++ b/docs/source/overview/core-concepts/sensors/camera.rst
@@ -407,14 +407,14 @@ absolute-difference images.
       .. code-block:: bash
 
          uv run python scripts/demos/sensors/ppisp_camera.py \
-             --renderer newton --max_steps 60
+             --renderer newton_renderer --max_steps 60
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
       .. code-block:: bash
 
          ./isaaclab.sh -p scripts/demos/sensors/ppisp_camera.py \
-             --renderer newton --max_steps 60
+             --renderer newton_renderer --max_steps 60
 
 Use ``--renderer isaac_rtx`` to run the same workflow with Isaac RTX. Pass
 ``--input_scene`` for a custom scene and ``--camera_prim_path`` if the stage

--- a/docs/source/overview/showroom.rst
+++ b/docs/source/overview/showroom.rst
@@ -8,8 +8,13 @@ interfaces within a code in a minimal way.
 
 A few quick showroom scripts to run and checkout:
 
+.. rst-class:: showroom-demo-list
 
 -  Spawn different arms and apply random joint position commands:
+
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
 
    .. tab-set::
       :sync-group: os
@@ -45,6 +50,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Spawn different biped robots:
 
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -79,6 +88,11 @@ A few quick showroom scripts to run and checkout:
 
 -  Spawn different deformable objects and let them fall from a height:
 
+   **Physics:** ``physx``, ``newton_vbd``
+
+   **Visualizer:** ``none``, ``kit`` for either physics backend; ``newton``,
+   ``rerun``, and ``viser`` with Newton VBD only
+
    .. tab-set::
       :sync-group: os
 
@@ -106,15 +120,18 @@ A few quick showroom scripts to run and checkout:
 
             isaaclab.bat -p scripts\demos\deformables.py
 
-   Add ``--backend newton`` to run the same demo with the experimental Newton
-   deformable backend.
-
    .. image:: ../_static/demos/deformables.jpg
       :width: 100%
       :alt: Deformable primitive-shaped objects in Isaac Lab
 
 
 -  Interactive inference of trained H1 rough terrain locomotion policy:
+
+   **Physics:** ``physx`` only
+
+   **Visualizer:** ``kit`` only
+
+   This demo downloads a policy and requires interactive input.
 
    .. tab-set::
       :sync-group: os
@@ -166,6 +183,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Spawn different hands and command them to open and close:
 
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -199,6 +220,10 @@ A few quick showroom scripts to run and checkout:
 
 
 -  Define multiple markers that are useful for visualizations:
+
+   **Physics:** ``physx`` only
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
 
    .. tab-set::
       :sync-group: os
@@ -234,6 +259,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Use the interactive scene and spawn varying assets in individual environments:
 
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -268,6 +297,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Compose task scenes into one heterogeneous simulation using clone combinations:
 
+   **Physics:** ``physx`` only
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -297,6 +330,10 @@ A few quick showroom scripts to run and checkout:
 
 
 -  Use the RigidObjectCollection spawn and view manipulation to demonstrate bin-packing example:
+
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
 
    .. tab-set::
       :sync-group: os
@@ -332,6 +369,13 @@ A few quick showroom scripts to run and checkout:
 
 
 -  Use the interactive scene and spawn a simple parallel robot for pick and place:
+
+   **Physics:** ``physx`` only
+
+   **Visualizer:** ``kit`` only
+
+   This demo requires interactive input and uses the CPU-only PhysX surface
+   gripper. Newton physics is not supported.
 
    .. tab-set::
       :sync-group: os
@@ -376,6 +420,12 @@ A few quick showroom scripts to run and checkout:
 
 
 -  Teleoperate a Franka Panda robot using Haply haptic device with force feedback:
+
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
+   Haply hardware is required.
 
    .. tab-set::
       :sync-group: os
@@ -422,6 +472,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Create and spawn procedurally generated terrains with different configurations:
 
+   **Physics:** ``physx`` only
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -457,6 +511,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Spawn a quadcopter in the default environment:
 
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -491,6 +549,10 @@ A few quick showroom scripts to run and checkout:
 
 -  Spawn different quadrupeds and make robots stand using position commands:
 
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``kit``, ``newton``, ``rerun``, ``viser``
+
    .. tab-set::
       :sync-group: os
 
@@ -524,6 +586,11 @@ A few quick showroom scripts to run and checkout:
 
 
 -  Spawn a multi-mesh ray caster that uses Warp kernels for raycasting
+
+   **Physics:** ``physx``, ``newton_mjwarp``
+
+   **Visualizer:** ``none``, ``newton``, ``rerun``, ``viser`` with either physics
+   backend; ``kit`` with PhysX only
 
    .. tab-set::
       :sync-group: os

--- a/docs/source/tutorials/01_assets/run_deformable_object.rst
+++ b/docs/source/tutorials/01_assets/run_deformable_object.rst
@@ -59,7 +59,7 @@ when the simulation is played.
 .. note::
     Deformable objects require a mesh object to be spawned with backend-specific deformable body physics
     properties and a matching deformable physics material.
-    Use ``--backend physx`` for the PhysX implementation or ``--backend newton`` for the experimental Newton
+    Use ``--backend physx`` for the PhysX implementation or ``--backend newton_vbd`` for the experimental Newton
     implementation.
 
 
@@ -185,14 +185,14 @@ To run the same tutorial with the experimental Newton deformable backend:
 
       .. code-block:: bash
 
-         uv run python scripts/tutorials/01_assets/run_deformable_object.py --backend newton --visualizer kit
+         uv run python scripts/tutorials/01_assets/run_deformable_object.py --backend newton_vbd --visualizer kit
 
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
       .. code-block:: bash
 
-         ./isaaclab.sh -p scripts/tutorials/01_assets/run_deformable_object.py --backend newton --visualizer kit
+         ./isaaclab.sh -p scripts/tutorials/01_assets/run_deformable_object.py --backend newton_vbd --visualizer kit
 
 
 This should open a stage with a ground plane, lights, and several cubes. Two of the four cubes must be dropping

--- a/scripts/demos/arms.py
+++ b/scripts/demos/arms.py
@@ -93,6 +93,7 @@ def design_scene() -> tuple[dict, list[list[float]]]:
     cfg.func("/World/Origin1/Table", cfg, translation=(0.55, 0.0, 1.05))
     # -- Robot
     franka_arm_cfg = FRANKA_PANDA_CFG.replace(prim_path="/World/Origin1/Robot")
+    franka_arm_cfg.spawn.usd_path = f"{ISAAC_NUCLEUS_DIR}/Robots/FrankaRobotics/FrankaPanda/franka.usd"
     franka_arm_cfg.init_state.pos = (0.0, 0.0, 1.05)
     franka_panda = franka_arm_cfg.class_type(franka_arm_cfg)
 

--- a/scripts/demos/heterogeneous_scene.py
+++ b/scripts/demos/heterogeneous_scene.py
@@ -48,9 +48,6 @@ parser.add_argument("--physics", default="physx", choices=["physx"], help="Physi
 add_launcher_args(parser)
 parser.set_defaults(visualizer=["kit"])
 args_cli, hydra_args = parser.parse_known_args()
-# the default Kit viewport cannot exist headless; explicit visualizer choices stay
-if args_cli.headless and args_cli.visualizer == ["kit"]:
-    args_cli.visualizer = []
 # strip consumed args so hydra-based task-config resolution does not re-parse them
 sys.argv = [sys.argv[0], *hydra_args]
 
@@ -84,7 +81,7 @@ DEFAULT_TASKS = (
     "IsaacContrib-Velocity-Flat-UnitreeGo1",
     "Isaac-Velocity-Flat-UnitreeGo2",
     "Isaac-Velocity-Flat-Cassie",
-    "Isaac-Velocity-Flat-Digit",
+    "IsaacContrib-Velocity-Flat-Digit",
     "Isaac-Velocity-Flat-G1",
     "Isaac-Velocity-Flat-H1",
     "IsaacContrib-Navigation-Flat-AnymalC",

--- a/scripts/demos/markers.py
+++ b/scripts/demos/markers.py
@@ -25,8 +25,6 @@ parser = argparse.ArgumentParser(
     conflict_handler="resolve",
 )
 parser.add_argument("--physics", default="physx", choices=["physx"], help="Physics backend.")
-# Newton visualizer not supported for markers
-parser.add_argument("--visualizer", default="kit", choices=["kit"], help="Visualizer backend.")
 add_launcher_args(parser)
 parser.set_defaults(visualizer=["kit"])
 args_cli = parser.parse_args()

--- a/scripts/demos/mpm/newton_mpm_granular.py
+++ b/scripts/demos/mpm/newton_mpm_granular.py
@@ -66,7 +66,7 @@ Y_ROT_NEG_45_DEG = (0.0, -math.sin(math.pi / 8.0), 0.0, math.cos(math.pi / 8.0))
 
 def create_visualizer_cfgs():
     """Create demo-specific visualizer configs for the requested backends."""
-    if "newton" not in args_cli.visualizer:
+    if "newton" not in (args_cli.visualizer or []):
         return []
 
     from isaaclab_visualizers.newton import NewtonVisualizerCfg
@@ -106,7 +106,7 @@ def create_sim_cfg():
 
 def preview_material(color):
     """Return a preview-surface material for Kit runs; Kit-less runs spawn no USD materials."""
-    if "kit" not in args_cli.visualizer:
+    if "kit" not in (args_cli.visualizer or []):
         return None
 
     import isaaclab.sim as sim_utils

--- a/scripts/demos/mpm/particle_pour.py
+++ b/scripts/demos/mpm/particle_pour.py
@@ -116,7 +116,7 @@ CAMERA_TARGET = (-0.01, 0.0, 0.38)
 
 def create_visualizer_cfgs():
     """Create demo-specific visualizer configs for requested backends."""
-    if "newton" not in args_cli.visualizer:
+    if "newton" not in (args_cli.visualizer or []):
         return []
 
     from isaaclab_visualizers.newton import NewtonVisualizerCfg
@@ -172,7 +172,7 @@ def launch_omniverse_asset_resolver():
     ``pxr`` cannot resolve; Kit ships the asset resolver that can. Kit-visualizer
     runs boot Kit anyway, so this only applies to Newton-only runs.
     """
-    if "kit" in args_cli.visualizer:
+    if "kit" in (args_cli.visualizer or []):
         return None
 
     from isaaclab.utils import has_kit
@@ -334,7 +334,7 @@ def create_sim_cfg():
 
 def preview_material(color):
     """Return a preview-surface material for Kit runs; Kit-less runs spawn no USD materials."""
-    if "kit" not in args_cli.visualizer:
+    if "kit" not in (args_cli.visualizer or []):
         return None
 
     import isaaclab.sim as sim_utils

--- a/scripts/demos/multi_asset.py
+++ b/scripts/demos/multi_asset.py
@@ -36,7 +36,7 @@ parser = argparse.ArgumentParser(
     conflict_handler="resolve",
 )
 parser.add_argument("--num_envs", type=int, default=512, help="Number of environments to spawn.")
-parser.add_argument("--physics", default="physx", choices=["physx"], help="Physics backend.")
+parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
 add_launcher_args(parser)
 # demos should open Kit visualizer by default
 parser.set_defaults(visualizer=["kit"])

--- a/scripts/demos/sensors/multi_mesh_raycaster.py
+++ b/scripts/demos/sensors/multi_mesh_raycaster.py
@@ -17,14 +17,20 @@
     # with random multiple objects
     python scripts/demos/sensors/multi_mesh_raycaster.py --num_envs 16 --asset_type objects
 
+    # with Newton (MJWarp) physics
+    python scripts/demos/sensors/multi_mesh_raycaster.py --physics newton_mjwarp
+
 """
 
 import argparse
 
-from isaaclab.app import AppLauncher
+from isaaclab.app import add_launcher_args, launch_simulation
 
 # add argparse arguments
-parser = argparse.ArgumentParser(description="Example on using the multi-mesh raycaster sensor.")
+parser = argparse.ArgumentParser(
+    description="Example on using the multi-mesh raycaster sensor.",
+    conflict_handler="resolve",
+)
 parser.add_argument("--num_envs", type=int, default=16, help="Number of environments to spawn.")
 parser.add_argument(
     "--asset_type",
@@ -33,28 +39,25 @@ parser.add_argument(
     help="Asset type to use.",
     choices=["allegro_hand", "anymal_d", "objects"],
 )
-# append AppLauncher cli args
-AppLauncher.add_app_launcher_args(parser)
+parser.add_argument("--physics", default="physx", choices=["physx", "newton_mjwarp"], help="Physics backend.")
+add_launcher_args(parser)
 # demos should open Kit visualizer by default
 parser.set_defaults(visualizer=["kit"])
-# parse the arguments
 args_cli = parser.parse_args()
-
-# launch omniverse app
-app_launcher = AppLauncher(args_cli)
-simulation_app = app_launcher.app
-
-"""Rest everything follows."""
+if args_cli.physics == "newton_mjwarp":
+    if not getattr(args_cli, "visualizer_explicit", False):
+        args_cli.visualizer = ["newton"]
+    elif "kit" in (args_cli.visualizer or []):
+        parser.error("the Kit visualizer is not supported with Newton physics; select newton, rerun, viser, or none")
 
 import random
 
 import torch
 
-from pxr import Gf, Sdf
-
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, AssetBaseCfg, RigidObjectCfg
 from isaaclab.markers.config import VisualizationMarkersCfg
+from isaaclab.physics import PhysicsCfg
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors.ray_caster import MultiMeshRayCasterCfg, patterns
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
@@ -65,6 +68,8 @@ from isaaclab.utils.configclass import configclass
 ##
 from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
 from isaaclab_assets.robots.anymal import ANYMAL_D_CFG
+
+DEBUG_VISUALIZATION_ENABLED = "none" not in (args_cli.visualizer or [])
 
 RAY_CASTER_MARKER_CFG = VisualizationMarkersCfg(
     markers={
@@ -79,7 +84,7 @@ RAY_CASTER_MARKER_CFG = VisualizationMarkersCfg(
 if args_cli.asset_type == "allegro_hand":
     asset_cfg = ALLEGRO_HAND_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
     ray_caster_cfg = MultiMeshRayCasterCfg(
-        prim_path="{ENV_REGEX_NS}/Robot",
+        prim_path="{ENV_REGEX_NS}/Robot/palm_link",
         update_period=1 / 60,
         offset=MultiMeshRayCasterCfg.OffsetCfg(pos=(0, -0.1, 0.3)),
         mesh_prim_paths=[
@@ -93,7 +98,7 @@ if args_cli.asset_type == "allegro_hand":
         ],
         ray_alignment="world",
         pattern_cfg=patterns.GridPatternCfg(resolution=0.005, size=(0.4, 0.4), direction=(0, 0, -1)),
-        debug_vis=not args_cli.headless,
+        debug_vis=DEBUG_VISUALIZATION_ENABLED,
         visualizer_cfg=RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/RayCaster"),
     )
 
@@ -113,42 +118,47 @@ elif args_cli.asset_type == "anymal_d":
         ],
         ray_alignment="world",
         pattern_cfg=patterns.GridPatternCfg(resolution=0.02, size=(2.5, 2.5), direction=(0, 0, -1)),
-        debug_vis=not args_cli.headless,
+        debug_vis=DEBUG_VISUALIZATION_ENABLED,
         visualizer_cfg=RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/RayCaster"),
     )
 
 elif args_cli.asset_type == "objects":
+    object_assets_cfg = [
+        sim_utils.CuboidCfg(
+            size=(0.3, 0.3, 0.3),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0), metallic=0.2),
+        ),
+        sim_utils.SphereCfg(
+            radius=0.3,
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
+        ),
+        sim_utils.CylinderCfg(
+            radius=0.2,
+            height=0.5,
+            axis="Y",
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
+        ),
+        sim_utils.CapsuleCfg(
+            radius=0.15,
+            height=0.5,
+            axis="Z",
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 1.0, 0.0), metallic=0.2),
+        ),
+        sim_utils.ConeCfg(
+            radius=0.2,
+            height=0.5,
+            axis="Z",
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 1.0), metallic=0.2),
+        ),
+    ]
+    if args_cli.physics == "newton_mjwarp":
+        # MJWarp requires homogeneous cloned worlds, so use one shape type across all environments.
+        object_assets_cfg = object_assets_cfg[:1]
+
     asset_cfg = RigidObjectCfg(
         prim_path="{ENV_REGEX_NS}/Object",
         spawn=sim_utils.MultiAssetSpawnerCfg(
-            assets_cfg=[
-                sim_utils.CuboidCfg(
-                    size=(0.3, 0.3, 0.3),
-                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0), metallic=0.2),
-                ),
-                sim_utils.SphereCfg(
-                    radius=0.3,
-                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 1.0), metallic=0.2),
-                ),
-                sim_utils.CylinderCfg(
-                    radius=0.2,
-                    height=0.5,
-                    axis="Y",
-                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), metallic=0.2),
-                ),
-                sim_utils.CapsuleCfg(
-                    radius=0.15,
-                    height=0.5,
-                    axis="Z",
-                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 1.0, 0.0), metallic=0.2),
-                ),
-                sim_utils.ConeCfg(
-                    radius=0.2,
-                    height=0.5,
-                    axis="Z",
-                    visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 1.0), metallic=0.2),
-                ),
-            ],
+            assets_cfg=object_assets_cfg,
             random_choice=True,
             rigid_props=sim_utils.RigidBodyPropertiesCfg(
                 solver_position_iteration_count=4, solver_velocity_iteration_count=0
@@ -168,7 +178,7 @@ elif args_cli.asset_type == "objects":
         ],
         ray_alignment="world",
         pattern_cfg=patterns.GridPatternCfg(resolution=0.01, size=(0.6, 0.6), direction=(0, 0, -1)),
-        debug_vis=not args_cli.headless,
+        debug_vis=DEBUG_VISUALIZATION_ENABLED,
         visualizer_cfg=RAY_CASTER_MARKER_CFG.replace(prim_path="/Visuals/RayCaster"),
     )
 else:
@@ -201,6 +211,8 @@ class RaycasterSensorSceneCfg(InteractiveSceneCfg):
 
 def randomize_shape_color(prim_path_expr: str):
     """Randomize the color of the geometry."""
+    # Import pxr only after launch_simulation has started Kit for PhysX runs.
+    from pxr import Gf, Sdf
 
     stage = sim_utils.get_current_stage()
     # resolve prim paths for spawning and cloning
@@ -217,7 +229,8 @@ def randomize_shape_color(prim_path_expr: str):
             # Note: Just need to acquire the right attribute about the property you want to set
             # Here is an example on setting color randomly
             color_spec = prim_spec.GetAttributeAtPath(prim_path + "/geometry/material/Shader.inputs:diffuseColor")
-            color_spec.default = Gf.Vec3f(random.random(), random.random(), random.random())
+            if color_spec is not None:
+                color_spec.default = Gf.Vec3f(random.random(), random.random(), random.random())
 
             # randomize scale
             scale_spec = prim_spec.GetAttributeAtPath(prim_path + ".xformOp:scale")
@@ -232,7 +245,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
     count = 0
 
     # Simulate physics
-    while simulation_app.is_running():
+    while sim.is_headless_or_exist_active_visualizer():
         if count % 500 == 0:
             # reset counter
             count = 0
@@ -276,29 +289,27 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
 def main():
     """Main function."""
+    with launch_simulation(cfg=PhysicsCfg(), launcher_args=args_cli) as physics_cfg:
+        # Initialize the simulation context
+        sim_cfg = sim_utils.SimulationCfg(dt=0.005, device=args_cli.device, physics=physics_cfg)
+        sim = sim_utils.SimulationContext(sim_cfg)
+        # Set main camera
+        sim.set_camera_view(eye=[3.5, 3.5, 3.5], target=[0.0, 0.0, 0.0])
+        # design scene
+        scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=True)
+        scene = InteractiveScene(scene_cfg)
 
-    # Initialize the simulation context
-    sim_cfg = sim_utils.SimulationCfg(dt=0.005, device=args_cli.device)
-    sim = sim_utils.SimulationContext(sim_cfg)
-    # Set main camera
-    sim.set_camera_view(eye=[3.5, 3.5, 3.5], target=[0.0, 0.0, 0.0])
-    # design scene
-    scene_cfg = RaycasterSensorSceneCfg(num_envs=args_cli.num_envs, env_spacing=2.0, replicate_physics=True)
-    scene = InteractiveScene(scene_cfg)
+        if args_cli.asset_type == "objects":
+            randomize_shape_color(scene_cfg.asset.prim_path.format(ENV_REGEX_NS="/World/envs/env_.*"))
 
-    if args_cli.asset_type == "objects":
-        randomize_shape_color(scene_cfg.asset.prim_path.format(ENV_REGEX_NS="/World/envs/env_.*"))
-
-    # Play the simulator
-    sim.reset()
-    # Now we are ready!
-    print("[INFO]: Setup complete...")
-    # Run the simulator
-    run_simulator(sim, scene)
+        # Play the simulator
+        sim.reset()
+        # Now we are ready!
+        print("[INFO]: Setup complete...")
+        # Run the simulator
+        run_simulator(sim, scene)
 
 
 if __name__ == "__main__":
     # run the main function
     main()
-    # close sim app
-    simulation_app.close()

--- a/scripts/demos/sensors/ppisp_camera.py
+++ b/scripts/demos/sensors/ppisp_camera.py
@@ -11,7 +11,7 @@ the Newton Warp or Isaac RTX renderer.
 
     # Run a finite smoke with the default Newton Warp renderer and save comparison images.
     uv run python scripts/demos/sensors/ppisp_camera.py \
-        --input_scene /path/to/scene.usd --renderer newton --visualizer none --max_steps 60
+        --input_scene /path/to/scene.usd --renderer newton_renderer --visualizer none --max_steps 60
 
     # Run the same saved-image workflow with Isaac RTX.
     uv run python scripts/demos/sensors/ppisp_camera.py \
@@ -68,8 +68,8 @@ parser.add_argument("--disable_fabric", action="store_true", help="Disable Fabri
 parser.add_argument(
     "--renderer",
     type=str,
-    choices=["newton", "isaac_rtx"],
-    default="newton",
+    choices=["newton_renderer", "isaac_rtx"],
+    default="newton_renderer",
     help="Camera renderer backend to use. Newton Warp is the default for this PPISP smoke.",
 )
 parser.add_argument(
@@ -169,7 +169,7 @@ class PpispCameraSceneCfg(InteractiveSceneCfg):
 
 def make_renderer_cfg() -> Any:
     """Create the selected camera renderer cfg."""
-    if args_cli.renderer == "newton":
+    if args_cli.renderer == "newton_renderer":
         from isaaclab_newton.renderers import NewtonWarpRendererCfg
 
         return NewtonWarpRendererCfg()
@@ -182,7 +182,7 @@ def make_renderer_cfg() -> Any:
 def make_sim_cfg() -> sim_utils.SimulationCfg:
     """Create the simulation cfg matching the selected renderer."""
     physics_cfg = None
-    if args_cli.renderer == "newton":
+    if args_cli.renderer == "newton_renderer":
         from isaaclab_newton.physics.mjwarp_manager_cfg import MJWarpSolverCfg
         from isaaclab_newton.physics.newton_manager_cfg import NewtonCfg
 
@@ -540,7 +540,7 @@ def main() -> None:
     sim.set_camera_view(eye=[2.5, 2.5, 2.5], target=[0.0, 0.0, 0.0])
 
     scene = create_duplicated_env_scene()
-    if args_cli.renderer == "newton":
+    if args_cli.renderer == "newton_renderer":
         bake_source_camera_pose_to_envs(source_stage, source_camera_prim_path)
     baseline_camera = make_camera(camera_prim_path, ppisp_cfg=None, width=width, height=height)
     ppisp_camera = make_camera(camera_prim_path, ppisp_cfg=ppisp_cfg, width=width, height=height)

--- a/scripts/demos/sensors/ppisp_camera_ovrtx.py
+++ b/scripts/demos/sensors/ppisp_camera_ovrtx.py
@@ -39,7 +39,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import Camera, CameraCfg
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, retrieve_file_path
 from isaaclab.utils.configclass import configclass
 
 DEFAULT_INPUT_SCENE = f"{ISAAC_NUCLEUS_DIR}/Samples/Scene_ParticleField/valiant_auto.usdz"
@@ -106,11 +106,6 @@ parser.add_argument(
     default=None,
     help="Directory to write comparison images. Defaults to scripts/demos/sensors/output/ppisp_camera_ovrtx.",
 )
-parser.add_argument(
-    "--disable_ovrtx_cloning",
-    action="store_true",
-    help="Export all envs to OVRTX instead of using OVRTX internal env cloning.",
-)
 parser.add_argument("--ovrtx_log_level", type=str, default="verbose", help="OVRTX carb log level.")
 parser.add_argument("--ovrtx_log_file", type=str, default="/tmp/ovrtx_renderer.log", help="OVRTX log file path.")
 
@@ -169,7 +164,6 @@ def make_renderer_cfg() -> Any:
         ) from exc
 
     return OVRTXRendererCfg(
-        use_ovrtx_cloning=not args_cli.disable_ovrtx_cloning,
         log_level=args_cli.ovrtx_log_level,
         log_file_path=args_cli.ovrtx_log_file,
     )
@@ -267,14 +261,15 @@ def bake_source_camera_pose_to_envs(source_stage: Usd.Stage, source_camera_prim_
     stage = sim_utils.get_current_stage()
     target_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
     camera_rel_path = source_camera_path_to_default_rel_path(source_stage, source_camera_prim_path)
+    scene_prims = sim_utils.find_matching_prims("/World/envs/env_.*/Scene", stage)
+    if not scene_prims:
+        raise RuntimeError("No duplicated scene prims found under /World/envs.")
+
     authored_count = 0
-    for env_id in range(args_cli.num_envs):
-        scene_path = f"/World/envs/env_{env_id}/Scene"
+    for scene_prim in scene_prims:
+        scene_path = scene_prim.GetPath().pathString
         target_camera_path = f"{scene_path}/{camera_rel_path}"
-        scene_prim = stage.GetPrimAtPath(scene_path)
         target_camera_prim = stage.GetPrimAtPath(target_camera_path)
-        if not scene_prim or not scene_prim.IsValid():
-            raise RuntimeError(f"Duplicated scene prim not found: {scene_path}")
         if not target_camera_prim or not target_camera_prim.IsValid():
             raise RuntimeError(f"Duplicated camera prim not found: {target_camera_path}")
 
@@ -520,6 +515,7 @@ def run_simulator(sim: sim_utils.SimulationContext, baseline_camera: Camera, ppi
 
 def main() -> None:
     """Main function."""
+    args_cli.input_scene = retrieve_file_path(args_cli.input_scene)
     source_stage = Usd.Stage.Open(args_cli.input_scene)
     if source_stage is None:
         raise RuntimeError(f"Failed to open input scene: {args_cli.input_scene}")

--- a/scripts/tutorials/01_assets/run_deformable_object.py
+++ b/scripts/tutorials/01_assets/run_deformable_object.py
@@ -22,7 +22,7 @@ from isaaclab.app import AppLauncher
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Tutorial on interacting with a deformable object.")
-parser.add_argument("--backend", type=str, default="physx", choices=["physx", "newton"], help="Physics backend.")
+parser.add_argument("--backend", type=str, default="physx", choices=["physx", "newton_vbd"], help="Physics backend.")
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # demos should open Kit visualizer by default
@@ -65,7 +65,7 @@ def design_scene():
     youngs_modulus = 1e5
     poissons_ratio = 0.4
     density = 500.0
-    if args_cli.backend == "newton":
+    if args_cli.backend == "newton_vbd":
         from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
         from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
 
@@ -175,7 +175,7 @@ def run_simulator(sim: sim_utils.SimulationContext, entities: dict, origins: tor
 def main():
     """Main function."""
     # Load kit helper
-    if args_cli.backend == "newton":
+    if args_cli.backend == "newton_vbd":
         from isaaclab_newton.physics import NewtonCfg
 
         from isaaclab_contrib.deformable.newton_manager_cfg import VBDSolverCfg

--- a/source/isaaclab/changelog.d/kellyg-standalone-script-smoke-tests.rst
+++ b/source/isaaclab/changelog.d/kellyg-standalone-script-smoke-tests.rst
@@ -1,0 +1,14 @@
+Fixed
+^^^^^
+
+* Fixed the Franka arms demo asset URL and OVRTX camera scene localization.
+
+* Fixed the heterogeneous-scene demo to use the current launcher arguments and
+  registered Digit task identifier.
+
+Changed
+^^^^^^^
+
+* **Breaking:** Renamed the ``newton`` renderer selector in the PPISP camera
+  demo to ``newton_renderer``. Update commands to pass
+  ``--renderer newton_renderer``.

--- a/source/isaaclab_newton/changelog.d/kellyg-standalone-script-smoke-tests.rst
+++ b/source/isaaclab_newton/changelog.d/kellyg-standalone-script-smoke-tests.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed headless execution of the Newton MPM standalone demos.
+
+* Added consistent ``newton_mjwarp`` physics selection to standalone demos
+  whose configurations already support Newton physics.


### PR DESCRIPTION
## Description

Documents the supported physics, renderer, and visualizer options alongside
each standalone demo shown on the showroom page, and updates the corresponding
demo and tutorial scripts so those selections are exposed consistently.

The script changes:

- add `newton_mjwarp` support where the existing scene configuration is
  compatible, including the multi-asset and multi-mesh raycaster demos;
- allow supported external visualizers instead of unnecessarily restricting
  scripts to Kit;
- make the Newton MPM demos safe to launch headlessly;
- align selector names with the preset APIs by using `newton_mjwarp` for
  Newton MJWarp physics and `newton_renderer` for the Newton renderer;
- update the deformable tutorial for its Newton VBD variant;
- fix the heterogeneous-scene launcher arguments and task identifier;
- fix the Franka arms asset URL and remote PPISP scene localization.

The standalone smoke-test framework, focused regression tests, and Newton core
compatibility changes were split into dependent draft PR #6704.

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Breaking change
- [x] Documentation update

## Testing

- Full Sphinx documentation build succeeded without warnings.
- Modified demo and tutorial scripts passed Python compilation.
- All-file pre-commit hooks passed.
- The supported backend and visualizer combinations were exercised during
  development; the reusable test matrix and core regression coverage are in
  #6704.
- Graphical outputs were captured and visually inspected for the available Kit
  and Newton visualizers.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the formatter and all pre-commit checks.
- [x] I have updated the documentation and changelog fragments.
- [x] I have verified every showcased demo lists options synchronized with its
  executable script.
- [x] Corresponding automated tests are included in dependent PR #6704.
- [ ] I have added my name to `CONTRIBUTORS.md` or my name already exists
  there.
