### PR TITLE
Update OVRTX idToLabels / idToSemantic raw IDs keys to int instead of stringifying them

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-fix-str-keys.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-fix-str-keys.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the OVRTX renderer producing string keys (e.g. ``"0"``, ``"1"``, ``"2"``) instead of integer keys
+  in the non-colorized ``idToLabels`` and ``idToSemantics`` mappings for ``semantic_segmentation`` and
+  ``instance_segmentation_fast``. Index ``camera.data.info[...]["idToLabels"]`` and
+  ``camera.data.info[...]["idToSemantics"]`` with integer pixel/semantic IDs when
+  ``colorize_semantic_segmentation=False`` or ``colorize_instance_segmentation=False``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_annotator_utils.py
@@ -223,13 +223,13 @@ def _color_keys_for_ids(ids: list[int], device: str) -> list[RgbaColor]:
 
 def build_semantic_id_to_labels(
     labels_by_id: dict[int, dict[str, str]], colorize: bool, device: str
-) -> dict[RgbaColor | str, dict[str, str]]:
+) -> dict[RgbaColor | int, dict[str, str]]:
     """Build the ``idToLabels`` mapping from decoded semantic IDs, keyed by RGBA color tuple or ID.
 
     Args:
         labels_by_id: Decoded ``{semantic_id: {type: label}}`` for IDs >= 2 from the SemanticIdMap.
         colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
-            (the Replicator fast-node contract); otherwise keys are the decimal semantic ID strings (matching
+            (the Replicator fast-node contract); otherwise keys are the raw integer semantic IDs (matching
             the raw ``int32`` output).
         device: Warp device used to compute colors when ``colorize`` is True.
 
@@ -241,7 +241,7 @@ def build_semantic_id_to_labels(
     sorted_ids = sorted(id_labels)
 
     if not colorize:
-        return {str(semantic_id): id_labels[semantic_id] for semantic_id in sorted_ids}
+        return {semantic_id: id_labels[semantic_id] for semantic_id in sorted_ids}
 
     color_keys = _color_keys_for_ids(sorted_ids, device)
     return {color_keys[idx]: id_labels[semantic_id] for idx, semantic_id in enumerate(sorted_ids)}
@@ -253,7 +253,7 @@ def build_instance_id_to_labels_and_semantics(
     semantic_id_to_labels: dict[int, dict[str, str]],
     colorize: bool,
     device: str,
-) -> tuple[dict[RgbaColor | str, str], dict[RgbaColor | str, dict[str, str]]]:
+) -> tuple[dict[RgbaColor | int, str], dict[RgbaColor | int, dict[str, str]]]:
     """Build the instance-segmentation ``idToLabels`` and ``idToSemantics`` mappings.
 
     Resolves each instance pixel ID through the three decoded maps, following the ovrtx / Replicator chain:
@@ -269,7 +269,7 @@ def build_instance_id_to_labels_and_semantics(
         stable_id_to_path: Decoded ``{stable_id: prim_path}`` from :func:`decode_stable_id_map`.
         semantic_id_to_labels: Decoded ``{semantic_id: {type: label}}`` from :func:`decode_semantic_id_map`.
         colorize: If True, keys are ``(r, g, b, a)`` color tuples matching the colorized segmentation buffer
-            (the Replicator fast-node contract); otherwise keys are the decimal pixel ID strings (matching the
+            (the Replicator fast-node contract); otherwise keys are the raw integer pixel IDs (matching the
             raw ``uint32`` output).
         device: Warp device used to compute colors when ``colorize`` is True.
 
@@ -294,7 +294,7 @@ def build_instance_id_to_labels_and_semantics(
         prim_paths.append(stable_id_to_path.get(stable_id, _RESERVED_INSTANCE_LABELS[UNLABELLED_ID]))
         semantics.append(semantic_id_to_labels.get(semantic_id, _RESERVED_SEMANTIC_LABELS[UNLABELLED_ID]))
 
-    keys = _color_keys_for_ids(pixel_ids, device) if colorize else [str(pixel_id) for pixel_id in pixel_ids]
+    keys = _color_keys_for_ids(pixel_ids, device) if colorize else pixel_ids
     id_to_labels = {key: prim_paths[idx] for idx, key in enumerate(keys)}
     id_to_semantics = {key: semantics[idx] for idx, key in enumerate(keys)}
     return id_to_labels, id_to_semantics

--- a/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
+++ b/source/isaaclab_ov/test/test_ovrtx_annotator_utils.py
@@ -92,12 +92,12 @@ def test_decode_semantic_id_map_rejects_label_spilling_into_count_field():
 
 
 def test_build_semantic_id_to_labels_non_colorize_keys_by_id():
-    """Non-colorized idToLabels is keyed by decimal semantic ID and always includes the reserved entries."""
+    """Non-colorized idToLabels is keyed by integer semantic ID and always includes the reserved entries."""
     id_to_labels = build_semantic_id_to_labels({2: {"class": "cone"}}, colorize=False, device="cpu")
     assert id_to_labels == {
-        "0": {"class": "BACKGROUND"},
-        "1": {"class": "UNLABELLED"},
-        "2": {"class": "cone"},
+        0: {"class": "BACKGROUND"},
+        1: {"class": "UNLABELLED"},
+        2: {"class": "cone"},
     }
 
 
@@ -174,7 +174,7 @@ def test_decode_stable_id_semantic_id_map_handles_empty_buffer():
 
 
 def test_build_instance_id_to_labels_and_semantics_non_colorize_keys_by_id():
-    """Non-colorized instance maps are keyed by decimal pixel ID with the reserved BACKGROUND/UNLABELLED entries."""
+    """Non-colorized instance maps are keyed by integer pixel ID with the reserved BACKGROUND/UNLABELLED entries."""
     id_to_labels, id_to_semantics = build_instance_id_to_labels_and_semantics(
         stable_id_semantic_id_map=[((1, 0, 0, 0), 2)],
         stable_id_to_path={(1, 0, 0, 0): "/World/Cone"},
@@ -182,11 +182,11 @@ def test_build_instance_id_to_labels_and_semantics_non_colorize_keys_by_id():
         colorize=False,
         device="cpu",
     )
-    assert id_to_labels == {"0": "BACKGROUND", "1": "UNLABELLED", "2": "/World/Cone"}
+    assert id_to_labels == {0: "BACKGROUND", 1: "UNLABELLED", 2: "/World/Cone"}
     assert id_to_semantics == {
-        "0": {"class": "BACKGROUND"},
-        "1": {"class": "UNLABELLED"},
-        "2": {"class": "cone"},
+        0: {"class": "BACKGROUND"},
+        1: {"class": "UNLABELLED"},
+        2: {"class": "cone"},
     }
 
 


### PR DESCRIPTION
# Description

Fixing an oversight from a previous PR where we stringified the keys of the non-colorized idToLabels and idToSemantics dicts.  This is now aligned with Newton and non-legacy RTX annotators

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

