### PR TITLE
Fix Newton particle BVH synchronization

### DIFF
--- a/source/isaaclab_newton/changelog.d/huidongc-newton-warp-particle-bvh.rst
+++ b/source/isaaclab_newton/changelog.d/huidongc-newton-warp-particle-bvh.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Newton particles disappearing from Newton Warp camera output by keeping the particle
+  bounding volume hierarchy synchronized with the current simulation state.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -2022,6 +2022,8 @@ class NewtonManager(PhysicsManager):
             raise RuntimeError("Registering a Newton sensor task requires an initialized model and state.")
         if model.shape_count > 0 and model.bvh_shapes is None:
             model.bvh_build_shapes(state)
+        if model.particle_count > 0 and model.bvh_particles is None:
+            model.bvh_build_particles(state)
         cls._sensor_tasks[name] = update_fn
         cls._sensor_state = state
         cls._sensor_state_dirty = True
@@ -2088,10 +2090,23 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def _refit_sensor_bvh(cls) -> None:
-        """Refit the model shape BVH against the current state."""
-        if cls._model is not None and cls._model.shape_count > 0 and cls._model.bvh_shapes is not None:
-            assert cls._sensor_state is not None
+        """Refit the model shape and particle BVHs against the current state."""
+        if cls._model is None:
+            return
+
+        refit_shapes = cls._model.shape_count > 0 and cls._model.bvh_shapes is not None
+        refit_particles = cls._model.particle_count > 0 and cls._model.bvh_particles is not None
+        if not refit_shapes and not refit_particles:
+            return
+
+        if cls._sensor_state is None:
+            raise RuntimeError("Refitting Newton sensor BVHs requires an initialized sensor state.")
+
+        if refit_shapes:
             cls._model.bvh_refit_shapes(cls._sensor_state)
+
+        if refit_particles:
+            cls._model.bvh_refit_particles(cls._sensor_state)
 
     @classmethod
     def _invalidate_sensor_graph(cls) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -2037,7 +2037,7 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def _update_sensor_tasks(cls, *names: str) -> None:
-        """Refit the shape BVH and run the requested scene-query tasks."""
+        """Refit the shape and particle BVHs and run the requested scene-query tasks."""
         for name in names:
             if name not in cls._sensor_tasks:
                 raise KeyError(f"Newton sensor task '{name}' is not registered.")
@@ -2072,7 +2072,7 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def _mark_sensor_state_dirty(cls) -> None:
-        """Bind the current state and mark the shape BVH stale.
+        """Bind the current state and mark the shape and particle BVHs stale.
 
         Writes through :class:`NewtonManager` rather than ``cls`` because the
         sensor-task registry and its dirty flag are singleton state owned by the

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -228,6 +228,8 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     monkeypatch.setattr(NewtonManager, "_sensor_state", None, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_state_dirty", True, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_flags", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_flags_host", None, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
     monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=False), raising=False)
 

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -173,6 +173,68 @@ def test_newton_cfg_collision_decimation_warning(num_substeps, collision_decimat
     assert cfg.collision_decimation == collision_decimation
 
 
+def test_refit_sensor_bvh_rejects_missing_sensor_state(monkeypatch):
+    """BVH refitting raises when a particle BVH exists without an initialized sensor state."""
+    model = SimpleNamespace(shape_count=0, particle_count=1, bvh_particles=object())
+    monkeypatch.setattr(NewtonManager, "_model", model, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state", None, raising=False)
+
+    with pytest.raises(RuntimeError, match="requires an initialized sensor state"):
+        NewtonManager._refit_sensor_bvh()
+
+
+def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
+    """Shape and particle BVHs are built and refit before a render task runs."""
+    from isaaclab.physics import PhysicsManager
+
+    state = object()
+    status = {"shape_refit": False, "particle_refit": False, "rendered": False}
+
+    class FakeModel:
+        shape_count = 1
+        particle_count = 1
+        bvh_shapes = None
+        bvh_particles = None
+
+        def bvh_build_shapes(self, current_state):
+            assert current_state is state
+            self.bvh_shapes = object()
+
+        def bvh_build_particles(self, current_state):
+            assert current_state is state
+            self.bvh_particles = object()
+
+        def bvh_refit_shapes(self, current_state):
+            assert current_state is state
+            status["shape_refit"] = True
+
+        def bvh_refit_particles(self, current_state):
+            assert current_state is state
+            status["particle_refit"] = True
+
+    model = FakeModel()
+
+    def render():
+        assert model.bvh_shapes is not None
+        assert model.bvh_particles is not None
+        assert status["shape_refit"]
+        assert status["particle_refit"]
+        status["rendered"] = True
+
+    monkeypatch.setattr(NewtonManager, "get_model", classmethod(lambda cls: model))
+    monkeypatch.setattr(NewtonManager, "get_state_0", classmethod(lambda cls: state))
+    monkeypatch.setattr(NewtonManager, "_model", model, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_tasks", {}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=False), raising=False)
+
+    NewtonManager._register_sensor_task("render", render)
+    NewtonManager._update_sensor_tasks("render")
+
+    assert status["rendered"]
+
+
 def test_newton_shape_cfg_defaults_match_newton_shape_config():
     """``NewtonShapeCfg`` contact defaults mirror Newton's ``ShapeConfig``.
 

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -225,6 +225,8 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     monkeypatch.setattr(NewtonManager, "get_state_0", classmethod(lambda cls: state))
     monkeypatch.setattr(NewtonManager, "_model", model, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_tasks", {}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state_dirty", True, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_graph", None, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
     monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=False), raising=False)


### PR DESCRIPTION
# Description

Build and refit particle BVHs through the sensor task pipeline so moving particles remain visible to Newton Warp cameras. Raise a runtime error when BVH refitting lacks an initialized sensor state.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

| Before | After |
| ------ | ----- |
| <img width="262" height="262" alt="franka_pour-newton-newton_renderer-rgb" src="https://github.com/user-attachments/assets/d034705d-54da-48ba-903c-2979b9537c49" /> | <img width="262" height="262" alt="franka_pour-newton-newton_renderer-rgb" src="https://github.com/user-attachments/assets/b05d71b3-0a31-4b53-afc2-fbe4d381c842" /> |

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
