### PR TITLE
Fix rigid body COM cache invalidation

### DIFF
--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -1144,20 +1144,23 @@ class TestCollectionComSetterCacheInvalidation:
             velocity_kwargs["full_data"] = True
         obj.write_body_com_velocity_to_sim_index(**velocity_kwargs)
 
+        data = obj.data
+        before = {
+            "body_com_pose_b": data.body_com_pose_b.torch.clone(),
+            "body_com_pose_w": data.body_com_pose_w.torch.clone(),
+            "body_link_vel_w": data.body_link_vel_w.torch.clone(),
+            "body_link_lin_vel_b": data.body_link_lin_vel_b.torch.clone(),
+            "body_link_state_w": data.body_link_state_w.torch.clone(),
+            "body_com_state_w": data.body_com_state_w.torch.clone(),
+        }
+        com_pose_b = before["body_com_pose_b"].clone()
+        com_pose_b[0, 1, 0] += 0.2
         if backend == "newton":
-            coms = torch.zeros((num_instances, num_bodies, 3), device=device)
+            coms = com_pose_b[..., :3]
             dtype = wp.vec3f
         else:
-            coms = _make_data_torch((num_instances, num_bodies), device, wp.transformf)
+            coms = com_pose_b
             dtype = wp.transformf
-        coms[0, 1, 0] = 0.2
-
-        data = obj.data
-        _ = data.body_com_pose_w
-        _ = data.body_link_vel_w
-        _ = data.body_link_lin_vel_b
-        _ = data.body_link_state_w
-        _ = data.body_com_state_w
 
         if setter == "index":
             obj.set_coms_index(coms=wp.from_torch(coms[:1, 1:2].contiguous(), dtype=dtype), env_ids=[0], body_ids=[1])
@@ -1168,21 +1171,25 @@ class TestCollectionComSetterCacheInvalidation:
                 body_mask=_make_item_mask(num_bodies, [1], device),
             )
 
-        dependents = (
-            data._body_com_pose_w,
-            data._body_link_vel_w,
-            data._body_link_lin_vel_b,
-            data._body_link_state_w,
-            data._body_com_state_w,
-        )
-        assert all(buffer.timestamp == -1.0 for buffer in dependents)
-
-        _ = data.body_com_pose_w
-        _ = data.body_link_vel_w
-        _ = data.body_link_lin_vel_b
-        _ = data.body_link_state_w
-        _ = data.body_com_state_w
-        assert all(buffer.timestamp == data._sim_timestamp for buffer in dependents)
+        after = {
+            "body_com_pose_b": data.body_com_pose_b.torch,
+            "body_com_pose_w": data.body_com_pose_w.torch,
+            "body_link_vel_w": data.body_link_vel_w.torch,
+            "body_link_lin_vel_b": data.body_link_lin_vel_b.torch,
+            "body_link_state_w": data.body_link_state_w.torch,
+            "body_com_state_w": data.body_com_state_w.torch,
+        }
+        torch.testing.assert_close(after["body_com_pose_b"][0, 1], com_pose_b[0, 1])
+        for name in (
+            "body_com_pose_w",
+            "body_link_vel_w",
+            "body_link_lin_vel_b",
+            "body_link_state_w",
+            "body_com_state_w",
+        ):
+            assert not torch.allclose(after[name][0, 1], before[name][0, 1]), name
+            torch.testing.assert_close(after[name][0, 0], before[name][0, 0])
+            torch.testing.assert_close(after[name][1], before[name][1])
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -1114,6 +1114,78 @@ class TestCollectionWritersBody:
 
 
 # ---------------------------------------------------------------------------
+# Tests: COM setter cache invalidation
+# ---------------------------------------------------------------------------
+
+
+_physics_backends = pytest.mark.parametrize(
+    "backend", [backend for backend in ("physx", "newton", "ovphysx") if backend in BACKENDS], indirect=False
+)
+
+
+class TestCollectionComSetterCacheInvalidation:
+    """Test immediate cache refresh after center-of-mass writes."""
+
+    @_physics_backends
+    @pytest.mark.parametrize("num_instances", [2])
+    @pytest.mark.parametrize("num_bodies", [2])
+    @_default_devices
+    @pytest.mark.parametrize("setter", ["index", "mask"])
+    def test_set_coms_refreshes_derived_caches(
+        self, backend, num_instances, num_bodies, device, collection_iface, setter
+    ):
+        obj, _ = collection_iface
+        obj.data.update(dt=0.01)
+
+        body_com_velocity = torch.zeros((num_instances, num_bodies, 6), device=device)
+        body_com_velocity[..., 5] = 1.0
+        velocity_kwargs = {"body_velocities": body_com_velocity}
+        if backend != "ovphysx":
+            velocity_kwargs["full_data"] = True
+        obj.write_body_com_velocity_to_sim_index(**velocity_kwargs)
+
+        if backend == "newton":
+            coms = torch.zeros((num_instances, num_bodies, 3), device=device)
+            dtype = wp.vec3f
+        else:
+            coms = _make_data_torch((num_instances, num_bodies), device, wp.transformf)
+            dtype = wp.transformf
+        coms[0, 1, 0] = 0.2
+
+        data = obj.data
+        _ = data.body_com_pose_w
+        _ = data.body_link_vel_w
+        _ = data.body_link_lin_vel_b
+        _ = data.body_link_state_w
+        _ = data.body_com_state_w
+
+        if setter == "index":
+            obj.set_coms_index(coms=wp.from_torch(coms[:1, 1:2].contiguous(), dtype=dtype), env_ids=[0], body_ids=[1])
+        else:
+            obj.set_coms_mask(
+                coms=wp.from_torch(coms.contiguous(), dtype=dtype),
+                env_mask=_make_env_mask(num_instances, device, True),
+                body_mask=_make_item_mask(num_bodies, [1], device),
+            )
+
+        dependents = (
+            data._body_com_pose_w,
+            data._body_link_vel_w,
+            data._body_link_lin_vel_b,
+            data._body_link_state_w,
+            data._body_com_state_w,
+        )
+        assert all(buffer.timestamp == -1.0 for buffer in dependents)
+
+        _ = data.body_com_pose_w
+        _ = data.body_link_vel_w
+        _ = data.body_link_lin_vel_b
+        _ = data.body_link_state_w
+        _ = data.body_com_state_w
+        assert all(buffer.timestamp == data._sim_timestamp for buffer in dependents)
+
+
+# ---------------------------------------------------------------------------
 # Tests: Alias/shorthand properties
 # ---------------------------------------------------------------------------
 

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -991,20 +991,23 @@ class TestRigidObjectComSetterCacheInvalidation:
         root_com_velocity[:, 5] = 1.0
         obj.write_root_com_velocity_to_sim_index(root_velocity=root_com_velocity)
 
+        data = obj.data
+        before = {
+            "body_com_pose_b": data.body_com_pose_b.torch.clone(),
+            "root_com_pose_w": data.root_com_pose_w.torch.clone(),
+            "root_link_vel_w": data.root_link_vel_w.torch.clone(),
+            "root_link_lin_vel_b": data.root_link_lin_vel_b.torch.clone(),
+            "root_link_state_w": data.root_link_state_w.torch.clone(),
+            "root_com_state_w": data.root_com_state_w.torch.clone(),
+        }
+        com_pose_b = before["body_com_pose_b"].clone()
+        com_pose_b[0, 0, 0] += 0.2
         if backend == "newton":
-            coms = torch.zeros((num_instances, 1, 3), device=device)
+            coms = com_pose_b[..., :3]
             dtype = wp.vec3f
         else:
-            coms = _make_data_torch((num_instances, 1), device, wp.transformf)
+            coms = com_pose_b
             dtype = wp.transformf
-        coms[0, 0, 0] = 0.2
-
-        data = obj.data
-        _ = data.root_com_pose_w
-        _ = data.root_link_vel_w
-        _ = data.root_link_lin_vel_b
-        _ = data.root_link_state_w
-        _ = data.root_com_state_w
 
         if setter == "index":
             obj.set_coms_index(coms=wp.from_torch(coms[:1].contiguous(), dtype=dtype), env_ids=[0])
@@ -1013,21 +1016,24 @@ class TestRigidObjectComSetterCacheInvalidation:
                 coms=wp.from_torch(coms.contiguous(), dtype=dtype), env_mask=_make_env_mask(2, device, True)
             )
 
-        dependents = (
-            data._root_com_pose_w,
-            data._root_link_vel_w,
-            data._root_link_lin_vel_b,
-            data._root_link_state_w,
-            data._root_com_state_w,
-        )
-        assert all(buffer.timestamp == -1.0 for buffer in dependents), [buffer.timestamp for buffer in dependents]
-
-        _ = data.root_com_pose_w
-        _ = data.root_link_vel_w
-        _ = data.root_link_lin_vel_b
-        _ = data.root_link_state_w
-        _ = data.root_com_state_w
-        assert all(buffer.timestamp == data._sim_timestamp for buffer in dependents)
+        after = {
+            "body_com_pose_b": data.body_com_pose_b.torch,
+            "root_com_pose_w": data.root_com_pose_w.torch,
+            "root_link_vel_w": data.root_link_vel_w.torch,
+            "root_link_lin_vel_b": data.root_link_lin_vel_b.torch,
+            "root_link_state_w": data.root_link_state_w.torch,
+            "root_com_state_w": data.root_com_state_w.torch,
+        }
+        torch.testing.assert_close(after["body_com_pose_b"][0], com_pose_b[0])
+        for name in (
+            "root_com_pose_w",
+            "root_link_vel_w",
+            "root_link_lin_vel_b",
+            "root_link_state_w",
+            "root_com_state_w",
+        ):
+            assert not torch.allclose(after[name][0], before[name][0]), name
+            torch.testing.assert_close(after[name][1], before[name][1])
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -967,6 +967,70 @@ class TestRigidObjectWritersBody:
 
 
 # ---------------------------------------------------------------------------
+# Tests: COM setter cache invalidation
+# ---------------------------------------------------------------------------
+
+
+_physics_backends = pytest.mark.parametrize(
+    "backend", [backend for backend in ("physx", "newton", "ovphysx") if backend in BACKENDS], indirect=False
+)
+
+
+class TestRigidObjectComSetterCacheInvalidation:
+    """Test immediate cache refresh after center-of-mass writes."""
+
+    @_physics_backends
+    @pytest.mark.parametrize("num_instances", [2])
+    @_default_devices
+    @pytest.mark.parametrize("setter", ["index", "mask"])
+    def test_set_coms_refreshes_derived_caches(self, backend, num_instances, device, rigid_object_iface, setter):
+        obj, _ = rigid_object_iface
+        obj.data.update(dt=0.01)
+
+        root_com_velocity = torch.zeros((2, 6), device=device)
+        root_com_velocity[:, 5] = 1.0
+        obj.write_root_com_velocity_to_sim_index(root_velocity=root_com_velocity)
+
+        if backend == "newton":
+            coms = torch.zeros((num_instances, 1, 3), device=device)
+            dtype = wp.vec3f
+        else:
+            coms = _make_data_torch((num_instances, 1), device, wp.transformf)
+            dtype = wp.transformf
+        coms[0, 0, 0] = 0.2
+
+        data = obj.data
+        _ = data.root_com_pose_w
+        _ = data.root_link_vel_w
+        _ = data.root_link_lin_vel_b
+        _ = data.root_link_state_w
+        _ = data.root_com_state_w
+
+        if setter == "index":
+            obj.set_coms_index(coms=wp.from_torch(coms[:1].contiguous(), dtype=dtype), env_ids=[0])
+        else:
+            obj.set_coms_mask(
+                coms=wp.from_torch(coms.contiguous(), dtype=dtype), env_mask=_make_env_mask(2, device, True)
+            )
+
+        dependents = (
+            data._root_com_pose_w,
+            data._root_link_vel_w,
+            data._root_link_lin_vel_b,
+            data._root_link_state_w,
+            data._root_com_state_w,
+        )
+        assert all(buffer.timestamp == -1.0 for buffer in dependents), [buffer.timestamp for buffer in dependents]
+
+        _ = data.root_com_pose_w
+        _ = data.root_link_vel_w
+        _ = data.root_link_lin_vel_b
+        _ = data.root_link_state_w
+        _ = data.root_com_state_w
+        assert all(buffer.timestamp == data._sim_timestamp for buffer in dependents)
+
+
+# ---------------------------------------------------------------------------
 # Tests: Alias/shorthand properties
 # ---------------------------------------------------------------------------
 

--- a/source/isaaclab_newton/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
+++ b/source/isaaclab_newton/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Newton rigid-object and rigid-object-collection center-of-mass writes
+  returning stale derived poses and velocities.

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -877,6 +877,7 @@ class RigidObject(BaseRigidObject):
             ],
             device=self.device,
         )
+        self.data._reset_body_com_pos_b_dependents()
         # tell the physics engine that some of the body properties have been updated
         SimulationManager.add_model_change(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
 
@@ -925,6 +926,7 @@ class RigidObject(BaseRigidObject):
             ],
             device=self.device,
         )
+        self.data._reset_body_com_pos_b_dependents()
         # tell the physics engine that some of the body properties have been updated
         SimulationManager.add_model_change(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
 

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object_data.py
@@ -198,6 +198,24 @@ class RigidObjectData(BaseRigidObjectData):
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )
 
+    def _reset_body_com_pos_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass offsets.
+
+        Changing the local center-of-mass position leaves the link pose unchanged, so this method
+        intentionally does not invalidate forward kinematics.
+        """
+        reset_timestamps(
+            [
+                self._body_com_pose_b,
+                self._root_com_pose_w,
+                self._root_link_vel_w,
+                self._root_link_vel_b,
+                self._root_link_lin_vel_b,
+                self._root_link_state_w,
+                self._root_com_state_w,
+            ]
+        )
+
     """
     Names.
     """

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -966,9 +966,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             ],
             device=self.device,
         )
-        # Invalidate derived buffers that depend on com position
-        self.data._body_com_pose_b.timestamp = -1.0
-        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pos_b_dependents()
         # Tell the physics engine that some of the body properties have been updated
         SimulationManager.add_model_change(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
 
@@ -1017,9 +1015,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             ],
             device=self.device,
         )
-        # Invalidate derived buffers that depend on com position
-        self.data._body_com_pose_b.timestamp = -1.0
-        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pos_b_dependents()
         # Tell the physics engine that some of the body properties have been updated
         SimulationManager.add_model_change(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
 

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -193,6 +193,22 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
             env_mask=env_mask, env_ids=env_ids, articulation_ids=self._root_view.articulation_ids
         )
 
+    def _reset_body_com_pos_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass positions.
+
+        Changing local center-of-mass positions leaves body link poses and center-of-mass velocities unchanged.
+        """
+        reset_timestamps(
+            [
+                self._body_com_pose_b,
+                self._body_com_pose_w,
+                self._body_link_vel_w,
+                self._body_link_lin_vel_b,
+                self._body_link_state_w,
+                self._body_com_state_w,
+            ]
+        )
+
     """
     Names.
     """

--- a/source/isaaclab_ovphysx/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
+++ b/source/isaaclab_ovphysx/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX rigid-object and rigid-object-collection center-of-mass writes
+  returning stale derived poses and velocities.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object.py
@@ -778,8 +778,7 @@ class RigidObject(BaseRigidObject):
             outputs=[self.data._body_com_pose_b.data],
             device=self._device,
         )
-        # Invalidate dependent root_com_pose timestamp -- it's derived from body_com_pose_b.
-        self.data._root_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pose_b_dependents()
         # Push cache to the wheel via pinned-CPU staging (RIGID_BODY_COM_POSE is CPU-only).
         cpu_env_ids = self._get_cpu_env_ids(env_ids)
         wp.copy(self._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
@@ -819,7 +818,7 @@ class RigidObject(BaseRigidObject):
             outputs=[self.data._body_com_pose_b.data],
             device=self._device,
         )
-        self.data._root_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pose_b_dependents()
         wp.copy(self._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
         self._root_view.set_attribute(
             TT.RIGID_BODY_COM_POSE,

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object/rigid_object_data.py
@@ -185,6 +185,21 @@ class RigidObjectData(BaseRigidObjectData):
             ]
         )
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from the body-frame center-of-mass pose.
+
+        Changing the local center-of-mass pose leaves the link pose and center-of-mass velocity unchanged.
+        """
+        reset_timestamps(
+            [
+                self._root_com_pose_w,
+                self._root_link_vel_w,
+                self._root_link_lin_vel_b,
+                self._root_link_state_w,
+                self._root_com_state_w,
+            ]
+        )
+
     """
     Names.
     """

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection.py
@@ -909,8 +909,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             outputs=[self.data._body_com_pose_b.data],
             device=self._device,
         )
-        # Invalidate derived buffers that depend on body_com_pose_b.
-        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pose_b_dependents()
         wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
         self._binding_write(
             TT.BODY_COM_POSE,
@@ -956,8 +955,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             outputs=[self.data._body_com_pose_b.data],
             device=self._device,
         )
-        # Invalidate derived buffers that depend on body_com_pose_b.
-        self.data._body_com_pose_w.timestamp = -1.0
+        self.data._reset_body_com_pose_b_dependents()
         wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
         self._binding_write(
             TT.BODY_COM_POSE,

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -190,6 +190,21 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
             ]
         )
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass poses.
+
+        Changing local center-of-mass poses leaves body link poses and center-of-mass velocities unchanged.
+        """
+        reset_timestamps(
+            [
+                self._body_com_pose_w,
+                self._body_link_vel_w,
+                self._body_link_lin_vel_b,
+                self._body_link_state_w,
+                self._body_com_state_w,
+            ]
+        )
+
     """
     Names.
     """

--- a/source/isaaclab_physx/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
+++ b/source/isaaclab_physx/changelog.d/rgrandia-fix-rigid-object-com-cache.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed PhysX rigid-object and rigid-object-collection center-of-mass writes
+  returning stale derived poses and velocities.

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -815,6 +815,7 @@ class RigidObject(BaseRigidObject):
             ],
             device=self.device,
         )
+        self.data._reset_body_com_pose_b_dependents()
         # Set into simulation, note that when updating "model" properties with PhysX we need to do it on CPU.
         cpu_env_ids = self._get_cpu_env_ids(env_ids)
         wp.copy(self._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object_data.py
@@ -162,6 +162,21 @@ class RigidObjectData(BaseRigidObjectData):
             ]
         )
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from the body-frame center-of-mass pose.
+
+        Changing the local center-of-mass pose leaves the link pose and center-of-mass velocity unchanged.
+        """
+        reset_timestamps(
+            [
+                self._root_com_pose_w,
+                self._root_link_vel_w,
+                self._root_link_lin_vel_b,
+                self._root_link_state_w,
+                self._root_com_state_w,
+            ]
+        )
+
     """
     Names.
     """

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -986,6 +986,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         )
         # Invalidate the cached buffer
         self.data._body_com_pose_b.timestamp = self.data._sim_timestamp
+        self.data._reset_body_com_pose_b_dependents()
         # Set into simulation, note that when updating "model" properties with PhysX we need to do it on CPU.
         # Convert from instance order (num_instances, num_bodies, 7) to view order (num_bodies*num_instances, 7) for
         # PhysX.

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection_data.py
@@ -169,6 +169,21 @@ class RigidObjectCollectionData(BaseRigidObjectCollectionData):
             ]
         )
 
+    def _reset_body_com_pose_b_dependents(self) -> None:
+        """Reset cached properties derived from body-frame center-of-mass poses.
+
+        Changing local center-of-mass poses leaves body link poses and center-of-mass velocities unchanged.
+        """
+        reset_timestamps(
+            [
+                self._body_com_pose_w,
+                self._body_link_vel_w,
+                self._body_link_lin_vel_b,
+                self._body_link_state_w,
+                self._body_com_state_w,
+            ]
+        )
+
     """
     Names.
     """


### PR DESCRIPTION
# Description

Fixes stale same-timestep derived rigid-body data after center-of-mass writes for rigid objects and rigid-object collections on PhysX, OVPhysX, and Newton.

The change invalidates only COM-dependent derived caches and adds shared index/mask setter regressions across the supported physics backends.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `uv run isaaclab -f`.
- [x] No documentation changes are required.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] I have added changelog fragments for every touched package.
- [x] My name is already listed in `CONTRIBUTORS.md`.

## Validation

- `uv run python -m pytest source/isaaclab/test/assets/test_rigid_object_iface.py source/isaaclab/test/assets/test_rigid_object_collection_iface.py -q`
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`