### PR TITLE
Add Isaac Lab Arena interop for imitation learning scripts (#6650)

### DIFF
--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -66,6 +66,15 @@ parser.add_argument(
     help="Number of continuous steps with task success for concluding a demo as successful. Default is 10.",
 )
 parser.add_argument(
+    "--reset_sim_buffer_each_episode",
+    action=argparse.BooleanOptionalAction,
+    default=True,
+    help=(
+        "Call env.sim.reset() before the initial episode and between recording attempts."
+        " Use --no-reset_sim_buffer_each_episode to preserve simulation buffers."
+    ),
+)
+parser.add_argument(
     "--cloudxr_env",
     type=str,
     default="cloudxrjs",
@@ -146,7 +155,7 @@ import isaaclab_mimic.envs  # noqa: F401
 from isaaclab_mimic.ui.instruction_display import InstructionDisplay, show_subtask_instructions
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry, parse_env_cfg
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +292,11 @@ def create_environment_config(
     env_cfg.terminations.time_out = None
     env_cfg.observations.policy.concatenate_terms = False
 
-    env_cfg.recorders: ActionStateRecorderManagerCfg = ActionStateRecorderManagerCfg()
+    demo_recorder_cfg_entry_point = gym.spec(args_cli.task.split(":")[-1]).kwargs.get("demo_recorder_cfg_entry_point")
+    if demo_recorder_cfg_entry_point is None:
+        env_cfg.recorders = ActionStateRecorderManagerCfg()
+    else:
+        env_cfg.recorders = load_cfg_from_registry(args_cli.task, "demo_recorder_cfg_entry_point")
     env_cfg.recorders.dataset_export_dir_path = output_dir
     env_cfg.recorders.dataset_filename = output_file_name
     env_cfg.recorders.dataset_export_mode = DatasetExportMode.EXPORT_SUCCEEDED_ONLY
@@ -472,7 +485,8 @@ def handle_reset(
         Reset success step count (0).
     """
     print("Resetting environment...")
-    env.sim.reset()
+    if args_cli.reset_sim_buffer_each_episode:
+        env.sim.reset()
     env.recorder_manager.reset()
     env.reset()
     if teleop_interface is not None and hasattr(teleop_interface, "reset"):
@@ -514,6 +528,12 @@ def run_simulation_loop(
     # Callback closures for the teleop device
     def reset_recording_instance():
         nonlocal should_reset_recording_instance
+        if success_step_count > 0:
+            print(
+                "Manual reset ignored. Success has fired and post-success steps are still recording. Please wait for"
+                " the automatic reset."
+            )
+            return
         should_reset_recording_instance = True
         print("Recording instance reset requested")
 
@@ -548,7 +568,8 @@ def run_simulation_loop(
         nonlocal running_recording_instance, label_text
 
         # Reset before starting
-        env.sim.reset()
+        if args_cli.reset_sim_buffer_each_episode:
+            env.sim.reset()
         env.reset()
         teleop_interface.reset()
 

--- a/source/isaaclab/changelog.d/peterd-arena-il-interop.rst
+++ b/source/isaaclab/changelog.d/peterd-arena-il-interop.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added support for an optional ``demo_recorder_cfg_entry_point`` Gym registry entry in demonstration collection.

--- a/source/isaaclab_mimic/changelog.d/peterd-arena-il-interop.rst
+++ b/source/isaaclab_mimic/changelog.d/peterd-arena-il-interop.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added support for environment-provided demonstration recorder configurations during Mimic generation.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/generation.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/generation.py
@@ -167,7 +167,7 @@ def setup_env_config(
         num_envs: Number of environments to run
         device: Device to run on
         generation_num_trials: Optional override for number of trials
-        recorder_cfg: Recorder manager configuration
+        recorder_cfg: Recorder manager configuration. Overrides recorder configurations supplied by the environment.
         dataset_compression: Whether to enable dataset compression
 
     Returns:
@@ -201,9 +201,8 @@ def setup_env_config(
 
     # Setup recorders
     if recorder_cfg is None:
-        env_cfg.recorders = ActionStateRecorderManagerCfg()
-    else:
-        env_cfg.recorders = recorder_cfg
+        recorder_cfg = env_cfg.mimic_recorder_config
+    env_cfg.recorders = recorder_cfg if recorder_cfg is not None else ActionStateRecorderManagerCfg()
     env_cfg.recorders.dataset_export_dir_path = output_dir
     env_cfg.recorders.dataset_filename = output_file_name
 


### PR DESCRIPTION
Cherry-pick of [f67ae28ad66f2401d5651637a5523308d1192c9f](https://github.com/isaac-sim/IsaacLab/commit/f67ae28ad66f2401d5651637a5523308d1192c9f) from Isaac Lab develop branch to release/3.0.0-beta2 to enable Isaac Lab Arena interop.

# Description

Isaac Lab Arena currently keeps it's own copy of Isaac Lab imitation learning scripts (record_demos.py, generate_dataset.py, etc.). This PR updates the imitation learning scripts in Isaac Lab to enable direct interop with Arena environments, allowing Arena to remove it's own copy of the scripts and directly invoke the Isaac Lab ones.

Changes are:

1. Add CLI arg to toggle sim buffer reset in recording script
2. Add configurable recorder cfg to recording script
3. Add configurable recorder cfg to data generation script

All additions are optional parameters and default to old behaviour so existing Isaac Lab workflows are not impacted.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task -->


