### PR TITLE
Fix stale skill guidance after install rewrite

### DIFF
--- a/skills/user/migrate-2x-to-3x/SKILL.md
+++ b/skills/user/migrate-2x-to-3x/SKILL.md
@@ -27,7 +27,7 @@ Do not copy migration tables into answers from memory. Read the official migrati
    - For custom `.kit` files, either list every direct Isaac Sim extension dependency explicitly or enable each extension before importing its Python module.
    - Do not add extension enables to plain Python modules that can be imported before Kit starts unless the code is guarded so it runs only inside a launched Kit app.
 5. Apply the smallest focused migration change.
-6. Run a targeted smoke test or import test. For direct Isaac Sim imports, use an app-launched command such as `./isaaclab.sh -p -m pytest PATH_TO_TEST` or a script that starts `AppLauncher` before enabling extensions.
+6. Run a targeted smoke test or import test. For direct Isaac Sim imports, ensure the test or script starts `AppLauncher` before enabling extensions. For example, run an app-launching test with `uv run --extra isaacsim --with pytest python -m pytest PATH_TO_TEST`.
 7. If the official docs are missing a recurring migration issue, update `docs/source/migration/migrating_to_isaaclab_3-0.rst` instead of expanding this skill with standalone documentation.
 
 ## Validation

--- a/skills/user/migrate-2x-to-3x/supplemental-checks.md
+++ b/skills/user/migrate-2x-to-3x/supplemental-checks.md
@@ -42,7 +42,6 @@ The external prototype migration skill called out useful search terms. Before us
 - `get_published_pretrained_checkpoint`
 - `noise_std_type`
 - `--viz`
-- ``
 - `-v0`
 
 ## Documentation Gaps

--- a/skills/user/migrate-from-isaac-gym/SKILL.md
+++ b/skills/user/migrate-from-isaac-gym/SKILL.md
@@ -18,7 +18,7 @@ Do not use this skill for Isaac Lab 2.x to 3.x migration. Use the `isaaclab-migr
 ## Workflow
 
 1. Identify the Isaac Gym task structure: assets, environment state tensors, observations, rewards, resets, and training runner.
-2. If the user needs a new full-feature Isaac Sim setup, point them to the pip/uv installation docs first. If the user expects execution or training, run a runtime preflight from the Isaac Lab checkout before a long port: verify `uv run python` uses the intended Python environment and checkout, imports `isaacsim` and `omni`, and provides the requested RL library.
+2. If the user needs a new full-feature Isaac Sim setup, point them to the automatic uv installation guide first. If the user expects PhysX or Kit execution, run a runtime preflight from the Isaac Lab checkout before a long port: verify `uv run --extra isaacsim python` uses the intended Python environment and checkout, imports `isaacsim` and `omni`, and provides the requested RL library.
 3. Read the IsaacGymEnvs migration guide and direct workflow docs before proposing edits.
 4. For a scratch or external migration project, start from the Isaac Lab template generator instead of hand-rolling package scaffolding. From the Isaac Lab checkout, use `uv run isaaclab -n`, choose an external project, choose the scratch path, choose the direct single-agent workflow for Isaac Gym style tasks, and select the needed RL library such as `rsl_rl`.
 5. Migrate to a direct workflow first by default. This preserves the single-class structure that most Isaac Gym tasks already use.
@@ -27,7 +27,7 @@ Do not use this skill for Isaac Lab 2.x to 3.x migration. Use the `isaaclab-migr
 8. Map assets to Isaac Lab asset configs and scene entities.
 9. Move action application, observation assembly, reward computation, termination checks, and reset logic into a `DirectRLEnv` or `DirectMARLEnv` implementation.
 10. Port training configuration to the selected Isaac Lab reinforcement learning workflow.
-11. Run a small smoke test before scaling training. Do not use deprecated `` examples; omit `--viz` for headless execution, or use `--viz none` only when a config or command would otherwise enable a visualizer.
+11. Run a small smoke test before scaling training. Omit `--viz` for headless execution, or use `--viz none` only when a config or command would otherwise enable a visualizer.
 12. For locomotion migrations, run the policy-success validation loop in [Reference](reference.md#policy-success-validation-loop). Validate a flat walking policy before rough-terrain curriculum training; rough terrain can start and still be unhealthy if episodes terminate immediately. If the legacy task's command range is broad, use a staged command curriculum or a simpler flat source config such as IsaacGymEnvs `Anymal.yaml` before claiming policy success.
 13. After the direct migration resets, steps, and trains, recommend a manager-based follow-up when the task has reusable observation, reward, command, curriculum, termination, or event logic.
 14. Use the `isaaclab-converting-direct-to-manager` skill for that follow-up instead of mixing manager conversion into the first parity pass.
@@ -48,7 +48,7 @@ For policy validation, follow the policy-success loop in [Reference](reference.m
 Runtime preflight for execution/training requests:
 
 ```bash
-uv run python -c "import importlib.util, sys; print(sys.executable); print(sys.version); print(importlib.util.find_spec('isaacsim')); print(importlib.util.find_spec('omni'))"
+uv run --extra isaacsim python -c "import importlib.util, sys; print(sys.executable); print(sys.version); print(importlib.util.find_spec('isaacsim')); print(importlib.util.find_spec('omni'))"
 ```
 
 For skill changes, run:

--- a/skills/user/migrate-from-isaac-gym/reference.md
+++ b/skills/user/migrate-from-isaac-gym/reference.md
@@ -109,7 +109,7 @@ uv run python "$PROJECT/validation/evaluate_checkpoint.py" \
   --num_envs 64 --steps 256 --device cuda:0
 ```
 
-Omit `--viz` for headless validation. Use `--viz none` only when a config or command would otherwise enable visualizers. Do not use deprecated `` in new validation commands.
+Omit `--viz` for headless validation. Use `--viz none` only when a config or command would otherwise enable visualizers.
 
 On Windows, use the same `uv` commands from PowerShell and set the same path order:
 

--- a/skills/user/setup-troubleshooting/evaluations.md
+++ b/skills/user/setup-troubleshooting/evaluations.md
@@ -7,7 +7,7 @@ Query: "Help me install Isaac Lab from source on my machine."
 Expected behavior:
 
 - Asks for OS, Python environment, Isaac Sim source, GPU/driver context, and desired backend.
-- Points to the official pip/uv Isaac Sim installation guide unless the user has a reason to use another supported path.
+- Points to the official automatic uv installation guide unless the user has a reason to use another supported path.
 - Uses documented uv commands for verification.
 
 Known failure modes:

--- a/skills/user/setup-troubleshooting/reference.md
+++ b/skills/user/setup-troubleshooting/reference.md
@@ -9,7 +9,7 @@
 
 ## Install Path Routing
 
-Ask which install path the user is following before prescribing commands. For a new full-feature Isaac Sim setup, route to the pip/uv guide first.
+Ask which install path the user is following before prescribing commands. For a new full-feature Isaac Sim setup, route to the automatic uv guide first.
 
 | User context | First reference |
 | --- | --- |

--- a/skills/user/train-rl-agents/evaluations.md
+++ b/skills/user/train-rl-agents/evaluations.md
@@ -28,7 +28,7 @@ Expected behavior:
 Known failure modes:
 
 - Starts a full-scale training run before checking shape and reset behavior.
-- Uses a raw `python` command instead of the Isaac Lab wrapper.
+- Uses a raw `python` command instead of the documented `uv run isaaclab train` entry point.
 
 ## Scenario 3: Visual Observations
 

--- a/skills/user/train-rl-agents/examples.md
+++ b/skills/user/train-rl-agents/examples.md
@@ -38,7 +38,7 @@ Always run a small random-action check first:
 uv run python scripts/environments/random_agent.py --task Isaac-Cartpole --num_envs 8
 ```
 
-For visual observations or camera tasks, lower `--num_envs` and confirm renderer and sensor support before scaling. Do not add `` unless the current task or docs explicitly require it.
+For visual observations or camera tasks, lower `--num_envs` and confirm renderer and sensor support before scaling. Camera support is automatic; select a compatible renderer instead of adding obsolete camera-launch options.
 
 ## After Training
 


### PR DESCRIPTION
# Description

Follow up on #6656 by repairing stale agent-skill guidance left after the installation documentation and launch-flag cleanup.

The flag cleanup mechanically removed some inline-code contents, leaving malformed sentences and an empty migration search term. A few adjacent workflows and evaluation criteria also still referred to the legacy Python wrapper or the former pip/uv installation wording.

This PR:

- repairs the malformed migration and camera-training guidance;
- updates direct Isaac Sim test and preflight commands to use the automatic uv workflow;
- aligns setup references and evaluation criteria with the unified installation guide; and
- keeps adjacent examples, references, and evaluations consistent with their skills.

This makes agent guidance readable again and prevents agents from recommending stale launcher workflows. No new dependencies are required.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Validation

- `uv run --no-project python tools/skills/cli.py check`
- `uv run isaaclab -f`

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have updated the directly related skill references, examples, and evaluations
- [x] My changes generate no new warnings
- [x] I have run the repository skill validator
- [x] A package changelog fragment is not required because this is a skills-only change
- [x] My name already exists in `CONTRIBUTORS.md`
