### PR TITLE
Fix Franka paths and pin CI OVRTX to 0.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -706,7 +706,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx ovphysx==0.4.13"
+        extra-pip-packages: "ovrtx>=0.3.0,<0.4.0 ovphysx==0.4.13"
         include-files: >-
           test_rendering_cartpole_kitless.py,
           test_rendering_dexsuite_kuka_homo_kitless.py,

--- a/.github/workflows/daily-compatibility.yml
+++ b/.github/workflows/daily-compatibility.yml
@@ -111,7 +111,7 @@ jobs:
         image-tag: ${{ env.DOCKER_IMAGE_TAG }}
         pytest-options: ""
         filter-pattern: "isaaclab_tasks"
-        extra-pip-packages: "ovrtx ovphysx==0.4.13"
+        extra-pip-packages: "ovrtx>=0.3.0,<0.4.0 ovphysx==0.4.13"
 
     - name: Copy All Test Results from IsaacLab Tasks Container
       run: |

--- a/source/isaaclab/changelog.d/fix-franka-legacy-path-beta2.rst
+++ b/source/isaaclab/changelog.d/fix-franka-legacy-path-beta2.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed simulator tests and examples to use the available legacy Franka Panda USD asset.

--- a/source/isaaclab/isaaclab/sim/spawners/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/__init__.py
@@ -19,7 +19,9 @@ There are two main ways of using the spawners:
     from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
     # spawn from USD file
-    cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
+    cfg = sim_utils.UsdFileCfg(
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+    )
     prim_path = "/World/myAsset"
 
     # spawn using the function from the module
@@ -33,7 +35,9 @@ There are two main ways of using the spawners:
     from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
     # spawn from USD file
-    cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
+    cfg = sim_utils.UsdFileCfg(
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+    )
     prim_path = "/World/myAsset"
 
     # use the `func` reference in the config class

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -25,6 +26,24 @@ def _root_pyproject() -> dict:
     """Load the root development ``pyproject.toml``."""
     with (_repo_root() / "pyproject.toml").open("rb") as f:
         return tomllib.load(f)
+
+
+def _ovrtx_requirement_from_setup() -> str:
+    """Return the OVRTX requirement declared by ``source/isaaclab_ov/setup.py``."""
+    setup_path = _repo_root() / "source/isaaclab_ov/setup.py"
+    module = ast.parse(setup_path.read_text(encoding="utf-8"))
+
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "EXTRAS_REQUIRE" for target in node.targets):
+            continue
+        extras_require = ast.literal_eval(node.value)
+        for dependency in extras_require["ovrtx"]:
+            if dependency.startswith("ovrtx"):
+                return dependency
+
+    raise AssertionError("Could not find the OVRTX requirement in source/isaaclab_ov/setup.py")
 
 
 def test_uv_run_extra_names_match_documented_workflow():
@@ -86,3 +105,19 @@ def test_uv_run_uses_managed_python():
     tool_uv = _root_pyproject()["tool"]["uv"]
 
     assert tool_uv["python-preference"] == "only-managed"
+
+
+def test_ci_ovrtx_installs_match_source_package_requirement():
+    """CI must not bypass the OVRTX version range declared by the source package."""
+    expected_requirement = _ovrtx_requirement_from_setup()
+
+    for workflow_path in (
+        ".github/workflows/build.yaml",
+        ".github/workflows/daily-compatibility.yml",
+    ):
+        workflow = (_repo_root() / workflow_path).read_text(encoding="utf-8")
+        ovrtx_install_lines = [
+            line.strip() for line in workflow.splitlines() if "extra-pip-packages:" in line and "ovrtx" in line
+        ]
+        assert ovrtx_install_lines
+        assert all(expected_requirement in line for line in ovrtx_install_lines)

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -44,7 +44,7 @@ def sim():
 def test_spawn_usd(sim):
     """Test loading prim from Usd file."""
     # Spawn cone
-    cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
+    cfg = sim_utils.UsdFileCfg(usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd")
     prim = cfg.func("/World/Franka", cfg)
     # Check validity
     assert prim.IsValid()

--- a/source/isaaclab/test/sim/test_utils_prims.py
+++ b/source/isaaclab/test/sim/test_utils_prims.py
@@ -84,7 +84,7 @@ def test_create_prim():
     assert prim.GetAttribute("size").Get() == 100
 
     # check adding USD reference
-    franka_usd = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    franka_usd = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
     prim = sim_utils.create_prim("/World/Test/USDReference", usd_path=franka_usd, stage=stage)
     # check USD reference set
     assert prim.IsValid()
@@ -328,7 +328,7 @@ def test_delete_prim():
     # check for usd reference
     prim = sim_utils.create_prim(
         "/World/Test/USDReference",
-        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
         stage=stage,
     )
     # delete prim
@@ -362,7 +362,7 @@ def test_get_usd_references():
     assert len(refs) == 0
 
     # Create a prim with a USD reference
-    franka_usd = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    franka_usd = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
     sim_utils.create_prim("/World/WithReference", usd_path=franka_usd, stage=stage)
     # Check that it has the expected reference (remote URLs are resolved to local paths)
     refs = sim_utils.get_usd_references("/World/WithReference", stage=stage)

--- a/source/isaaclab/test/sim/test_utils_queries.py
+++ b/source/isaaclab/test/sim/test_utils_queries.py
@@ -98,7 +98,9 @@ def test_get_all_matching_child_prims():
     # note: isaac sim function does not support instanced prims so we add it here
     #  after the above test for the above test to still pass.
     sim_utils.create_prim(
-        "/World/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+        "/World/Franka",
+        "Xform",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
     )
 
     # test with predicate
@@ -123,13 +125,19 @@ def test_get_first_matching_child_prim():
     # create scene
     sim_utils.create_prim("/World/Floor")
     sim_utils.create_prim(
-        "/World/env_1/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+        "/World/env_1/Franka",
+        "Xform",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
     )
     sim_utils.create_prim(
-        "/World/env_2/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+        "/World/env_2/Franka",
+        "Xform",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
     )
     sim_utils.create_prim(
-        "/World/env_0/Franka", "Xform", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+        "/World/env_0/Franka",
+        "Xform",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
     )
 
     # test
@@ -152,7 +160,9 @@ def test_find_global_fixed_joint_prim():
     # create scene
     sim_utils.create_prim("/World")
     sim_utils.create_prim("/World/ANYmal", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd")
-    sim_utils.create_prim("/World/Franka", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd")
+    sim_utils.create_prim(
+        "/World/Franka", usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+    )
     if "4.5" in ISAAC_NUCLEUS_DIR:
         franka_usd = f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd"
     else:

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -18,7 +18,7 @@ def test_nucleus_connection():
 def test_check_file_path_nucleus():
     """Test checking a file path on the Nucleus server."""
     # robot file path
-    usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+    usd_path = f"{assets_utils.ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
     # check file path
     assert assets_utils.check_file_path(usd_path) == 2
 

--- a/source/isaaclab_assets/changelog.d/fix-franka-legacy-path-beta2.rst
+++ b/source/isaaclab_assets/changelog.d/fix-franka-legacy-path-beta2.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed :obj:`~isaaclab_assets.FRANKA_PANDA_CFG` to use the available legacy Franka Panda USD asset.

--- a/source/isaaclab_assets/isaaclab_assets/robots/franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/franka.py
@@ -25,7 +25,7 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 FRANKA_PANDA_CFG = ArticulationCfg(
     spawn=sim_utils.UsdFileCfg(
-        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd",
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
         activate_contact_sensors=False,
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
             disable_gravity=False,

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/franka_cabinet/franka_cabinet_env_cfg.py
@@ -47,7 +47,7 @@ class FrankaCabinetEnvCfg(DirectRLEnvCfg):
     robot = ArticulationCfg(
         prim_path="/World/envs/env_.*/Robot",
         spawn=sim_utils.UsdFileCfg(
-            usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd",
+            usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd",
             activate_contact_sensors=False,
             rigid_props=sim_utils.RigidBodyPropertiesCfg(
                 disable_gravity=False,


### PR DESCRIPTION
# Description

Update all 14 Isaac Lab 6.0 references to the Franka Panda instanceable USD so they resolve under
`FrankaEmika/Legacy/`.

The asset is no longer available at the previous URL: the focused asset-path test reports the old path as missing,
while the new S3 object returns HTTP 200. This change covers the spawner examples, simulator and asset tests,
`FRANKA_PANDA_CFG`, and the direct Franka cabinet task.

Also backport the OVRTX CI pinning behavior from upstream develop commit
[`ea8f511280`](https://github.com/isaac-sim/IsaacLab/commit/ea8f511280c5d8cbf93c98e88e383ec66bd0f38d).
The release branch stores its OVRTX requirement in `source/isaaclab_ov/setup.py`, so both release CI jobs now install
the matching `ovrtx>=0.3.0,<0.4.0` range. A regression test rejects future bare OVRTX installs.

No dependencies are added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- Confirmed the focused asset-path test fails with the old URL (`0 != 2`).
- Confirmed the OVRTX regression test fails with the original bare CI inputs.
- `uv run python -m pytest source/isaaclab/test/utils/test_assets.py::test_check_file_path_nucleus -q`
- `uv run python -m pytest source/isaaclab/test/cli/test_uv_run_pyproject.py -q`
- `uv run python tools/changelog/cli.py check release/3.0.0-beta2`
- `uv run isaaclab -f`
- `uv run isaaclab -d`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fixes are effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
