### PR TITLE
Restore CPU PhysX stage initialization

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -24,6 +24,7 @@ log.outputStreamLevel = "Warn"
 ##################################
 [dependencies]
 "omni.physics" = {}
+"omni.physics.physx" = {}
 "omni.physics.stageupdate" = {}
 "omni.physx" = {}
 "omni.physx.tensors" = {}

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -61,6 +61,7 @@ keywords = ["experience", "app", "usd"]
 "omni.kit.window.status_bar" = {}
 "omni.kit.window.toolbar" = {}
 "omni.physics" = {}
+"omni.physics.physx" = {}
 "omni.physics.stageupdate" = {}
 "omni.physx" = {}
 "omni.physx.tensors" = {}

--- a/source/isaaclab_physx/changelog.d/fix-physx-cpu-lifecycle.rst
+++ b/source/isaaclab_physx/changelog.d/fix-physx-cpu-lifecycle.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed CPU PhysX collision broadphase initialization by restoring backend
+  registration without explicitly attaching the USD stage.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -788,18 +788,16 @@ class PhysxManager(PhysicsManager):
         physx = omni.physx.get_physx_interface()
         physx_sim = omni.physx.get_physx_simulation_interface()
 
-        # The Kit app owns loading the low-level physics extensions, but the
-        # Isaac Sim SimulationManager is no longer guaranteed to be loaded.
-        # Attach the current USD stage here so PhysX tensor views can find the
-        # scene without relying on Isaac Sim's default warm-start callback.
-        physx_sim.attach_stage(stage_id)
+        # Attach stage to PhysX BEFORE loading/starting - only needed for GPU pipeline.
+        # For CPU, the old SimulationManager never called attach_stage() explicitly.
+        # Calling attach_stage() + force_load_physics_from_usd() together causes a
+        # double-initialization that corrupts the CPU broadphase (MBP) collision setup,
+        # causing objects to fall through surfaces non-deterministically.
+        if is_gpu:
+            physx_sim.attach_stage(stage_id)
 
         # warmup physx
-        # Calling attach_stage() and force_load_physics_from_usd() together on
-        # CPU can corrupt PhysX broadphase state, so only force-load the GPU
-        # pipeline after the stage is attached.
-        if is_gpu:
-            physx.force_load_physics_from_usd()
+        physx.force_load_physics_from_usd()
         physx.start_simulation()
         physx.update_simulation(cls.get_physics_dt(), 0.0)
         physx_sim.fetch_results()

--- a/source/isaaclab_physx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_physx/test/assets/test_rigid_object.py
@@ -1254,8 +1254,8 @@ def test_write_state_functions_data_consistency(num_cubes, device, with_offset, 
 
 
 @pytest.mark.isaacsim_ci
-def test_warmup_cpu_attaches_stage_without_force_load():
-    """Regression test: CPU warmup must attach the stage without force-loading it.
+def test_warmup_attach_stage_not_called_for_cpu():
+    """Regression test: CPU warmup must force-load without explicitly attaching the stage.
 
     Bug (commit 0ba9c5cb3b): ``PhysxManager._warmup_and_create_views()`` called
     ``_physx_sim.attach_stage()`` unconditionally before ``force_load_physics_from_usd()``.
@@ -1263,19 +1263,16 @@ def test_warmup_cpu_attaches_stage_without_force_load():
     double-initialization that corrupts the CPU MBP broadphase, producing
     non-deterministic collision failures (objects passing through surfaces).
 
-    The legacy CPU pipeline attached implicitly via ``force_load_physics_from_usd()``.
-    In Isaac Sim 6, the legacy force-load call no longer attaches the stage, so CPU
-    warmup must instead use the explicit attachment pattern without force-loading.
+    The CPU pipeline attaches implicitly via ``force_load_physics_from_usd()`` when
+    the ``omni.physics.physx`` bridge registers the backend.
 
-    This test verifies that ``attach_stage`` is called exactly once and
-    ``force_load_physics_from_usd`` is not called during CPU warmup.
-    The simulation test itself (1 cube falling onto a ground plane) is intentionally
-    omitted here because the MBP corruption is non-deterministic and depends on scene
-    complexity (multiple dynamic actors on a mesh collider), making it unreliable as a
-    unit test assertion.
+    This test verifies that the PhysX backend is registered with the unified physics
+    API, ``attach_stage`` is not called, and ``force_load_physics_from_usd`` is called
+    exactly once during CPU warmup.
     """
     from unittest.mock import MagicMock, patch
 
+    import omni.kit.app
     import omni.physx
 
     with build_simulation_context(device="cpu", add_ground_plane=True, dt=0.01, auto_add_lighting=True) as sim:
@@ -1294,11 +1291,12 @@ def test_warmup_cpu_attaches_stage_without_force_load():
         ):
             sim.reset()
 
-        assert physx_sim_spy.attach_stage.call_count == 1, (
-            f"attach_stage() was called {physx_sim_spy.attach_stage.call_count} time(s) during CPU warmup; "
-            "the CPU pipeline requires one explicit stage attachment."
+        extension_manager = omni.kit.app.get_app().get_extension_manager()
+        assert extension_manager.is_extension_enabled("omni.physics.physx"), (
+            "The omni.physics.physx bridge must register PhysX with the unified physics API."
         )
-        assert physx_spy.force_load_physics_from_usd.call_count == 0, (
-            "force_load_physics_from_usd() was called during CPU warmup. Calling it after attach_stage() "
-            "causes CPU MBP broadphase double-initialization."
+        assert physx_sim_spy.attach_stage.call_count == 0, (
+            f"attach_stage() was called {physx_sim_spy.attach_stage.call_count} time(s) during CPU warmup. "
+            "This indicates the CPU MBP broadphase double-initialization regression is present."
         )
+        physx_spy.force_load_physics_from_usd.assert_called_once_with()


### PR DESCRIPTION
# Description

Restore the CPU PhysX stage-initialization path from #4675 while preserving the
Isaac Sim core-extension removal from #6499.

#6499 removed `isaacsim.core.simulation_manager`, which also removed the
registration bridge between the unified physics API and PhysX. The replacement
CPU path explicitly attached the stage and skipped
`force_load_physics_from_usd()`. This reintroduced non-deterministic CPU
broadphase collision failures, observed by the SkillGen test in #6687.

This change:

- adds `omni.physics.physx` to the GUI and headless app experiences so PhysX is
  registered without restoring the Isaac Sim core extension or its Warp
  dependency;
- restores the pre-#6499 warmup behavior: only GPU explicitly attaches the
  stage, while CPU uses `force_load_physics_from_usd()`;
- updates the regression test to verify the bridge is enabled, CPU does not call
  `attach_stage()`, and CPU force-loads exactly once.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `uv run python -m pytest source/isaaclab_physx/test/assets/test_rigid_object.py::test_warmup_attach_stage_not_called_for_cpu source/isaaclab_physx/test/assets/test_rigid_object.py::test_initialization -q`
  - 5 passed across CPU and GPU initialization.
- CPU SkillGen environment creation and 20 random-action steps passed for
  `IsaacContrib-Stack-Cube-Franka-IK-Rel-Skillgen`.
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] Documentation changes are not required for this internal lifecycle fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_physx/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
