### PR TITLE
Finalize perf-smoke staging gate

### DIFF
--- a/.github/workflows/perf-smoke-era-roll.yaml
+++ b/.github/workflows/perf-smoke-era-roll.yaml
@@ -121,6 +121,7 @@ jobs:
       branches: "${{ needs.detect.outputs.commit }}:develop"
       commit_count: "1"
       samples_per_commit: ${{ needs.detect.outputs.min_samples }}
+      tasks: "__ALL_TASKS__"
       target_branch: develop
       strict_ancestry: true
       dry_run: false

--- a/.github/workflows/perf-smoke-seed-baselines.yaml
+++ b/.github/workflows/perf-smoke-seed-baselines.yaml
@@ -328,6 +328,7 @@ jobs:
           --baseline_remote origin \
           --gpu_model "${GPU_MODEL}" \
           --target_branch "${SEED_TARGET_BRANCH}" \
+          --expected_records seed-artifacts/seed_records.json \
           --tasks "${SEED_TASKS/__ALL_TASKS__/}" \
           --backends "${SEED_BACKENDS}" \
           --repo_dir "${{ github.workspace }}" \

--- a/tools/perf_smoke_test/aggregate.py
+++ b/tools/perf_smoke_test/aggregate.py
@@ -132,33 +132,89 @@ def _render_crossed(crossed: list[dict]) -> list[str]:
     return parts
 
 
-def _build_summary_table(rows: list[tuple]) -> str:
+def _fmt_change(value: float | None) -> str:
+    """Format a signed percent change where positive means faster."""
+    return f"{value:+.2f}%" if value is not None else "N/A"
+
+
+def _runtime_context(bench_result: BenchResult) -> tuple[str, str]:
+    """Return concise GPU and runtime labels for one benchmark result."""
+    runtime_resources = bench_result.runtime_resources or {}
+    launch_config = bench_result.launch_config or {}
+    gpu_name = (
+        runtime_resources.get("gpu_name") or launch_config.get("gpu_model_raw") or launch_config.get("gpu_model", "")
+    )
+    provenance = bench_result.provenance or {}
+    software = provenance.get("software") or {}
+    runtime = ", ".join(
+        part
+        for part in (
+            f"cuda={runtime_resources.get('cuda_version')}" if runtime_resources.get("cuda_version") else "",
+            f"driver={runtime_resources.get('nvidia_driver_version')}"
+            if runtime_resources.get("nvidia_driver_version")
+            else "",
+            f"warp={software.get('warp')}" if software.get("warp") else "",
+        )
+        if part
+    )
+    return str(gpu_name or "N/A"), runtime or "N/A"
+
+
+def _row_explanation(result) -> str:
+    """Explain one verdict in reviewer-facing language."""
+    if result.verdict == OracleVerdict.HARD_FAILURE:
+        explanation = (
+            f"Benchmark failed during {result.failure_phase}"
+            if result.failure_phase
+            else "Benchmark produced no usable FPS"
+        )
+    elif result.threshold_source == "no_baseline":
+        explanation = "No compatible baseline yet"
+    elif result.threshold_source == "insufficient_window":
+        explanation = f"Baseline warming up ({result.baseline_sample_count}/{MIN_BASELINE_SAMPLES} samples)"
+    elif result.verdict == OracleVerdict.BLOCK:
+        explanation = "Blocking-level slowdown detected"
+    elif result.verdict == OracleVerdict.WARN:
+        explanation = "Possible slowdown; review recommended"
+    else:
+        explanation = "No meaningful slowdown"
+    if result.was_retried:
+        explanation += (
+            "; retry also failed" if result.verdict == OracleVerdict.HARD_FAILURE else "; passed only after retry"
+        )
+    return explanation
+
+
+def _build_reviewer_table(rows: list[tuple]) -> str:
+    """Build the compact table reviewers see first."""
+    verdict_labels = {
+        OracleVerdict.PASS: "✅ PASS",
+        OracleVerdict.WARN: "⚠️ WARN",
+        OracleVerdict.BLOCK: "🚫 BLOCK",
+        OracleVerdict.HARD_FAILURE: "❌ HARD FAILURE",
+    }
+    lines = [
+        "| Task | Backend | Result | FPS | Baseline | Change | Samples | What it means |",
+        "|---|---|---|---:|---:|---:|---:|---|",
+    ]
+    for result, _ in rows:
+        lines.append(
+            f"| {result.task_id} | {result.backend} | {verdict_labels[result.verdict]}"
+            f" | {_fmt(result.measured_fps)} | {_fmt(result.baseline_fps)} | {_fmt_change(result.regression_pct)}"
+            f" | {result.baseline_sample_count} | {_row_explanation(result)} |"
+        )
+    return "\n".join(lines)
+
+
+def _build_technical_table(rows: list[tuple]) -> str:
+    """Build the complete diagnostic table shown on demand."""
     lines = [
         "| Task | Backend | Verdict | FPS | Baseline | Samples | Regression% | Floor | Threshold | Phase | "
         "Retry | GPU | Runtime | Note |",
         "|---|---|---|---:|---:|---:|---:|---:|---|---|---|---|---|---|",
     ]
     for result, bench_result in rows:
-        runtime_resources = bench_result.runtime_resources or {}
-        launch_config = bench_result.launch_config or {}
-        gpu_name = (
-            runtime_resources.get("gpu_name")
-            or launch_config.get("gpu_model_raw")
-            or launch_config.get("gpu_model", "")
-        )
-        provenance = bench_result.provenance or {}
-        software = provenance.get("software") or {}
-        runtime = ", ".join(
-            part
-            for part in (
-                f"cuda={runtime_resources.get('cuda_version')}" if runtime_resources.get("cuda_version") else "",
-                f"driver={runtime_resources.get('nvidia_driver_version')}"
-                if runtime_resources.get("nvidia_driver_version")
-                else "",
-                f"warp={software.get('warp')}" if software.get("warp") else "",
-            )
-            if part
-        )
+        gpu_name, runtime = _runtime_context(bench_result)
         # result.note already carries the config_mismatch string on the
         # config-mismatch HARD_FAILURE path; dedupe so it is not shown twice.
         note_parts = list(dict.fromkeys(part for part in (result.note, bench_result.config_mismatch) if part))
@@ -167,10 +223,77 @@ def _build_summary_table(rows: list[tuple]) -> str:
             f"| {result.task_id} | {result.backend} | {result.verdict.value}"
             f" | {_fmt(result.measured_fps)} | {_fmt(result.baseline_fps)} | {result.baseline_sample_count}"
             f" | {_fmt(result.regression_pct, 2)} | {_fmt(result.hard_floor_fps)} | {result.threshold_source}"
-            f" | {result.failure_phase or ''} | {result.was_retried} | {gpu_name}"
+            f" | {result.failure_phase or ''} | {'yes' if result.was_retried else 'no'} | {gpu_name}"
             f" | {runtime} | {'; '.join(note_parts)} |"
         )
     return "\n".join(lines)
+
+
+def _build_summary_markdown(rows: list[tuple], *, blocking: bool) -> str:
+    """Build reviewer-first Markdown for the sticky PR comment."""
+    counts = {verdict: 0 for verdict in OracleVerdict}
+    for result, _ in rows:
+        counts[result.verdict] += 1
+
+    if not rows:
+        overall = "❌ No benchmark results were produced"
+    elif counts[OracleVerdict.HARD_FAILURE]:
+        overall = "❌ One or more benchmarks failed before producing usable performance data"
+    elif counts[OracleVerdict.BLOCK]:
+        overall = "🚫 One or more blocking-level performance regressions were detected"
+    elif counts[OracleVerdict.WARN]:
+        overall = "⚠️ No confirmed regression, but one or more results need attention"
+    else:
+        overall = "✅ No meaningful performance regressions detected"
+
+    warnings_label = "warning" if counts[OracleVerdict.WARN] == 1 else "warnings"
+    blocks_label = "blocking signal" if counts[OracleVerdict.BLOCK] == 1 else "blocking signals"
+    failures_label = "benchmark failure" if counts[OracleVerdict.HARD_FAILURE] == 1 else "benchmark failures"
+    count_summary = " · ".join(
+        (
+            f"✅ {counts[OracleVerdict.PASS]} passed",
+            f"⚠️ {counts[OracleVerdict.WARN]} {warnings_label}",
+            f"🚫 {counts[OracleVerdict.BLOCK]} {blocks_label}",
+            f"❌ {counts[OracleVerdict.HARD_FAILURE]} {failures_label}",
+        )
+    )
+    mode = (
+        "**Blocking:** BLOCK and HARD FAILURE results fail the check."
+        if blocking
+        else "**Advisory:** results are reported for review but do not fail the PR."
+    )
+
+    contexts = {_runtime_context(bench_result) for _, bench_result in rows}
+    if len(contexts) == 1:
+        gpu_name, runtime = next(iter(contexts))
+    elif contexts:
+        gpu_name, runtime = "Multiple; see technical details", "Multiple; see technical details"
+    else:
+        gpu_name, runtime = "N/A", "N/A"
+
+    return "\n\n".join(
+        (
+            f"### Overall result\n\n**{overall}**\n\n{count_summary}\n\n{mode}",
+            f"### Run context\n\n- **GPU:** {gpu_name}\n- **Runtime:** {runtime}",
+            "### How to read this\n\n"
+            "Start with **BLOCK** and **HARD FAILURE**, then review any **WARN** rows.\n\n"
+            "- **✅ PASS:** no meaningful slowdown was detected.\n"
+            "- **⚠️ WARN:** the result is uncertain—for example, the baseline is still warming up, the run "
+            "needed a retry, or performance is in the warning band.\n"
+            "- **🚫 BLOCK:** performance crossed a blocking threshold. This fails the check only when the gate "
+            "is in blocking mode.\n"
+            "- **❌ HARD FAILURE:** the benchmark did not produce usable FPS, usually because it failed during "
+            "import, initialization, or runtime.\n"
+            "- **FPS:** current throughput; higher is better. **Baseline:** the median of compatible historical "
+            "runs. **Change:** `+` is faster and `-` is slower.\n"
+            f"- **Samples:** compatible historical runs. At least {MIN_BASELINE_SAMPLES} are required before "
+            "the rolling baseline can make a confident decision.",
+            _build_reviewer_table(rows),
+            "<details>\n<summary>Technical details</summary>\n\n"
+            "Threshold values, failure phases, retries, hardware, runtime versions, and diagnostic notes:\n\n"
+            f"{_build_technical_table(rows)}\n\n</details>",
+        )
+    )
 
 
 def _write_github_output(**values) -> None:
@@ -355,9 +478,9 @@ def main() -> int:
             baseline_update_failed = True
             print(f"::error::Baseline push failed: {exc}")
 
-    table = _build_summary_table(rows)
+    summary = _build_summary_markdown(rows, blocking=blocking)
     print("\n## Performance Smoke Results\n")
-    print(table)
+    print(summary)
     print()
 
     if args.summary_file:
@@ -370,7 +493,7 @@ def main() -> int:
                         f"Baseline pushed SHA: `{_short_sha(baseline_push_result.pushed_sha)}` "
                         f"after {baseline_push_result.attempts} attempt(s)\n\n"
                     )
-            fh.write(table)
+            fh.write(summary)
             fh.write("\n")
 
     if args.omni_github_dir:

--- a/tools/perf_smoke_test/aggregate.py
+++ b/tools/perf_smoke_test/aggregate.py
@@ -179,9 +179,7 @@ def _row_explanation(result) -> str:
     else:
         explanation = "No meaningful slowdown"
     if result.was_retried:
-        explanation += (
-            "; retry also failed" if result.verdict == OracleVerdict.HARD_FAILURE else "; passed only after retry"
-        )
+        explanation += "; retry also failed" if result.verdict == OracleVerdict.HARD_FAILURE else "; result was retried"
     return explanation
 
 

--- a/tools/perf_smoke_test/baseline_manager.py
+++ b/tools/perf_smoke_test/baseline_manager.py
@@ -278,6 +278,7 @@ def _stable_sample_id(metadata: dict[str, Any]) -> str:
         "fps",
         "attempt",
         "was_retried",
+        "sample_index",
     )
     payload = {key: metadata.get(key) for key in keys if metadata.get(key) is not None}
     if not payload.get("ci_run_id"):
@@ -306,6 +307,7 @@ def make_sample_metadata(
     source_branch: str | None = None,
     trusted_source: str = "protected_branch",
     commit_sha: str | None = None,
+    sample_index: int | None = None,
 ) -> dict[str, Any]:
     bench_result = bench_result or {}
     launch_config = bench_result.get("launch_config") or {}
@@ -338,6 +340,7 @@ def make_sample_metadata(
         "baseline_epoch": bench_result.get("baseline_epoch") or launch_config.get("baseline_epoch", 1),
         "attempt": bench_result.get("attempt"),
         "was_retried": bench_result.get("was_retried"),
+        "sample_index": sample_index,
         "ci_run_id": os.environ.get("GITHUB_RUN_ID"),
         "ci_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
         "ci_workflow": os.environ.get("GITHUB_WORKFLOW"),

--- a/tools/perf_smoke_test/seed_baselines.py
+++ b/tools/perf_smoke_test/seed_baselines.py
@@ -60,6 +60,12 @@ from oracle import compare  # noqa: E402
 from task_config import TaskConfig, load_tasks  # noqa: E402
 
 _TOOL_DIR = Path(__file__).resolve().parent
+_CONTAINER_LOCAL_JIT_CACHE_BUCKETS = frozenset(
+    {
+        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "physx"),
+        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "newton"),
+    }
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -364,6 +370,11 @@ def _prepare_jit_cache(cache_dir: Path) -> Path:
     return cache_dir
 
 
+def _uses_container_local_jit_cache(task: TaskConfig) -> bool:
+    """Return whether a task/backend must avoid the host-mounted JIT cache."""
+    return (task.task_id, task.backend_key) in _CONTAINER_LOCAL_JIT_CACHE_BUCKETS
+
+
 def _prepare_kit_cache(cache_dir: Path) -> Path:
     """Create a writable Kit cache directory for one task/backend bucket."""
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -398,7 +409,7 @@ def _docker_run_benchmark(
     image: str,
     task: TaskConfig,
     artifact_dir: Path,
-    jit_cache: Path,
+    jit_cache: Path | None,
     kit_cache: Path,
     seed_src_dir: Path | None,
     container_name: str,
@@ -411,7 +422,7 @@ def _docker_run_benchmark(
         # Warp and Kit create nested cache directories at runtime. A permissive
         # umask keeps them writable for successive containers.
         "umask 000\n"
-        "mkdir -p /tmp/bench_out\n"
+        "mkdir -p /tmp/bench_out /tmp/jit-cache/warp /tmp/jit-cache/nv\n"
         "cd /workspace/isaaclab\n"
         "rm -f _isaac_sim\n"
         "ln -s /isaac-sim _isaac_sim\n"
@@ -461,11 +472,10 @@ def _docker_run_benchmark(
         "WARP_CACHE_PATH=/tmp/jit-cache/warp",
         "-e",
         "CUDA_CACHE_PATH=/tmp/jit-cache/nv",
-        "-v",
-        f"{jit_cache}:/tmp/jit-cache",
-        "-v",
-        f"{kit_cache}:/isaac-sim/kit/cache",
     ]
+    if jit_cache is not None:
+        cmd += ["-v", f"{jit_cache}:/tmp/jit-cache"]
+    cmd += ["-v", f"{kit_cache}:/isaac-sim/kit/cache"]
     if seed_src_dir is not None:
         # Bind-mount the historical source over the image's IsaacLab tree so the
         # container runs (and git-tags) the seed commit, not the baked source.
@@ -539,7 +549,11 @@ def _write_launch_config(task: TaskConfig, artifact_dir: Path, gpu_model: str) -
 
 
 def _record_from_result(
-    artifact_dir: Path, gpu_model: str, target_branch: str, known_commit: str | None = None
+    artifact_dir: Path,
+    gpu_model: str,
+    target_branch: str,
+    sample_index: int,
+    known_commit: str | None = None,
 ) -> BaselineUpdateRecord | None:
     """Turn one built ``perf_smoke_test_result.json`` into a baseline sample.
 
@@ -587,6 +601,7 @@ def _record_from_result(
         target_branch=target_branch,
         trusted_source="seed",
         commit_sha=commit_sha,
+        sample_index=sample_index,
     )
     short = (commit_sha or "????????")[:8]
     print(
@@ -700,9 +715,13 @@ def main() -> int:
                 prep_skips.append(f"{target_branch}/{short}")
                 continue
         for task in tasks:
-            task_jit_cache = _prepare_jit_cache(
-                _cache_bucket_path(jit_cache_root, target_branch, commit, task.task_id, task.backend_key)
-            )
+            if _uses_container_local_jit_cache(task):
+                task_jit_cache = None
+                print(f"[seed] using container-local JIT cache for {task.task_id}/{task.backend_key}")
+            else:
+                task_jit_cache = _prepare_jit_cache(
+                    _cache_bucket_path(jit_cache_root, target_branch, commit, task.task_id, task.backend_key)
+                )
             task_kit_cache = _prepare_kit_cache(
                 _cache_bucket_path(kit_cache_root, target_branch, commit, task.task_id, task.backend_key)
             )
@@ -735,7 +754,13 @@ def main() -> int:
                 wall_time_s = int(time.time() - start)
                 _build_bench_result(task, artifact_dir, exit_code, wall_time_s)
 
-                record = _record_from_result(artifact_dir, gpu_model, target_branch, known_commit=commit)
+                record = _record_from_result(
+                    artifact_dir,
+                    gpu_model,
+                    target_branch,
+                    sample_index=sample_idx,
+                    known_commit=commit,
+                )
                 if record is not None:
                     records.append(record)
                     continue
@@ -764,6 +789,12 @@ def main() -> int:
                     "fps": r.fps,
                     "commit_sha": (r.sample_metadata or {}).get("commit_sha"),
                     "target_branch": (r.sample_metadata or {}).get("target_branch"),
+                    "launch_config_hash": (r.sample_metadata or {}).get("launch_config_hash"),
+                    "benchmark_contract_hash": (r.sample_metadata or {}).get("benchmark_contract_hash"),
+                    "runtime_contract_hash": (r.sample_metadata or {}).get("runtime_contract_hash"),
+                    "baseline_epoch": (r.sample_metadata or {}).get("baseline_epoch"),
+                    "sample_index": (r.sample_metadata or {}).get("sample_index"),
+                    "sample_id": (r.sample_metadata or {}).get("sample_id"),
                 }
                 for r in records
             ],

--- a/tools/perf_smoke_test/test/test_aggregate_reseed.py
+++ b/tools/perf_smoke_test/test/test_aggregate_reseed.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 _GATE_DIR = Path(__file__).resolve().parents[1]
 if str(_GATE_DIR) not in sys.path:
@@ -26,6 +27,7 @@ import aggregate  # noqa: E402
 from baseline_manager import update_baseline  # noqa: E402
 from contracts import BenchResult  # noqa: E402
 from gate_config import MIN_BASELINE_SAMPLES  # noqa: E402
+from gate_types import OracleVerdict  # noqa: E402
 
 _RUNTIME_HASH = "runtime-a"
 
@@ -157,3 +159,58 @@ def test_reseed_not_flagged_without_valid_measurement(tmp_path, monkeypatch) -> 
     outputs = _run_aggregate(tmp_path, monkeypatch, _bench_result(fps=None, info_present=False), baseline_count=0)
 
     assert "reseed_tasks" not in outputs
+
+
+def test_sticky_summary_explains_results_in_reviewer_language() -> None:
+    """The sticky comment leads with actionable guidance and keeps diagnostics available."""
+    result = SimpleNamespace(
+        task_id="Isaac-Cartpole-Direct",
+        backend="physx",
+        verdict=OracleVerdict.BLOCK,
+        measured_fps=90.0,
+        baseline_fps=100.0,
+        regression_pct=-10.0,
+        baseline_sample_count=5,
+        threshold_source="rolling_window",
+        hard_floor_fps=None,
+        failure_phase=None,
+        was_retried=False,
+        note="block_confirmed(n=1)",
+        crossed_thresholds=[],
+    )
+
+    summary = aggregate._build_summary_markdown([(result, _bench_result(fps=90.0))], blocking=False)
+
+    assert "### Overall result" in summary
+    assert "blocking-level performance regressions were detected" in summary
+    assert "Advisory" in summary
+    assert "### How to read this" in summary
+    assert "Start with **BLOCK** and **HARD FAILURE**" in summary
+    assert "| Isaac-Cartpole-Direct | physx | 🚫 BLOCK | 90.0 | 100.0 | -10.00% | 5 |" in summary
+    assert "<summary>Technical details</summary>" in summary
+    assert "block_confirmed(n=1)" in summary
+
+
+def test_sticky_summary_identifies_baseline_warmup() -> None:
+    """WARN rows clearly distinguish baseline collection from a regression."""
+    result = SimpleNamespace(
+        task_id="Isaac-Cartpole-Direct",
+        backend="newton",
+        verdict=OracleVerdict.WARN,
+        measured_fps=100.0,
+        baseline_fps=None,
+        regression_pct=None,
+        baseline_sample_count=2,
+        threshold_source="insufficient_window",
+        hard_floor_fps=None,
+        failure_phase=None,
+        was_retried=False,
+        note="insufficient baseline samples",
+        crossed_thresholds=[],
+    )
+
+    summary = aggregate._build_summary_markdown([(result, _bench_result())], blocking=True)
+
+    assert "No confirmed regression" in summary
+    assert "Baseline warming up (2/5 samples)" in summary
+    assert "**Blocking:** BLOCK and HARD FAILURE results fail the check." in summary

--- a/tools/perf_smoke_test/test/test_aggregate_reseed.py
+++ b/tools/perf_smoke_test/test/test_aggregate_reseed.py
@@ -174,7 +174,7 @@ def test_sticky_summary_explains_results_in_reviewer_language() -> None:
         threshold_source="rolling_window",
         hard_floor_fps=None,
         failure_phase=None,
-        was_retried=False,
+        was_retried=True,
         note="block_confirmed(n=1)",
         crossed_thresholds=[],
     )
@@ -187,6 +187,8 @@ def test_sticky_summary_explains_results_in_reviewer_language() -> None:
     assert "### How to read this" in summary
     assert "Start with **BLOCK** and **HARD FAILURE**" in summary
     assert "| Isaac-Cartpole-Direct | physx | 🚫 BLOCK | 90.0 | 100.0 | -10.00% | 5 |" in summary
+    assert "Blocking-level slowdown detected; result was retried" in summary
+    assert "passed only after retry" not in summary
     assert "<summary>Technical details</summary>" in summary
     assert "block_confirmed(n=1)" in summary
 

--- a/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
+++ b/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
@@ -16,7 +16,12 @@ _GATE_DIR = Path(__file__).resolve().parents[1]
 if str(_GATE_DIR) not in sys.path:
     sys.path.insert(0, str(_GATE_DIR))
 
-from baseline_manager import load_baseline, match_context_from_bench_result, update_baseline  # noqa: E402
+from baseline_manager import (  # noqa: E402
+    load_baseline,
+    make_sample_metadata,
+    match_context_from_bench_result,
+    update_baseline,
+)
 from contracts import CONTRACT_SCHEMA_VERSION, BenchResult  # noqa: E402
 from gate_types import FpsMeanThreshold, OracleVerdict, ThresholdSource  # noqa: E402
 from hashing import stable_hash  # noqa: E402
@@ -87,6 +92,36 @@ def test_stable_hash_is_key_order_independent() -> None:
     right = {"backend": "physx", "runtime": {"torch": "2.9.0", "warp": "1.13.0"}}
 
     assert stable_hash(left) == stable_hash(right)
+
+
+def test_seed_sample_index_prevents_identical_fps_deduplication(monkeypatch) -> None:
+    """Repeated samples remain unique even when they report identical FPS."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
+    bench_result = _bench_result(fps=100.0).to_dict()
+
+    first = make_sample_metadata(
+        gpu_model="l40s",
+        task_id="Isaac-Cartpole-Direct",
+        backend="physx",
+        fps=100.0,
+        bench_result=bench_result,
+        target_branch="develop",
+        commit_sha="abc123",
+        sample_index=0,
+    )
+    second = make_sample_metadata(
+        gpu_model="l40s",
+        task_id="Isaac-Cartpole-Direct",
+        backend="physx",
+        fps=100.0,
+        bench_result=bench_result,
+        target_branch="develop",
+        commit_sha="abc123",
+        sample_index=1,
+    )
+
+    assert first["sample_id"] != second["sample_id"]
 
 
 def test_oracle_pass_warn_and_block_from_typed_result() -> None:

--- a/tools/perf_smoke_test/test/test_image_era.py
+++ b/tools/perf_smoke_test/test/test_image_era.py
@@ -273,3 +273,10 @@ def test_era_roll_policy_new_then_recorded_then_changed(tmp_path) -> None:
     assert image_era.era_key_from_tree(work) != era_key
     assert _resolve_matched(work) is False
     assert image_era.load_manifest_from_git(remote="origin", repo_dir=work)["eras"][era_key]["image"] == "repo:sha-a"
+
+
+def test_era_roll_seeds_full_task_matrix() -> None:
+    """A new image era immediately fills every perf-smoke task bucket."""
+    workflow = Path(__file__).resolve().parents[3] / ".github/workflows/perf-smoke-era-roll.yaml"
+
+    assert 'tasks: "__ALL_TASKS__"' in workflow.read_text()

--- a/tools/perf_smoke_test/test/test_seed_ancestry.py
+++ b/tools/perf_smoke_test/test/test_seed_ancestry.py
@@ -146,6 +146,20 @@ def test_prepare_jit_cache_opens_task_cache(tmp_path: Path) -> None:
     assert cache_dir.stat().st_mode & 0o777 == 0o777
 
 
+def test_only_failing_camera_backends_use_container_local_jit_cache() -> None:
+    """Only camera backends that failed on the host mount bypass cache reuse."""
+    camera_task = "Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct"
+
+    assert seed_baselines._uses_container_local_jit_cache(SimpleNamespace(task_id=camera_task, backend_key="physx"))
+    assert seed_baselines._uses_container_local_jit_cache(SimpleNamespace(task_id=camera_task, backend_key="newton"))
+    assert not seed_baselines._uses_container_local_jit_cache(
+        SimpleNamespace(task_id=camera_task, backend_key="physx_newton_renderer")
+    )
+    assert not seed_baselines._uses_container_local_jit_cache(
+        SimpleNamespace(task_id="Isaac-Cartpole-Direct", backend_key="newton")
+    )
+
+
 def test_seed_source_directories_are_unique_and_disposable() -> None:
     """Independent seeder invocations do not reuse source-clone residue."""
     first = seed_baselines._create_seed_source_dir()
@@ -261,3 +275,37 @@ def test_docker_benchmark_copies_internal_output_after_exit(tmp_path: Path, monk
     assert calls[1] == ["docker", "cp", "perf-seed-test:/tmp/bench_out/.", str(artifact_dir)]
     assert calls[2] == ["chmod", "-R", "a+rwX", str(artifact_dir)]
     assert calls[3] == ["docker", "rm", "-f", "perf-seed-test"]
+
+
+def test_docker_benchmark_can_use_container_local_jit_cache(tmp_path: Path, monkeypatch) -> None:
+    """A container-local cache creates JIT roots without a host bind mount."""
+    calls: list[list[str]] = []
+
+    def _run(cmd: list[str], **_kwargs) -> SimpleNamespace:
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    task = SimpleNamespace(
+        task_id="Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct",
+        num_envs=16,
+        num_frames=10,
+        warmup_frames=2,
+        seed=42,
+    )
+    monkeypatch.setattr(seed_baselines, "hydra_args_for_task", lambda _task: [])
+    monkeypatch.setattr(seed_baselines.subprocess, "run", _run)
+
+    exit_code = seed_baselines._docker_run_benchmark(
+        image="isaac-lab:test",
+        task=task,
+        artifact_dir=tmp_path / "artifacts",
+        jit_cache=None,
+        kit_cache=tmp_path / "kit-cache",
+        seed_src_dir=tmp_path / "source",
+        container_name="perf-seed-test",
+    )
+
+    docker_run = calls[0]
+    assert exit_code == 0
+    assert not any(arg.endswith(":/tmp/jit-cache") for arg in docker_run)
+    assert "mkdir -p /tmp/bench_out /tmp/jit-cache/warp /tmp/jit-cache/nv" in docker_run[-1]

--- a/tools/perf_smoke_test/test/test_verify_baselines.py
+++ b/tools/perf_smoke_test/test/test_verify_baselines.py
@@ -6,7 +6,8 @@
 """GPU-free checks for the seeded-baseline usability verifier.
 
 Mirrors how the gate selects samples: a sample counts only if it shares a single
-fingerprint bucket AND its ``commit_sha`` is an ancestor of the target tip.
+fingerprint bucket, targets the evaluated branch, and its ``commit_sha`` is an
+ancestor of the target tip.
 """
 
 from __future__ import annotations
@@ -23,14 +24,23 @@ if str(_GATE_DIR) not in sys.path:
 import verify_baselines  # noqa: E402
 
 
-def _sample(fps: float, commit: str, runtime_hash: str = "rt-a", epoch: int = 1) -> dict:
+def _sample(
+    fps: float,
+    commit: str,
+    runtime_hash: str = "rt-a",
+    epoch: int = 1,
+    target_branch: str = "develop",
+    sample_id: str | None = None,
+) -> dict:
     return {
         "fps": fps,
         "commit_sha": commit,
+        "target_branch": target_branch,
         "launch_config_hash": "lc-a",
         "benchmark_contract_hash": "bc-a",
         "runtime_contract_hash": runtime_hash,
         "baseline_epoch": epoch,
+        "sample_id": sample_id or f"{commit}-{fps}",
     }
 
 
@@ -78,6 +88,73 @@ def test_usable_count_excludes_samples_missing_commit_sha_under_ancestry() -> No
     usable, _, _ = verify_baselines.usable_sample_count(records, lambda c: True)
 
     assert usable == 1
+
+
+def test_usable_count_requires_target_branch_match() -> None:
+    """Staging samples cannot satisfy a develop verification."""
+    records = [
+        _sample(100.0, "develop", target_branch="develop"),
+        _sample(100.0, "staging", target_branch="perf-smoke/develop-staging"),
+    ]
+
+    usable, total, _ = verify_baselines.usable_sample_count(records, target_branch="develop")
+
+    assert usable == 1
+    assert total == 2
+
+
+def test_usable_count_requires_current_seeder_sample_ids() -> None:
+    """Old matching fingerprints cannot hide missing samples from the current run."""
+    records = [
+        _sample(100.0, "old1", sample_id="old-1"),
+        _sample(100.0, "old2", sample_id="old-2"),
+        _sample(100.0, "new1", sample_id="new-1"),
+    ]
+
+    usable, total, _ = verify_baselines.usable_sample_count(
+        records,
+        target_branch="develop",
+        expected_sample_ids={"new-1", "new-2"},
+    )
+
+    assert usable == 1
+    assert total == 3
+
+
+def test_expected_sample_ids_are_scoped_to_gpu_and_target_branch(tmp_path: Path) -> None:
+    """The current-run verification ignores records for other gate contexts."""
+    summary = tmp_path / "seed_records.json"
+    summary.write_text(
+        json.dumps(
+            [
+                {
+                    "gpu_model": "l40s",
+                    "task_id": "task-a",
+                    "backend": "physx",
+                    "target_branch": "develop",
+                    "sample_id": "expected",
+                },
+                {
+                    "gpu_model": "l40s",
+                    "task_id": "task-a",
+                    "backend": "physx",
+                    "target_branch": "perf-smoke/develop-staging",
+                    "sample_id": "wrong-branch",
+                },
+                {
+                    "gpu_model": "rtx6000",
+                    "task_id": "task-a",
+                    "backend": "physx",
+                    "target_branch": "develop",
+                    "sample_id": "wrong-gpu",
+                },
+            ]
+        )
+    )
+
+    expected = verify_baselines._load_expected_sample_ids(summary, "l40s", "develop")
+
+    assert expected == {("task-a", "physx"): {"expected"}}
 
 
 # --------------------------------------------------------------------------------------

--- a/tools/perf_smoke_test/verify_baselines.py
+++ b/tools/perf_smoke_test/verify_baselines.py
@@ -10,7 +10,8 @@ The gate keeps a baseline sample only when both hold:
 1. Its fingerprint -- ``launch_config_hash``, ``benchmark_contract_hash``,
    ``runtime_contract_hash``, ``baseline_epoch`` (within a
    ``gpu_model``/``task_id``/``backend_key`` bucket) -- matches the run.
-2. Its ``commit_sha`` is an ancestor of the run's ``base_sha`` (the target
+2. Its ``target_branch`` matches the branch the gate will evaluate.
+3. Its ``commit_sha`` is an ancestor of the run's ``base_sha`` (the target
    branch HEAD). See :func:`baseline_manager._sample_matches`.
 
 This tool replays that selection against the ``perf-baselines`` branch for a
@@ -58,6 +59,9 @@ def _fingerprint(record: dict[str, Any]) -> tuple:
 def usable_sample_count(
     records: Iterable[dict[str, Any]],
     is_ancestor: Callable[[str], bool] | None = None,
+    *,
+    target_branch: str | None = None,
+    expected_sample_ids: set[str] | None = None,
 ) -> tuple[int, int, int]:
     """Return ``(usable, total, num_fingerprints)`` for a bucket's samples.
 
@@ -72,12 +76,18 @@ def usable_sample_count(
         is_ancestor: Predicate ``commit_sha -> bool``; when provided, only samples
             with a ``commit_sha`` that satisfies it are eligible (mirrors the
             gate's ancestry filter). ``None`` disables the ancestry filter.
+        target_branch: Exact target branch required by the gate.
+        expected_sample_ids: When provided, only samples produced by the current
+            seeder invocation are eligible.
     """
     records = list(records)
-    if is_ancestor is None:
-        eligible = records
-    else:
-        eligible = [r for r in records if r.get("commit_sha") and is_ancestor(str(r["commit_sha"]))]
+    eligible = records
+    if target_branch is not None:
+        eligible = [r for r in eligible if r.get("target_branch") == target_branch]
+    if expected_sample_ids is not None:
+        eligible = [r for r in eligible if r.get("sample_id") in expected_sample_ids]
+    if is_ancestor is not None:
+        eligible = [r for r in eligible if r.get("commit_sha") and is_ancestor(str(r["commit_sha"]))]
     by_fingerprint: dict[tuple, int] = defaultdict(int)
     for record in eligible:
         by_fingerprint[_fingerprint(record)] += 1
@@ -103,6 +113,31 @@ def _load_samples(ref: str, gpu_model: str, task_id: str, backend: str, *, repo_
     return records
 
 
+def _load_expected_sample_ids(
+    path: Path,
+    gpu_model: str,
+    target_branch: str,
+) -> dict[tuple[str, str], set[str]]:
+    """Load current-run sample IDs grouped by task/backend bucket."""
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, list):
+        raise ValueError("expected records must be a JSON list")
+    by_bucket: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for record in payload:
+        if not isinstance(record, dict):
+            continue
+        if canonical_gpu_model(str(record.get("gpu_model", ""))) != gpu_model:
+            continue
+        if record.get("target_branch") != target_branch:
+            continue
+        task_id = record.get("task_id")
+        backend = record.get("backend")
+        sample_id = record.get("sample_id")
+        if task_id and backend and sample_id:
+            by_bucket[(str(task_id), str(backend))].add(str(sample_id))
+    return dict(by_bucket)
+
+
 def verify_bucket(
     ref: str,
     gpu_model: str,
@@ -110,6 +145,8 @@ def verify_bucket(
     backend: str,
     base_sha: str | None,
     *,
+    target_branch: str | None = None,
+    expected_sample_ids: set[str] | None = None,
     repo_dir: Path | None = None,
 ) -> tuple[int, int, int]:
     """Load a bucket from git and report ``(usable, total, num_fingerprints)``."""
@@ -120,7 +157,12 @@ def verify_bucket(
         def predicate(commit_sha: str) -> bool:
             return _git_is_ancestor(commit_sha, str(base_sha), repo_dir=repo_dir)
 
-    return usable_sample_count(records, predicate)
+    return usable_sample_count(
+        records,
+        predicate,
+        target_branch=target_branch,
+        expected_sample_ids=expected_sample_ids,
+    )
 
 
 def _resolve_tip(ref: str, repo_dir: Path | None = None) -> str | None:
@@ -149,6 +191,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--target_branch", default="develop", help="Branch whose tip is used when --base_sha is empty.")
     parser.add_argument("--tasks", default="", help="Comma-separated task_id allowlist (empty = all tasks.json tasks).")
     parser.add_argument("--backends", default="", help="Comma-separated backend_key allowlist (empty = all backends).")
+    parser.add_argument(
+        "--expected_records",
+        default=None,
+        type=Path,
+        help="Seeder summary whose sample IDs must exist on the baseline branch.",
+    )
     parser.add_argument("--repo_dir", default=None, help="Repo root for git lookups (default: cwd).")
     parser.add_argument(
         "--require",
@@ -173,6 +221,18 @@ def main() -> int:
     if not base_sha:
         print(f"::warning::[verify] could not resolve target tip for {args.target_branch!r}; ancestry not checked")
 
+    expected_ids_by_bucket: dict[tuple[str, str], set[str]] | None = None
+    if args.expected_records:
+        try:
+            expected_ids_by_bucket = _load_expected_sample_ids(
+                args.expected_records,
+                gpu_model,
+                args.target_branch,
+            )
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print(f"::error::[verify] could not load expected records {args.expected_records}: {exc}")
+            return 1
+
     task_filter = {t.strip() for t in args.tasks.split(",") if t.strip()}
     backend_filter = {b.strip() for b in args.backends.split(",") if b.strip()}
     tasks = [
@@ -188,8 +248,20 @@ def main() -> int:
     results: list[dict[str, Any]] = []
     all_ok = True
     for task in tasks:
+        expected_sample_ids = (
+            expected_ids_by_bucket.get((task.task_id, task.backend_key), set())
+            if expected_ids_by_bucket is not None
+            else None
+        )
         usable, total, fingerprints = verify_bucket(
-            ref, gpu_model, task.task_id, task.backend_key, base_sha, repo_dir=repo_dir
+            ref,
+            gpu_model,
+            task.task_id,
+            task.backend_key,
+            base_sha,
+            target_branch=args.target_branch,
+            expected_sample_ids=expected_sample_ids,
+            repo_dir=repo_dir,
         )
         ok = usable >= MIN_BASELINE_SAMPLES
         all_ok = all_ok and ok


### PR DESCRIPTION
# Description

Finalizes the focused perf-smoke follow-ups on `perf-smoke/develop-staging` before the production replay onto current `develop`.

- Isolates Warp JIT compilation inside the container for the two camera backends that still hit cross-user cache permissions.
- Preserves equal FPS measurements as distinct samples instead of accidentally deduplicating them.
- Verifies newly seeded baselines against the exact target branch, current-run sample IDs, runtime fingerprint, and commit ancestry.
- Seeds the full task/backend matrix when a new image era is published.
- Replaces the technical-only sticky comment with an overall result, plain-language guidance, a compact reviewer table, and collapsed diagnostics.

After squash merge, the staging branch's push-triggered L40S gate and full-matrix seeder will provide the final end-to-end validation. The later production PR will replay this tested gate onto current `develop` and include #6474's benchmark timing semantics.

No required dependencies are added.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Test plan

- [x] `tools/perf_smoke_test/test`: 62 passed
- [x] `tools/perf_smoke_test/validate_tasks.py`
- [x] GitHub workflow YAML syntax validation
- [x] Full pre-commit suite
- [x] Regression tests fail under the old sample-deduplication and verifier behavior
- [ ] Post-merge L40S staging gate and full-matrix seeder

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fixes work
- [x] No public API documentation or package changelog fragment is required
- [x] Contributor affiliation is represented by NVIDIA Corporation & Affiliates