### PR TITLE
Fix observation modifier callable resolution

### DIFF
--- a/source/isaaclab/changelog.d/ecstayalive-fix-observation-modifier-resolution.rst
+++ b/source/isaaclab/changelog.d/ecstayalive-fix-observation-modifier-resolution.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed class-based observation modifiers restored from dictionaries failing signature validation before their
+  callable was resolved.

--- a/source/isaaclab/isaaclab/managers/observation_manager.py
+++ b/source/isaaclab/isaaclab/managers/observation_manager.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 from prettytable import PrettyTable
 
-from isaaclab.utils import class_to_dict, modifiers, noise
+from isaaclab.utils import class_to_dict, modifiers, noise, string_to_callable
 from isaaclab.utils.buffers import CircularBuffer
 
 from .manager_base import ManagerBase, ManagerTermBase
@@ -581,6 +581,9 @@ class ObservationManager(ManagerBase):
                     for mod_cfg in term_cfg.modifiers:
                         # check if class modifier and initialize with observation size when adding
                         if isinstance(mod_cfg, modifiers.ModifierCfg):
+                            # resolve string-based modifiers before checking whether they are classes
+                            if isinstance(mod_cfg.func, str):
+                                mod_cfg.func = string_to_callable(str(mod_cfg.func))
                             # to list of modifiers - instantiate class-based modifiers
                             if inspect.isclass(mod_cfg.func):
                                 mod_cfg.func = mod_cfg.func(cfg=mod_cfg, data_dim=obs_dims, device=self._env.device)

--- a/source/isaaclab/test/managers/test_observation_manager.py
+++ b/source/isaaclab/test/managers/test_observation_manager.py
@@ -668,6 +668,37 @@ def test_modifier_compute(setup_env):
     assert torch.max(obs_critic["term_4"]) <= 0.5
 
 
+def test_modifier_class_from_dict(setup_env):
+    """Test class-based modifiers restored from a dictionary."""
+    env = setup_env
+    modifier = modifiers.IntegratorCfg(dt=env.dt)
+
+    @configclass
+    class MyObservationManagerCfg:
+        """Test config class for observation manager."""
+
+        @configclass
+        class PolicyCfg(ObservationGroupCfg):
+            """Test config class for policy observation group."""
+
+            concatenate_terms = False
+            term_1 = ObservationTermCfg(func=pos_w_data, modifiers=[modifier])
+
+        policy: ObservationGroupCfg = PolicyCfg()
+
+    cfg = MyObservationManagerCfg()
+    cfg.from_dict(cfg.to_dict())
+    modifier_cfg = cfg.policy.term_1.modifiers[0]
+    assert isinstance(modifier_cfg.func, str)
+
+    obs_manager = ObservationManager(cfg, env)
+    modifier_cfg = obs_manager.cfg.policy.term_1.modifiers[0]
+    assert isinstance(modifier_cfg.func, modifiers.ModifierBase)
+
+    observations = obs_manager.compute()
+    torch.testing.assert_close(observations["policy"]["term_1"], env.data.pos_w * env.dt / 2)
+
+
 def test_serialize(setup_env):
     """Test serialize call for ManagerTermBase terms."""
     env = setup_env


### PR DESCRIPTION
# Description

## Summary

Resolve class-based observation modifier callables restored from strings before class instantiation and signature validation.

When an observation configuration containing a class-based modifier is serialized with `to_dict()` and restored with `from_dict()`, the modifier callable is represented as a string-like `ResolvableString`. `ObservationManager` previously inspected this unresolved value before determining whether it represented a modifier class.

This caused signature validation to inspect `ResolvableString.__call__` instead of the actual modifier class and raise an error similar to:

```text
ValueError: Modifier ... expects mandatory parameters: ['kwargs']
```

The modifier callable is now resolved with `string_to_callable()` before the existing class detection and instantiation logic runs. Converting the value with `str()` also normalizes `ResolvableString` instances before resolution.

A regression test covers the complete configuration dictionary round-trip using a class-based `IntegratorCfg` modifier. It verifies that:

- The callable is restored as a string-like value after `to_dict()` and `from_dict()`.
- `ObservationManager` resolves and instantiates the modifier as a `ModifierBase`.
- The resolved modifier produces the expected observation output.

No new runtime dependencies are introduced.

Fixes #6067

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

The regression test was verified to fail before the fix with the reported mandatory `kwargs` signature-validation error and pass after applying the fix.

The complete ObservationManager test file was also executed:

```text
source/isaaclab/test/managers/test_observation_manager.py

16 passed
```

The following additional checks passed:

- Ruff linting
- Ruff formatting
- Trailing-whitespace and end-of-file checks
- Codespell
- RST validation
- License-header validation
- Changelog fragment validation

The Git LFS pre-commit hook could not run locally because `git-lfs` was not installed. The modified Python and RST files were verified with `git check-attr` and are not tracked by Git LFS.

## Checklist

- [x] I have read and understood the [[contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run all pre-commit checks with `./isaaclab.sh --format`
  - All applicable checks passed, except the Git LFS hook because `git-lfs` was unavailable locally.
- [x] Documentation changes are not required for this internal bug fix.
- [x] My changes generate no new warnings.
- [x] I have added a regression test that proves the fix is effective.
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`.
  - An extension version bump is not required for changes targeting `develop`.
- [ ] I have added my name to `CONTRIBUTORS.md`, or my name already exists there.