### PR TITLE
[Changelog] Restore nightly compilation across branch layouts

### DIFF
--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -5,9 +5,9 @@
 
 # Nightly auto-compile: rolls accumulated fragments under
 # ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
-# bumps each ``extension.toml``, deletes consumed fragments, and pushes the
-# result back to each branch in the configured list. Keeps every tracked
-# branch's changelog current without requiring a maintainer to run
+# bumps each package's version metadata, deletes consumed fragments, and
+# pushes the result back to each branch in the configured list. Keeps every
+# tracked branch's changelog current without requiring a maintainer to run
 # ``compile`` by hand.
 #
 # Scheduled workflow — must live on the default branch (``main``) for the
@@ -210,15 +210,11 @@ jobs:
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
           git config user.name "isaaclab-bot[bot]"
           git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
-          # ``pyproject.toml`` is staged alongside ``extension.toml`` because
-          # ``Package.write_version`` bumps both when a ``[project]`` block
-          # exists. Missing it leaves the pyproject write unstaged, which
-          # makes the subsequent ``git pull --rebase`` refuse with
-          # ``cannot pull with rebase: You have unstaged changes``.
-          git add source/*/changelog.d/ \
-                  source/*/docs/CHANGELOG.rst \
-                  source/*/config/extension.toml \
-                  source/*/pyproject.toml
+          # Stage every tracked compiler output under ``source/``. Active
+          # branches store package versions in ``pyproject.toml``, while
+          # release branches still use ``config/extension.toml``; naming both
+          # path globs makes ``git add`` fail when either layout is absent.
+          git add --update -- source/
           if git diff --staged --quiet; then
             echo "No changelog fragments found — nothing to commit."
           else
@@ -231,21 +227,29 @@ jobs:
             # action. The trigger event suffix (``schedule`` vs
             # ``workflow_dispatch``) is preserved for traceability.
             #
-            # The body lists every package that bumped, derived from the
-            # staged ``extension.toml`` diff so the entries are accurate
-            # regardless of which packages happen to have pending
-            # fragments this run.
+            # The body lists every package that bumped, derived from whichever
+            # supported version metadata file changed on the target branch.
             MSG_FILE=$(mktemp)
             {
               echo "[CI][Auto Version Bump] Compile changelog fragments (${{ github.event_name }})"
               echo
               echo "Bumped packages:"
-              for tom in $(git diff --staged --name-only -- 'source/*/config/extension.toml'); do
-                pkg=$(echo "$tom" | sed -E 's|source/([^/]+)/config/extension.toml|\1|')
-                old=$(git diff --staged "$tom" | awk -F'"' '/^-version/{print $2; exit}')
-                new=$(git diff --staged "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
-                echo "- $pkg: $old → $new"
-              done
+              git diff --staged --name-only -- \
+                'source/*/config/extension.toml' \
+                'source/*/pyproject.toml' \
+                | sed -E 's|source/([^/]+)/.*|\1|' \
+                | sort -u \
+                | while IFS= read -r pkg; do
+                    pyproject="source/$pkg/pyproject.toml"
+                    if git diff --staged --quiet -- "$pyproject"; then
+                      tom="source/$pkg/config/extension.toml"
+                    else
+                      tom="$pyproject"
+                    fi
+                    old=$(git diff --staged -- "$tom" | awk -F'"' '/^-version/{print $2; exit}')
+                    new=$(git diff --staged -- "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
+                    echo "- $pkg: $old → $new"
+                  done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
             # Rebase onto the target branch's current tip in case a human


### PR DESCRIPTION
## 1. Summary

Restores scheduled changelog compilation on `develop` while preserving release-branch support by staging tracked compiler outputs independently of the package-version metadata layout. This addresses nine consecutive nightly failures since July 16.

## 2. Root cause

- Scheduled runs load `.github/workflows/nightly-changelog.yml` from the default `main` branch.
- `develop` now stores package versions in `pyproject.toml` and has no extension manifests, while the release branch still versions packages through `config/extension.toml`.
- The main workflow named both layouts in one `git add`, so the absent extension path made the develop job exit 128 after compilation succeeded.
- Auto-commit messages only inspected extension-manifest diffs, so they could not describe develop version bumps.

## 3. Test plan

- [x] Reproduced the unmatched `extension.toml` pathspec in [nightly run 30070931422](https://github.com/isaac-sim/IsaacLab/actions/runs/30070931422).
- [x] Compiled current `upstream/develop`; patched staging captured every tracked output and rendered 14 `pyproject.toml` version transitions.
- [x] Compiled the latest release pre-bump state; patched staging captured all three `extension.toml` bumps and rendered the expected package transitions.
- [x] Ran `./isaaclab.sh -p -m pytest tools/changelog/test` on `develop` (90 passed).
- [x] Ran `./isaaclab.sh -f` before staging, after staging, and after commit.
- [x] Confirmed no source-package changelog fragment is required for this workflow-only change.
