### PR TITLE
Fix curriculum live plot collection

### DIFF
--- a/source/isaaclab/changelog.d/huidongc-fix-curriculum-iterable-terms.rst
+++ b/source/isaaclab/changelog.d/huidongc-fix-curriculum-iterable-terms.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab.managers.CurriculumManager.get_active_iterable_terms`
+  crashing with ``TypeError`` when a curriculum term state is a ``dict``, which
+  broke Newton visualizer live plots during training.

--- a/source/isaaclab/isaaclab/managers/curriculum_manager.py
+++ b/source/isaaclab/isaaclab/managers/curriculum_manager.py
@@ -163,7 +163,7 @@ class CurriculumManager(ManagerBase):
                     for key, value in term_state.items():
                         if isinstance(value, torch.Tensor):
                             value = value.item()
-                        terms[term_name].append(value)
+                        data.append(value)
                 else:
                     # log directly if not a dict
                     if isinstance(term_state, torch.Tensor):


### PR DESCRIPTION
# Description

Curriculum states represented as dictionaries caused live plot collection to index a list with a string, producing repeated TypeError messages during Newton visualization for Franka Pour (experimental env for particles).

Append dictionary values to the term data list so curriculum metrics can be collected and plotted correctly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
