### PR TITLE
Enable Rerun particle visualization by default

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/huidongc-rerun-particles.rst
+++ b/source/isaaclab_visualizers/changelog.d/huidongc-rerun-particles.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added particle visualization toggle to :class:`~isaaclab_visualizers.rerun.RerunVisualizerCfg`, enabled by default.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
@@ -271,6 +271,7 @@ class RerunVisualizer(BaseVisualizer):
         if self.cfg.open_browser and not start_server_in_viewer:
             _open_rerun_web_viewer(viewer_host, web_port, rerun_address)
         self._viewer.set_model(self._model)
+        self._viewer.show_particles = self.cfg.show_particles
         apply_viewer_visible_worlds(
             self._viewer,
             env_ids=self._env_ids,
@@ -304,6 +305,7 @@ class RerunVisualizer(BaseVisualizer):
                 ("grpc_port", grpc_port),
                 ("web_port", web_port),
                 ("open_browser", self.cfg.open_browser),
+                ("show_particles", self.cfg.show_particles),
                 ("record_to_rrd", self.cfg.record_to_rrd or "<none>"),
             ],
         )

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer_cfg.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer_cfg.py
@@ -52,5 +52,11 @@ class RerunVisualizerCfg(VisualizerCfg):
     Rerun viewer rather than only showing the latest value.
     """
 
+    show_particles: bool = True
+    """Whether to show model particles.
+
+    Disable this option to reduce streaming overhead for large particle clouds.
+    """
+
     record_to_rrd: str | None = None
     """Path to save .rrd recording file. None = no recording."""


### PR DESCRIPTION
# Description

Expose the particle toggle through RerunVisualizerCfg so particle entities are streamed without additional setup while retaining an opt-out for large particle clouds.

Rerun must enable show_particles at the producer before particle entities can appear in the viewer. When disabled, Newton skips logging particle point batches, so Rerun never discovers /model/particles and cannot expose its visibility control. This creates a chicken-and-egg problem: users cannot enable particles from the UI because the entity required for that control does not exist, and Rerun provides no viewer-to-producer callback to start streaming it.

Enabling particles by default ensures the entity is streamed and available in the Rerun UI. Users can still hide it with the eye icon or disable show_particles explicitly when reducing streaming overhead is more important.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

[particle-vis-with-rerun.webm](https://github.com/user-attachments/assets/3dfc8045-1669-46a2-beab-8fb19e86bfb7)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
