### PR TITLE
Xfail nondeterministic OVRTX Cartpole RGB rendering

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-cartpole-xfail-04.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-cartpole-xfail-04.skip
@@ -1,0 +1,2 @@
+Test-only: temporarily marked the OVRTX 0.4 Cartpole RGB/RGBA comparison as an expected failure pending
+NVBUG#6152566. No user-facing API change.

--- a/source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py
@@ -21,11 +21,15 @@ from rendering_test_utils import (
 pytestmark = [pytest.mark.isaacsim_ci, pytest.mark.arm_ci]
 
 _OVRTX_TEXTURE_READINESS_XFAIL_REASON = "OVRTX 0.4 may return before textured materials are ready (NVBUG#6505191)."
+_OVRTX_RGB_XFAIL_REASON = "OVRTX 0.4 produces nondeterministic Cartpole RGB/RGBA output (NVBUG#6152566)."
 _RENDERING_PARAMS = make_xfail_rendering_params(
     KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS,
     {
-        ("ovphysx", "ovrtx_renderer", data_type): _OVRTX_TEXTURE_READINESS_XFAIL_REASON
-        for data_type in ("albedo", "simple_shading_diffuse_mdl", "simple_shading_full_mdl")
+        ("newton", "ovrtx_renderer", "rgb"): _OVRTX_RGB_XFAIL_REASON,
+        **{
+            ("ovphysx", "ovrtx_renderer", data_type): _OVRTX_TEXTURE_READINESS_XFAIL_REASON
+            for data_type in ("albedo", "simple_shading_diffuse_mdl", "simple_shading_full_mdl")
+        },
     },
 )
 _COMPARISON_SCORES: list[dict] = []


### PR DESCRIPTION
## Summary

- Temporarily mark the Newton-OVRTX Cartpole RGB/RGBA golden comparison as a non-strict expected failure.
- Follow the OVRTX expected-failure convention introduced by #6592.
- Track removal against NVBUG#6152566.

## Motivation

A 20-process A/B test used the same Isaac Lab code, GPU, driver, and x86 host:

- OVRTX 0.4: 15/20 runs exceeded the 1.5% pixel gate; pairwise mean was 1.067% and maximum was 1.839%.
- OVRTX 0.3: 20/20 runs passed; pairwise mean was 0.0045% and maximum was 0.0485%.

## Follow-up

Remove the xfail when the upstream nondeterminism tracked by NVBUG#6152566 is fixed and validated in Isaac Lab.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there