### PR TITLE
Relax OVRTX Cartpole RGB pixel tolerance

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-cartpole-rgb-tolerance-04.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-cartpole-rgb-tolerance-04.skip
@@ -1,0 +1,2 @@
+Test-only: raised the Newton-OVRTX Cartpole RGB/RGBA pixel-difference tolerance to cover the OVRTX 0.4
+variation tracked by NVBUG#6152566. No user-facing API change.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -57,6 +57,10 @@ MAX_DIFFERENT_PIXELS_PERCENTAGE_BY_ENV_NAME = {
     "dexsuite_kuka_hetero": 8.0,
 }
 
+# OVRTX 0.4 Cartpole RGB/RGBA varies by up to 1.839% across otherwise structurally equivalent runs
+# (NVBUG#6152566). Keep the relaxed threshold scoped to this exact case; the SSIM gate remains enabled.
+_CARTPOLE_OVRTX_RGB_MAX_DIFFERENT_PIXELS_PERCENTAGE = 2.0
+
 # Minimum SSIM score below which two images are considered structurally different. SSIM is a perceptual metric
 # robust to uniform per-pixel noise that penalises structural changes (geometry shifts, swapped colours, missing
 # materials, etc.), so it complements the per-pixel L2 gate by catching regressions that survive a loosened pixel
@@ -1344,12 +1348,15 @@ def rendering_test_cartpole(
             data_type,
             compare_golden=compare_golden and data_type == "rgb",
         )
+        max_different_pixels_percentage = MAX_DIFFERENT_PIXELS_PERCENTAGE_BY_ENV_NAME["cartpole"]
+        if physics_backend == "newton" and renderer == "ovrtx_renderer" and data_type == "rgb":
+            max_different_pixels_percentage = _CARTPOLE_OVRTX_RGB_MAX_DIFFERENT_PIXELS_PERCENTAGE
         validate_camera_outputs(
             "cartpole",
             physics_backend,
             renderer,
             camera_outputs,
-            max_different_pixels_percentage=MAX_DIFFERENT_PIXELS_PERCENTAGE_BY_ENV_NAME["cartpole"],
+            max_different_pixels_percentage=max_different_pixels_percentage,
             comparison_scores=comparison_scores,
         )
 

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1348,7 +1348,7 @@ def rendering_test_cartpole(
             compare_golden=compare_golden and data_type == "rgb",
         )
         max_different_pixels_percentage = MAX_DIFFERENT_PIXELS_PERCENTAGE_BY_ENV_NAME["cartpole"]
-        if physics_backend == "newton" and renderer == "ovrtx_renderer" and data_type == "rgb":
+        if physics_backend == "newton" and renderer == "ovrtx_renderer" and data_type in ("rgb", "rgba"):
             max_different_pixels_percentage = _CARTPOLE_OVRTX_RGB_MAX_DIFFERENT_PIXELS_PERCENTAGE
         validate_camera_outputs(
             "cartpole",

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -57,8 +57,7 @@ MAX_DIFFERENT_PIXELS_PERCENTAGE_BY_ENV_NAME = {
     "dexsuite_kuka_hetero": 8.0,
 }
 
-# OVRTX 0.4 Cartpole RGB/RGBA varies by up to 1.839% across otherwise structurally equivalent runs
-# (NVBUG#6152566). Keep the relaxed threshold scoped to this exact case; the SSIM gate remains enabled.
+# Allow OVRTX Cartpole RGB/RGBA variation tracked by NVBUG#6152566; the SSIM gate remains enabled.
 _CARTPOLE_OVRTX_RGB_MAX_DIFFERENT_PIXELS_PERCENTAGE = 2.0
 
 # Minimum SSIM score below which two images are considered structurally different. SSIM is a perceptual metric


### PR DESCRIPTION
## Summary

- Raise the pixel-difference allowance from 1.5% to 2.0% only for the Newton-OVRTX Cartpole RGB/RGBA comparison.
- Keep the existing SSIM gate and every other rendering threshold unchanged.
- Document the OVRTX 0.4 nondeterminism tracked by NVBUG#6152566.
- 
This is an alternative to the xfail change in #6719 and follows the OVRTX 0.4 dependency bump in #6592.

## Motivation

A 20-process A/B test used the same Isaac Lab code, GPU, driver, and x86 host:

- OVRTX 0.4: 15/20 runs exceeded the 1.5% pixel gate; pairwise mean was 1.067% and maximum was 1.839%.
- OVRTX 0.3: 20/20 runs passed; pairwise mean was 0.0045% and maximum was 0.0485%.

The Cartpole comparison is a small 192x192 tiled image whose pole and cart span only a few pixels. A 2.0% case-specific threshold covers the measured OVRTX 0.4 variation while allowing unrelated Python failures and structural image regressions to remain visible.

## Follow-up

Restore the stricter tolerance when the upstream nondeterminism tracked by NVBUG#6152566 is fixed and validated in Isaac Lab.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there