### PR TITLE
Fix grammar and typos in environments documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,6 +62,7 @@ Guidelines for modifications:
 * Asier Arranz
 * Bikram Pandit
 * Bingjie Tang
+* Bodo Wirth
 * Bocheng Zou
 * Brayden Zhang
 * Brian Bingham

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -288,7 +288,7 @@ for the lift-cube environment:
     | |gr1_pick_place|        | |gr1_pick_place-link|        | Pick up and place an object in a basket with a GR-1 humanoid robot          |                                         |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
     | |gr1_pp_waist|          | |gr1_pp_waist-link|          | Pick up and place an object in a basket with a GR-1 humanoid robot          |                                         |
-    |                         |                              | with waist degrees-of-freedom enables that provides a wider reach space.    |                                         |
+    |                         |                              | with enabled waist degrees of freedom, providing a wider reach space.       |                                         |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
     | |g1_pick_place|         | |g1_pick_place-link|         | Pick up and place an object in a basket with a Unitree G1 humanoid robot    |                                         |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
@@ -365,10 +365,10 @@ for the lift-cube environment:
     | |galbot_stack|          | |galbot_stack-link|          | Stack three cubes (bottom to top: blue, red, green) with the left arm of    | **physics=** ``isaacsim_physx``,        |
     |                         |                              | a Galbot humanoid robot                                                     | ``newton_mjwarp``                       |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
-    | |agibot_place_mug|      | |agibot_place_mug-link|      | Pick up and place a mug upright with a Agibot A2D humanoid robot            | **physics=** ``isaacsim_physx``,        |
+    | |agibot_place_mug|      | |agibot_place_mug-link|      | Pick up and place a mug upright with an Agibot A2D humanoid robot           | **physics=** ``isaacsim_physx``,        |
     |                         |                              |                                                                             | ``newton_mjwarp``                       |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
-    | |agibot_place_toy|      | |agibot_place_toy-link|      | Pick up and place an object in a box with a Agibot A2D humanoid robot       | **physics=** ``isaacsim_physx``,        |
+    | |agibot_place_toy|      | |agibot_place_toy-link|      | Pick up and place an object in a box with an Agibot A2D humanoid robot      | **physics=** ``isaacsim_physx``,        |
     |                         |                              |                                                                             | ``newton_mjwarp``                       |
     +-------------------------+------------------------------+-----------------------------------------------------------------------------+-----------------------------------------+
     | |reach_openarm_bi|      | |reach_openarm_bi-link|      | Move the end-effector to sampled target poses with the OpenArm robot        |                                         |
@@ -487,7 +487,7 @@ For example:
 AutoMate
 ~~~~~~~~
 
-Environments based on 100 diverse assembly tasks, each involving the insertion of a plug into a socket. These tasks share a common configuration and differ by th geometry and properties of the parts.
+Environments based on 100 diverse assembly tasks, each involving the insertion of a plug into a socket. These tasks share a common configuration and differ by the geometry and properties of the parts.
 
 You can switch between tasks by specifying the corresponding asset ID. Available asset IDs include:
 


### PR DESCRIPTION
## Summary

Fixes several minor grammar and typographical errors in the environments
overview documentation.

## Motivation and context

These changes improve the clarity and readability of the environment
descriptions.

## Dependencies

None.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works: N/A
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`: N/A
- [x] I have added my name to `CONTRIBUTORS.md` or my name already exists there: probably N/A for such a minor change