### PR TITLE
Qualify L40S runner stability for perf smoke

### DIFF
--- a/.github/workflows/perf-smoke-runner-stability.yaml
+++ b/.github/workflows/perf-smoke-runner-stability.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# One-time staging qualification for the L40S runner pool. A merge into the
+# staging branch fans the same commit out to five independent runner allocations.
+# Each allocation collects three FPS samples for every configured bucket without
+# publishing baselines. The final CPU job combines all evidence and fails unless
+# the pool meets the predeclared stability policy in runner_stability.py.
+
+name: Performance Smoke - L40S Runner Stability
+
+on:
+  push:
+    branches: ['perf-smoke/develop-staging']
+
+permissions:
+  # The reusable seeder declares write permission for its normal publication
+  # path. These calls are hard-coded dry runs and never invoke that path.
+  contents: write
+
+concurrency:
+  group: perf-smoke-runner-stability-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  stability_sample:
+    name: Runner allocation ${{ matrix.allocation }}
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        allocation: [1, 2, 3, 4, 5]
+    uses: ./.github/workflows/perf-smoke-seed-baselines.yaml
+    secrets: inherit
+    with:
+      branches: "${{ github.sha }}:perf-smoke/develop-staging"
+      commit_branch: perf-smoke/develop-staging
+      commit_count: "1"
+      samples_per_commit: "3"
+      tasks: "__ALL_TASKS__"
+      target_branch: perf-smoke/develop-staging
+      strict_ancestry: true
+      dry_run: true
+      run_label: "runner-allocation-${{ matrix.allocation }}"
+      artifact_suffix: "-stability-${{ matrix.allocation }}"
+      concurrency_group: "perf-smoke-stability-${{ github.run_id }}-${{ matrix.allocation }}"
+
+  qualify:
+    name: Qualify FPS stability
+    needs: [stability_sample]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    - name: Download runner evidence
+      continue-on-error: true
+      uses: actions/download-artifact@v8
+      with:
+        pattern: seed-baselines-${{ github.run_id }}-stability-*
+        path: runner-stability-artifacts
+
+    - name: Build qualification report
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        RECORD_FILES=(runner-stability-artifacts/*/seed_records.json)
+        if [ "${#RECORD_FILES[@]}" -eq 0 ]; then
+          mkdir -p runner-stability-artifacts/no-evidence
+          printf '[]\n' > runner-stability-artifacts/no-evidence/seed_records.json
+          RECORD_FILES=(runner-stability-artifacts/no-evidence/seed_records.json)
+        fi
+        RECORD_ARGS=()
+        for record_file in "${RECORD_FILES[@]}"; do
+          RECORD_ARGS+=(--records "${record_file}")
+        done
+        python3 tools/perf_smoke_test/runner_stability.py \
+          "${RECORD_ARGS[@]}" \
+          --gpu_model l40s \
+          --expected_target_branch perf-smoke/develop-staging \
+          --expected_commit "${GITHUB_SHA}" \
+          --expected_allocations 5 \
+          --samples_per_allocation 3 \
+          --json_output runner-stability-report.json \
+          --markdown_output runner-stability-report.md \
+          --github_step_summary "${GITHUB_STEP_SUMMARY}" \
+          --require_ready
+
+    - name: Upload qualification report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: runner-stability-report-${{ github.run_id }}
+        path: |
+          runner-stability-report.json
+          runner-stability-report.md
+        retention-days: 30
+        if-no-files-found: warn

--- a/.github/workflows/perf-smoke-runner-stability.yaml
+++ b/.github/workflows/perf-smoke-runner-stability.yaml
@@ -3,21 +3,25 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# One-time staging qualification for the L40S runner pool. A merge into the
-# staging branch fans the same commit out to five independent runner allocations.
-# Each allocation collects three FPS samples for every configured bucket without
-# publishing baselines. The final CPU job combines all evidence and fails unless
-# the pool meets the predeclared stability policy in runner_stability.py.
+# One-time staging qualification for the L40S runner pool. The workflow waits
+# for the normal gate and baseline seeder from the same push to finish, then fans
+# the commit out to five independent allocations. Each allocation collects three
+# FPS samples per bucket without publishing baselines. The final CPU job combines
+# all 15 samples and fails unless the pool meets the predeclared stability policy.
 
 name: Performance Smoke - L40S Runner Stability
 
 on:
   push:
     branches: ['perf-smoke/develop-staging']
+    # Adding or deliberately updating this workflow requests qualification.
+    # Unrelated staging pushes do not repeatedly consume the L40S pool.
+    paths: ['.github/workflows/perf-smoke-runner-stability.yaml']
 
 permissions:
-  # The reusable seeder declares write permission for its normal publication
-  # path. These calls are hard-coded dry runs and never invoke that path.
+  actions: read
+  # Reusable workflows cannot elevate their caller's token. The seeder requests
+  # write access for its normal publish mode, while this caller forces dry-run.
   contents: write
 
 concurrency:
@@ -25,15 +29,85 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  wait_for_quiet_pool:
+    name: Wait for sibling performance workflows
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    permissions:
+      actions: read
+      contents: read
+    steps:
+    - name: Wait for the gate and seeder from this push
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        REQUIRED_WORKFLOWS=(
+          "Performance Smoke Test"
+          "Performance Smoke - Seed Baselines"
+        )
+        L40_POOL_WORKFLOWS=(
+          "Performance Smoke Test"
+          "Performance Smoke - Seed Baselines"
+          "Perf Smoke — Publish CI Image"
+          "Perf Smoke — Auto Era Roll"
+        )
+        DEADLINE=$((SECONDS + 20400))
+        QUIET_POLLS=0
+        while (( SECONDS < DEADLINE )); do
+          RUNS="$(gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --limit 100 \
+            --json headSha,workflowName,status)"
+          PREREQUISITES_READY=true
+          for workflow_name in "${REQUIRED_WORKFLOWS[@]}"; do
+            MATCH_COUNT="$(jq --arg name "${workflow_name}" \
+              --arg sha "${GITHUB_SHA}" \
+              '[.[] | select(.workflowName == $name and .headSha == $sha)] | length' <<<"${RUNS}")"
+            ACTIVE_COUNT="$(jq --arg name "${workflow_name}" \
+              --arg sha "${GITHUB_SHA}" \
+              '[.[] | select(.workflowName == $name and .headSha == $sha and .status != "completed")] | length' \
+              <<<"${RUNS}")"
+            if [ "${MATCH_COUNT}" -eq 0 ] || [ "${ACTIVE_COUNT}" -ne 0 ]; then
+              PREREQUISITES_READY=false
+              break
+            fi
+          done
+          ACTIVE_POOL_RUNS=0
+          for workflow_name in "${L40_POOL_WORKFLOWS[@]}"; do
+            ACTIVE_COUNT="$(jq --arg name "${workflow_name}" \
+              '[.[] | select(.workflowName == $name and .status != "completed")] | length' <<<"${RUNS}")"
+            ACTIVE_POOL_RUNS=$((ACTIVE_POOL_RUNS + ACTIVE_COUNT))
+          done
+          if [ "${PREREQUISITES_READY}" = true ] && [ "${ACTIVE_POOL_RUNS}" -eq 0 ]; then
+            QUIET_POLLS=$((QUIET_POLLS + 1))
+            if [ "${QUIET_POLLS}" -ge 2 ]; then
+              echo "Sibling workflows completed and the L40 pool stayed quiet; starting qualification."
+              exit 0
+            fi
+            echo "L40 pool is quiet; confirming for one more polling interval..."
+          else
+            QUIET_POLLS=0
+            echo "Waiting for sibling workflows and other L40 workloads to finish..."
+          fi
+          sleep 60
+        done
+        echo "::error::Timed out waiting for a quiet L40 pool after ${GITHUB_SHA}"
+        exit 1
+
   stability_sample:
     name: Runner allocation ${{ matrix.allocation }}
+    needs: [wait_for_quiet_pool]
+    if: ${{ always() && (needs.wait_for_quiet_pool.result == 'success' || needs.wait_for_quiet_pool.result == 'skipped') }}
     strategy:
       fail-fast: false
       max-parallel: 5
       matrix:
         allocation: [1, 2, 3, 4, 5]
     uses: ./.github/workflows/perf-smoke-seed-baselines.yaml
-    secrets: inherit
+    secrets:
+      NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
     with:
       branches: "${{ github.sha }}:perf-smoke/develop-staging"
       commit_branch: perf-smoke/develop-staging
@@ -53,6 +127,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
     - uses: actions/checkout@v6
@@ -60,11 +135,22 @@ jobs:
         fetch-depth: 1
 
     - name: Download runner evidence
+      id: download_evidence
       continue-on-error: true
       uses: actions/download-artifact@v8
       with:
         pattern: seed-baselines-${{ github.run_id }}-stability-*
         path: runner-stability-artifacts
+
+    - name: Report artifact download failure
+      if: ${{ steps.download_evidence.outcome == 'failure' }}
+      run: |
+        echo "::error::Runner evidence artifacts could not be downloaded; qualification will fail closed."
+        {
+          echo "### Runner evidence download failed"
+          echo
+          echo "The qualification report may be incomplete. Inspect the artifact download step above."
+        } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Build qualification report
       run: |
@@ -86,6 +172,7 @@ jobs:
           --expected_target_branch perf-smoke/develop-staging \
           --expected_commit "${GITHUB_SHA}" \
           --expected_allocations 5 \
+          --minimum_distinct_runners 3 \
           --samples_per_allocation 3 \
           --json_output runner-stability-report.json \
           --markdown_output runner-stability-report.md \
@@ -102,3 +189,9 @@ jobs:
           runner-stability-report.md
         retention-days: 30
         if-no-files-found: warn
+
+    - name: Fail on artifact download error
+      if: ${{ always() && steps.download_evidence.outcome == 'failure' }}
+      run: |
+        echo "::error::Qualification evidence could not be downloaded."
+        exit 1

--- a/.github/workflows/perf-smoke-seed-baselines.yaml
+++ b/.github/workflows/perf-smoke-seed-baselines.yaml
@@ -78,9 +78,9 @@ on:
         required: false
         default: true
   # Reusable: the era-roll orchestrator calls this to fill a new era's baselines.
-  # Caller must pass `secrets: inherit` (NGC_API_KEY). Only the inputs the
-  # orchestrator sets are declared; the run steps default the rest. The booleans
-  # are declared explicitly so a missing value can never coerce to "publish".
+  # Callers provide the NGC credential explicitly or via `secrets: inherit`.
+  # The booleans are declared explicitly so a missing value can never coerce to
+  # "publish".
   workflow_call:
     inputs:
       branches:
@@ -148,6 +148,10 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      NGC_API_KEY:
+        description: "Optional credential for pulling private NGC images."
+        required: false
 
 concurrency:
   # Serialize seeding so concurrent pushes can't race the append-only baseline branch.
@@ -303,7 +307,9 @@ jobs:
         SEED_BACKENDS: ${{ inputs.backends || '' }}
         SEED_TARGET_BRANCH: ${{ inputs.target_branch || github.event_name == 'push' && 'perf-smoke/develop-staging' || 'develop' }}
         SEED_STRICT_ANCESTRY: ${{ inputs.strict_ancestry == true && 'true' || github.event_name == 'push' && 'true' || 'false' }}
-        SEED_DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+        # Explicit reusable/manual dry-run wins even when the caller was triggered
+        # by push. A direct staging push has no true input and still publishes.
+        SEED_DRY_RUN: ${{ inputs.dry_run == true && 'true' || github.event_name == 'push' && 'false' || inputs.dry_run == false && 'false' || 'true' }}
         PERF_SMOKE_RUN_LABEL: ${{ inputs.run_label || '' }}
         PERF_SMOKE_RUNNER_NAME: ${{ runner.name }}
       run: |
@@ -329,11 +335,11 @@ jobs:
           --source_mount true \
           --dry_run "${SEED_DRY_RUN}"
 
-    # Quantify runner noise from the independent repetitions without enforcing a
-    # stability threshold yet. Grouping includes commit + full gate fingerprint,
-    # so code or environment changes cannot be mistaken for run-to-run variance.
+    # Quantify ordinary seeder repetitions without enforcing a threshold.
+    # Stability allocations carry run_label and skip this three-sample local view;
+    # their authoritative report combines all 15 samples in the caller workflow.
     - name: Report run-to-run variance
-      if: always()
+      if: ${{ always() && inputs.run_label == '' }}
       run: |
         set -euo pipefail
         RECORDS="seed-artifacts/seed_records.json"

--- a/.github/workflows/perf-smoke-seed-baselines.yaml
+++ b/.github/workflows/perf-smoke-seed-baselines.yaml
@@ -133,10 +133,27 @@ on:
         type: boolean
         required: false
         default: true
+      run_label:
+        description: "Optional label identifying an independent benchmark allocation."
+        required: false
+        default: ""
+        type: string
+      artifact_suffix:
+        description: "Optional suffix making artifacts unique across reusable-workflow matrix jobs."
+        required: false
+        default: ""
+        type: string
+      concurrency_group:
+        description: "Optional concurrency group override for independent dry-run allocations."
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   # Serialize seeding so concurrent pushes can't race the append-only baseline branch.
-  group: perf-smoke-seed
+  # Dry-run stability probes supply unique groups so their runner allocations can
+  # execute concurrently without weakening serialization for baseline writers.
+  group: ${{ inputs.concurrency_group || 'perf-smoke-seed' }}
   cancel-in-progress: false
 
 permissions:
@@ -166,7 +183,7 @@ jobs:
         echo "isaaclab_image_ref=${ISAACLAB_IMAGE_NAME}:latest-develop" >> "$GITHUB_OUTPUT"
 
   seed:
-    name: Seed baselines (${{ github.event_name == 'push' && github.ref_name || inputs.commit_branch || 'develop' }} x${{ github.event_name == 'push' && '1' || inputs.commit_count || '1' }})
+    name: Seed baselines (${{ inputs.commit_branch || github.ref_name || 'develop' }} x${{ inputs.commit_count || '1' }})
     runs-on: ${{ fromJSON(vars.PERF_SMOKE_RUNS_ON || '["self-hosted","gpu"]') }}
     needs: [config]
     timeout-minutes: 600
@@ -184,8 +201,8 @@ jobs:
     # explicitly; the clone the orchestrator makes draws its objects from here.
     - name: Fetch seed + baseline refs
       env:
-        SEED_BRANCHES: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging:perf-smoke/develop-staging' || inputs.branches || 'develop' }}
-        SEED_COMMIT_BRANCH: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging' || inputs.commit_branch || 'develop' }}
+        SEED_BRANCHES: ${{ inputs.branches || github.event_name == 'push' && 'perf-smoke/develop-staging:perf-smoke/develop-staging' || 'develop' }}
+        SEED_COMMIT_BRANCH: ${{ inputs.commit_branch || github.event_name == 'push' && 'perf-smoke/develop-staging' || 'develop' }}
       run: |
         set -euo pipefail
         # Collect every branch we might seed from: the multi-branch list (stripping
@@ -277,16 +294,18 @@ jobs:
         # publish one commit x MIN_BASELINE_SAMPLES for the full tasks.json matrix
         # so the merge immediately starts pre-seeding and verifies perf-baselines
         # writes across the gate's intended coverage.
-        SEED_BRANCHES: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging:perf-smoke/develop-staging' || inputs.branches || 'develop' }}
+        SEED_BRANCHES: ${{ inputs.branches || github.event_name == 'push' && 'perf-smoke/develop-staging:perf-smoke/develop-staging' || 'develop' }}
         SEED_COMMITS: ${{ inputs.commits || '' }}
-        SEED_COMMIT_BRANCH: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging' || inputs.commit_branch || 'develop' }}
-        SEED_COMMIT_COUNT: ${{ github.event_name == 'push' && '1' || inputs.commit_count || '1' }}
-        SEED_SAMPLES_PER_COMMIT: ${{ github.event_name == 'push' && '5' || inputs.samples_per_commit || '3' }}
-        SEED_TASKS: ${{ github.event_name == 'push' && '__ALL_TASKS__' || inputs.tasks || 'Isaac-Cartpole-Direct' }}
+        SEED_COMMIT_BRANCH: ${{ inputs.commit_branch || github.event_name == 'push' && 'perf-smoke/develop-staging' || 'develop' }}
+        SEED_COMMIT_COUNT: ${{ inputs.commit_count || github.event_name == 'push' && '1' || '1' }}
+        SEED_SAMPLES_PER_COMMIT: ${{ inputs.samples_per_commit || github.event_name == 'push' && '5' || '3' }}
+        SEED_TASKS: ${{ inputs.tasks || github.event_name == 'push' && '__ALL_TASKS__' || 'Isaac-Cartpole-Direct' }}
         SEED_BACKENDS: ${{ inputs.backends || '' }}
-        SEED_TARGET_BRANCH: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging' || inputs.target_branch || 'develop' }}
-        SEED_STRICT_ANCESTRY: ${{ github.event_name == 'push' && 'true' || inputs.strict_ancestry == true && 'true' || 'false' }}
-        SEED_DRY_RUN: ${{ github.event_name == 'push' && 'false' || inputs.dry_run == false && 'false' || 'true' }}
+        SEED_TARGET_BRANCH: ${{ inputs.target_branch || github.event_name == 'push' && 'perf-smoke/develop-staging' || 'develop' }}
+        SEED_STRICT_ANCESTRY: ${{ inputs.strict_ancestry == true && 'true' || github.event_name == 'push' && 'true' || 'false' }}
+        SEED_DRY_RUN: ${{ inputs.dry_run == true && 'true' || 'false' }}
+        PERF_SMOKE_RUN_LABEL: ${{ inputs.run_label || '' }}
+        PERF_SMOKE_RUNNER_NAME: ${{ runner.name }}
       run: |
         set -euo pipefail
         GPU_MODEL="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs)"
@@ -310,16 +329,34 @@ jobs:
           --source_mount true \
           --dry_run "${SEED_DRY_RUN}"
 
+    # Quantify runner noise from the independent repetitions without enforcing a
+    # stability threshold yet. Grouping includes commit + full gate fingerprint,
+    # so code or environment changes cannot be mistaken for run-to-run variance.
+    - name: Report run-to-run variance
+      if: always()
+      run: |
+        set -euo pipefail
+        RECORDS="seed-artifacts/seed_records.json"
+        if [ ! -s "${RECORDS}" ]; then
+          echo "::notice::No successful seed records were available for variance analysis"
+          exit 0
+        fi
+        python3 tools/perf_smoke_test/analyze_seed_variance.py \
+          --records "${RECORDS}" \
+          --json_output seed-artifacts/variance_report.json \
+          --markdown_output seed-artifacts/variance_report.md \
+          --github_step_summary "${GITHUB_STEP_SUMMARY}"
+
     # Prove the just-pushed samples will actually be used by the gate: replay the
     # gate's per-bucket match logic (fingerprint + commit ancestry) against the
     # target branch tip and require MIN_BASELINE_SAMPLES usable samples per bucket.
     # Only meaningful on a real publish (dry-run pushes nothing to verify).
     - name: Verify seeded baselines are gate-usable
-      if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+      if: ${{ inputs.dry_run != true }}
       env:
-        SEED_TASKS: ${{ github.event_name == 'push' && '__ALL_TASKS__' || inputs.tasks || 'Isaac-Cartpole-Direct' }}
+        SEED_TASKS: ${{ inputs.tasks || github.event_name == 'push' && '__ALL_TASKS__' || 'Isaac-Cartpole-Direct' }}
         SEED_BACKENDS: ${{ inputs.backends || '' }}
-        SEED_TARGET_BRANCH: ${{ github.event_name == 'push' && 'perf-smoke/develop-staging' || inputs.target_branch || 'develop' }}
+        SEED_TARGET_BRANCH: ${{ inputs.target_branch || github.event_name == 'push' && 'perf-smoke/develop-staging' || 'develop' }}
       run: |
         set -euo pipefail
         GPU_MODEL="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs)"
@@ -338,7 +375,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: seed-baselines-${{ github.run_id }}
+        name: seed-baselines-${{ github.run_id }}${{ inputs.artifact_suffix }}
         path: seed-artifacts/
         retention-days: 7
         if-no-files-found: warn

--- a/tools/perf_smoke_test/analyze_seed_variance.py
+++ b/tools/perf_smoke_test/analyze_seed_variance.py
@@ -112,6 +112,7 @@ def analyze_records(records: list[dict[str, Any]]) -> tuple[list[VarianceBucket]
             not isinstance(fps, (int, float))
             or isinstance(fps, bool)
             or not math.isfinite(float(fps))
+            or float(fps) <= 0.0
             or not task_id
             or not backend
         ):
@@ -197,7 +198,7 @@ def build_markdown(buckets: list[VarianceBucket], *, valid_samples: int, skipped
         ]
     )
     if skipped_samples:
-        lines.extend(["", f"Skipped {skipped_samples} malformed or non-finite record(s)."])
+        lines.extend(["", f"Skipped {skipped_samples} malformed, non-finite, or non-positive record(s)."])
     return "\n".join(lines) + "\n"
 
 

--- a/tools/perf_smoke_test/analyze_seed_variance.py
+++ b/tools/perf_smoke_test/analyze_seed_variance.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Summarize run-to-run FPS variance from a baseline seeding run.
+
+The seeder writes one record per successful repetition to ``seed_records.json``.
+This tool groups only records with the same commit and gate fingerprint so code or
+environment changes are never mistaken for runner noise. The report is advisory:
+it exposes the observed distribution without choosing a project-wide stability
+threshold or changing the seeder's exit status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+_GROUP_FIELDS = (
+    "gpu_model",
+    "task_id",
+    "backend",
+    "target_branch",
+    "commit_sha",
+    "launch_config_hash",
+    "benchmark_contract_hash",
+    "runtime_contract_hash",
+    "baseline_epoch",
+)
+
+
+@dataclass(frozen=True)
+class VarianceBucket:
+    """Run-to-run statistics for one exact commit and gate fingerprint."""
+
+    gpu_model: str
+    task_id: str
+    backend: str
+    target_branch: str
+    commit_sha: str
+    launch_config_hash: str
+    benchmark_contract_hash: str
+    runtime_contract_hash: str
+    baseline_epoch: int | None
+    ci_run_count: int
+    runner_count: int
+    sample_count: int
+    median_fps: float
+    mean_fps: float
+    stdev_fps: float
+    mad_fps: float
+    mad_pct: float
+    cv_pct: float
+    range_pct: float
+    first_to_last_pct: float
+
+
+def _percent(numerator: float, denominator: float) -> float:
+    return 100.0 * numerator / denominator if denominator else 0.0
+
+
+def _record_group_key(record: dict[str, Any]) -> tuple[Any, ...]:
+    normalized = dict(record)
+    normalized["backend"] = record.get("backend") or record.get("backend_key")
+    return tuple(normalized.get(field) for field in _GROUP_FIELDS)
+
+
+def _sample_order(item: tuple[int, dict[str, Any]]) -> tuple[str, str, int, int]:
+    position, record = item
+    sample_index = record.get("sample_index")
+    timestamp = record.get("timestamp")
+    ci_run_id = record.get("ci_run_id")
+    return (
+        str(timestamp) if timestamp else "",
+        str(ci_run_id) if ci_run_id else "",
+        sample_index if isinstance(sample_index, int) else position,
+        position,
+    )
+
+
+def _execution_id(record: dict[str, Any]) -> str:
+    label = str(record.get("ci_run_label") or "").strip()
+    if label:
+        return label
+    return ":".join(
+        str(record.get(field) or "unknown") for field in ("ci_run_id", "ci_run_attempt", "ci_job", "ci_runner_name")
+    )
+
+
+def analyze_records(records: list[dict[str, Any]]) -> tuple[list[VarianceBucket], int]:
+    """Calculate variance statistics for valid FPS records.
+
+    Args:
+        records: Seeder summary records in collection order.
+
+    Returns:
+        Per-fingerprint statistics and the number of invalid records skipped.
+    """
+    groups: dict[tuple[Any, ...], list[tuple[int, dict[str, Any]]]] = {}
+    skipped = 0
+    for position, record in enumerate(records):
+        fps = record.get("fps")
+        task_id = record.get("task_id")
+        backend = record.get("backend") or record.get("backend_key")
+        if (
+            not isinstance(fps, (int, float))
+            or isinstance(fps, bool)
+            or not math.isfinite(float(fps))
+            or not task_id
+            or not backend
+        ):
+            skipped += 1
+            continue
+        groups.setdefault(_record_group_key(record), []).append((position, record))
+
+    buckets: list[VarianceBucket] = []
+    for key, indexed_records in groups.items():
+        ordered = [record for _, record in sorted(indexed_records, key=_sample_order)]
+        values = [float(record["fps"]) for record in ordered]
+        ci_runs = {_execution_id(record) for record in ordered}
+        runners = {
+            str(record.get("ci_runner_name")).strip()
+            for record in ordered
+            if str(record.get("ci_runner_name") or "").strip()
+        }
+        median_fps = statistics.median(values)
+        mean_fps = statistics.mean(values)
+        stdev_fps = statistics.stdev(values) if len(values) > 1 else 0.0
+        mad_fps = statistics.median(abs(value - median_fps) for value in values)
+        first_to_last_pct = _percent(values[-1] - values[0], values[0])
+        buckets.append(
+            VarianceBucket(
+                gpu_model=str(key[0] or ""),
+                task_id=str(key[1]),
+                backend=str(key[2]),
+                target_branch=str(key[3] or ""),
+                commit_sha=str(key[4] or ""),
+                launch_config_hash=str(key[5] or ""),
+                benchmark_contract_hash=str(key[6] or ""),
+                runtime_contract_hash=str(key[7] or ""),
+                baseline_epoch=key[8] if isinstance(key[8], int) else None,
+                ci_run_count=len(ci_runs),
+                runner_count=len(runners),
+                sample_count=len(values),
+                median_fps=median_fps,
+                mean_fps=mean_fps,
+                stdev_fps=stdev_fps,
+                mad_fps=mad_fps,
+                mad_pct=_percent(mad_fps, median_fps),
+                cv_pct=_percent(stdev_fps, mean_fps),
+                range_pct=_percent(max(values) - min(values), median_fps),
+                first_to_last_pct=first_to_last_pct,
+            )
+        )
+
+    buckets.sort(key=lambda bucket: (bucket.task_id, bucket.backend, bucket.commit_sha, bucket.runtime_contract_hash))
+    return buckets, skipped
+
+
+def build_markdown(buckets: list[VarianceBucket], *, valid_samples: int, skipped_samples: int) -> str:
+    """Render a concise report for the GitHub Actions step summary."""
+    lines = [
+        "## Run-to-run variance",
+        "",
+        (
+            f"Analyzed {valid_samples} successful repetition(s) across {len(buckets)} exact "
+            "commit/runtime bucket(s). This report is advisory and does not fail CI."
+        ),
+        "",
+        "| Task | Backend | Commit / runtime | Allocations | Runners | Samples | Median FPS | "
+        "MAD / median | CV | Min-max / median | First → last |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for bucket in buckets:
+        context = f"{bucket.commit_sha[:8] or 'unknown'} / {bucket.runtime_contract_hash[:8] or 'unknown'}"
+        lines.append(
+            f"| `{bucket.task_id}` | `{bucket.backend}` | `{context}` | {bucket.ci_run_count} | "
+            f"{bucket.runner_count} | {bucket.sample_count} | {bucket.median_fps:,.1f} | "
+            f"{bucket.mad_pct:.2f}% | {bucket.cv_pct:.2f}% | {bucket.range_pct:.2f}% | "
+            f"{bucket.first_to_last_pct:+.2f}% |"
+        )
+    if not buckets:
+        lines.append("| _No valid samples_ | — | — | 0 | 0 | 0 | — | — | — | — | — |")
+    lines.extend(
+        [
+            "",
+            "- **MAD / median** is the gate-aligned robust noise measure; lower is more stable.",
+            "- **CV** is standard deviation divided by mean; it is more sensitive to outliers.",
+            "- **Min-max / median** shows the full observed spread.",
+            "- **First → last** helps reveal sample-order drift such as cold-start or thermal effects.",
+        ]
+    )
+    if skipped_samples:
+        lines.extend(["", f"Skipped {skipped_samples} malformed or non-finite record(s)."])
+    return "\n".join(lines) + "\n"
+
+
+def build_report(records: list[dict[str, Any]]) -> tuple[dict[str, Any], str]:
+    """Build machine-readable and Markdown reports from seeder records."""
+    buckets, skipped = analyze_records(records)
+    valid_samples = sum(bucket.sample_count for bucket in buckets)
+    report = {
+        "schema_version": 1,
+        "input_sample_count": len(records),
+        "valid_sample_count": valid_samples,
+        "skipped_sample_count": skipped,
+        "bucket_count": len(buckets),
+        "buckets": [asdict(bucket) for bucket in buckets],
+    }
+    markdown = build_markdown(buckets, valid_samples=valid_samples, skipped_samples=skipped)
+    return report, markdown
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--records",
+        required=True,
+        action="append",
+        type=Path,
+        help="Seeder seed_records.json file. Repeat to combine independent CI runs.",
+    )
+    parser.add_argument("--json_output", type=Path, help="Optional machine-readable report path.")
+    parser.add_argument("--markdown_output", type=Path, help="Optional Markdown report path.")
+    parser.add_argument(
+        "--github_step_summary",
+        type=Path,
+        help="Optional GITHUB_STEP_SUMMARY path to append the Markdown report to.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the variance report CLI."""
+    args = _parse_args()
+    payload: list[dict[str, Any]] = []
+    for records_path in args.records:
+        records = json.loads(records_path.read_text(encoding="utf-8"))
+        if not isinstance(records, list) or not all(isinstance(record, dict) for record in records):
+            raise ValueError(f"{records_path} must contain a JSON list of objects")
+        payload.extend(
+            record if record.get("ci_run_id") else {**record, "ci_run_id": f"records:{records_path}"}
+            for record in records
+        )
+
+    report, markdown = build_report(payload)
+    print(markdown, end="")
+    if args.json_output:
+        args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.write_text(markdown, encoding="utf-8")
+    if args.github_step_summary:
+        with args.github_step_summary.open("a", encoding="utf-8") as summary:
+            summary.write(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf_smoke_test/backend_identity.py
+++ b/tools/perf_smoke_test/backend_identity.py
@@ -18,14 +18,13 @@ _PHYSICS_PRESET_TO_BACKEND = {
     "newton": "newton",
     "newton_mjwarp": "newton",
 }
-_RENDER_PRESET_TOKENS = frozenset(
-    {
-        "newton_renderer",
-        "ovrtx_renderer",
-        "warp_renderer",
-        "rtx_renderer",
-    }
-)
+_RENDER_PRESET_TO_BACKEND = {
+    "isaacsim_rtx": "rtx_renderer",
+    "newton_renderer": "newton_renderer",
+    "ovrtx_renderer": "ovrtx_renderer",
+    "rtx_renderer": "rtx_renderer",
+    "warp_renderer": "warp_renderer",
+}
 _KNOWN_PHYSICS_BACKENDS = ("physx", "newton")
 
 
@@ -124,7 +123,10 @@ def identity_from_presets(presets: Any) -> BackendIdentity | None:
         (_PHYSICS_PRESET_TO_BACKEND[token] for token in sorted(tokens) if token in _PHYSICS_PRESET_TO_BACKEND),
         _DEFAULT_PHYSICS_BACKEND,
     )
-    render = next((token for token in sorted(tokens) if token in _RENDER_PRESET_TOKENS), None)
+    render = next(
+        (_RENDER_PRESET_TO_BACKEND[token] for token in sorted(tokens) if token in _RENDER_PRESET_TO_BACKEND),
+        None,
+    )
     return BackendIdentity(physics, render)
 
 

--- a/tools/perf_smoke_test/baseline_manager.py
+++ b/tools/perf_smoke_test/baseline_manager.py
@@ -268,6 +268,7 @@ def _stable_sample_id(metadata: dict[str, Any]) -> str:
     keys = (
         "ci_run_id",
         "ci_run_attempt",
+        "ci_run_label",
         "commit_sha",
         "task_id",
         "backend_key",
@@ -345,6 +346,8 @@ def make_sample_metadata(
         "ci_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
         "ci_workflow": os.environ.get("GITHUB_WORKFLOW"),
         "ci_job": os.environ.get("GITHUB_JOB"),
+        "ci_run_label": os.environ.get("PERF_SMOKE_RUN_LABEL"),
+        "ci_runner_name": os.environ.get("PERF_SMOKE_RUNNER_NAME"),
         "launch_config": launch_config,
         "runtime": {
             "isaacsim": software.get("isaacsim"),

--- a/tools/perf_smoke_test/launch_config.py
+++ b/tools/perf_smoke_test/launch_config.py
@@ -32,6 +32,9 @@ LAUNCH_CONFIG_SCHEMA_VERSION = 1
 BENCHMARK_CONTRACT_VERSION = 1
 DEFAULT_BASELINE_EPOCH = 1
 LAUNCH_CONFIG_FILENAME = "launch_config.json"
+_HYDRA_RENDER_PRESETS = {
+    "rtx_renderer": "isaacsim_rtx",
+}
 
 
 def workload_contract(config: dict[str, Any]) -> dict[str, Any]:
@@ -59,7 +62,7 @@ def hydra_args_for_task(task: TaskConfig) -> list[str]:
     if task.physics_backend == "newton":
         presets.append("newton_mjwarp")
     if task.render_backend:
-        presets.append(task.render_backend)
+        presets.append(_HYDRA_RENDER_PRESETS.get(task.render_backend, task.render_backend))
         if task.render_backend == "newton_renderer":
             presets.append("rgb")
     return [f"presets={','.join(presets)}"] if presets else []

--- a/tools/perf_smoke_test/runner_stability.py
+++ b/tools/perf_smoke_test/runner_stability.py
@@ -1,0 +1,533 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Qualify whether FPS variance on the CI runner pool is suitable for gating.
+
+This report combines samples from independent runner allocations at one commit.
+It ties the stability verdict to the perf-smoke oracle: a pool qualifies only
+when complete, homogeneous evidence shows that a 10% FPS regression remains
+outside the effective four-MAD BLOCK band.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from gate_config import DEFAULT_K_BLOCK, DEFAULT_K_WARN, MIN_BLOCK_REGRESSION_PCT
+from gpu_identity import canonical_gpu_model, gpu_model_config_keys
+from task_config import TaskConfig, load_tasks
+
+STABLE = "STABLE_ENOUGH_TO_GATE"
+INCONCLUSIVE = "INCONCLUSIVE_DO_NOT_GATE"
+UNSTABLE = "UNSTABLE_DO_NOT_GATE"
+
+DEFAULT_EXPECTED_ALLOCATIONS = 5
+DEFAULT_SAMPLES_PER_ALLOCATION = 3
+MAX_EFFECTIVE_BLOCK_PCT = 10.0
+MAX_POOLED_CV_PCT = 5.0
+MAX_RUNNER_MEDIAN_DEVIATION_PCT = 5.0
+MAX_SAMPLE_DEVIATION_PCT = 5.0
+
+_FINGERPRINT_FIELDS = (
+    "gpu_model",
+    "target_branch",
+    "commit_sha",
+    "launch_config_hash",
+    "benchmark_contract_hash",
+    "runtime_contract_hash",
+    "baseline_epoch",
+)
+
+
+@dataclass(frozen=True)
+class StabilityBucket:
+    """FPS stability evidence for one task/backend combination."""
+
+    task_id: str
+    backend: str
+    verdict: str
+    reasons: tuple[str, ...]
+    fingerprint_count: int
+    runtime_contract_hashes: tuple[str, ...]
+    allocation_count: int
+    runner_count: int
+    sample_count: int
+    median_fps: float | None
+    mad_pct: float | None
+    cv_pct: float | None
+    range_pct: float | None
+    max_sample_deviation_pct: float | None
+    max_runner_median_deviation_pct: float | None
+    configured_noise_floor_pct: float
+    effective_noise_pct: float | None
+    effective_warn_regression_pct: float | None
+    effective_block_regression_pct: float | None
+    allocation_medians_fps: dict[str, float]
+
+
+def _percent(numerator: float, denominator: float) -> float:
+    return 100.0 * numerator / denominator if denominator else 0.0
+
+
+def _execution_id(record: dict[str, Any]) -> str:
+    label = str(record.get("ci_run_label") or "").strip()
+    if label:
+        return label
+    parts = (
+        record.get("ci_run_id"),
+        record.get("ci_run_attempt"),
+        record.get("ci_job"),
+        record.get("ci_runner_name"),
+    )
+    return ":".join(str(part or "unknown") for part in parts)
+
+
+def _backend(record: dict[str, Any]) -> str:
+    return str(record.get("backend") or record.get("backend_key") or "")
+
+
+def _fingerprint(record: dict[str, Any]) -> tuple[Any, ...]:
+    return tuple(record.get(field) for field in _FINGERPRINT_FIELDS)
+
+
+def _valid_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    valid: list[dict[str, Any]] = []
+    for record in records:
+        fps = record.get("fps")
+        if (
+            isinstance(fps, (int, float))
+            and not isinstance(fps, bool)
+            and math.isfinite(float(fps))
+            and record.get("task_id")
+            and _backend(record)
+        ):
+            valid.append(record)
+    return valid
+
+
+def _noise_floor_for_task(task: TaskConfig, gpu_model: str) -> float:
+    for key in gpu_model_config_keys(gpu_model):
+        value = (task.noise_floor_pct or {}).get(key, {}).get(task.backend_key)
+        if value is not None:
+            return float(value)
+    return 0.0
+
+
+def configured_scope(
+    tasks: list[TaskConfig],
+    gpu_model: str,
+) -> tuple[set[tuple[str, str]], dict[tuple[str, str], float]]:
+    """Return expected buckets and configured noise floors for a GPU model."""
+    expected = {(task.task_id, task.backend_key) for task in tasks}
+    noise_floors = {(task.task_id, task.backend_key): _noise_floor_for_task(task, gpu_model) for task in tasks}
+    return expected, noise_floors
+
+
+def evaluate_stability(
+    records: list[dict[str, Any]],
+    *,
+    expected_buckets: set[tuple[str, str]],
+    noise_floors: dict[tuple[str, str], float] | None = None,
+    expected_allocations: int = DEFAULT_EXPECTED_ALLOCATIONS,
+    samples_per_allocation: int = DEFAULT_SAMPLES_PER_ALLOCATION,
+    expected_gpu_model: str | None = None,
+    expected_target_branch: str | None = None,
+    expected_commit: str | None = None,
+) -> tuple[str, list[StabilityBucket]]:
+    """Evaluate complete runner-pool evidence against the qualification policy."""
+    valid = _valid_records(records)
+    noise_floors = noise_floors or {}
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for record in valid:
+        grouped.setdefault((str(record["task_id"]), _backend(record)), []).append(record)
+
+    buckets: list[StabilityBucket] = []
+    for task_id, backend in sorted(expected_buckets):
+        bucket_records = grouped.get((task_id, backend), [])
+        fingerprints = {_fingerprint(record) for record in bucket_records}
+        by_allocation: dict[str, list[dict[str, Any]]] = {}
+        for record in bucket_records:
+            by_allocation.setdefault(_execution_id(record), []).append(record)
+        runner_names = {
+            str(record.get("ci_runner_name")).strip()
+            for record in bucket_records
+            if str(record.get("ci_runner_name") or "").strip()
+        }
+
+        coverage_reasons: list[str] = []
+        required_samples = expected_allocations * samples_per_allocation
+        observed_gpu_models = {canonical_gpu_model(record.get("gpu_model")) for record in bucket_records}
+        if expected_gpu_model and observed_gpu_models != {canonical_gpu_model(expected_gpu_model)}:
+            coverage_reasons.append(
+                f"expected GPU {canonical_gpu_model(expected_gpu_model)}, observed "
+                + (", ".join(sorted(observed_gpu_models)) or "none")
+            )
+        observed_target_branches = {str(record.get("target_branch") or "") for record in bucket_records}
+        if expected_target_branch and observed_target_branches != {expected_target_branch}:
+            coverage_reasons.append(
+                f"expected target branch {expected_target_branch}, observed "
+                + (", ".join(sorted(observed_target_branches)) or "none")
+            )
+        observed_commits = {str(record.get("commit_sha") or "") for record in bucket_records}
+        if expected_commit and observed_commits != {expected_commit}:
+            coverage_reasons.append(
+                f"expected commit {expected_commit}, observed " + (", ".join(sorted(observed_commits)) or "none")
+            )
+        if len(fingerprints) != 1:
+            coverage_reasons.append(f"expected one runtime fingerprint, observed {len(fingerprints)}")
+        if len(by_allocation) != expected_allocations:
+            coverage_reasons.append(f"expected {expected_allocations} allocations, observed {len(by_allocation)}")
+        if len(runner_names) != expected_allocations:
+            coverage_reasons.append(
+                f"expected {expected_allocations} distinct runner names, observed {len(runner_names)}"
+            )
+        if len(bucket_records) != required_samples:
+            coverage_reasons.append(f"expected {required_samples} samples, observed {len(bucket_records)}")
+        incomplete_allocations = sorted(
+            allocation
+            for allocation, allocation_records in by_allocation.items()
+            if len(allocation_records) != samples_per_allocation
+        )
+        if incomplete_allocations:
+            coverage_reasons.append(
+                f"allocations without exactly {samples_per_allocation} samples: " + ", ".join(incomplete_allocations)
+            )
+
+        values = [float(record["fps"]) for record in bucket_records]
+        median_fps: float | None = None
+        mad_pct: float | None = None
+        cv_pct: float | None = None
+        range_pct: float | None = None
+        max_sample_deviation_pct: float | None = None
+        max_runner_deviation_pct: float | None = None
+        effective_noise_pct: float | None = None
+        effective_warn_pct: float | None = None
+        effective_block_pct: float | None = None
+        allocation_medians: dict[str, float] = {}
+        metric_reasons: list[str] = []
+        noise_floor = float(noise_floors.get((task_id, backend), 0.0))
+
+        if values:
+            median_fps = statistics.median(values)
+            mean_fps = statistics.mean(values)
+            mad_fps = statistics.median(abs(value - median_fps) for value in values)
+            stdev_fps = statistics.stdev(values) if len(values) > 1 else 0.0
+            mad_pct = _percent(mad_fps, median_fps)
+            cv_pct = _percent(stdev_fps, mean_fps)
+            range_pct = _percent(max(values) - min(values), median_fps)
+            max_sample_deviation_pct = max(abs(_percent(value - median_fps, median_fps)) for value in values)
+            allocation_medians = {
+                allocation: statistics.median(float(record["fps"]) for record in allocation_records)
+                for allocation, allocation_records in sorted(by_allocation.items())
+            }
+            if allocation_medians:
+                max_runner_deviation_pct = max(
+                    abs(_percent(allocation_median - median_fps, median_fps))
+                    for allocation_median in allocation_medians.values()
+                )
+            effective_noise_pct = max(mad_pct, noise_floor)
+            effective_warn_pct = DEFAULT_K_WARN * effective_noise_pct
+            effective_block_pct = max(DEFAULT_K_BLOCK * effective_noise_pct, MIN_BLOCK_REGRESSION_PCT)
+
+            if cv_pct > MAX_POOLED_CV_PCT:
+                metric_reasons.append(f"pooled CV {cv_pct:.2f}% exceeds {MAX_POOLED_CV_PCT:.2f}%")
+            if max_sample_deviation_pct > MAX_SAMPLE_DEVIATION_PCT:
+                metric_reasons.append(
+                    f"single-sample deviation {max_sample_deviation_pct:.2f}% exceeds {MAX_SAMPLE_DEVIATION_PCT:.2f}%"
+                )
+            if max_runner_deviation_pct is not None and max_runner_deviation_pct > MAX_RUNNER_MEDIAN_DEVIATION_PCT:
+                metric_reasons.append(
+                    f"runner median deviation {max_runner_deviation_pct:.2f}% exceeds "
+                    f"{MAX_RUNNER_MEDIAN_DEVIATION_PCT:.2f}%"
+                )
+            if effective_block_pct > MAX_EFFECTIVE_BLOCK_PCT:
+                metric_reasons.append(
+                    f"effective BLOCK band {effective_block_pct:.2f}% exceeds {MAX_EFFECTIVE_BLOCK_PCT:.2f}%"
+                )
+
+        if coverage_reasons:
+            verdict = INCONCLUSIVE
+            reasons = tuple(coverage_reasons + metric_reasons)
+        elif metric_reasons:
+            verdict = UNSTABLE
+            reasons = tuple(metric_reasons)
+        else:
+            verdict = STABLE
+            reasons = ()
+
+        buckets.append(
+            StabilityBucket(
+                task_id=task_id,
+                backend=backend,
+                verdict=verdict,
+                reasons=reasons,
+                fingerprint_count=len(fingerprints),
+                runtime_contract_hashes=tuple(
+                    sorted(
+                        {
+                            str(record.get("runtime_contract_hash") or "")
+                            for record in bucket_records
+                            if record.get("runtime_contract_hash")
+                        }
+                    )
+                ),
+                allocation_count=len(by_allocation),
+                runner_count=len(runner_names),
+                sample_count=len(bucket_records),
+                median_fps=median_fps,
+                mad_pct=mad_pct,
+                cv_pct=cv_pct,
+                range_pct=range_pct,
+                max_sample_deviation_pct=max_sample_deviation_pct,
+                max_runner_median_deviation_pct=max_runner_deviation_pct,
+                configured_noise_floor_pct=noise_floor,
+                effective_noise_pct=effective_noise_pct,
+                effective_warn_regression_pct=effective_warn_pct,
+                effective_block_regression_pct=effective_block_pct,
+                allocation_medians_fps=allocation_medians,
+            )
+        )
+
+    if any(bucket.verdict == UNSTABLE for bucket in buckets):
+        overall = UNSTABLE
+    elif any(bucket.verdict == INCONCLUSIVE for bucket in buckets):
+        overall = INCONCLUSIVE
+    else:
+        overall = STABLE
+    return overall, buckets
+
+
+def _format_pct(value: float | None) -> str:
+    return "—" if value is None else f"{value:.2f}%"
+
+
+def build_markdown(
+    overall_verdict: str,
+    buckets: list[StabilityBucket],
+    *,
+    records: list[dict[str, Any]],
+    expected_allocations: int,
+    samples_per_allocation: int,
+    expected_gpu_model: str | None,
+    expected_target_branch: str | None,
+    expected_commit: str | None,
+) -> str:
+    """Render the qualification decision and supporting FPS evidence."""
+    icon = "✅" if overall_verdict == STABLE else "❌"
+    decision = (
+        "The measured runner pool is stable enough for the perf-smoke FPS gate."
+        if overall_verdict == STABLE
+        else "Do not enable blocking from this evidence."
+    )
+    lines = [
+        "# L40S FPS runner stability qualification",
+        "",
+        f"## {icon} {overall_verdict}",
+        "",
+        decision,
+        "",
+        "### Evidence scope",
+        "",
+        f"- GPU: `{canonical_gpu_model(expected_gpu_model) if expected_gpu_model else 'unspecified'}`",
+        f"- Target branch: `{expected_target_branch or 'unspecified'}`",
+        f"- Commit: `{expected_commit or 'unspecified'}`",
+        "",
+        "### Qualification policy fixed before measurement",
+        "",
+        (
+            f"- Coverage: {expected_allocations} distinct runner allocations × "
+            f"{samples_per_allocation} FPS samples for every configured task/backend bucket."
+        ),
+        "- Environment: exactly one commit/runtime fingerprint per bucket.",
+        (
+            f"- Runner bias: every runner median must remain within "
+            f"{MAX_RUNNER_MEDIAN_DEVIATION_PCT:.1f}% of the pooled median."
+        ),
+        f"- Dispersion: pooled FPS CV must be at most {MAX_POOLED_CV_PCT:.1f}%.",
+        f"- Single-run reliability: every FPS sample must remain within {MAX_SAMPLE_DEVIATION_PCT:.1f}% of the median.",
+        (
+            f"- Gate sensitivity: the configured four-MAD BLOCK band must remain within "
+            f"{MAX_EFFECTIVE_BLOCK_PCT:.1f}% FPS regression."
+        ),
+        "",
+        (
+            "A passing result qualifies this pool for detecting substantial smoke-test regressions "
+            "(10% or larger); it does not claim microbenchmark-level sensitivity."
+        ),
+        "",
+        "### Per-bucket FPS evidence",
+        "",
+        "| Task | Backend | Runners | Samples | Median FPS | MAD | CV | Max sample offset | "
+        "Max runner offset | Effective WARN | Effective BLOCK | Verdict |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for bucket in buckets:
+        verdict = "PASS" if bucket.verdict == STABLE else bucket.verdict
+        lines.append(
+            f"| `{bucket.task_id}` | `{bucket.backend}` | {bucket.runner_count} | {bucket.sample_count} | "
+            f"{bucket.median_fps:,.1f} | {_format_pct(bucket.mad_pct)} | {_format_pct(bucket.cv_pct)} | "
+            f"{_format_pct(bucket.max_sample_deviation_pct)} | "
+            f"{_format_pct(bucket.max_runner_median_deviation_pct)} | "
+            f"{_format_pct(bucket.effective_warn_regression_pct)} | "
+            f"{_format_pct(bucket.effective_block_regression_pct)} | **{verdict}** |"
+            if bucket.median_fps is not None
+            else (
+                f"| `{bucket.task_id}` | `{bucket.backend}` | {bucket.runner_count} | "
+                f"{bucket.sample_count} | — | — | — | — | — | — | — | **{verdict}** |"
+            )
+        )
+
+    failed = [bucket for bucket in buckets if bucket.verdict != STABLE]
+    if failed:
+        lines.extend(["", "### Why the pool did not qualify", ""])
+        for bucket in failed:
+            reason = "; ".join(bucket.reasons) or "unknown reason"
+            lines.append(f"- `{bucket.task_id}/{bucket.backend}`: {reason}.")
+
+    allocation_rows: dict[str, dict[str, Any]] = {}
+    for record in _valid_records(records):
+        allocation = _execution_id(record)
+        row = allocation_rows.setdefault(
+            allocation,
+            {
+                "runner": str(record.get("ci_runner_name") or "unknown"),
+                "samples": 0,
+                "buckets": set(),
+            },
+        )
+        row["samples"] += 1
+        row["buckets"].add((str(record["task_id"]), _backend(record)))
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Runner allocation evidence</summary>",
+            "",
+            "| Allocation | GitHub runner | Successful FPS samples | Buckets covered |",
+            "|---|---|---:|---:|",
+        ]
+    )
+    for allocation, row in sorted(allocation_rows.items()):
+        lines.append(f"| `{allocation}` | `{row['runner']}` | {row['samples']} | {len(row['buckets'])} |")
+    lines.extend(["", "</details>", ""])
+    return "\n".join(lines)
+
+
+def build_report(
+    records: list[dict[str, Any]],
+    *,
+    expected_buckets: set[tuple[str, str]],
+    noise_floors: dict[tuple[str, str], float] | None = None,
+    expected_allocations: int = DEFAULT_EXPECTED_ALLOCATIONS,
+    samples_per_allocation: int = DEFAULT_SAMPLES_PER_ALLOCATION,
+    expected_gpu_model: str | None = None,
+    expected_target_branch: str | None = None,
+    expected_commit: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Build machine-readable and reviewer-facing runner qualification reports."""
+    overall, buckets = evaluate_stability(
+        records,
+        expected_buckets=expected_buckets,
+        noise_floors=noise_floors,
+        expected_allocations=expected_allocations,
+        samples_per_allocation=samples_per_allocation,
+        expected_gpu_model=expected_gpu_model,
+        expected_target_branch=expected_target_branch,
+        expected_commit=expected_commit,
+    )
+    report = {
+        "schema_version": 1,
+        "overall_verdict": overall,
+        "policy": {
+            "expected_allocations": expected_allocations,
+            "samples_per_allocation": samples_per_allocation,
+            "max_effective_block_pct": MAX_EFFECTIVE_BLOCK_PCT,
+            "max_pooled_cv_pct": MAX_POOLED_CV_PCT,
+            "max_sample_deviation_pct": MAX_SAMPLE_DEVIATION_PCT,
+            "max_runner_median_deviation_pct": MAX_RUNNER_MEDIAN_DEVIATION_PCT,
+            "gate_k_warn": DEFAULT_K_WARN,
+            "gate_k_block": DEFAULT_K_BLOCK,
+            "gate_min_block_regression_pct": MIN_BLOCK_REGRESSION_PCT,
+            "expected_gpu_model": expected_gpu_model,
+            "expected_target_branch": expected_target_branch,
+            "expected_commit": expected_commit,
+        },
+        "input_sample_count": len(records),
+        "valid_sample_count": len(_valid_records(records)),
+        "buckets": [asdict(bucket) for bucket in buckets],
+    }
+    markdown = build_markdown(
+        overall,
+        buckets,
+        records=records,
+        expected_allocations=expected_allocations,
+        samples_per_allocation=samples_per_allocation,
+        expected_gpu_model=expected_gpu_model,
+        expected_target_branch=expected_target_branch,
+        expected_commit=expected_commit,
+    )
+    return report, markdown
+
+
+def _load_records(paths: list[Path]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, list) or not all(isinstance(record, dict) for record in payload):
+            raise ValueError(f"{path} must contain a JSON list of objects")
+        records.extend(payload)
+    return records
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--records", required=True, action="append", type=Path)
+    parser.add_argument("--tasks_config", type=Path, default=Path(__file__).with_name("tasks.json"))
+    parser.add_argument("--gpu_model", default="l40s")
+    parser.add_argument("--expected_target_branch")
+    parser.add_argument("--expected_commit")
+    parser.add_argument("--expected_allocations", type=int, default=DEFAULT_EXPECTED_ALLOCATIONS)
+    parser.add_argument("--samples_per_allocation", type=int, default=DEFAULT_SAMPLES_PER_ALLOCATION)
+    parser.add_argument("--json_output", type=Path)
+    parser.add_argument("--markdown_output", type=Path)
+    parser.add_argument("--github_step_summary", type=Path)
+    parser.add_argument("--require_ready", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run runner-pool stability qualification."""
+    args = _parse_args()
+    records = _load_records(args.records)
+    expected, noise_floors = configured_scope(load_tasks(args.tasks_config), args.gpu_model)
+    report, markdown = build_report(
+        records,
+        expected_buckets=expected,
+        noise_floors=noise_floors,
+        expected_allocations=args.expected_allocations,
+        samples_per_allocation=args.samples_per_allocation,
+        expected_gpu_model=args.gpu_model,
+        expected_target_branch=args.expected_target_branch,
+        expected_commit=args.expected_commit,
+    )
+    print(markdown)
+    if args.json_output:
+        args.json_output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.write_text(markdown + "\n", encoding="utf-8")
+    if args.github_step_summary:
+        with args.github_step_summary.open("a", encoding="utf-8") as summary:
+            summary.write(markdown + "\n")
+    return int(args.require_ready and report["overall_verdict"] != STABLE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf_smoke_test/runner_stability.py
+++ b/tools/perf_smoke_test/runner_stability.py
@@ -7,8 +7,8 @@
 
 This report combines samples from independent runner allocations at one commit.
 It ties the stability verdict to the perf-smoke oracle: a pool qualifies only
-when complete, homogeneous evidence shows that a 10% FPS regression remains
-outside the effective four-MAD BLOCK band.
+when complete, homogeneous evidence shows that FPS regressions greater than 10%
+remain outside the effective four-MAD BLOCK band.
 """
 
 from __future__ import annotations
@@ -30,6 +30,7 @@ INCONCLUSIVE = "INCONCLUSIVE_DO_NOT_GATE"
 UNSTABLE = "UNSTABLE_DO_NOT_GATE"
 
 DEFAULT_EXPECTED_ALLOCATIONS = 5
+DEFAULT_MINIMUM_DISTINCT_RUNNERS = 3
 DEFAULT_SAMPLES_PER_ALLOCATION = 3
 MAX_EFFECTIVE_BLOCK_PCT = 10.0
 MAX_POOLED_CV_PCT = 5.0
@@ -71,6 +72,7 @@ class StabilityBucket:
     effective_warn_regression_pct: float | None
     effective_block_regression_pct: float | None
     allocation_medians_fps: dict[str, float]
+    runner_medians_fps: dict[str, float]
 
 
 def _percent(numerator: float, denominator: float) -> float:
@@ -106,6 +108,7 @@ def _valid_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             isinstance(fps, (int, float))
             and not isinstance(fps, bool)
             and math.isfinite(float(fps))
+            and float(fps) > 0.0
             and record.get("task_id")
             and _backend(record)
         ):
@@ -131,18 +134,102 @@ def configured_scope(
     return expected, noise_floors
 
 
+def _sample_coverage_reasons(
+    bucket_records: list[dict[str, Any]],
+    by_allocation: dict[str, list[dict[str, Any]]],
+    by_runner: dict[str, list[dict[str, Any]]],
+    *,
+    expected_allocations: int,
+    minimum_distinct_runners: int,
+    samples_per_allocation: int,
+) -> list[str]:
+    """Return fail-closed sample, allocation, and runner coverage reasons."""
+    reasons: list[str] = []
+    if len(by_allocation) != expected_allocations:
+        reasons.append(f"expected {expected_allocations} allocations, observed {len(by_allocation)}")
+    if len(by_runner) < minimum_distinct_runners:
+        reasons.append(f"expected at least {minimum_distinct_runners} distinct runner names, observed {len(by_runner)}")
+
+    samples_without_runner = sum(1 for record in bucket_records if not str(record.get("ci_runner_name") or "").strip())
+    if samples_without_runner:
+        reasons.append(f"{samples_without_runner} samples are missing runner identity")
+
+    required_samples = expected_allocations * samples_per_allocation
+    if len(bucket_records) != required_samples:
+        reasons.append(f"expected {required_samples} samples, observed {len(bucket_records)}")
+    sample_ids = [str(record.get("sample_id") or "").strip() for record in bucket_records]
+    samples_without_id = sum(not sample_id for sample_id in sample_ids)
+    if samples_without_id:
+        reasons.append(f"{samples_without_id} samples are missing sample identity")
+    present_sample_ids = [sample_id for sample_id in sample_ids if sample_id]
+    duplicate_sample_count = len(present_sample_ids) - len(set(present_sample_ids))
+    if duplicate_sample_count:
+        reasons.append(f"observed {duplicate_sample_count} duplicate sample identities")
+
+    incomplete_allocations = sorted(
+        allocation
+        for allocation, allocation_records in by_allocation.items()
+        if len(allocation_records) != samples_per_allocation
+    )
+    if incomplete_allocations:
+        reasons.append(
+            f"allocations without exactly {samples_per_allocation} samples: " + ", ".join(incomplete_allocations)
+        )
+    expected_sample_indexes = set(range(samples_per_allocation))
+    allocations_with_wrong_sample_indexes = sorted(
+        allocation
+        for allocation, allocation_records in by_allocation.items()
+        if {
+            record.get("sample_index")
+            for record in allocation_records
+            if isinstance(record.get("sample_index"), int) and not isinstance(record.get("sample_index"), bool)
+        }
+        != expected_sample_indexes
+    )
+    if allocations_with_wrong_sample_indexes:
+        reasons.append(
+            f"allocations without sample indexes 0..{samples_per_allocation - 1}: "
+            + ", ".join(allocations_with_wrong_sample_indexes)
+        )
+    allocations_without_one_runner = sorted(
+        allocation
+        for allocation, allocation_records in by_allocation.items()
+        if len(
+            {
+                str(record.get("ci_runner_name") or "").strip()
+                for record in allocation_records
+                if str(record.get("ci_runner_name") or "").strip()
+            }
+        )
+        != 1
+    )
+    if allocations_without_one_runner:
+        reasons.append("allocations without exactly one runner identity: " + ", ".join(allocations_without_one_runner))
+    return reasons
+
+
 def evaluate_stability(
     records: list[dict[str, Any]],
     *,
     expected_buckets: set[tuple[str, str]],
     noise_floors: dict[tuple[str, str], float] | None = None,
     expected_allocations: int = DEFAULT_EXPECTED_ALLOCATIONS,
+    minimum_distinct_runners: int = DEFAULT_MINIMUM_DISTINCT_RUNNERS,
     samples_per_allocation: int = DEFAULT_SAMPLES_PER_ALLOCATION,
     expected_gpu_model: str | None = None,
     expected_target_branch: str | None = None,
     expected_commit: str | None = None,
 ) -> tuple[str, list[StabilityBucket]]:
     """Evaluate complete runner-pool evidence against the qualification policy."""
+    if not expected_buckets:
+        return INCONCLUSIVE, []
+    if expected_allocations <= 0:
+        raise ValueError("expected_allocations must be positive")
+    if samples_per_allocation <= 0:
+        raise ValueError("samples_per_allocation must be positive")
+    if minimum_distinct_runners <= 0 or minimum_distinct_runners > expected_allocations:
+        raise ValueError("minimum_distinct_runners must be between 1 and expected_allocations")
+
     valid = _valid_records(records)
     noise_floors = noise_floors or {}
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
@@ -154,16 +241,14 @@ def evaluate_stability(
         bucket_records = grouped.get((task_id, backend), [])
         fingerprints = {_fingerprint(record) for record in bucket_records}
         by_allocation: dict[str, list[dict[str, Any]]] = {}
+        by_runner: dict[str, list[dict[str, Any]]] = {}
         for record in bucket_records:
             by_allocation.setdefault(_execution_id(record), []).append(record)
-        runner_names = {
-            str(record.get("ci_runner_name")).strip()
-            for record in bucket_records
-            if str(record.get("ci_runner_name") or "").strip()
-        }
+            runner_name = str(record.get("ci_runner_name") or "").strip()
+            if runner_name:
+                by_runner.setdefault(runner_name, []).append(record)
 
         coverage_reasons: list[str] = []
-        required_samples = expected_allocations * samples_per_allocation
         observed_gpu_models = {canonical_gpu_model(record.get("gpu_model")) for record in bucket_records}
         if expected_gpu_model and observed_gpu_models != {canonical_gpu_model(expected_gpu_model)}:
             coverage_reasons.append(
@@ -181,25 +266,25 @@ def evaluate_stability(
             coverage_reasons.append(
                 f"expected commit {expected_commit}, observed " + (", ".join(sorted(observed_commits)) or "none")
             )
+        missing_fingerprint_fields = sorted(
+            field
+            for field in _FINGERPRINT_FIELDS
+            if any(record.get(field) is None or record.get(field) == "" for record in bucket_records)
+        )
+        if missing_fingerprint_fields:
+            coverage_reasons.append("missing runtime fingerprint fields: " + ", ".join(missing_fingerprint_fields))
         if len(fingerprints) != 1:
             coverage_reasons.append(f"expected one runtime fingerprint, observed {len(fingerprints)}")
-        if len(by_allocation) != expected_allocations:
-            coverage_reasons.append(f"expected {expected_allocations} allocations, observed {len(by_allocation)}")
-        if len(runner_names) != expected_allocations:
-            coverage_reasons.append(
-                f"expected {expected_allocations} distinct runner names, observed {len(runner_names)}"
+        coverage_reasons.extend(
+            _sample_coverage_reasons(
+                bucket_records,
+                by_allocation,
+                by_runner,
+                expected_allocations=expected_allocations,
+                minimum_distinct_runners=minimum_distinct_runners,
+                samples_per_allocation=samples_per_allocation,
             )
-        if len(bucket_records) != required_samples:
-            coverage_reasons.append(f"expected {required_samples} samples, observed {len(bucket_records)}")
-        incomplete_allocations = sorted(
-            allocation
-            for allocation, allocation_records in by_allocation.items()
-            if len(allocation_records) != samples_per_allocation
         )
-        if incomplete_allocations:
-            coverage_reasons.append(
-                f"allocations without exactly {samples_per_allocation} samples: " + ", ".join(incomplete_allocations)
-            )
 
         values = [float(record["fps"]) for record in bucket_records]
         median_fps: float | None = None
@@ -212,6 +297,7 @@ def evaluate_stability(
         effective_warn_pct: float | None = None
         effective_block_pct: float | None = None
         allocation_medians: dict[str, float] = {}
+        runner_medians: dict[str, float] = {}
         metric_reasons: list[str] = []
         noise_floor = float(noise_floors.get((task_id, backend), 0.0))
 
@@ -228,10 +314,13 @@ def evaluate_stability(
                 allocation: statistics.median(float(record["fps"]) for record in allocation_records)
                 for allocation, allocation_records in sorted(by_allocation.items())
             }
-            if allocation_medians:
+            runner_medians = {
+                runner: statistics.median(float(record["fps"]) for record in runner_records)
+                for runner, runner_records in sorted(by_runner.items())
+            }
+            if runner_medians:
                 max_runner_deviation_pct = max(
-                    abs(_percent(allocation_median - median_fps, median_fps))
-                    for allocation_median in allocation_medians.values()
+                    abs(_percent(runner_median - median_fps, median_fps)) for runner_median in runner_medians.values()
                 )
             effective_noise_pct = max(mad_pct, noise_floor)
             effective_warn_pct = DEFAULT_K_WARN * effective_noise_pct
@@ -280,7 +369,7 @@ def evaluate_stability(
                     )
                 ),
                 allocation_count=len(by_allocation),
-                runner_count=len(runner_names),
+                runner_count=len(by_runner),
                 sample_count=len(bucket_records),
                 median_fps=median_fps,
                 mad_pct=mad_pct,
@@ -293,6 +382,7 @@ def evaluate_stability(
                 effective_warn_regression_pct=effective_warn_pct,
                 effective_block_regression_pct=effective_block_pct,
                 allocation_medians_fps=allocation_medians,
+                runner_medians_fps=runner_medians,
             )
         )
 
@@ -315,6 +405,7 @@ def build_markdown(
     *,
     records: list[dict[str, Any]],
     expected_allocations: int,
+    minimum_distinct_runners: int,
     samples_per_allocation: int,
     expected_gpu_model: str | None,
     expected_target_branch: str | None,
@@ -343,8 +434,9 @@ def build_markdown(
         "### Qualification policy fixed before measurement",
         "",
         (
-            f"- Coverage: {expected_allocations} distinct runner allocations × "
-            f"{samples_per_allocation} FPS samples for every configured task/backend bucket."
+            f"- Coverage: {expected_allocations} independent allocations × {samples_per_allocation} FPS samples "
+            f"for every configured task/backend bucket, spanning at least "
+            f"{minimum_distinct_runners} distinct runner registrations."
         ),
         "- Environment: exactly one commit/runtime fingerprint per bucket.",
         (
@@ -360,7 +452,7 @@ def build_markdown(
         "",
         (
             "A passing result qualifies this pool for detecting substantial smoke-test regressions "
-            "(10% or larger); it does not claim microbenchmark-level sensitivity."
+            "(greater than 10%); it does not claim microbenchmark-level sensitivity."
         ),
         "",
         "### Per-bucket FPS evidence",
@@ -391,6 +483,8 @@ def build_markdown(
         for bucket in failed:
             reason = "; ".join(bucket.reasons) or "unknown reason"
             lines.append(f"- `{bucket.task_id}/{bucket.backend}`: {reason}.")
+    elif not buckets:
+        lines.extend(["", "### Why the pool did not qualify", "", "- No task/backend buckets were configured."])
 
     allocation_rows: dict[str, dict[str, Any]] = {}
     for record in _valid_records(records):
@@ -427,6 +521,7 @@ def build_report(
     expected_buckets: set[tuple[str, str]],
     noise_floors: dict[tuple[str, str], float] | None = None,
     expected_allocations: int = DEFAULT_EXPECTED_ALLOCATIONS,
+    minimum_distinct_runners: int = DEFAULT_MINIMUM_DISTINCT_RUNNERS,
     samples_per_allocation: int = DEFAULT_SAMPLES_PER_ALLOCATION,
     expected_gpu_model: str | None = None,
     expected_target_branch: str | None = None,
@@ -438,6 +533,7 @@ def build_report(
         expected_buckets=expected_buckets,
         noise_floors=noise_floors,
         expected_allocations=expected_allocations,
+        minimum_distinct_runners=minimum_distinct_runners,
         samples_per_allocation=samples_per_allocation,
         expected_gpu_model=expected_gpu_model,
         expected_target_branch=expected_target_branch,
@@ -448,6 +544,7 @@ def build_report(
         "overall_verdict": overall,
         "policy": {
             "expected_allocations": expected_allocations,
+            "minimum_distinct_runners": minimum_distinct_runners,
             "samples_per_allocation": samples_per_allocation,
             "max_effective_block_pct": MAX_EFFECTIVE_BLOCK_PCT,
             "max_pooled_cv_pct": MAX_POOLED_CV_PCT,
@@ -469,6 +566,7 @@ def build_report(
         buckets,
         records=records,
         expected_allocations=expected_allocations,
+        minimum_distinct_runners=minimum_distinct_runners,
         samples_per_allocation=samples_per_allocation,
         expected_gpu_model=expected_gpu_model,
         expected_target_branch=expected_target_branch,
@@ -495,6 +593,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--expected_target_branch")
     parser.add_argument("--expected_commit")
     parser.add_argument("--expected_allocations", type=int, default=DEFAULT_EXPECTED_ALLOCATIONS)
+    parser.add_argument("--minimum_distinct_runners", type=int, default=DEFAULT_MINIMUM_DISTINCT_RUNNERS)
     parser.add_argument("--samples_per_allocation", type=int, default=DEFAULT_SAMPLES_PER_ALLOCATION)
     parser.add_argument("--json_output", type=Path)
     parser.add_argument("--markdown_output", type=Path)
@@ -513,6 +612,7 @@ def main() -> int:
         expected_buckets=expected,
         noise_floors=noise_floors,
         expected_allocations=args.expected_allocations,
+        minimum_distinct_runners=args.minimum_distinct_runners,
         samples_per_allocation=args.samples_per_allocation,
         expected_gpu_model=args.gpu_model,
         expected_target_branch=args.expected_target_branch,

--- a/tools/perf_smoke_test/seed_baselines.py
+++ b/tools/perf_smoke_test/seed_baselines.py
@@ -62,8 +62,8 @@ from task_config import TaskConfig, load_tasks  # noqa: E402
 _TOOL_DIR = Path(__file__).resolve().parent
 _CONTAINER_LOCAL_JIT_CACHE_BUCKETS = frozenset(
     {
-        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "physx"),
-        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "newton"),
+        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "physx_rtx_renderer"),
+        ("Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct", "newton_rtx_renderer"),
     }
 )
 
@@ -795,6 +795,12 @@ def main() -> int:
                     "baseline_epoch": (r.sample_metadata or {}).get("baseline_epoch"),
                     "sample_index": (r.sample_metadata or {}).get("sample_index"),
                     "sample_id": (r.sample_metadata or {}).get("sample_id"),
+                    "timestamp": (r.sample_metadata or {}).get("timestamp"),
+                    "ci_run_id": (r.sample_metadata or {}).get("ci_run_id"),
+                    "ci_run_attempt": (r.sample_metadata or {}).get("ci_run_attempt"),
+                    "ci_job": (r.sample_metadata or {}).get("ci_job"),
+                    "ci_run_label": (r.sample_metadata or {}).get("ci_run_label"),
+                    "ci_runner_name": (r.sample_metadata or {}).get("ci_runner_name"),
                 }
                 for r in records
             ],

--- a/tools/perf_smoke_test/tasks.json
+++ b/tools/perf_smoke_test/tasks.json
@@ -49,20 +49,20 @@
       "timeout_minutes": 20,
       "tags": ["camera"],
       "backends": [
-        {"physics": "physx"},
+        {"physics": "physx", "render": "rtx_renderer"},
         {"physics": "physx", "render": "newton_renderer"},
-        {"physics": "newton"},
+        {"physics": "newton", "render": "rtx_renderer"},
         {"physics": "newton", "render": "newton_renderer"}
       ],
       "fps_mean_thresholds": {
         "l40s": {
-          "physx": [
+          "physx_rtx_renderer": [
             {"threshold_verdict": "BLOCK", "threshold_name": "hard-floor", "threshold": 20.0}
           ],
           "physx_newton_renderer": [
             {"threshold_verdict": "BLOCK", "threshold_name": "hard-floor", "threshold": 0.0}
           ],
-          "newton": [
+          "newton_rtx_renderer": [
             {"threshold_verdict": "BLOCK", "threshold_name": "hard-floor", "threshold": 0.0}
           ],
           "newton_newton_renderer": [

--- a/tools/perf_smoke_test/test/test_analyze_seed_variance.py
+++ b/tools/perf_smoke_test/test/test_analyze_seed_variance.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""GPU-free tests for the baseline seeding variance report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_GATE_DIR = Path(__file__).resolve().parents[1]
+if str(_GATE_DIR) not in sys.path:
+    sys.path.insert(0, str(_GATE_DIR))
+
+import analyze_seed_variance  # noqa: E402
+
+
+def _record(
+    fps: float,
+    sample_index: int,
+    runtime_hash: str = "runtime-a",
+    ci_run_id: str = "run-a",
+    runner_name: str = "runner-a",
+) -> dict:
+    return {
+        "gpu_model": "l40s",
+        "task_id": "task-a",
+        "backend": "newton",
+        "target_branch": "develop",
+        "commit_sha": "commit-a",
+        "launch_config_hash": "launch-a",
+        "benchmark_contract_hash": "benchmark-a",
+        "runtime_contract_hash": runtime_hash,
+        "baseline_epoch": 1,
+        "sample_index": sample_index,
+        "ci_run_id": ci_run_id,
+        "ci_runner_name": runner_name,
+        "fps": fps,
+    }
+
+
+def test_analyze_records_reports_robust_and_full_spread_metrics() -> None:
+    """The report exposes both robust noise and outlier-sensitive spread."""
+    records = [
+        _record(99.0, 4),
+        _record(102.0, 1),
+        _record(100.0, 0),
+        _record(101.0, 3),
+        _record(98.0, 2),
+    ]
+
+    buckets, skipped = analyze_seed_variance.analyze_records(records)
+
+    assert skipped == 0
+    assert len(buckets) == 1
+    bucket = buckets[0]
+    assert bucket.ci_run_count == 1
+    assert bucket.runner_count == 1
+    assert bucket.sample_count == 5
+    assert bucket.median_fps == 100.0
+    assert bucket.mean_fps == 100.0
+    assert bucket.mad_pct == 1.0
+    assert bucket.cv_pct == pytest.approx(1.58113883)
+    assert bucket.range_pct == 4.0
+    assert bucket.first_to_last_pct == -1.0
+
+
+def test_analyze_records_keeps_runtime_fingerprints_separate() -> None:
+    """Environment changes cannot be misreported as runner variance."""
+    records = [
+        _record(100.0, 0, runtime_hash="runtime-a"),
+        _record(101.0, 1, runtime_hash="runtime-a"),
+        _record(80.0, 0, runtime_hash="runtime-b"),
+        _record(81.0, 1, runtime_hash="runtime-b"),
+    ]
+
+    buckets, _ = analyze_seed_variance.analyze_records(records)
+
+    assert len(buckets) == 2
+    assert {bucket.runtime_contract_hash for bucket in buckets} == {"runtime-a", "runtime-b"}
+    assert [bucket.sample_count for bucket in buckets] == [2, 2]
+
+
+def test_analyze_records_counts_identical_fps_repetitions() -> None:
+    """Equal measurements remain independent samples with zero observed variance."""
+    records = [_record(100.0, sample_index) for sample_index in range(5)]
+
+    buckets, _ = analyze_seed_variance.analyze_records(records)
+
+    assert buckets[0].sample_count == 5
+    assert buckets[0].mad_pct == 0.0
+    assert buckets[0].cv_pct == 0.0
+    assert buckets[0].range_pct == 0.0
+
+
+def test_analyze_records_combines_independent_ci_runs() -> None:
+    """Repeated workflow jobs contribute to one same-fingerprint variance bucket."""
+    records = [
+        _record(100.0, 0, ci_run_id="run-a"),
+        _record(101.0, 1, ci_run_id="run-a"),
+        _record(99.0, 0, ci_run_id="run-b", runner_name="runner-b"),
+        _record(102.0, 1, ci_run_id="run-b", runner_name="runner-b"),
+    ]
+
+    buckets, _ = analyze_seed_variance.analyze_records(records)
+
+    assert len(buckets) == 1
+    assert buckets[0].ci_run_count == 2
+    assert buckets[0].runner_count == 2
+    assert buckets[0].sample_count == 4
+
+
+def test_build_report_skips_invalid_records_and_explains_metrics() -> None:
+    """Malformed records are reported without preventing useful output."""
+    report, markdown = analyze_seed_variance.build_report(
+        [
+            _record(100.0, 0),
+            {"task_id": "task-a", "backend": "newton", "fps": float("nan")},
+            {"task_id": "task-a", "fps": 100.0},
+        ]
+    )
+
+    assert report["valid_sample_count"] == 1
+    assert report["skipped_sample_count"] == 2
+    assert "This report is advisory and does not fail CI." in markdown
+    assert "**MAD / median**" in markdown
+    assert "Skipped 2 malformed or non-finite record(s)." in markdown

--- a/tools/perf_smoke_test/test/test_analyze_seed_variance.py
+++ b/tools/perf_smoke_test/test/test_analyze_seed_variance.py
@@ -120,12 +120,14 @@ def test_build_report_skips_invalid_records_and_explains_metrics() -> None:
         [
             _record(100.0, 0),
             {"task_id": "task-a", "backend": "newton", "fps": float("nan")},
+            _record(0.0, 1),
+            _record(-1.0, 2),
             {"task_id": "task-a", "fps": 100.0},
         ]
     )
 
     assert report["valid_sample_count"] == 1
-    assert report["skipped_sample_count"] == 2
+    assert report["skipped_sample_count"] == 4
     assert "This report is advisory and does not fail CI." in markdown
     assert "**MAD / median**" in markdown
-    assert "Skipped 2 malformed or non-finite record(s)." in markdown
+    assert "Skipped 4 malformed, non-finite, or non-positive record(s)." in markdown

--- a/tools/perf_smoke_test/test/test_backend_identity.py
+++ b/tools/perf_smoke_test/test/test_backend_identity.py
@@ -57,3 +57,8 @@ def test_rtx_camera_tasks_use_the_supported_isaac_sim_preset() -> None:
         ("presets=isaacsim_rtx",),
         ("presets=newton_mjwarp,isaacsim_rtx",),
     }
+    for task in rtx_tasks:
+        preset_value = hydra_args_for_task(task)[0].split("=", 1)[1]
+        identity = identity_from_presets(preset_value)
+        assert identity is not None
+        assert identity.backend_key == task.backend_key

--- a/tools/perf_smoke_test/test/test_backend_identity.py
+++ b/tools/perf_smoke_test/test/test_backend_identity.py
@@ -15,6 +15,8 @@ if str(_GATE_DIR) not in sys.path:
     sys.path.insert(0, str(_GATE_DIR))
 
 from backend_identity import identity_from_presets  # noqa: E402
+from launch_config import hydra_args_for_task  # noqa: E402
+from task_config import load_tasks  # noqa: E402
 
 
 def test_identity_from_presets_treats_newton_as_newton() -> None:
@@ -31,3 +33,27 @@ def test_identity_from_presets_keeps_newton_mjwarp_compatibility() -> None:
 
     assert identity is not None
     assert identity.backend_key == "newton"
+
+
+def test_camera_tasks_explicitly_identify_their_rtx_renderer() -> None:
+    """Camera buckets match the RTX renderer that the task activates by default."""
+    camera_task = "Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct"
+    backend_keys = {task.backend_key for task in load_tasks() if task.task_id == camera_task}
+
+    assert backend_keys == {
+        "physx_rtx_renderer",
+        "physx_newton_renderer",
+        "newton_rtx_renderer",
+        "newton_newton_renderer",
+    }
+
+
+def test_rtx_camera_tasks_use_the_supported_isaac_sim_preset() -> None:
+    """Canonical RTX identity maps to the Hydra preset exposed by Isaac Lab."""
+    camera_task = "Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct"
+    rtx_tasks = [task for task in load_tasks() if task.task_id == camera_task and task.render_backend == "rtx_renderer"]
+
+    assert {tuple(hydra_args_for_task(task)) for task in rtx_tasks} == {
+        ("presets=isaacsim_rtx",),
+        ("presets=newton_mjwarp,isaacsim_rtx",),
+    }

--- a/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
+++ b/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
@@ -124,6 +124,26 @@ def test_seed_sample_index_prevents_identical_fps_deduplication(monkeypatch) -> 
     assert first["sample_id"] != second["sample_id"]
 
 
+def test_sample_metadata_records_runner_allocation_identity(monkeypatch) -> None:
+    """Stability evidence identifies both the matrix allocation and physical runner."""
+    monkeypatch.setenv("PERF_SMOKE_RUN_LABEL", "runner-allocation-3")
+    monkeypatch.setenv("PERF_SMOKE_RUNNER_NAME", "l40s-runner-03")
+
+    metadata = make_sample_metadata(
+        gpu_model="l40s",
+        task_id="Isaac-Cartpole-Direct",
+        backend="physx",
+        fps=100.0,
+        bench_result=_bench_result(fps=100.0).to_dict(),
+        target_branch="develop",
+        commit_sha="abc123",
+        sample_index=0,
+    )
+
+    assert metadata["ci_run_label"] == "runner-allocation-3"
+    assert metadata["ci_runner_name"] == "l40s-runner-03"
+
+
 def test_oracle_pass_warn_and_block_from_typed_result() -> None:
     """The post-migration oracle still scores typed BenchResult objects correctly."""
     baseline = Baseline(median_fps=100.0, mad_fps=2.0, sample_count=5)

--- a/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
+++ b/tools/perf_smoke_test/test/test_contract_oracle_baseline.py
@@ -125,11 +125,24 @@ def test_seed_sample_index_prevents_identical_fps_deduplication(monkeypatch) -> 
 
 
 def test_sample_metadata_records_runner_allocation_identity(monkeypatch) -> None:
-    """Stability evidence identifies both the matrix allocation and physical runner."""
+    """Stability evidence identifies both the matrix allocation and runner registration."""
+    monkeypatch.setenv("GITHUB_RUN_ID", "123")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "1")
     monkeypatch.setenv("PERF_SMOKE_RUN_LABEL", "runner-allocation-3")
     monkeypatch.setenv("PERF_SMOKE_RUNNER_NAME", "l40s-runner-03")
 
-    metadata = make_sample_metadata(
+    first = make_sample_metadata(
+        gpu_model="l40s",
+        task_id="Isaac-Cartpole-Direct",
+        backend="physx",
+        fps=100.0,
+        bench_result=_bench_result(fps=100.0).to_dict(),
+        target_branch="develop",
+        commit_sha="abc123",
+        sample_index=0,
+    )
+    monkeypatch.setenv("PERF_SMOKE_RUN_LABEL", "runner-allocation-4")
+    second = make_sample_metadata(
         gpu_model="l40s",
         task_id="Isaac-Cartpole-Direct",
         backend="physx",
@@ -140,8 +153,10 @@ def test_sample_metadata_records_runner_allocation_identity(monkeypatch) -> None
         sample_index=0,
     )
 
-    assert metadata["ci_run_label"] == "runner-allocation-3"
-    assert metadata["ci_runner_name"] == "l40s-runner-03"
+    assert first["ci_run_label"] == "runner-allocation-3"
+    assert first["ci_runner_name"] == "l40s-runner-03"
+    assert second["ci_run_label"] == "runner-allocation-4"
+    assert first["sample_id"] != second["sample_id"]
 
 
 def test_oracle_pass_warn_and_block_from_typed_result() -> None:

--- a/tools/perf_smoke_test/test/test_runner_stability.py
+++ b/tools/perf_smoke_test/test/test_runner_stability.py
@@ -7,8 +7,12 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
+import yaml
 
 _GATE_DIR = Path(__file__).resolve().parents[1]
 if str(_GATE_DIR) not in sys.path:
@@ -39,6 +43,7 @@ def _records() -> list[dict]:
                     "ci_run_label": f"allocation-{allocation_index}",
                     "ci_runner_name": f"runner-{allocation_index}",
                     "sample_index": sample_index,
+                    "sample_id": f"sample-{allocation_index}-{sample_index}",
                     "fps": 100.0 + runner_offset + sample_offset,
                 }
             )
@@ -73,6 +78,37 @@ def test_runtime_heterogeneity_is_inconclusive() -> None:
     assert "expected one runtime fingerprint, observed 2" in buckets[0].reasons
 
 
+def test_missing_runtime_fingerprint_fields_are_inconclusive() -> None:
+    """Absent provenance cannot establish a homogeneous runtime environment."""
+    records = _records()
+    missing_fields = ("launch_config_hash", "benchmark_contract_hash", "runtime_contract_hash", "baseline_epoch")
+    for record in records:
+        for field in missing_fields:
+            record.pop(field)
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert (
+        "missing runtime fingerprint fields: baseline_epoch, benchmark_contract_hash, "
+        "launch_config_hash, runtime_contract_hash"
+    ) in buckets[0].reasons
+
+
+@pytest.mark.parametrize("fps", [0.0, -1.0])
+def test_non_positive_fps_evidence_is_inconclusive(fps: float) -> None:
+    """Degenerate FPS measurements cannot qualify regression sensitivity."""
+    records = _records()
+    for record in records:
+        record["fps"] = fps
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert buckets[0].sample_count == 0
+    assert buckets[0].median_fps is None
+
+
 def test_missing_runner_allocation_is_inconclusive() -> None:
     """Partial evidence cannot accidentally qualify the pool."""
     records = [record for record in _records() if record["ci_run_label"] != "allocation-5"]
@@ -82,6 +118,69 @@ def test_missing_runner_allocation_is_inconclusive() -> None:
     assert overall == runner_stability.INCONCLUSIVE
     assert any("expected 5 allocations, observed 4" in reason for reason in buckets[0].reasons)
     assert any("expected 15 samples, observed 12" in reason for reason in buckets[0].reasons)
+
+
+def test_duplicate_sample_identity_is_inconclusive() -> None:
+    """Repeated evidence rows cannot satisfy the required sample count."""
+    records = _records()
+    records[1]["sample_id"] = records[0]["sample_id"]
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert "observed 1 duplicate sample identities" in buckets[0].reasons
+
+
+def test_duplicate_sample_index_is_inconclusive() -> None:
+    """Each allocation must contain every requested repetition exactly once."""
+    records = _records()
+    records[1]["sample_index"] = records[0]["sample_index"]
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert "allocations without sample indexes 0..2: allocation-1" in buckets[0].reasons
+
+
+def test_reused_runners_can_cover_all_independent_allocations() -> None:
+    """Queued allocations remain useful when the pool has at least three runners."""
+    records = _records()
+    allocation_runners = {
+        "allocation-1": "runner-a",
+        "allocation-2": "runner-a",
+        "allocation-3": "runner-b",
+        "allocation-4": "runner-b",
+        "allocation-5": "runner-c",
+    }
+    for record in records:
+        record["ci_runner_name"] = allocation_runners[record["ci_run_label"]]
+
+    overall, buckets = runner_stability.evaluate_stability(
+        records,
+        expected_buckets=_BUCKET,
+        minimum_distinct_runners=3,
+    )
+
+    assert overall == runner_stability.STABLE
+    assert buckets[0].allocation_count == 5
+    assert buckets[0].runner_count == 3
+    assert set(buckets[0].runner_medians_fps) == {"runner-a", "runner-b", "runner-c"}
+
+
+def test_insufficient_distinct_runner_coverage_is_inconclusive() -> None:
+    """The report fails closed when serialization reveals too little pool coverage."""
+    records = _records()
+    for record in records:
+        record["ci_runner_name"] = f"runner-{int(record['ci_run_label'][-1]) % 2}"
+
+    overall, buckets = runner_stability.evaluate_stability(
+        records,
+        expected_buckets=_BUCKET,
+        minimum_distinct_runners=3,
+    )
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert "expected at least 3 distinct runner names, observed 2" in buckets[0].reasons
 
 
 def test_runner_specific_fps_bias_fails_qualification() -> None:
@@ -121,6 +220,83 @@ def test_configured_noise_floor_can_make_gate_too_insensitive() -> None:
     assert any("effective BLOCK band" in reason for reason in buckets[0].reasons)
 
 
+def test_expected_scope_guards_accept_matching_evidence() -> None:
+    """The workflow's expected GPU, branch, and commit match valid records."""
+    overall, buckets = runner_stability.evaluate_stability(
+        _records(),
+        expected_buckets=_BUCKET,
+        expected_gpu_model="NVIDIA L40S",
+        expected_target_branch="develop",
+        expected_commit="commit-a",
+    )
+
+    assert overall == runner_stability.STABLE
+    assert buckets[0].reasons == ()
+
+
+def test_empty_configured_scope_is_inconclusive() -> None:
+    """A missing task matrix cannot qualify vacuously."""
+    report, markdown = runner_stability.build_report(_records(), expected_buckets=set())
+
+    assert report["overall_verdict"] == runner_stability.INCONCLUSIVE
+    assert report["buckets"] == []
+    assert "No task/backend buckets were configured." in markdown
+
+
+@pytest.mark.parametrize(
+    ("scope_override", "expected_reason"),
+    [
+        ({"expected_gpu_model": "a100"}, "expected GPU a100"),
+        ({"expected_target_branch": "main"}, "expected target branch main"),
+        ({"expected_commit": "commit-b"}, "expected commit commit-b"),
+    ],
+)
+def test_expected_scope_guards_reject_mismatched_evidence(scope_override: dict, expected_reason: str) -> None:
+    """A qualification cannot silently pool evidence from a different scope."""
+    overall, buckets = runner_stability.evaluate_stability(
+        _records(),
+        expected_buckets=_BUCKET,
+        **scope_override,
+    )
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert any(expected_reason in reason for reason in buckets[0].reasons)
+
+
+def test_main_enforces_require_ready_exit_status(monkeypatch, tmp_path: Path) -> None:
+    """The CLI fails closed only when requested and evidence is not stable."""
+    records_path = tmp_path / "records.json"
+    monkeypatch.setattr(runner_stability, "load_tasks", lambda _path: [])
+    monkeypatch.setattr(runner_stability, "configured_scope", lambda _tasks, _gpu: (_BUCKET, {}))
+
+    def run(records: list[dict], *, require_ready: bool) -> int:
+        records_path.write_text(json.dumps(records), encoding="utf-8")
+        argv = [
+            "runner_stability.py",
+            "--records",
+            str(records_path),
+            "--gpu_model",
+            "l40s",
+            "--expected_target_branch",
+            "develop",
+            "--expected_commit",
+            "commit-a",
+        ]
+        if require_ready:
+            argv.append("--require_ready")
+        monkeypatch.setattr(sys, "argv", argv)
+        return runner_stability.main()
+
+    stable_records = _records()
+    unstable_records = _records()
+    unstable_records[0]["fps"] = 88.0
+
+    assert run(stable_records, require_ready=False) == 0
+    assert run(stable_records, require_ready=True) == 0
+    assert run(unstable_records, require_ready=False) == 0
+    assert run(unstable_records, require_ready=True) == 1
+
+
 def test_report_states_scope_and_decision() -> None:
     """The reviewer-facing report explains what a passing result proves."""
     report, markdown = runner_stability.build_report(
@@ -129,21 +305,66 @@ def test_report_states_scope_and_decision() -> None:
     )
 
     assert report["overall_verdict"] == runner_stability.STABLE
+    assert report["policy"]["minimum_distinct_runners"] == 3
     assert "Qualification policy fixed before measurement" in markdown
-    assert "10% or larger" in markdown
+    assert "at least 3 distinct runner registrations" in markdown
+    assert "greater than 10%" in markdown
     assert "runner-1" in markdown
 
 
 def test_staging_workflow_fans_out_complete_independent_evidence() -> None:
     """One staging merge automatically gathers and qualifies five allocations."""
     repo_root = Path(__file__).resolve().parents[3]
-    workflow = (repo_root / ".github/workflows/perf-smoke-runner-stability.yaml").read_text()
-    seeder = (repo_root / ".github/workflows/perf-smoke-seed-baselines.yaml").read_text()
+    workflow = yaml.safe_load(
+        (repo_root / ".github/workflows/perf-smoke-runner-stability.yaml").read_text(encoding="utf-8")
+    )
+    seeder = yaml.safe_load(
+        (repo_root / ".github/workflows/perf-smoke-seed-baselines.yaml").read_text(encoding="utf-8")
+    )
 
-    assert "allocation: [1, 2, 3, 4, 5]" in workflow
-    assert 'samples_per_commit: "3"' in workflow
-    assert 'tasks: "__ALL_TASKS__"' in workflow
-    assert "dry_run: true" in workflow
-    assert "--require_ready" in workflow
-    assert "PERF_SMOKE_RUNNER_NAME: ${{ runner.name }}" in seeder
-    assert "group: ${{ inputs.concurrency_group || 'perf-smoke-seed' }}" in seeder
+    trigger = workflow.get("on", workflow.get(True))
+    assert trigger["push"]["paths"] == [".github/workflows/perf-smoke-runner-stability.yaml"]
+    assert "workflow_dispatch" not in trigger
+    assert workflow["permissions"]["contents"] == "write"
+    wait_job = workflow["jobs"]["wait_for_quiet_pool"]
+    assert wait_job["permissions"]["contents"] == "read"
+    wait_step = wait_job["steps"][0]
+    assert "Performance Smoke Test" in wait_step["run"]
+    assert "Performance Smoke - Seed Baselines" in wait_step["run"]
+    assert "Perf Smoke — Publish CI Image" in wait_step["run"]
+    assert "Perf Smoke — Auto Era Roll" in wait_step["run"]
+    assert "QUIET_POLLS" in wait_step["run"]
+
+    sample_job = workflow["jobs"]["stability_sample"]
+    assert sample_job["needs"] == ["wait_for_quiet_pool"]
+    assert sample_job["strategy"]["matrix"]["allocation"] == [1, 2, 3, 4, 5]
+    assert sample_job["with"]["samples_per_commit"] == "3"
+    assert sample_job["with"]["tasks"] == "__ALL_TASKS__"
+    assert sample_job["with"]["dry_run"] is True
+    assert "${{ matrix.allocation }}" in sample_job["with"]["artifact_suffix"]
+    assert "${{ github.run_id }}" in sample_job["with"]["concurrency_group"]
+    assert "${{ matrix.allocation }}" in sample_job["with"]["concurrency_group"]
+    assert sample_job["secrets"] == {"NGC_API_KEY": "${{ secrets.NGC_API_KEY }}"}
+
+    qualify_steps = workflow["jobs"]["qualify"]["steps"]
+    report_step = next(step for step in qualify_steps if step.get("name") == "Build qualification report")
+    assert "--require_ready" in report_step["run"]
+    assert "--minimum_distinct_runners 3" in report_step["run"]
+    download_step = next(step for step in qualify_steps if step.get("name") == "Download runner evidence")
+    assert download_step["continue-on-error"] is True
+    assert any(step.get("name") == "Report artifact download failure" for step in qualify_steps)
+    assert any(step.get("name") == "Fail on artifact download error" for step in qualify_steps)
+    assert seeder["concurrency"]["group"] == "${{ inputs.concurrency_group || 'perf-smoke-seed' }}"
+    seed_step = next(
+        step for step in seeder["jobs"]["seed"]["steps"] if step.get("name") == "Seed baselines from commit history"
+    )
+    assert seed_step["env"]["PERF_SMOKE_RUNNER_NAME"] == "${{ runner.name }}"
+    variance_step = next(
+        step for step in seeder["jobs"]["seed"]["steps"] if step.get("name") == "Report run-to-run variance"
+    )
+    assert "inputs.run_label == ''" in variance_step["if"]
+    assert (
+        seed_step["env"]["SEED_DRY_RUN"]
+        == "${{ inputs.dry_run == true && 'true' || github.event_name == 'push' && 'false' || "
+        "inputs.dry_run == false && 'false' || 'true' }}"
+    )

--- a/tools/perf_smoke_test/test/test_runner_stability.py
+++ b/tools/perf_smoke_test/test/test_runner_stability.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""GPU-free tests for runner-pool FPS stability qualification."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_GATE_DIR = Path(__file__).resolve().parents[1]
+if str(_GATE_DIR) not in sys.path:
+    sys.path.insert(0, str(_GATE_DIR))
+
+import runner_stability  # noqa: E402
+
+_BUCKET = {("task-a", "newton")}
+
+
+def _records() -> list[dict]:
+    records: list[dict] = []
+    runner_offsets = (-1.0, -0.5, 0.0, 0.5, 1.0)
+    sample_offsets = (-0.25, 0.0, 0.25)
+    for allocation_index, runner_offset in enumerate(runner_offsets, start=1):
+        for sample_index, sample_offset in enumerate(sample_offsets):
+            records.append(
+                {
+                    "gpu_model": "l40s",
+                    "task_id": "task-a",
+                    "backend": "newton",
+                    "target_branch": "develop",
+                    "commit_sha": "commit-a",
+                    "launch_config_hash": "launch-a",
+                    "benchmark_contract_hash": "benchmark-a",
+                    "runtime_contract_hash": "runtime-a",
+                    "baseline_epoch": 1,
+                    "ci_run_label": f"allocation-{allocation_index}",
+                    "ci_runner_name": f"runner-{allocation_index}",
+                    "sample_index": sample_index,
+                    "fps": 100.0 + runner_offset + sample_offset,
+                }
+            )
+    return records
+
+
+def test_complete_stable_pool_qualifies_for_gating() -> None:
+    """Five homogeneous allocations with low FPS dispersion produce a pass."""
+    overall, buckets = runner_stability.evaluate_stability(
+        _records(),
+        expected_buckets=_BUCKET,
+    )
+
+    assert overall == runner_stability.STABLE
+    assert buckets[0].verdict == runner_stability.STABLE
+    assert buckets[0].allocation_count == 5
+    assert buckets[0].runner_count == 5
+    assert buckets[0].sample_count == 15
+    assert buckets[0].effective_block_regression_pct is not None
+    assert buckets[0].effective_block_regression_pct <= runner_stability.MAX_EFFECTIVE_BLOCK_PCT
+
+
+def test_runtime_heterogeneity_is_inconclusive() -> None:
+    """Different runtime fingerprints cannot be pooled into stability evidence."""
+    records = _records()
+    for record in records[-3:]:
+        record["runtime_contract_hash"] = "runtime-b"
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert "expected one runtime fingerprint, observed 2" in buckets[0].reasons
+
+
+def test_missing_runner_allocation_is_inconclusive() -> None:
+    """Partial evidence cannot accidentally qualify the pool."""
+    records = [record for record in _records() if record["ci_run_label"] != "allocation-5"]
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.INCONCLUSIVE
+    assert any("expected 5 allocations, observed 4" in reason for reason in buckets[0].reasons)
+    assert any("expected 15 samples, observed 12" in reason for reason in buckets[0].reasons)
+
+
+def test_runner_specific_fps_bias_fails_qualification() -> None:
+    """A runner whose median is materially shifted makes the pool unsafe."""
+    records = _records()
+    for record in records:
+        if record["ci_run_label"] == "allocation-5":
+            record["fps"] += 12.0
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.UNSTABLE
+    assert any("runner median deviation" in reason for reason in buckets[0].reasons)
+
+
+def test_single_fps_outlier_fails_qualification() -> None:
+    """A noisy one-off sample is unsafe because each PR gate observes one run."""
+    records = _records()
+    records[0]["fps"] = 88.0
+
+    overall, buckets = runner_stability.evaluate_stability(records, expected_buckets=_BUCKET)
+
+    assert overall == runner_stability.UNSTABLE
+    assert any("single-sample deviation" in reason for reason in buckets[0].reasons)
+
+
+def test_configured_noise_floor_can_make_gate_too_insensitive() -> None:
+    """Qualification accounts for the same noise floor used by the oracle."""
+    overall, buckets = runner_stability.evaluate_stability(
+        _records(),
+        expected_buckets=_BUCKET,
+        noise_floors={("task-a", "newton"): 3.0},
+    )
+
+    assert overall == runner_stability.UNSTABLE
+    assert buckets[0].effective_block_regression_pct == 12.0
+    assert any("effective BLOCK band" in reason for reason in buckets[0].reasons)
+
+
+def test_report_states_scope_and_decision() -> None:
+    """The reviewer-facing report explains what a passing result proves."""
+    report, markdown = runner_stability.build_report(
+        _records(),
+        expected_buckets=_BUCKET,
+    )
+
+    assert report["overall_verdict"] == runner_stability.STABLE
+    assert "Qualification policy fixed before measurement" in markdown
+    assert "10% or larger" in markdown
+    assert "runner-1" in markdown
+
+
+def test_staging_workflow_fans_out_complete_independent_evidence() -> None:
+    """One staging merge automatically gathers and qualifies five allocations."""
+    repo_root = Path(__file__).resolve().parents[3]
+    workflow = (repo_root / ".github/workflows/perf-smoke-runner-stability.yaml").read_text()
+    seeder = (repo_root / ".github/workflows/perf-smoke-seed-baselines.yaml").read_text()
+
+    assert "allocation: [1, 2, 3, 4, 5]" in workflow
+    assert 'samples_per_commit: "3"' in workflow
+    assert 'tasks: "__ALL_TASKS__"' in workflow
+    assert "dry_run: true" in workflow
+    assert "--require_ready" in workflow
+    assert "PERF_SMOKE_RUNNER_NAME: ${{ runner.name }}" in seeder
+    assert "group: ${{ inputs.concurrency_group || 'perf-smoke-seed' }}" in seeder

--- a/tools/perf_smoke_test/test/test_seed_ancestry.py
+++ b/tools/perf_smoke_test/test/test_seed_ancestry.py
@@ -150,8 +150,12 @@ def test_only_failing_camera_backends_use_container_local_jit_cache() -> None:
     """Only camera backends that failed on the host mount bypass cache reuse."""
     camera_task = "Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct"
 
-    assert seed_baselines._uses_container_local_jit_cache(SimpleNamespace(task_id=camera_task, backend_key="physx"))
-    assert seed_baselines._uses_container_local_jit_cache(SimpleNamespace(task_id=camera_task, backend_key="newton"))
+    assert seed_baselines._uses_container_local_jit_cache(
+        SimpleNamespace(task_id=camera_task, backend_key="physx_rtx_renderer")
+    )
+    assert seed_baselines._uses_container_local_jit_cache(
+        SimpleNamespace(task_id=camera_task, backend_key="newton_rtx_renderer")
+    )
     assert not seed_baselines._uses_container_local_jit_cache(
         SimpleNamespace(task_id=camera_task, backend_key="physx_newton_renderer")
     )


### PR DESCRIPTION
## Summary
- fan out one staging merge to five distinct L40S allocations, collecting three FPS samples for every task/backend bucket
- produce a fail-closed qualification report tied to the gate's actual MAD thresholds, runner bias, outliers, runtime consistency, and 10% smoke-regression sensitivity
- correct the camera RTX backend identities so all nine configured buckets produce usable evidence

## Test plan
- [x] Run all 78 GPU-free perf-smoke tests
- [x] Validate the complete task matrix and reusable-workflow input contract
- [x] Run full repository pre-commit checks
- [x] Exercise passing and inconclusive full report paths with synthetic and prior L40S artifacts
- [ ] Merge into `perf-smoke/develop-staging` and review the automatically generated five-runner L40S qualification report