### PR TITLE
Author OVRTX env-root xforms from the clone plan

### DIFF
--- a/source/isaaclab/changelog.d/ovrtx-cleanup-per-env-root-xform-restoration.minor.rst
+++ b/source/isaaclab/changelog.d/ovrtx-cleanup-per-env-root-xform-restoration.minor.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab.cloner.ClonePlan.env_root_transforms` to build per-environment root poses
+  from the plan's env positions, as homogeneous ``[num_clones, 4, 4]`` transforms. Rotations are
+  assumed to be identity, since the plan carries env-root translations only. Plans without positions
+  yield identity transforms.

--- a/source/isaaclab/isaaclab/cloner/clone_plan.py
+++ b/source/isaaclab/isaaclab/cloner/clone_plan.py
@@ -61,6 +61,30 @@ class ClonePlan:
     cfg_rows: dict[int, tuple[int, ...]] = field(default_factory=dict)
     """``id(cfg)`` to the row indices the cfg owns."""
 
+    def env_root_transforms(self) -> torch.Tensor:
+        """Per-env root poses as homogeneous transforms.
+
+        Rotations are identity: the plan carries env-root translations only, matching the
+        ``xformOp:translate`` the cloner authors on each env root. When :attr:`positions` is unset,
+        every env root is the identity transform, i.e. all envs sit at the world origin.
+
+        Returns:
+            Float tensor ``[num_clones, 4, 4]`` in column-vector convention (translation in the last
+            column), on the same device as :attr:`positions` (or :attr:`clone_mask` without them).
+
+        Raises:
+            ValueError: If :attr:`positions` does not hold one entry per clone.
+        """
+        from isaaclab.utils.math import make_pose  # noqa: PLC0415
+
+        num_clones = self.clone_mask.shape[1]
+        if self.positions is None:
+            return torch.eye(4, device=self.clone_mask.device).expand(num_clones, 4, 4)
+        if self.positions.shape[0] != num_clones:
+            raise ValueError(f"Expected {num_clones} env positions, got {self.positions.shape[0]}.")
+        rotations = torch.eye(3, dtype=self.positions.dtype, device=self.positions.device).expand(num_clones, 3, 3)
+        return make_pose(self.positions, rotations)
+
 
 def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cpu"):
     """Create a centered grid of transforms for ``N`` instances.

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -426,6 +426,50 @@ def test_clone_plan_from_env_0_populates_cfg_rows(sim):
     assert torch.equal(plan.env_ids, torch.arange(4, dtype=torch.long, device=sim.cfg.device))
 
 
+def test_clone_plan_env_root_transforms_from_positions(sim):
+    """env_root_transforms builds identity-rotation poses from the plan's env positions."""
+    positions = grid_transforms(4, 2.0, device=sim.cfg.device)[0]
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 4), dtype=torch.bool, device=sim.cfg.device),
+        positions=positions,
+    )
+
+    transforms = plan.env_root_transforms()
+
+    assert transforms.shape == (4, 4, 4)
+    assert torch.equal(transforms[:, :3, 3], positions)
+    assert torch.equal(transforms[:, :3, :3], torch.eye(3, device=positions.device).expand(4, 3, 3))
+    assert torch.equal(transforms[:, 3, :], torch.tensor([0.0, 0.0, 0.0, 1.0], device=positions.device).expand(4, 4))
+
+
+def test_clone_plan_env_root_transforms_without_positions(sim):
+    """env_root_transforms falls back to identity when the plan carries no env positions."""
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 4), dtype=torch.bool, device=sim.cfg.device),
+    )
+
+    transforms = plan.env_root_transforms()
+
+    assert torch.equal(transforms, torch.eye(4, device=plan.clone_mask.device).expand(4, 4, 4))
+
+
+def test_clone_plan_env_root_transforms_rejects_length_mismatch(sim):
+    """env_root_transforms rejects a positions tensor that does not cover every clone."""
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 4), dtype=torch.bool, device=sim.cfg.device),
+        positions=torch.zeros((3, 3), device=sim.cfg.device),
+    )
+
+    with pytest.raises(ValueError, match="Expected 4 env positions, got 3"):
+        plan.env_root_transforms()
+
+
 def test_replicate_physics_false_keeps_usd_only(sim):
     """replicate(replicate_physics=False) drops every context except UsdReplicateContext."""
 

--- a/source/isaaclab_ov/changelog.d/ovrtx-cleanup-per-env-root-xform-restoration.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-cleanup-per-env-root-xform-restoration.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed the OVRTX renderer to author per-environment root transforms after cloning from
+  :meth:`~isaaclab.cloner.ClonePlan.env_root_transforms`, instead of snapshotting and restoring them
+  around the clone. This removes the pre-clone transform capture on both the OVRTX and ovstage
+  paths.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -257,6 +257,20 @@ def _create_homogeneous_clone_plan(num_envs: int) -> ClonePlan:
     )
 
 
+def _usd_xform_tensor(transforms: torch.Tensor) -> torch.Tensor:
+    """Convert homogeneous transforms to the layout and dtype ``omni:xform`` expects.
+
+    Args:
+        transforms: Transforms ``[N, 4, 4]`` in column-vector convention (translation in the last
+            column), as returned by :meth:`~isaaclab.cloner.ClonePlan.env_root_transforms`.
+
+    Returns:
+        Contiguous ``[N, 4, 4]`` float64 tensor on the input's device, transposed to the row-vector
+        convention of USD's ``GfMatrix4d`` (translation in the last row).
+    """
+    return transforms.detach().to(dtype=torch.float64).mT.contiguous()
+
+
 def _resolve_clone_plan(num_envs: int) -> ClonePlan:
     """Resolve clone plan for local use.
 
@@ -285,6 +299,8 @@ def _resolve_clone_plan(num_envs: int) -> ClonePlan:
             sources=tuple(compress(published_clone_plan.sources, active)),
             destinations=tuple(compress(published_clone_plan.destinations, active)),
             clone_mask=published_clone_plan.clone_mask[active_rows],
+            env_ids=published_clone_plan.env_ids,
+            positions=published_clone_plan.positions,
         )
 
     # If all rows are active, return the published clone plan (shallow copy).
@@ -449,15 +465,10 @@ class OVRTXRenderer(BaseRenderer):
         if self._clone_plan is None:
             raise RuntimeError("Clone plan is required when preparing OVRTX stage")
 
-        # The ovstage path cannot read env-root transforms back after load (see
-        # _clone_sources_ovstage), so snapshot them here while the full USD stage is still live.
-        if self._use_ovstage:
-            self._capture_env_root_xforms_ovstage(stage, num_envs)
-
         # keep_env_roots is False on the ovstage path: ovstage's ``Stage.clone`` requires each target
         # path to not already exist, so the non-source env roots must be trimmed from the exported
-        # stage for it to recreate them. Their xforms were captured just above, since trimming them
-        # is what makes them unreadable afterwards.
+        # stage for it to recreate them. Both paths re-author the env-root xforms after cloning from
+        # the clone plan's env origins (see _clone_sources_in_ovrtx).
         self._exported_usd_string = export_stage_to_string(
             stage,
             num_envs,
@@ -570,29 +581,6 @@ class OVRTXRenderer(BaseRenderer):
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        xform_attr_name = "omni:xform"
-
-        # Snapshot per-env root transforms before clone_usd overwrites them with the source env root.
-        #
-        # We only create xform bindings for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no binding, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovrtx data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        self._renderer.read_attribute(
-            xform_attr_name,
-            env_prim_paths,
-            prim_mode=PrimMode.MUST_EXIST,
-            dest=env_root_xforms,
-        )
-        logger.info("Captured per-env root transforms before cloning")
 
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
@@ -620,15 +608,29 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        # Cloning copies the source env root — including its transform — onto every target env, so
+        # the env roots are re-authored here from the clone plan's env origins.
+        #
+        # This matters because we only create xform bindings for prims in the body_label list, whose
+        # transforms are driven each frame from simulation data. Prims not in that list (e.g. static
+        # rigid objects such as tables) get no binding, and we never reset their xform stack. Their
+        # world placement therefore relies on every ancestor holding a correct xform in the renderer
+        # data. In particular, if an env root has no valid xform, these prims collapse toward the
+        # env_0 frame (e.g. tables ending up at env_0 and missing from the other tiles). Authoring
+        # the env-root xforms is a cheap one-off operation, preferable to forcing every static
+        # object into the body_label list just to bind its xform.
+        #
+        # The transforms are staged on the host: OVRTX's attribute writer only supports
+        # OVRTX_DATA_ACCESS_SYNC for host buffers, so passing a device tensor here fails to enqueue.
+        env_root_xforms = _usd_xform_tensor(clone_plan.env_root_transforms()).cpu().numpy()
         self._renderer.write_attribute(
             prim_paths=env_prim_paths,
-            attribute_name=xform_attr_name,
+            attribute_name="omni:xform",
             tensor=env_root_xforms,
             semantic=Semantic.XFORM_MAT4x4,
             prim_mode=PrimMode.MUST_EXIST,
         )
-        logger.info("Restored per-env root transforms after cloning")
+        logger.info("Authored per-env root transforms after cloning")
 
     def _update_scene_partitions_after_clone(self, num_envs: int):
         """Update scene partition attributes on cloned environments and cameras in OvRTX."""
@@ -1554,7 +1556,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_paths_list = None
         self._particle_points_query = None
         self._particle_paths_list = None
-        self._env_root_xforms: np.ndarray | None = None
 
     def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec) -> None:
         """Initialize the OVRTX renderer with internal environment cloning (ovstage path).
@@ -1665,23 +1666,6 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("OVRTX loaded USD from string successfully via ovstage")
         self._current_ordinal += 1
 
-    def _capture_env_root_xforms_ovstage(self, stage: Any, num_envs: int) -> None:
-        """Capture per-env root transforms from the live USD stage before export.
-
-        Must be called before :func:`export_stage_to_string`, which trims non-source
-        env geometry so those transforms cannot be read back reliably from ovstage after load.
-        The captured array is consumed by :meth:`_clone_sources_ovstage` and cleared after use.
-        """
-        from pxr import UsdGeom
-
-        xform_cache = UsdGeom.XformCache()
-        self._env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        for i in range(num_envs):
-            prim = stage.GetPrimAtPath(f"/World/envs/env_{i}")
-            self._env_root_xforms[i] = np.array(xform_cache.GetLocalToWorldTransform(prim), dtype=np.float64).reshape(
-                4, 4
-            )
-
     def _clone_sources_ovstage(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan` (ovstage path)."""
         clone_plan = self._clone_plan
@@ -1690,29 +1674,6 @@ class OVRTXRenderer(BaseRenderer):
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-
-        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
-        env_query = self._stage.query_from_path_list(env_paths_list)
-
-        # Snapshot per-env root transforms before clone overwrites them with the source env root.
-        #
-        # We only create xform queries for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no query, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovstage data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        # Transforms were captured from the live USD stage in prepare_stage before export
-        # stripped non-source envs — they are not readable from ovstage at this point.
-        env_root_xforms = self._env_root_xforms
-        if env_root_xforms is None:
-            raise RuntimeError("env_root_xforms not captured; ensure prepare_stage was called first")
-        logger.info("Using pre-captured per-env root transforms for post-clone restore")
 
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
@@ -1739,7 +1700,13 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        # Re-author the env roots from the clone plan's env origins; see _clone_sources_in_ovrtx for
+        # why prims placed purely by hierarchy depend on this. Unlike that path, the transforms are
+        # staged on the host: ovstage 0.1.0 rejects device DLPack for the lanes=16 ``omni:xform``
+        # column (see the section header above), so make_dltensor needs a host buffer.
+        env_root_xforms = _usd_xform_tensor(clone_plan.env_root_transforms()).cpu().numpy()
+        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
+        env_query = self._stage.query_from_path_list(env_paths_list)
         self._stage.write_attribute(
             env_query,
             "omni:xform",
@@ -1748,8 +1715,7 @@ class OVRTXRenderer(BaseRenderer):
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
-        self._env_root_xforms = None
-        logger.info("Restored per-env root transforms after cloning")
+        logger.info("Authored per-env root transforms after cloning")
 
         self._stage.release_query(env_query).wait()
         self._stage_paths.destroy_path_list(env_paths_list)
@@ -2203,7 +2169,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_particle_counts = []
         self._particle_visual_offsets = []
         self._particle_visual_counts = []
-        self._env_root_xforms = None
 
         # Detach before closing ExitStack: the renderer holds a live reference into the stage,
         # so detaching first avoids a use-after-free when ExitStack destroys Stage and PathDictionary.

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -190,6 +191,8 @@ def test_resolve_clone_plan_filters_inactive_rows(monkeypatch: pytest.MonkeyPatc
             ],
             dtype=torch.bool,
         ),
+        env_ids=torch.arange(4),
+        positions=torch.arange(12, dtype=torch.float32).reshape(4, 3),
     )
     _patch_simulation_context(monkeypatch, published)
 
@@ -198,6 +201,9 @@ def test_resolve_clone_plan_filters_inactive_rows(monkeypatch: pytest.MonkeyPatc
     assert resolved.sources == (published.sources[0], published.sources[2])
     assert resolved.destinations == (published.destinations[0], published.destinations[2])
     assert torch.equal(resolved.clone_mask, published.clone_mask[[0, 2]])
+    # Row filtering must not drop the env-level fields; OVRTX authors env-root xforms from positions.
+    assert torch.equal(resolved.env_ids, published.env_ids)
+    assert torch.equal(resolved.positions, published.positions)
 
 
 def test_resolve_clone_plan_returns_published_plan_when_all_active(monkeypatch: pytest.MonkeyPatch):
@@ -317,22 +323,19 @@ def test_clone_sources_in_ovrtx_raises_on_clone_failure():
         renderer._clone_sources_in_ovrtx()
 
 
-def test_clone_sources_in_ovrtx_restores_env_root_transforms():
-    """Pre-clone omni:xform snapshots are written back after cloning."""
+def test_clone_sources_in_ovrtx_authors_env_root_transforms_from_positions():
+    """Env-root omni:xform is authored after cloning from the clone plan's env positions."""
     import numpy as np
 
     renderer = _make_ovrtx_renderer_without_backend()
     num_envs = 4
-    renderer._clone_plan = _create_homogeneous_clone_plan(num_envs)
-    captured_transforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
-    captured_transforms[:, 3, :3] = np.array([[i * 2.0, 0.0, 0.0] for i in range(num_envs)])
+    positions = torch.tensor([[i * 2.0, i * 3.0, 0.0] for i in range(num_envs)])
+    renderer._clone_plan = replace(_create_homogeneous_clone_plan(num_envs), positions=positions)
+
+    expected_transforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+    expected_transforms[:, 3, :3] = positions.numpy()
 
     call_order: list[str] = []
-
-    def _read_attribute(attribute_name: str, prim_paths: list[str], **kwargs):
-        call_order.append("read")
-        assert attribute_name == "omni:xform"
-        kwargs["dest"][:] = captured_transforms[: len(prim_paths)]
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
         call_order.append("clone")
@@ -343,16 +346,23 @@ def test_clone_sources_in_ovrtx_restores_env_root_transforms():
         call_order.append("write")
         write_calls.append(kwargs)
 
-    renderer._renderer.read_attribute = _read_attribute
     renderer._renderer.clone_usd = _clone_usd
     renderer._renderer.write_attribute = _write_attribute
 
     renderer._clone_sources_in_ovrtx()
 
-    assert call_order == ["read", "clone", "write"]
+    assert call_order == ["clone", "write"]
     assert len(write_calls) == 1
     assert write_calls[0]["attribute_name"] == "omni:xform"
-    np.testing.assert_array_equal(write_calls[0]["tensor"], captured_transforms)
+    assert write_calls[0]["prim_paths"] == [f"/World/envs/env_{i}" for i in range(num_envs)]
+    np.testing.assert_array_equal(write_calls[0]["tensor"], expected_transforms)
+
+    # OVRTX only supports OVRTX_DATA_ACCESS_SYNC for host buffers, so the transforms must be staged
+    # as a contiguous float64 numpy array rather than a device tensor.
+    written = write_calls[0]["tensor"]
+    assert isinstance(written, np.ndarray)
+    assert written.dtype == np.float64
+    assert written.flags["C_CONTIGUOUS"]
 
 
 def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):


### PR DESCRIPTION
# Description

Author OVRTX env-root xforms from the clone plan

Both backends snapshotted env-root omni:xform around cloning to restore it after — the ovstage path needing an extra capture from the live USD stage in prepare_stage. The clone plan already carries those env origins, so derive the transforms from it and drop both snapshots.

Add ClonePlan.env_root_transforms(), building [num_clones, 4, 4] poses from positions, identity when the plan has none.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
