### PR TITLE
Improve Newton inverse kinematics support

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -151,6 +151,7 @@ The following modules are available in the ``isaaclab_newton`` extension:
 
    assets
    cloner
+   ik
    physics
    renderers
    sensors

--- a/docs/source/api/lab_newton/isaaclab_newton.ik.rst
+++ b/docs/source/api/lab_newton/isaaclab_newton.ik.rst
@@ -1,0 +1,95 @@
+isaaclab_newton.ik
+==================
+
+.. automodule:: isaaclab_newton.ik
+
+Newton inverse kinematics
+-------------------------
+
+Newton IK expresses a solve as an ordered list of objectives. Pose objectives
+consume action coordinates, while joint-limit and joint-posture objectives add
+constraints without changing the action dimension.
+
+The following manager-based action tracks a relative Franka end-effector pose,
+respects the model's joint limits, and uses the robot's nominal configuration
+as a low-weight preference in the redundant solution space:
+
+.. code-block:: python
+
+   from isaaclab_newton.envs.mdp import NewtonInverseKinematicsActionCfg
+   from isaaclab_newton.ik import (
+       NewtonIKJointLimitObjectiveCfg,
+       NewtonIKJointPostureObjectiveCfg,
+       NewtonIKPoseObjectiveCfg,
+   )
+
+   arm_action = NewtonInverseKinematicsActionCfg(
+       asset_name="robot",
+       joint_names=["panda_joint[1-7]"],
+       objectives=[
+           NewtonIKPoseObjectiveCfg(
+               body_name="panda_hand",
+               body_offset_pos=(0.0, 0.0, 0.107),
+               command_type="pose",
+               use_relative_mode=True,
+               scale=0.2,
+           ),
+           NewtonIKJointLimitObjectiveCfg(weight=0.1),
+           NewtonIKJointPostureObjectiveCfg(
+               joint_names=[f"panda_joint{i}" for i in range(1, 8)],
+               target_positions=(0.0, -0.569, 0.0, -2.810, 0.0, 3.037, 0.741),
+               weight=0.01,
+           ),
+       ],
+   )
+
+Posture-objective joint names are exact names rather than regular expressions.
+Set :attr:`~isaaclab_newton.ik.NewtonIKJointPostureObjectiveCfg.target_positions`
+to the robot's nominal configuration, or leave it as ``None`` to use positions
+from the finalized Newton prototype.
+
+Manager-based action
+~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: isaaclab_newton.envs.mdp
+
+.. autoclass:: NewtonInverseKinematicsActionCfg
+   :members:
+   :show-inheritance:
+   :exclude-members: __init__
+
+.. autoclass:: NewtonInverseKinematicsAction
+   :members:
+   :show-inheritance:
+
+Solver
+~~~~~~
+
+.. currentmodule:: isaaclab_newton.ik
+
+.. autoclass:: NewtonIKSolverCfg
+   :members:
+   :show-inheritance:
+   :exclude-members: __init__
+
+.. autoclass:: NewtonIKSolver
+   :members:
+   :show-inheritance:
+
+Objectives
+~~~~~~~~~~
+
+.. autoclass:: NewtonIKPoseObjectiveCfg
+   :members:
+   :show-inheritance:
+   :exclude-members: __init__
+
+.. autoclass:: NewtonIKJointLimitObjectiveCfg
+   :members:
+   :show-inheritance:
+   :exclude-members: __init__
+
+.. autoclass:: NewtonIKJointPostureObjectiveCfg
+   :members:
+   :show-inheritance:
+   :exclude-members: __init__

--- a/source/isaaclab_newton/changelog.d/maximiliank-newton-ik-support.minor.rst
+++ b/source/isaaclab_newton/changelog.d/maximiliank-newton-ik-support.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_newton.ik.NewtonIKJointPostureObjective` and
+  :class:`~isaaclab_newton.ik.NewtonIKJointPostureObjectiveCfg` for regularizing
+  selected scalar joints toward a reference posture.
+
+Fixed
+^^^^^
+
+* Fixed Newton inverse kinematics for assets whose articulation root is below
+  the asset prim and for prototype builders that share mesh geometry with the
+  finalized simulation model.

--- a/source/isaaclab_newton/isaaclab_newton/envs/mdp/actions/newton_ik_actions.py
+++ b/source/isaaclab_newton/isaaclab_newton/envs/mdp/actions/newton_ik_actions.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import torch
 import warp as wp
-from newton import JointType
+from newton import JointType, ModelBuilder
 from newton import Model as NewtonModel
 from newton.selection import ArticulationView
 
@@ -35,6 +36,22 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_prototype_articulation_path(
+    source_path: str, asset_suffix: str, articulation_root_prim_path: str | None
+) -> str:
+    """Resolve the controlled articulation path in the single-environment prototype."""
+    return source_path + asset_suffix + (articulation_root_prim_path or "")
+
+
+def _finalize_prototype_model(builder: ModelBuilder, device: str) -> NewtonModel:
+    """Finalize an IK prototype without consuming geometry shared with the simulation model."""
+    prototype_builder = copy.copy(builder)
+    prototype_builder.shape_source = [
+        copy.copy(geometry) if geometry is not None else None for geometry in prototype_builder.shape_source
+    ]
+    return prototype_builder.finalize(device=device)
 
 
 @wp.kernel(enable_backward=False)
@@ -180,9 +197,14 @@ class NewtonInverseKinematicsAction(ActionTerm):
         plan = sim_utils.SimulationContext.instance().get_clone_plan()
         source_path, _, asset_suffix = resolve_clone_plan_source(self._asset.cfg.prim_path, plan)
         # The proto builder is keyed by the bare clone source; the articulation
-        # lives at the asset suffix below it (e.g. ".../env_0" + "/Robot").
-        self._source_path = source_path + asset_suffix
-        prototype_model = NewtonManager._cl_protos[source_path].finalize(device=NewtonManager.get_model().device)
+        # lives at the asset suffix below it (e.g. ".../env_0" + "/Robot"), optionally
+        # deeper when the asset authors its articulation root on a child prim.
+        self._source_path = _resolve_prototype_articulation_path(
+            source_path, asset_suffix, getattr(self._asset.cfg, "articulation_root_prim_path", None)
+        )
+        prototype_model = _finalize_prototype_model(
+            NewtonManager._cl_protos[source_path], device=NewtonManager.get_model().device
+        )
         prototype_view = ArticulationView(
             prototype_model,
             self._source_path,
@@ -200,6 +222,7 @@ class NewtonInverseKinematicsAction(ActionTerm):
             device=self.device,
             objectives=self.cfg.objectives,
             link_resolver=lambda body_name: self._resolve_prototype_link_index(prototype_view, body_name),
+            joint_resolver=lambda joint_name: self._resolve_prototype_scalar_joint_indices(prototype_view, joint_name),
         )
 
         # Bind each pose objective to the live body it reads and its action slice.
@@ -366,6 +389,32 @@ class NewtonInverseKinematicsAction(ActionTerm):
         selected_indices = self._layout_indices(layout)
         local_link_index = prototype_view.link_names.index(body_name)
         return layout.offset + selected_indices[local_link_index]
+
+    def _resolve_prototype_scalar_joint_indices(
+        self, prototype_view: ArticulationView, joint_name: str
+    ) -> tuple[int, int]:
+        """Resolve one-coordinate/one-DoF joint indices in the prototype model."""
+        if joint_name not in prototype_view.joint_names:
+            raise ValueError(f"Newton IK joint-posture objective could not find joint '{joint_name}'.")
+        joint_index = prototype_view.joint_names.index(joint_name)
+        coord_count = prototype_view.joint_coord_counts[joint_index]
+        dof_count = prototype_view.joint_dof_counts[joint_index]
+        if coord_count != 1 or dof_count != 1:
+            raise ValueError(
+                "Newton IK joint-posture objectives currently support only scalar joints; "
+                f"'{joint_name}' has {coord_count} coordinates and {dof_count} DoFs."
+            )
+
+        coord_layout = prototype_view.frequency_layouts[NewtonModel.AttributeFrequency.JOINT_COORD]
+        dof_layout = prototype_view.frequency_layouts[NewtonModel.AttributeFrequency.JOINT_DOF]
+        coord_selected = self._layout_indices(coord_layout)
+        dof_selected = self._layout_indices(dof_layout)
+        coord_local = prototype_view.joint_coord_names.index(joint_name)
+        dof_local = prototype_view.joint_dof_names.index(joint_name)
+        return (
+            coord_layout.offset + coord_selected[coord_local],
+            dof_layout.offset + dof_selected[dof_local],
+        )
 
     @staticmethod
     def _layout_indices(layout) -> list[int]:

--- a/source/isaaclab_newton/isaaclab_newton/envs/mdp/actions/newton_ik_actions_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/envs/mdp/actions/newton_ik_actions_cfg.py
@@ -26,7 +26,8 @@ class NewtonInverseKinematicsActionCfg(ActionTermCfg):
     (:class:`~isaaclab_newton.ik.NewtonIKPoseObjectiveCfg`) are command-driven
     and contribute action dimensions -- one drives a single-body solve, several
     drive a multi-body solve. Constraint objectives such as
-    :class:`~isaaclab_newton.ik.NewtonIKJointLimitObjectiveCfg` add residuals
+    :class:`~isaaclab_newton.ik.NewtonIKJointLimitObjectiveCfg` and
+    :class:`~isaaclab_newton.ik.NewtonIKJointPostureObjectiveCfg` add residuals
     but no action dimensions. The action vector is the concatenation of every
     pose objective's slice, in list order.
 

--- a/source/isaaclab_newton/isaaclab_newton/ik/__init__.pyi
+++ b/source/isaaclab_newton/isaaclab_newton/ik/__init__.pyi
@@ -9,14 +9,22 @@ __all__ = [
     "NewtonIKObjective",
     "NewtonIKPoseObjective",
     "NewtonIKJointLimitObjective",
+    "NewtonIKJointPostureObjective",
     "NewtonIKObjectiveCfg",
     "NewtonIKPoseObjectiveCfg",
     "NewtonIKJointLimitObjectiveCfg",
+    "NewtonIKJointPostureObjectiveCfg",
 ]
 
-from .newton_ik_objectives import NewtonIKJointLimitObjective, NewtonIKObjective, NewtonIKPoseObjective
+from .newton_ik_objectives import (
+    NewtonIKJointLimitObjective,
+    NewtonIKJointPostureObjective,
+    NewtonIKObjective,
+    NewtonIKPoseObjective,
+)
 from .newton_ik_objectives_cfg import (
     NewtonIKJointLimitObjectiveCfg,
+    NewtonIKJointPostureObjectiveCfg,
     NewtonIKObjectiveCfg,
     NewtonIKPoseObjectiveCfg,
 )

--- a/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_objectives.py
+++ b/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_objectives.py
@@ -23,17 +23,63 @@ and populating :attr:`NewtonIKObjective.solver_objectives`.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import newton.ik as ik
+import numpy as np
 import warp as wp
 
-from .newton_ik_objectives_cfg import NewtonIKJointLimitObjectiveCfg, NewtonIKPoseObjectiveCfg
+from .newton_ik_objectives_cfg import (
+    NewtonIKJointLimitObjectiveCfg,
+    NewtonIKJointPostureObjectiveCfg,
+    NewtonIKPoseObjectiveCfg,
+)
 
 # Numeric command codes consumed by the action's Warp kernel.
 COMMAND_POSITION = 0
 COMMAND_POSE = 1
+
+
+@wp.kernel
+def _joint_posture_residuals(
+    joint_q: wp.array2d(dtype=wp.float32),
+    coordinate_indices: wp.array(dtype=wp.int32),
+    target_positions: wp.array(dtype=wp.float32),
+    weights: wp.array(dtype=wp.float32),
+    start_idx: int,
+    residuals: wp.array2d(dtype=wp.float32),
+):
+    row, posture_idx = wp.tid()
+    coordinate_idx = coordinate_indices[posture_idx]
+    residuals[row, start_idx + posture_idx] = weights[posture_idx] * (
+        joint_q[row, coordinate_idx] - target_positions[posture_idx]
+    )
+
+
+@wp.kernel
+def _joint_posture_jacobian_from_autodiff(
+    q_grad: wp.array2d(dtype=wp.float32),
+    dof_indices: wp.array(dtype=wp.int32),
+    start_idx: int,
+    jacobian: wp.array3d(dtype=wp.float32),
+):
+    row, posture_idx = wp.tid()
+    dof_idx = dof_indices[posture_idx]
+    jacobian[row, start_idx + posture_idx, dof_idx] = q_grad[row, dof_idx]
+
+
+@wp.kernel
+def _joint_posture_jacobian_analytic(
+    dof_indices: wp.array(dtype=wp.int32),
+    weights: wp.array(dtype=wp.float32),
+    start_idx: int,
+    jacobian: wp.array3d(dtype=wp.float32),
+):
+    row, posture_idx = wp.tid()
+    dof_idx = dof_indices[posture_idx]
+    jacobian[row, start_idx + posture_idx, dof_idx] = weights[posture_idx]
 
 
 @dataclass(frozen=True)
@@ -51,6 +97,9 @@ class NewtonIKBuildContext:
 
     resolve_link: Callable[[str], int]
     """Maps a body name to its Newton link index in the prototype model."""
+
+    resolve_joint: Callable[[str], tuple[int, int]] | None = None
+    """Maps a scalar joint name to its Newton ``(coordinate, DoF)`` indices."""
 
 
 class NewtonIKObjective:
@@ -132,6 +181,117 @@ class NewtonIKJointLimitObjective(NewtonIKObjective):
             joint_limit_lower=ctx.model.joint_limit_lower,
             joint_limit_upper=ctx.model.joint_limit_upper,
             weight=cfg.weight,
+        )
+        self.solver_objectives = [self.objective]
+
+
+class _IKObjectiveJointPosture(ik.IKObjective):
+    """Newton objective penalizing selected scalar joint-coordinate errors."""
+
+    def __init__(
+        self,
+        coordinate_indices: wp.array,
+        dof_indices: wp.array,
+        target_positions: wp.array,
+        weights: wp.array,
+    ) -> None:
+        super().__init__()
+        self.coordinate_indices = coordinate_indices
+        self.dof_indices = dof_indices
+        self.target_positions = target_positions
+        self.weights = weights
+        self.num_joints = len(coordinate_indices)
+        self.e_array = None
+
+    def residual_dim(self) -> int:
+        return self.num_joints
+
+    def init_buffers(self, model, jacobian_mode) -> None:
+        self._require_batch_layout()
+        if jacobian_mode == ik.IKJacobianType.AUTODIFF:
+            e = np.zeros((self.n_batch, self.total_residuals), dtype=np.float32)
+            e[:, self.residual_offset : self.residual_offset + self.num_joints] = 1.0
+            self.e_array = wp.array(e.flatten(), dtype=wp.float32, device=self.device)
+
+    def supports_analytic(self) -> bool:
+        return True
+
+    def compute_residuals(self, body_q, joint_q, model, residuals, start_idx, problem_idx) -> None:
+        wp.launch(
+            _joint_posture_residuals,
+            dim=(joint_q.shape[0], self.num_joints),
+            inputs=[joint_q, self.coordinate_indices, self.target_positions, self.weights, start_idx],
+            outputs=[residuals],
+            device=self.device,
+        )
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx, dq_dof) -> None:
+        self._require_batch_layout()
+        tape.backward(grads={tape.outputs[0]: self.e_array})
+        wp.launch(
+            _joint_posture_jacobian_from_autodiff,
+            dim=(self.n_batch, self.num_joints),
+            inputs=[tape.gradients[dq_dof], self.dof_indices, start_idx],
+            outputs=[jacobian],
+            device=self.device,
+        )
+
+    def compute_jacobian_analytic(self, body_q, joint_q, model, jacobian, joint_S_s, start_idx) -> None:
+        wp.launch(
+            _joint_posture_jacobian_analytic,
+            dim=(joint_q.shape[0], self.num_joints),
+            inputs=[self.dof_indices, self.weights, start_idx],
+            outputs=[jacobian],
+            device=self.device,
+        )
+
+
+class NewtonIKJointPostureObjective(NewtonIKObjective):
+    """Soft reference-posture objective over explicitly named scalar joints."""
+
+    def __init__(self, cfg: NewtonIKJointPostureObjectiveCfg, ctx: NewtonIKBuildContext):
+        if ctx.resolve_joint is None:
+            raise ValueError("Newton IK joint-posture objectives require a scalar-joint resolver.")
+        if not cfg.joint_names:
+            raise ValueError("Newton IK joint-posture objectives require at least one joint name.")
+        if len(set(cfg.joint_names)) != len(cfg.joint_names):
+            raise ValueError("Newton IK joint-posture objective joint names must be unique.")
+
+        resolved = [ctx.resolve_joint(name) for name in cfg.joint_names]
+        coordinate_indices = [int(indices[0]) for indices in resolved]
+        dof_indices = [int(indices[1]) for indices in resolved]
+
+        if cfg.target_positions is None:
+            model_joint_q = ctx.model.joint_q.numpy()
+            target_positions = [float(model_joint_q[index]) for index in coordinate_indices]
+        else:
+            target_positions = [float(value) for value in cfg.target_positions]
+            if len(target_positions) != len(cfg.joint_names):
+                raise ValueError(
+                    "Newton IK joint-posture target_positions must contain one value per joint: "
+                    f"got {len(target_positions)} values for {len(cfg.joint_names)} joints."
+                )
+
+        weight_values = (
+            [float(cfg.weight)] * len(cfg.joint_names)
+            if _is_scalar(cfg.weight)
+            else [float(value) for value in cfg.weight]
+        )
+        if len(weight_values) != len(cfg.joint_names):
+            raise ValueError(
+                "Newton IK joint-posture weight must be a float or contain one value per joint: "
+                f"got {len(weight_values)} values for {len(cfg.joint_names)} joints."
+            )
+        if any(not math.isfinite(value) for value in target_positions):
+            raise ValueError("Newton IK joint-posture target positions must be finite.")
+        if any(not math.isfinite(value) or value < 0.0 for value in weight_values):
+            raise ValueError("Newton IK joint-posture weights must be finite and non-negative.")
+
+        self.objective = _IKObjectiveJointPosture(
+            coordinate_indices=wp.array(coordinate_indices, dtype=wp.int32, device=ctx.device),
+            dof_indices=wp.array(dof_indices, dtype=wp.int32, device=ctx.device),
+            target_positions=wp.array(target_positions, dtype=wp.float32, device=ctx.device),
+            weights=wp.array(weight_values, dtype=wp.float32, device=ctx.device),
         )
         self.solver_objectives = [self.objective]
 

--- a/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_objectives_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_objectives_cfg.py
@@ -101,3 +101,33 @@ class NewtonIKJointLimitObjectiveCfg(NewtonIKObjectiveCfg):
 
     weight: float = 0.1
     """Residual weight [unitless] applied to limit violations."""
+
+
+@configclass
+class NewtonIKJointPostureObjectiveCfg(NewtonIKObjectiveCfg):
+    """Soft reference-posture objective for selected scalar joints.
+
+    This constraint-only objective adds one weighted residual per selected
+    joint and contributes no action dimensions. At a low weight it acts as a
+    secondary posture preference that resolves redundant IK solutions without
+    materially competing with end-effector objectives.
+
+    Only one-coordinate/one-DoF joints are supported. Quaternion-valued ball
+    and free joints require a manifold-aware orientation residual and are
+    rejected rather than treated as ordinary scalar coordinates.
+    """
+
+    class_type: type | str = "isaaclab_newton.ik.newton_ik_objectives:NewtonIKJointPostureObjective"
+
+    joint_names: list[str] = MISSING  # type: ignore[assignment]
+    """Exact names of scalar joints included in the posture objective."""
+
+    target_positions: tuple[float, ...] | None = None
+    """Reference positions [m or rad], in :attr:`joint_names` order.
+
+    When ``None``, the corresponding positions from the finalized Newton
+    prototype model are used.
+    """
+
+    weight: float | tuple[float, ...] = 0.01
+    """Residual weight, either shared by all joints or one value per joint."""

--- a/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_solver.py
+++ b/source/isaaclab_newton/isaaclab_newton/ik/newton_ik_solver.py
@@ -33,6 +33,8 @@ class NewtonIKSolver:
     action term lives in the action, not here. ``link_resolver`` maps an
     objective's body name to a Newton link index; the caller owns it because the
     name-to-index mapping depends on the model layout (e.g. cloned env prefixes).
+    ``joint_resolver`` similarly maps scalar joint names to coordinate and DoF
+    indices for joint-space objectives.
     """
 
     cfg: NewtonIKSolverCfg
@@ -46,12 +48,19 @@ class NewtonIKSolver:
         device: str,
         objectives: Sequence[NewtonIKObjectiveCfg],
         link_resolver: Callable[[str], int],
+        joint_resolver: Callable[[str], tuple[int, int]] | None = None,
     ):
         if not objectives:
             raise ValueError("NewtonIKSolver requires at least one objective cfg.")
 
         self.cfg = cfg
-        ctx = NewtonIKBuildContext(model=model, num_envs=num_envs, device=device, resolve_link=link_resolver)
+        ctx = NewtonIKBuildContext(
+            model=model,
+            num_envs=num_envs,
+            device=device,
+            resolve_link=link_resolver,
+            resolve_joint=joint_resolver,
+        )
 
         self.objectives: list[NewtonIKObjective] = []
         self.objectives_by_name: dict[str, NewtonIKObjective] = {}

--- a/source/isaaclab_newton/test/ik/test_newton_ik_actions.py
+++ b/source/isaaclab_newton/test/ik/test_newton_ik_actions.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from isaaclab_newton.envs.mdp.actions.newton_ik_actions import (
+    _finalize_prototype_model,
+    _resolve_prototype_articulation_path,
+)
+
+
+class _Geometry:
+    pass
+
+
+class _Builder:
+    def __init__(self) -> None:
+        self.shape_source = [_Geometry(), None]
+
+    def finalize(self, *, device: str):
+        del device
+        return self.shape_source
+
+
+def test_resolve_prototype_articulation_path_includes_nested_root():
+    path = _resolve_prototype_articulation_path("/World/envs/env_0", "/Robot", "/torso")
+
+    assert path == "/World/envs/env_0/Robot/torso"
+
+
+def test_finalize_prototype_model_isolates_shared_geometry():
+    builder = _Builder()
+    original_shape_source = builder.shape_source
+    original_geometry = builder.shape_source[0]
+
+    finalized_shape_source = _finalize_prototype_model(builder, "cpu")
+
+    assert builder.shape_source is original_shape_source
+    assert builder.shape_source[0] is original_geometry
+    assert finalized_shape_source is not original_shape_source
+    assert finalized_shape_source[0] is not original_geometry
+    assert finalized_shape_source[1] is None

--- a/source/isaaclab_newton/test/ik/test_newton_ik_solver.py
+++ b/source/isaaclab_newton/test/ik/test_newton_ik_solver.py
@@ -7,11 +7,19 @@ from __future__ import annotations
 
 import isaaclab_newton.ik.newton_ik_objectives as objectives_module
 import isaaclab_newton.ik.newton_ik_solver as ik_solver_module
+import newton
+import pytest
 import torch
 import warp as wp
-from isaaclab_newton.ik.newton_ik_objectives import NewtonIKBuildContext, NewtonIKObjective, NewtonIKPoseObjective
+from isaaclab_newton.ik.newton_ik_objectives import (
+    NewtonIKBuildContext,
+    NewtonIKJointPostureObjective,
+    NewtonIKObjective,
+    NewtonIKPoseObjective,
+)
 from isaaclab_newton.ik.newton_ik_objectives_cfg import (
     NewtonIKJointLimitObjectiveCfg,
+    NewtonIKJointPostureObjectiveCfg,
     NewtonIKObjectiveCfg,
     NewtonIKPoseObjectiveCfg,
 )
@@ -22,14 +30,21 @@ from isaaclab.utils.configclass import configclass
 
 # Maps the stub body names used across these tests to Newton link indices.
 _LINKS = {"ee": 0, "torso": 1, "custom": 0}
+_JOINTS = {"shoulder": (0, 0), "elbow": (1, 1)}
 
 
 def _resolver(body_name: str) -> int:
     return _LINKS[body_name]
 
 
+def _joint_resolver(joint_name: str) -> tuple[int, int]:
+    return _JOINTS[joint_name]
+
+
 class _Model:
     joint_coord_count = 2
+    joint_dof_count = 2
+    joint_q = wp.array([0.25, -0.5], dtype=wp.float32, device="cpu")
     joint_limit_lower = None
     joint_limit_upper = None
     body_label = None
@@ -87,6 +102,7 @@ def _pose_solver(cfg: NewtonIKSolverCfg | None = None, num_envs: int = 2, object
         device="cpu",
         objectives=[NewtonIKPoseObjectiveCfg(body_name="ee")] if objectives is None else objectives,
         link_resolver=_resolver,
+        joint_resolver=_joint_resolver,
     )
 
 
@@ -112,6 +128,116 @@ def test_constraint_objectives_carry_no_target_or_action(monkeypatch):
     # pure constraint (no name, no action dimensions).
     assert list(solver.objectives_by_name) == ["ee"]
     assert [obj.action_dim for obj in solver.objectives] == [6, 0]
+
+
+def test_joint_posture_objective_is_constraint_and_uses_named_reference(monkeypatch):
+    _patch_newton_ik(monkeypatch)
+    solver = _pose_solver(
+        objectives=[
+            NewtonIKPoseObjectiveCfg(body_name="ee"),
+            NewtonIKJointPostureObjectiveCfg(
+                joint_names=["shoulder", "elbow"],
+                target_positions=(0.3, -0.4),
+                weight=0.05,
+            ),
+        ]
+    )
+
+    posture = solver.objectives[1]
+    assert list(solver.objectives_by_name) == ["ee"]
+    assert posture.action_dim == 0
+    assert torch.equal(wp.to_torch(posture.objective.coordinate_indices), torch.tensor([0, 1], dtype=torch.int32))
+    assert torch.equal(wp.to_torch(posture.objective.dof_indices), torch.tensor([0, 1], dtype=torch.int32))
+    assert torch.allclose(wp.to_torch(posture.objective.target_positions), torch.tensor([0.3, -0.4]))
+    assert torch.allclose(wp.to_torch(posture.objective.weights), torch.full((2,), 0.05))
+
+
+def test_joint_posture_objective_defaults_to_model_posture(monkeypatch):
+    _patch_newton_ik(monkeypatch)
+    solver = _pose_solver(
+        objectives=[
+            NewtonIKPoseObjectiveCfg(body_name="ee"),
+            NewtonIKJointPostureObjectiveCfg(joint_names=["shoulder", "elbow"]),
+        ]
+    )
+
+    posture = solver.objectives[1]
+    assert torch.allclose(wp.to_torch(posture.objective.target_positions), wp.to_torch(_Model.joint_q))
+
+
+def test_joint_posture_objective_residual_and_analytic_jacobian():
+    ctx = NewtonIKBuildContext(
+        model=_Model(),
+        num_envs=2,
+        device="cpu",
+        resolve_link=_resolver,
+        resolve_joint=_joint_resolver,
+    )
+    posture = NewtonIKJointPostureObjective(
+        NewtonIKJointPostureObjectiveCfg(joint_names=["shoulder", "elbow"], target_positions=(0.25, -0.5), weight=0.2),
+        ctx,
+    ).objective
+    posture.set_batch_layout(total_residuals=3, residual_offset=1, n_batch=2)
+    posture.bind_device("cpu")
+    posture.init_buffers(_Model(), objectives_module.ik.IKJacobianType.ANALYTIC)
+
+    joint_q = wp.array([[0.5, -1.0], [0.1, -0.3]], dtype=wp.float32, device="cpu")
+    residuals = wp.zeros((2, 3), dtype=wp.float32, device="cpu")
+    problem_idx = wp.array([0, 1], dtype=wp.int32, device="cpu")
+    posture.compute_residuals(None, joint_q, _Model(), residuals, 1, problem_idx)
+
+    assert torch.allclose(
+        wp.to_torch(residuals),
+        torch.tensor([[0.0, 0.05, -0.1], [0.0, -0.03, 0.04]]),
+    )
+
+    jacobian = wp.zeros((2, 3, 2), dtype=wp.float32, device="cpu")
+    posture.compute_jacobian_analytic(None, joint_q, _Model(), jacobian, None, 1)
+    expected = torch.zeros((2, 3, 2))
+    expected[:, 1, 0] = 0.2
+    expected[:, 2, 1] = 0.2
+    assert torch.allclose(wp.to_torch(jacobian), expected)
+
+
+@pytest.mark.parametrize(
+    "jacobian_mode",
+    [objectives_module.ik.IKJacobianType.AUTODIFF, objectives_module.ik.IKJacobianType.ANALYTIC],
+)
+def test_joint_posture_objective_converges_with_newton_solver(jacobian_mode):
+    builder = newton.ModelBuilder(gravity=wp.vec3(0.0, 0.0, 0.0))
+    unit_inertia = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    link_1 = builder.add_link(mass=1.0, inertia=unit_inertia)
+    joint_1 = builder.add_joint_revolute(parent=-1, child=link_1, axis=newton.Axis.Z)
+    link_2 = builder.add_link(mass=1.0, inertia=unit_inertia)
+    joint_2 = builder.add_joint_revolute(parent=link_1, child=link_2, axis=newton.Axis.Z)
+    builder.add_articulation([joint_1, joint_2])
+    model = builder.finalize(device="cpu", requires_grad=True)
+
+    ctx = NewtonIKBuildContext(
+        model=model,
+        num_envs=2,
+        device="cpu",
+        resolve_link=_resolver,
+        resolve_joint=_joint_resolver,
+    )
+    posture = NewtonIKJointPostureObjective(
+        NewtonIKJointPostureObjectiveCfg(joint_names=["shoulder", "elbow"], target_positions=(0.25, -0.5), weight=0.2),
+        ctx,
+    ).objective
+    solver = objectives_module.ik.IKSolver(
+        model,
+        2,
+        [posture],
+        lambda_initial=1.0e-3,
+        jacobian_mode=jacobian_mode,
+    )
+    requires_grad = jacobian_mode == objectives_module.ik.IKJacobianType.AUTODIFF
+    seed = wp.array([[1.0, -1.0], [-0.75, 0.9]], dtype=wp.float32, device="cpu", requires_grad=requires_grad)
+    solved = wp.zeros((2, 2), dtype=wp.float32, device="cpu", requires_grad=requires_grad)
+
+    solver.step(seed, solved, iterations=20)
+
+    assert torch.allclose(wp.to_torch(solved), torch.tensor([[0.25, -0.5], [0.25, -0.5]]), atol=1.0e-4)
 
 
 def test_multiple_pose_objectives_register_distinct_targets(monkeypatch):


### PR DESCRIPTION
# Description

This PR improves Newton inverse kinematics for fixed-base articulations and adds a reusable reference-posture objective for redundant robots.

The Newton IK action now resolves articulation roots authored below the configured asset prim and finalizes an isolated copy of prototype geometry. Previously, the action assumed that the asset prim was the articulation root and finalized geometry shared with the simulation model, which could make valid nested assets fail or consume shared mesh resources.

The new `NewtonIKJointPostureObjectiveCfg` adds a low-weight preference over explicitly named scalar joints. It supports analytic and autodiff Jacobians, per-joint targets and weights, prototype-posture defaults, and validation for unsupported or malformed configurations. A generated API page documents a complete Franka pose + joint-limit + posture action configuration.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Documentation update

## Screenshots

Not applicable.

## Validation

- `uv run python -m pytest source/isaaclab_newton/test/ik/test_newton_ik_actions.py source/isaaclab_newton/test/ik/test_newton_ik_solver.py` (13 passed)
- `uv run isaaclab -f`
- `uv run isaaclab -d`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective and that my feature works
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in `CONTRIBUTORS.md`