### PR TITLE
Re-enable Franka kitless rendering tests with selective skips

### DIFF
--- a/source/isaaclab_tasks/changelog.d/huidongc-selective-skip-for-kitless-rendering-tests.skip
+++ b/source/isaaclab_tasks/changelog.d/huidongc-selective-skip-for-kitless-rendering-tests.skip
@@ -1,0 +1,2 @@
+Test-only: re-enable kit-less Franka soft and cloth rendering tests
+with selective skips for known broken cases. No user-facing change.

--- a/source/isaaclab_tasks/test/core/test_rendering_franka_cloth_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_franka_cloth_kitless.py
@@ -14,21 +14,11 @@ from rendering_test_utils import (
     make_determinism_fixture,
     make_generate_html_report_fixture,
     make_require_ovlibs_install_fixture,
-    make_xfail_rendering_params,
     rendering_test_franka_cloth,
 )
 
-pytestmark = [
-    pytest.mark.isaacsim_ci,
-    # FrankaClothSceneCfg inherits _FrankaSoftSceneCfg, so it spawns the same
-    # SeattleLabTable asset that broke test_rendering_franka_soft_kitless.
-    pytest.mark.skip(reason="The table is missing from the Franka soft asset, so the golden images no longer match."),
-]
+pytestmark = pytest.mark.isaacsim_ci
 
-_RENDERING_PARAMS = make_xfail_rendering_params(
-    KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS,
-    {("newton", "ovrtx_renderer", "motion_vectors"): ("OVRTX 0.4 omits deformable motion vectors (NVBUG#6489754).")},
-)
 _COMPARISON_SCORES: list[dict] = []
 
 _determinism_fixture = make_determinism_fixture()
@@ -37,7 +27,7 @@ _attach_comparison_properties_fixture = make_attach_comparison_properties_fixtur
 _require_ovlibs_install_fixture = make_require_ovlibs_install_fixture()
 
 
-@pytest.mark.parametrize("physics_backend,renderer,data_type", _RENDERING_PARAMS)
+@pytest.mark.parametrize("physics_backend,renderer,data_type", KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)
 def test_rendering_franka_cloth_kitless(ovstage_variant, physics_backend, renderer, data_type):
     """Camera output must match golden images for the Franka cloth test setup."""
     rendering_test_franka_cloth(physics_backend, renderer, data_type, _COMPARISON_SCORES)

--- a/source/isaaclab_tasks/test/core/test_rendering_franka_soft_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_franka_soft_kitless.py
@@ -17,10 +17,7 @@ from rendering_test_utils import (
     rendering_test_franka_soft,
 )
 
-pytestmark = [
-    pytest.mark.isaacsim_ci,
-    pytest.mark.skip(reason="The table is missing from the Franka soft asset, so the golden images no longer match."),
-]
+pytestmark = pytest.mark.isaacsim_ci
 
 _COMPARISON_SCORES: list[dict] = []
 

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1703,6 +1703,12 @@ def rendering_test_franka_cloth(
     if renderer == "ovrtx_renderer" and data_type == "instance_segmentation":
         pytest.skip("instance_segmentation crashes with the OVRTX renderer on franka_cloth (NVBUG#6463802).")
 
+    if renderer == "newton_renderer":
+        pytest.skip("Missing table in Newton Warp renderer (OMPE-103086)")
+
+    if physics_backend == "newton" and renderer == "ovrtx_renderer" and data_type == "motion_vectors":
+        pytest.skip("Missing cloth in OVRTX 0.4 motion vectors (NVBUG#6489754).")
+
     from isaaclab.envs import ManagerBasedRLEnv
 
     env_cfg = _make_franka_cloth_camera_env_cfg(data_type)
@@ -1828,6 +1834,9 @@ def rendering_test_franka_soft(
 
     if renderer == "ovrtx_renderer" and data_type == "instance_segmentation":
         pytest.skip("instance_segmentation crashes with the OVRTX renderer on franka_soft (NVBUG#6463802).")
+
+    if renderer == "newton_renderer":
+        pytest.skip("Missing table in Newton Warp renderer (OMPE-103086)")
 
     _skip_if_newton_motion_vectors(physics_backend, data_type)
 

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1706,7 +1706,7 @@ def rendering_test_franka_cloth(
     if renderer == "newton_renderer":
         pytest.skip("Missing table in Newton Warp renderer (OMPE-103086)")
 
-    if physics_backend == "newton" and renderer == "ovrtx_renderer" and data_type == "motion_vectors":
+    if renderer == "ovrtx_renderer" and data_type == "motion_vectors":
         pytest.skip("Missing cloth in OVRTX 0.4 motion vectors (NVBUG#6489754).")
 
     from isaaclab.envs import ManagerBasedRLEnv


### PR DESCRIPTION
# Description

Drop blanket skips on franka cloth/soft kitless rendering tests and skip only newton_renderer (OMPE-103086) and OVRTX cloth motion vectors (NVBUG#6489754).

## Type of change

- Test config (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
