### PR TITLE
Fix Isaac RTX Visualizer perspective camera only seeing env_0

### DIFF
--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -38,6 +38,7 @@ app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
 renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
+rtx.scenePartitioning.showAllPartitionsByDefault = true
 
 # Disable print outs on extension startup information
 # this only disables the app print_and_log function

--- a/source/isaaclab_visualizers/changelog.d/isaac-rtx-scene-partition-spectator-mode.rst
+++ b/source/isaaclab_visualizers/changelog.d/isaac-rtx-scene-partition-spectator-mode.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed the perspective camera in the kit rendering app showing only the first
+  environment when RTX scene partitioning is enabled. Added
+  ``rtx.scenePartitioning.showAllPartitionsByDefault = true`` to
+  ``isaaclab.python.rendering.kit`` so all environments are visible by default.
+* Fixed :class:`~isaaclab_visualizers.kit.KitVisualizer` incorrectly writing a
+  scene-partition attribute onto the camera prim in spectator mode (when no
+  specific environments are selected). The camera partition update now returns
+  early when ``_resolved_visible_env_ids`` is ``None``.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -636,7 +636,11 @@ class KitVisualizer(BaseVisualizer):
             self._controlled_camera_path,
         )
 
-        env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0
+        if self._resolved_visible_env_ids is None:
+            return
+
+        env_id = self._resolved_visible_env_ids[0]
+
         camera_prim = usd_stage.GetPrimAtPath(self._controlled_camera_path)
         if not camera_prim.IsValid() or not camera_prim.IsA(UsdGeom.Camera):
             logger.debug(


### PR DESCRIPTION
# Description

Fix Isaac RTX Visualizer perspective camera only seeing env_0

Set rtx.scenePartitioning.showAllPartitionsByDefault=true in the rendering app so the perspective camera shows all environments by default when RTX scene partitioning is active.

Also return early in KitVisualizer when _resolved_visible_env_ids is None (spectator mode) to prevent incorrectly writing an omni:scenePartition attribute on the camera prim that would lock it to env_0.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
