### PR TITLE
Adopt the engage-relative SO-101 clutch retargeter

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -455,7 +455,8 @@ These environments use the Isaac Teleop XR pipeline with motion controllers or h
      - Controllers
      - Right
      - **Arm:** right controller grip pose drives the end-effector via absolute IK
-       (clutch-rebased; IK tracks position, orientation soft-weighted).
+       (clutch-rebased; IK tracks position, orientation soft-weighted). Hold the squeeze (grip)
+       button to engage the clutch; release it to re-clutch — the arm holds its pose while released.
        **Gripper:** right trigger (analog).
    * - ``IsaacContrib-PickPlace-GR1T2-Abs``
      - Hand tracking

--- a/source/isaaclab_tasks/changelog.d/so101-clutch-consolidation.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/so101-clutch-consolidation.minor.rst
@@ -1,0 +1,15 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed the ``Isaac-Stack-Cube-SO101-IK-Abs-v0`` teleop pipeline to the
+  consolidated engage-relative :class:`~isaacteleop.retargeters.SO101ClutchRetargeter` from Isaac
+  Teleop 1.5. The clutch now
+  rebases the full end-effector pose instead of position only, and engaging additionally requires
+  the controller squeeze -- operators must hold the grip button to drive the arm and release it to
+  re-clutch. Removed the ``orientation_offset`` calibration argument, which no longer exists: the
+  commanded home orientation now comes from the task's configured home transform. That orientation
+  still carries a ``TODO(measure-in-sim)`` and must be measured from
+  ``ee_frame.data.target_pose_source`` before the task commands the correct gripper orientation.
+  Requires ``isaacteleop`` 1.5 or newer. Against 1.4 the constructor call is still accepted and
+  silently runs the previous position-only behaviour, so check the installed version if
+  orientation control appears unchanged.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_ik_abs_env_cfg.py
@@ -36,31 +36,78 @@ _TELEOP_AVAILABLE = True
 _SO101_GRIPPER_OFFSET = SO101_GRIPPER_OPEN  # [rad] closedness c=0 -> open
 _SO101_GRIPPER_SCALE = SO101_GRIPPER_CLOSE - SO101_GRIPPER_OPEN  # [rad] c=1 -> close
 
-# Clutch EE reset-origin home: the ``base_T_ee`` transform [m] for the gripper's pose in the
-# robot base frame at the seated reset pose. The clutch seeds its home from this on reset / first
-# engage (no live end-effector is read; the base rebase is handled upstream by
-# ``target_frame_prim_path`` and the EE state forward is the clutch's own running home). The robot
-# ``init_state`` MUST forward-kinematics to this value, or engaging snaps the arm -- this is the
-# forward kinematics of the seated ``_SO101_STACK_INIT_JOINT_POS`` measured in sim, so re-measure
-# (read ``ee_frame.data.target_pos_source`` at reset) if those init joints change. Only the
-# translation drives the IK position command; the orientation command is the live controller grip
-# orientation composed with the clutch's fixed calibration offset, not this transform's rotation.
-_BASE_T_GRIPPER_HOME = np.eye(4, dtype=np.float32)
-_BASE_T_GRIPPER_HOME[:3, 3] = (0.01918, -0.18852, 0.18887)
 
-# Fixed controller-grip -> gripper_link orientation calibration offset [x, y, z, w] (xyzw),
-# passed to the clutch as a body-frame right multiply. ``None`` uses the clutch default (Rz(pi)).
-# Derivation: with ``q_grip`` the controller grip orientation and ``q_G0`` the gripper_link
-# orientation in the base frame (both xyzw) at the reset pose, the offset is
-# ``quat_inv(q_grip) (x) q_G0`` (xyzw); tuning it here needs no Teleop rebuild.
-# Set to RPY (roll, pitch, yaw) = (-90, 0, 60) degrees (intrinsic XYZ), i.e.
-# ``Rotation.from_euler("XYZ", [-90, 0, 60], degrees=True).as_quat()``.
-_SO101_ORIENTATION_OFFSET_XYZW: tuple[float, float, float, float] | None = (
-    -0.61237244,
-    0.35355339,
-    0.35355339,
-    0.61237244,
-)
+def _matrix_from_quat_xyzw(quat_xyzw: tuple[float, float, float, float]) -> np.ndarray:
+    """Convert an ``(x, y, z, w)`` quaternion to a 3x3 rotation matrix.
+
+    Local to this module on purpose. The measured value below is stored as a quaternion because
+    that is natively what the sensor produces, and converting here keeps the stored literal exact:
+    a hand-typed 3x3 would be a rounded 9-number transcription that the retargeter's orthonormality
+    check polices, whereas any 4-number quaternion normalizes to an exactly proper rotation.
+
+    Args:
+        quat_xyzw: Rotation as ``(qx, qy, qz, qw)``; need not be normalized.
+
+    Returns:
+        The equivalent 3x3 rotation matrix, ``float64``.
+    """
+    q = np.asarray(quat_xyzw, dtype=np.float64)
+    x, y, z, w = q / np.linalg.norm(q)
+    return np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+
+
+# Clutch EE home: the ``base_T_ee`` transform [m] for the gripper's pose in the robot base frame
+# at the seated reset pose, stored as the (position, quaternion) pair the sensor natively reports
+# and assembled into a 4x4 below. **Both** blocks are used -- the translation seeds the clutch's
+# home position, the rotation seeds its home orientation. The clutch seeds its held pose from this
+# at construction and re-seeds it on every episode reset (from this static transform, never from
+# live arm state -- the reset pulse can reach the retargeter on either side of the arm teleport).
+# The robot ``init_state`` MUST forward-kinematics to this transform, or engaging snaps the arm.
+#
+# The position is the forward kinematics of the seated ``_SO101_STACK_INIT_JOINT_POS``, measured in
+# sim. Re-measure BOTH values together if those init joints change.
+#
+# TODO(measure-in-sim): the quaternion below is still identity and is WRONG. It is the orientation
+# the clutch commands on the very first engage, so today the wrist slews to base-frame identity and
+# stays there: orientation is a wrist-only task here (``orientation_joint_names``), so the residual
+# never self-heals. It is not recoverable from the calibration offset this file used to carry --
+# that derivation was ``quat_inv(q_grip) (x) q_G0`` and ``q_grip`` at that moment was never
+# recorded -- so it needs a fresh measurement:
+#
+#   1. Launch the task and call ``env.reset()``.
+#   2. Read the pose ONCE, and take both blocks from that single read:
+#
+#          pose = env.unwrapped.scene["ee_frame"].data.target_pose_source.torch[0, 0]
+#
+#      One read matters. ``target_pos_source`` and ``target_quat_source`` are separate properties
+#      off a lazily-recomputed ``SensorBase.data``, so reading them separately can stitch one 4x4
+#      out of two different instants. ``target_pose_source`` is a single 7-vector
+#      ``(x, y, z, qx, qy, qz, qw)`` concatenated from both buffers in one launch -- see
+#      ``source/isaaclab_physx/isaaclab_physx/sensors/frame_transformer/
+#      frame_transformer_data.py:25-40``.
+#   3. Self-check BEFORE using it: ``pose[:3]`` must still equal ``_BASE_T_GRIPPER_HOME_POS`` to
+#      ~1 mm. If it does not, the arm is not at the seated pose -- either it has been stepped away
+#      from ``_SO101_STACK_INIT_JOINT_POS`` (step with a held pose, or do not step at all), or the
+#      sensor has not populated yet, whose identity/zero pre-initialisation this same check
+#      catches. Either way the orientation you would read does not belong to this home.
+#   4. Paste ``pose[3:]`` into ``_BASE_T_GRIPPER_HOME_QUAT`` as-is. It is ``(qx, qy, qz, qw)`` --
+#      **xyzw, NO reorder**. Two independent confirmations: the buffer is allocated ``wp.quatf``
+#      with the identity written at index 3 (``frame_transformer_data.py:170,176``), and Isaac Lab's
+#      own :func:`isaaclab.utils.math.matrix_from_quat` documents its input as ``(x, y, z, w)``
+#      (``source/isaaclab/isaaclab/utils/math.py:169``). Do not "fix" this to wxyz.
+_BASE_T_GRIPPER_HOME_POS = (0.01918, -0.18852, 0.18887)  # [m] measured
+_BASE_T_GRIPPER_HOME_QUAT = (0.0, 0.0, 0.0, 1.0)  # (qx, qy, qz, qw) -- TODO(measure-in-sim)
+
+_BASE_T_GRIPPER_HOME = np.eye(4, dtype=np.float32)
+_BASE_T_GRIPPER_HOME[:3, :3] = _matrix_from_quat_xyzw(_BASE_T_GRIPPER_HOME_QUAT)
+_BASE_T_GRIPPER_HOME[:3, 3] = _BASE_T_GRIPPER_HOME_POS
 
 
 def _build_so101_stack_pipeline():
@@ -71,11 +118,15 @@ def _build_so101_stack_pipeline():
     tensor via TensorReorderer.
 
     The SO-101 is 5-DOF and driven by a full-SE3-pose IK over all 5 arm joints (shoulder_pan,
-    shoulder_lift, elbow_flex, wrist_flex, wrist_roll): the clutch emits the controller pose
-    (position + grip orientation composed with a fixed calibration offset) and the IK tracks
-    position exactly while best-effort tracking orientation (soft-weighted). The gripper jaw
-    tracks the trigger proportionally (analog), and the EE position is clutch-rebased around a
-    captured origin so engaging teleop does not teleport the arm.
+    shoulder_lift, elbow_flex, wrist_flex, wrist_roll): the clutch emits an absolute EE pose and
+    the IK tracks position exactly while best-effort tracking orientation (soft-weighted). The
+    gripper jaw tracks the trigger proportionally (analog).
+
+    The clutch rebases the **full pose** around an origin captured on engage, so engaging teleop
+    does not teleport the arm: both the home position and the home orientation re-latch on every
+    engage and the orientation delta is composed on the left (base frame). Engagement requires the
+    session to be RUNNING **and** the controller squeeze to exceed the retargeter's threshold --
+    the operator holds the grip button to drive the arm and releases it to re-clutch.
 
     Returns:
         OutputCombiner with a single "action" output containing the flattened
@@ -104,22 +155,26 @@ def _build_so101_stack_pipeline():
     # receives base-frame data matching the absolute-pose IK command frame.
     transformed_controllers = controllers.transformed(transform_input.output(ValueInput.VALUE))
 
-    # Clutch (relative-origin) EE-pose retargeter (right hand). Emits the same absolute 7D
+    # Clutch (engage-relative) EE-pose retargeter (right hand). Emits the same absolute 7D
     # "ee_pose" contract as Se3AbsRetargeter (node name + output key "ee_pose"), but rebases
-    # controller motion around an origin captured on engage. It seeds the home from the static
-    # ``home_base_T_ee`` reset-origin on reset / first engage and keeps its own running home
-    # thereafter (so a mid-task re-clutch resumes from the last commanded pose). The robot
-    # ``init_state`` must reset the arm to ``_BASE_T_GRIPPER_HOME`` so the first engage does not
-    # jump. The full pose (position + orientation) drives the 5-joint SE3 IK below.
+    # controller motion around an origin captured on engage. It seeds its held pose from the static
+    # ``home_base_T_ee`` and re-seeds it there on every episode reset; between resets a re-clutch
+    # resumes from the last commanded pose. The robot ``init_state`` must reset the arm to
+    # ``_BASE_T_GRIPPER_HOME`` so neither the first engage nor a reset jumps. The full pose
+    # (position + orientation) drives the 5-joint SE3 IK below.
+    #
+    # ``MEASURED_BASE_T_EE_INPUT`` is deliberately NOT wired. It is an OptionalType input, so
+    # omitting it from connect() is legal, and the last-commanded-home fallback it selects is the
+    # correct behaviour here: the task slews the arm to ``_BASE_T_GRIPPER_HOME`` on reset, which is
+    # exactly the pose the clutch re-seeds to. Wiring it would need a per-frame base-frame EE feed
+    # the device does not provide.
+    #
+    # ``squeeze_threshold`` is left at the retargeter default: engagement is RUNNING AND
+    # squeeze > threshold, so the operator holds the controller grip button while driving the arm.
     clutch = SO101ClutchRetargeter(
         name="ee_pose",
-        input_device=ControllersSource.RIGHT,
         home_base_T_ee=_BASE_T_GRIPPER_HOME,
-        orientation_offset=(
-            np.array(_SO101_ORIENTATION_OFFSET_XYZW, dtype=np.float64)
-            if _SO101_ORIENTATION_OFFSET_XYZW is not None
-            else None
-        ),
+        input_device=ControllersSource.RIGHT,
     )
     connected_clutch = clutch.connect(
         {
@@ -291,8 +346,8 @@ class SO101CubeStackEnvCfg(stack_joint_pos_env_cfg.SO101CubeStackEnvCfg):
             # prim's world transform each frame and left-multiplies its inverse onto the XR
             # anchor (``base_T_world @ world_T_anchor``), so the clutch retargeter works
             # in the base frame -- the IK command's root frame (the FrameTransformer source
-            # also uses ``Robot/base``). The clutch's reset-origin home (_BASE_T_GRIPPER_HOME)
-            # provides the engage seed, so no live end-effector feed is needed. Teleop runs a
-            # single env (env_0).
+            # also uses ``Robot/base``). The clutch's configured home (_BASE_T_GRIPPER_HOME)
+            # provides both the startup seed and the reset seed, so no live end-effector feed is
+            # needed. Teleop runs a single env (env_0).
             target_frame_prim_path="/World/envs/env_0/Robot/base",
         )

--- a/source/isaaclab_tasks/test/contrib/test_so101_teleop_pipeline.py
+++ b/source/isaaclab_tasks/test/contrib/test_so101_teleop_pipeline.py
@@ -18,11 +18,13 @@ wiring:
   ``[pos_x, pos_y, pos_z, quat_x, quat_y, quat_z, quat_w, gripper]``.
 - Each entry in ``output_order`` must resolve to a declared element name; an undeclared
   name resolves silently to a constant 0.0 instead of raising.
-- The clutch declares only the controller input (no ``robot_ee_pos`` / ``robot_base_pos``): the
-  base-frame rebase is handled upstream by ``target_frame_prim_path`` and the engage home is the
-  clutch's static reset-origin config, so no live end-effector or base feed is wired.
+- The clutch declares no ``robot_ee_pos`` / ``robot_base_pos``: the base-frame rebase is handled
+  upstream by ``target_frame_prim_path`` and the home is the clutch's static configured transform,
+  so no live end-effector or base feed is wired. Its optional ``measured_base_T_ee`` input is
+  declared but deliberately left unconnected by the builder.
 """
 
+import numpy as np
 import pytest
 
 pytest.importorskip("isaacteleop")
@@ -71,16 +73,22 @@ def test_so101_pipeline_output_order():
     )
 
 
-def test_clutch_consumes_controller_only():
-    """The clutch declares only the controller; no ``robot_ee_pos`` / ``robot_base_pos`` inputs.
+def test_clutch_consumes_controller_and_optional_measured_pose():
+    """The clutch declares the controller plus an optional measured EE pose -- nothing else.
 
     The world->base rebase happens upstream in the device via ``target_frame_prim_path`` (set to
-    the robot base), and the engage home is the clutch's static ``home_base_T_ee`` reset-origin, so
-    the clutch needs no live end-effector or base feed. This guards that the builder does not wire
-    inputs the device no longer provides.
+    the robot base), and the home is the clutch's static ``home_base_T_ee``, so the clutch needs no
+    ``robot_ee_pos`` / ``robot_base_pos`` feed. ``measured_base_T_ee`` is declared but
+    ``OptionalType``, and the builder deliberately leaves it unconnected: this task slews the arm
+    to ``_BASE_T_GRIPPER_HOME`` on reset, which is the same pose the clutch re-seeds to, so the
+    last-commanded-home fallback is correct here. This guards that the builder does not wire inputs
+    the device no longer provides.
     """
-    clutch = SO101ClutchRetargeter(name="ee_pose")
-    assert list(clutch.input_spec()) == [ControllersSource.RIGHT]
+    clutch = SO101ClutchRetargeter(name="ee_pose", home_base_T_ee=np.eye(4, dtype=np.float32))
+    assert set(clutch.input_spec()) == {
+        ControllersSource.RIGHT,
+        SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT,
+    }
     assert not hasattr(SO101ClutchRetargeter, "ROBOT_EE_POS_INPUT")
     assert not hasattr(SO101ClutchRetargeter, "ROBOT_BASE_POS_INPUT")
     # The builder still flattens to the 8D action contract.


### PR DESCRIPTION
The clutch now clutches the full pose rather than position only, so the fixed controller-to-gripper calibration offset is gone and the gripper's base-frame orientation at the reset pose belongs in the rotation block of _BASE_T_GRIPPER_HOME instead.

That rotation block is still identity and is marked TODO(measure-in-sim). The value is not recoverable from the offset this file used to carry: the derivation needed the controller orientation at calibration time, which was never recorded. Until it is measured the wrist slews to base-frame identity on the first engage and stays there, because orientation is a wrist-only task here and the least-squares residual never self-heals. The transform is now assembled from a position and a quaternion literal so the measured value can be pasted in exactly as the FrameTransformer reports it.

Teleop engagement now also requires holding the controller squeeze button, so the operator-facing device table says so.

# Description

> [!IMPORTANT]
> Confirm the pull request base before submitting. Target `develop` for all
> contributions. The `release/3.0.0-beta2` branch is a frozen stable landing
> snapshot and is not used for ongoing maintenance.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
