### PR TITLE
fix(cli): CLI subcommands exiting 0 when the child command fails

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -140,6 +140,7 @@ Guidelines for modifications:
 * Michael Gussert
 * Michael Lin
 * Michael Noseworthy
+* Michael Wedd
 * Michal Hapala
 * Miguel Alonso Jr
 * Mihir Kulkarni

--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -765,7 +765,7 @@ Please make sure that you add tests for your changes.
                # Run a particular test
                isaaclab.bat -p -m pytest source/isaaclab/test/deps/test_torch.py::test_array_slicing
 
-All of these commands exit with the underlying pytest exit code, so a test
+All of these commands exit with a nonzero code when tests fail, so a test
 failure fails the invoking shell or CI step as well.
 
 Tools

--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -765,6 +765,8 @@ Please make sure that you add tests for your changes.
                # Run a particular test
                isaaclab.bat -p -m pytest source/isaaclab/test/deps/test_torch.py::test_array_slicing
 
+All of these commands exit with the underlying pytest exit code, so a test
+failure fails the invoking shell or CI step as well.
 
 Tools
 -----

--- a/source/isaaclab/changelog.d/fix-cli-exit-code-propagation.rst
+++ b/source/isaaclab/changelog.d/fix-cli-exit-code-propagation.rst
@@ -1,8 +1,8 @@
 Fixed
 ^^^^^
 
-* Fixed ``isaaclab.sh -t``, ``--new``, ``--vscode``, and ``--docker`` exiting with code 0
-  even when the underlying Python command failed. The remaining ``run_python_command`` call
-  sites now pass ``check=True``, matching the fix already applied to the ``-p`` paths, so
-  failures propagate the child's exit code (e.g. test failures are no longer reported as
-  success in CI).
+* Fixed ``isaaclab.sh -t``, ``--new``, and ``--docker`` exiting with code 0 even when the
+  underlying Python command failed. These ``run_python_command`` call sites now pass
+  ``check=True``, matching the fix already applied to the ``-p`` paths, so failures
+  propagate the child's exit code (e.g. test failures are no longer reported as success
+  in CI). The ``--vscode`` settings generation stays best-effort by design.

--- a/source/isaaclab/changelog.d/fix-cli-exit-code-propagation.rst
+++ b/source/isaaclab/changelog.d/fix-cli-exit-code-propagation.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed ``isaaclab.sh -t``, ``--new``, ``--vscode``, and ``--docker`` exiting with code 0
+  even when the underlying Python command failed. The remaining ``run_python_command`` call
+  sites now pass ``check=True``, matching the fix already applied to the ``-p`` paths, so
+  failures propagate the child's exit code (e.g. test failures are no longer reported as
+  success in CI).

--- a/source/isaaclab/isaaclab/cli/commands/misc.py
+++ b/source/isaaclab/isaaclab/cli/commands/misc.py
@@ -44,11 +44,11 @@ def command_new(new_args: list[str]) -> None:
 
     print_info("Installing template dependencies...")
     reqs = ISAACLAB_ROOT / "tools" / "template" / "requirements.txt"
-    run_python_command("pip", ["install", "-q", "-r", str(reqs)], is_module=True)
+    run_python_command("pip", ["install", "-q", "-r", str(reqs)], is_module=True, check=True)
 
     print_info("Running template generator...")
     cli_script = ISAACLAB_ROOT / "tools" / "template" / "cli.py"
-    run_python_command(cli_script, new_args)
+    run_python_command(cli_script, new_args, check=True)
 
 
 def command_test(test_args: list[str]) -> None:
@@ -57,7 +57,7 @@ def command_test(test_args: list[str]) -> None:
     Args:
         test_args: Additional pytest arguments.
     """
-    run_python_command("-m", ["pytest", str(ISAACLAB_ROOT / "tools")] + test_args)
+    run_python_command("-m", ["pytest", str(ISAACLAB_ROOT / "tools")] + test_args, check=True)
 
 
 def command_vscode_settings() -> None:
@@ -70,7 +70,7 @@ def command_vscode_settings() -> None:
 
     # Check if the file exists before attempting to run it.
     if setup_vscode_script.exists():
-        run_python_command(setup_vscode_script, [])
+        run_python_command(setup_vscode_script, [], check=True)
         print_info("VS Code settings generated successfully.")
     else:
         print_warning("Unable to find the script 'setup_vscode.py'. Aborting vscode settings setup.")
@@ -120,4 +120,4 @@ def command_run_docker(args: list[str]) -> None:
     """
     script_path = ISAACLAB_ROOT / "docker" / "container.py"
     print_info(f"Running docker utility script from: {script_path}")
-    run_python_command(script_path, args)
+    run_python_command(script_path, args, check=True)

--- a/source/isaaclab/isaaclab/cli/commands/misc.py
+++ b/source/isaaclab/isaaclab/cli/commands/misc.py
@@ -70,7 +70,9 @@ def command_vscode_settings() -> None:
 
     # Check if the file exists before attempting to run it.
     if setup_vscode_script.exists():
-        run_python_command(setup_vscode_script, [], check=True)
+        # Best-effort: a failure generating editor settings should not abort the
+        # invoking command (this also runs inside the install flow).
+        run_python_command(setup_vscode_script, [])
         print_info("VS Code settings generated successfully.")
     else:
         print_warning("Unable to find the script 'setup_vscode.py'. Aborting vscode settings setup.")

--- a/source/isaaclab/test/cli/test_exit_code_propagation.py
+++ b/source/isaaclab/test/cli/test_exit_code_propagation.py
@@ -5,18 +5,12 @@
 
 """Tests that CLI subcommands propagate the exit code of the commands they run."""
 
-import os
 import sys
 
 import pytest
 
-# Make the CLI importable straight from the source tree so this test also runs
-# outside an environment where the isaaclab package is installed.
-ISAACLAB_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, os.path.join(ISAACLAB_PATH, "source", "isaaclab"))
-
-from isaaclab.cli import utils  # noqa: E402
-from isaaclab.cli.commands import misc  # noqa: E402
+from isaaclab.cli import utils
+from isaaclab.cli.commands import misc
 
 
 def test_run_command_check_propagates_exit_code():
@@ -34,24 +28,39 @@ def test_run_command_no_check_swallows_exit_code():
     assert result.returncode == 3
 
 
-def test_misc_commands_request_checked_execution(monkeypatch):
-    """Every python child launched by the misc subcommands must pass check=True.
+def test_run_python_command_forwards_check(monkeypatch):
+    """check=True must survive the delegation from run_python_command to run_command."""
+    seen = {}
 
-    This is the regression guard for the -t/--new/--vscode/--docker paths
-    reporting success while their child failed.
-    """
+    def fake_run_command(cmd, **kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(utils, "extract_python_exe", lambda: sys.executable)
+    monkeypatch.setattr(utils, "run_command", fake_run_command)
+    utils.run_python_command("script.py", [], check=True)
+    assert seen.get("check") is True
+
+
+# command_vscode_settings is deliberately absent: settings generation is
+# best-effort (it also runs inside the install flow) and must not abort the
+# invoking command on failure.
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        pytest.param(lambda: misc.command_new([]), id="new"),
+        pytest.param(lambda: misc.command_test([]), id="test"),
+        pytest.param(lambda: misc.command_run_docker([]), id="docker"),
+    ],
+)
+def test_misc_commands_request_checked_execution(monkeypatch, invoke):
+    """Regression guard for -t/--new/--docker reporting success while their child failed."""
     calls = []
 
     def record(script_or_module, args, **kwargs):
         calls.append((str(script_or_module), kwargs.get("check", False)))
 
     monkeypatch.setattr(misc, "run_python_command", record)
-
-    misc.command_new([])
-    misc.command_test([])
-    misc.command_vscode_settings()
-    misc.command_run_docker([])
-
-    assert len(calls) == 5  # command_new launches pip install + the generator
+    invoke()
+    assert calls, "command did not launch a python child"
     unchecked = [script for script, checked in calls if not checked]
     assert not unchecked, f"child commands launched without check=True: {unchecked}"

--- a/tools/test_cli_exit_codes.py
+++ b/tools/test_cli_exit_codes.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests that CLI subcommands propagate the exit code of the commands they run."""
+
+import os
+import sys
+
+import pytest
+
+# Make the CLI importable straight from the source tree so this test also runs
+# outside an environment where the isaaclab package is installed.
+ISAACLAB_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ISAACLAB_PATH, "source", "isaaclab"))
+
+from isaaclab.cli import utils  # noqa: E402
+from isaaclab.cli.commands import misc  # noqa: E402
+
+
+def test_run_command_check_propagates_exit_code():
+    """A failing child with check=True exits the process with the child's code."""
+    fail = [sys.executable, "-c", "import sys; sys.exit(3)"]
+    with pytest.raises(SystemExit) as excinfo:
+        utils.run_command(fail, check=True, capture_output=True)
+    assert excinfo.value.code == 3
+
+
+def test_run_command_no_check_swallows_exit_code():
+    """check=False is the opt-out: the caller sees the code but the process continues."""
+    fail = [sys.executable, "-c", "import sys; sys.exit(3)"]
+    result = utils.run_command(fail, check=False, capture_output=True)
+    assert result.returncode == 3
+
+
+def test_misc_commands_request_checked_execution(monkeypatch):
+    """Every python child launched by the misc subcommands must pass check=True.
+
+    This is the regression guard for the -t/--new/--vscode/--docker paths
+    reporting success while their child failed.
+    """
+    calls = []
+
+    def record(script_or_module, args, **kwargs):
+        calls.append((str(script_or_module), kwargs.get("check", False)))
+
+    monkeypatch.setattr(misc, "run_python_command", record)
+
+    misc.command_new([])
+    misc.command_test([])
+    misc.command_vscode_settings()
+    misc.command_run_docker([])
+
+    assert len(calls) == 5  # command_new launches pip install + the generator
+    unchecked = [script for script, checked in calls if not checked]
+    assert not unchecked, f"child commands launched without check=True: {unchecked}"


### PR DESCRIPTION
# Description

Follow-up to #5237 and #5238. PR #5238 fixed `isaaclab -p` exiting 0 on child
failure, but the same bug remained in the `-t`, `--new`, and `--docker`
subcommands. `run_python_command` defaults to `check=False`, so these commands
reported success even when their Python child failed.

This passes `check=True` at the three affected call sites, matching the existing
`-p` behavior. Probe-style subprocesses and the interactive Isaac Sim launch
retain their explicit unchecked behavior.

The regression coverage is consolidated into the existing
`source/isaaclab/test/cli/test_misc_commands.py` module. One mocked test invokes
all three subcommands and verifies their exact checked calls without launching
child processes.

## Type of change

- Bug fix (non-breaking change)

## Validation

- `uv run python -m pytest source/isaaclab/test/cli/test_misc_commands.py -q`
  (`8 passed in 0.03s`)
- Verified an invalid pytest option now makes `isaaclab -t` return pytest's
  nonzero exit code instead of 0.
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added focused regression coverage
- [x] I have added a changelog fragment
- [x] The contributor is listed in `CONTRIBUTORS.md`

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
