### PR TITLE
Stop emitting invalid omni-github log paths

### DIFF
--- a/.github/actions/upload-omni-github-test-results/junit_to_omni_github_results.py
+++ b/.github/actions/upload-omni-github-test-results/junit_to_omni_github_results.py
@@ -107,7 +107,6 @@ def _convert_testcase(
         "duration": _duration_seconds(testcase),
         "group_id": group_id,
         "retries": retries,
-        "log_paths": log_paths,
     }
     if testcase.attrib.get("name"):
         row["test_name"] = testcase.attrib["name"]

--- a/.github/actions/upload-omni-github-test-results/test_junit_to_omni_github_results.py
+++ b/.github/actions/upload-omni-github-test-results/test_junit_to_omni_github_results.py
@@ -119,7 +119,6 @@ def test_convert_junit_marks_crashes_and_timeouts(tmp_path: Path) -> None:
             "crash": True,
             "duration": 0.0,
             "group_id": "Docker + Tests / environments",
-            "log_paths": [],
             "message": "Process killed by signal 15 after timeout",
             "passed": False,
             "retries": 0,
@@ -131,8 +130,8 @@ def test_convert_junit_marks_crashes_and_timeouts(tmp_path: Path) -> None:
     ]
 
 
-def test_convert_junit_adds_log_paths_for_junit_and_comparison_artifacts(tmp_path: Path) -> None:
-    """Converted rows should point at the uploaded JUnit and comparison image artifacts."""
+def test_convert_junit_omits_log_paths_for_external_artifact_urls(tmp_path: Path) -> None:
+    """Converted rows should omit external artifacts that are not per-test log files."""
     converter = _load_converter_module()
     reports_dir = tmp_path
     output_dir = tmp_path / "out"
@@ -163,10 +162,7 @@ def test_convert_junit_adds_log_paths_for_junit_and_comparison_artifacts(tmp_pat
     )
 
     rows = _load_rows(output_dir)
-    assert rows[0]["log_paths"] == [
-        junit_log_url,
-        comparison_images_url,
-    ]
+    assert "log_paths" not in rows[0]
 
 
 def test_convert_junit_appends_markers_to_test_type_with_separator(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

omni-github interprets `log_paths` as files relative to the uploaded
test-result artifact. Isaac Lab was putting external GitHub artifact URLs in
that field, so ingestion emitted `log_path_not_found` warnings for every
converted test row.

This change omits `log_paths` from converted rows. The existing JUnit and
comparison-image artifact uploads remain unchanged.

To view an example of warning logs:
1. Visit [this workflow upload result](https://omni-github.horde-aks.nvidia.com/test-results/upload-data-verification?repository_url=https%3A%2F%2Fgithub.com%2Fisaac-sim%2FIsaacLab%2Factions%2Fruns%2F30330740408&run_attempt=1&job_filter=all-jobs) and click "Load"
2. Click any "View report" link with status as `Processed_with_warnings` in the "Processing Evidence" table.
3. You'll see many log_path_not_found warnings as the screenshot below shows

<img width="869" height="659" alt="Screenshot 2026-07-28 at 15 42 24" src="https://github.com/user-attachments/assets/2c178f17-9bc5-44a9-9572-1d1fee1c8528" />


## Type of change

- Bug fix (non-breaking)

## Validation

- `pytest .github/actions/upload-omni-github-test-results/test_junit_to_omni_github_results.py`
  — 4 passed
- Ruff and Ruff format passed for the modified files.
- The all-files pre-commit run passed every available hook. The Git LFS pointer
  hook could not run because `git-lfs` is not installed on the development
  host.

## Checklist

- [x] The change is focused and includes regression coverage.
- [x] No package under `source/` was changed, so no changelog fragment is
  required.
- [x] No documentation or dependency changes are required.
