### PR TITLE
Standardize benchmark warm-up steps

### DIFF
--- a/docs/source/testing/benchmarks.rst
+++ b/docs/source/testing/benchmarks.rst
@@ -149,7 +149,7 @@ Measure environment stepping performance without any RL library:
        --task Isaac-Cartpole \
        --num_envs 4096 \
        --num_frames 1000 \
-       --warmup_frames 50 \
+       --warmup_steps 50 \
        --benchmark_formatter json \
        --output_path ./results
 
@@ -218,7 +218,9 @@ Environment-Step Timing Semantics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Runtime, training, and play benchmarks report
-:class:`~isaaclab.benchmark.EnvironmentStepTiming`. The default
+:class:`~isaaclab.benchmark.EnvironmentStepTiming`. Its ``warmup_steps`` field
+records the exact number of initial ``env.step()`` calls excluded from
+timing. The default
 ``host_return`` measurement mode records wall time until ``env.step()`` returns
 without forcing queued device work to complete. It describes the host-visible
 call boundary, not a device-complete boundary; asynchronously queued work can be
@@ -413,7 +415,7 @@ Non-RL / Runtime Benchmark Arguments
    * - ``--num_frames``
      - ``1000``
      - Number of environment steps to measure
-   * - ``--warmup_frames``
+   * - ``--warmup_steps``
      - ``50``
      - Exact number of environment steps to exclude from timing; zero measures the first step
    * - ``--measure_sync_step``
@@ -474,7 +476,7 @@ RL Play Arguments
    * - ``--num_frames``
      - ``100``
      - Number of measured inference steps
-   * - ``--warmup_frames``
+   * - ``--warmup_steps``
      - ``1``
      - Number of preceding environment steps to exclude from timing and throughput
    * - ``--checkpoint``
@@ -487,15 +489,16 @@ RL Play Arguments
      - ``false``
      - Collect the serialized synchronized diagnostic described above
 
-Runtime and play execute ``warmup_frames + num_frames`` environment steps. Thus,
+Runtime and play execute ``warmup_steps + num_frames`` environment steps. Thus,
 the requested ``num_frames`` is always the exact number of measured steps. Play
-warmup frames are excluded only from timing and throughput; they still contribute
+warm-up steps are excluded only from timing and throughput; they still contribute
 to reward, episode-length, success-rate, and resource measurements.
 
-Runtime warmup frames are excluded from steady-state timing, throughput, and
-synchronized environment-step measurements. When warmup is nonzero, the first
-warmup frame ordinary wall-clock time is retained separately as the ``first_step`` startup diagnostic.
-With zero warmup, the first measured frame supplies that diagnostic.
+Runtime warm-up steps are excluded from steady-state timing, throughput, and
+synchronized environment-step measurements. When warm-up is nonzero, the first
+warm-up step's ordinary wall-clock time is retained separately as the
+``first_step`` startup diagnostic. With zero warm-up, the first measured step
+supplies that diagnostic.
 
 Measurement Types
 -----------------

--- a/scripts/benchmarks/test/test_benchmark_smoke.py
+++ b/scripts/benchmarks/test/test_benchmark_smoke.py
@@ -62,7 +62,7 @@ def test_adapters_reject_non_positive_workloads(library: str, workflow: str, arg
 def test_adapters_reject_negative_warmup_steps(library: str, workflow: str, monkeypatch, capsys):
     """Benchmark adapters reject negative warm-up counts."""
     module = _load_adapter(library, workflow)
-    warmup_argument = "--warmup_frames" if workflow == "play" else "--warmup_steps"
+    warmup_argument = "--warmup_steps"
     argv = ["--task", _TASK, warmup_argument, "-1", "--headless"]
     monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
 
@@ -83,7 +83,7 @@ def test_adapters_default_to_one_warmup_step(library: str, workflow: str, monkey
 
     args = module._parse_args(argv)[0]
 
-    warmup_count = args.warmup_frames if workflow == "play" else args.warmup_steps
+    warmup_count = args.warmup_steps
     assert warmup_count == 1
 
 
@@ -104,13 +104,13 @@ def test_adapters_accept_short_synchronized_step_flag(library: str, workflow: st
 def test_play_adapters_accept_warmup_larger_than_measured_workload(library: str, monkeypatch):
     """Play warm-up adds calls without consuming the measured workload."""
     module = _load_adapter(library, "play")
-    argv = ["--task", _TASK, "--num_frames", "2", "--warmup_frames", "3", "--headless"]
+    argv = ["--task", _TASK, "--num_frames", "2", "--warmup_steps", "3", "--headless"]
     monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
 
     args = module._parse_args(argv)[0]
 
     assert args.num_frames == 2
-    assert args.warmup_frames == 3
+    assert args.warmup_steps == 3
 
 
 @pytest.mark.parametrize(
@@ -179,6 +179,7 @@ def test_training_and_play_write_bundles(
     assert training_data["runtime"]["total_fps"]["mean"] > 0
     training_timing = training_data["runtime"]["environment_step_timing"]
     assert training_timing["environment_step_calls"] > 0
+    assert training_timing["warmup_steps"] == 1
     assert training_timing["environment_step_fps"]["mean"] > 0
     assert training_timing["simulation_step_calls"] is None
     assert training_timing["simulation_step_time_s"] is None
@@ -213,6 +214,7 @@ def test_training_and_play_write_bundles(
     assert play_data["runtime"]["total_fps"]["mean"] > 0
     play_timing = play_data["runtime"]["environment_step_timing"]
     assert play_timing["environment_step_calls"] == 250
+    assert play_timing["warmup_steps"] == 1
     assert play_timing["environment_step_fps"]["mean"] > 0
     assert play_timing["simulation_step_calls"] is None
     assert play_timing["simulation_step_time_s"] is None
@@ -244,6 +246,7 @@ def test_training_and_play_write_bundles(
         synchronized_play_data = _load_play_bundle(synchronized_play_output)
         synchronized_timing = synchronized_play_data["runtime"]["environment_step_timing"]
         assert synchronized_timing["environment_step_calls"] == 10
+        assert synchronized_timing["warmup_steps"] == 1
         assert synchronized_timing["simulation_step_calls"] > 0
         assert synchronized_timing["simulation_step_time_s"]["mean"] > 0.0
         assert synchronized_timing["outside_simulation_step_time_s"]["mean"] >= 0.0
@@ -259,6 +262,8 @@ def test_training_and_play_write_bundles(
         assert play_omniperf["runtime"]["Mean Total FPS"] == pytest.approx(play_data["runtime"]["total_fps"]["mean"])
         assert training_omniperf["benchmark_info"]["environment_step_measurement_mode"] == "host_return"
         assert play_omniperf["benchmark_info"]["environment_step_measurement_mode"] == "host_return"
+        assert training_omniperf["benchmark_info"]["environment_step_warmup_steps"] == 1
+        assert play_omniperf["benchmark_info"]["environment_step_warmup_steps"] == 1
         if library == "rsl_rl":
             synchronized_omniperf = json.loads(next(synchronized_play_output.glob("*_omniperf.json")).read_text())
             assert (

--- a/scripts/benchmarks/test/test_runtime_smoke.py
+++ b/scripts/benchmarks/test/test_runtime_smoke.py
@@ -29,7 +29,7 @@ def test_runtime_writes_all_requested_formats(tmp_path, measure_sync_step: bool)
         "16",
         "--num_frames",
         "20",
-        "--warmup_frames",
+        "--warmup_steps",
         "0",
         "--seed",
         "0",
@@ -59,9 +59,10 @@ def test_runtime_writes_all_requested_formats(tmp_path, measure_sync_step: bool)
     schema_data = json.loads(schema_files[0].read_text())
     assert schema_data["run"]["config"]["physics_backend"] == "newton_mjwarp"
     assert schema_data["runtime"]["iterations_completed"] == 20
-    assert schema_data["extra"]["warmup_frames"] == 0
+    assert schema_data["extra"] is None
     assert schema_data["runtime"]["startup_time_s"]["first_step"] > 0.0
     timing = schema_data["runtime"]["environment_step_timing"]
+    assert timing["warmup_steps"] == 0
     assert timing["environment_step_calls"] == 20
     assert timing["environment_step_fps"]["mean"] > 0
     if measure_sync_step:
@@ -79,6 +80,7 @@ def test_runtime_writes_all_requested_formats(tmp_path, measure_sync_step: bool)
     assert timing["environment_step_time_s"]["std"] >= 0.0
     omniperf_data = json.loads(omniperf_files[0].read_text())
     assert omniperf_data["benchmark_info"]["environment_step_measurement_mode"] == timing["measurement_mode"]
+    assert omniperf_data["benchmark_info"]["environment_step_warmup_steps"] == 0
     if measure_sync_step:
         assert "Mean Serialized Diagnostic Total FPS" in omniperf_data["runtime"]
         assert "Mean Total FPS" not in omniperf_data["runtime"]

--- a/source/isaaclab/changelog.d/antoiner-benchmark-warmup-steps.major.rst
+++ b/source/isaaclab/changelog.d/antoiner-benchmark-warmup-steps.major.rst
@@ -1,0 +1,10 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Renamed ``--warmup_frames`` to ``--warmup_steps`` for runtime
+  and play benchmarks, and renamed ``warmup_frames`` to ``warmup_steps`` in
+  :class:`~isaaclab.benchmark.BenchmarkRuntimeRequest` and
+  :class:`~isaaclab.benchmark.BenchmarkPlayRequest`. Use the new step-based
+  names when invoking or configuring benchmarks. Benchmark bundles now record
+  the excluded count in
+  :attr:`~isaaclab.benchmark.EnvironmentStepTiming.warmup_steps`.

--- a/source/isaaclab/isaaclab/benchmark/api.py
+++ b/source/isaaclab/isaaclab/benchmark/api.py
@@ -84,7 +84,7 @@ class BenchmarkRuntimeRequest:
         task: Registered Gym task identifier.
         num_envs: Number of parallel environments.
         num_frames: Number of measured environment steps.
-        warmup_frames: Number of warm-up steps excluded from throughput measurements.
+        warmup_steps: Number of warm-up steps excluded from throughput measurements.
         seed: Environment seed.
         measure_synchronized_step_breakdown: Whether to collect serialized synchronized
             environment/simulation step diagnostics.
@@ -97,7 +97,7 @@ class BenchmarkRuntimeRequest:
     task: str
     num_envs: int | None = None
     num_frames: int = 1000
-    warmup_frames: int = 50
+    warmup_steps: int = 50
     seed: int | None = None
     measure_synchronized_step_breakdown: bool = False
     presets: tuple[str, ...] = field(default_factory=tuple)
@@ -224,7 +224,7 @@ class BenchmarkPlayRequest:
         agent: Optional task agent configuration entry point.
         num_envs: Number of parallel environments.
         num_frames: Number of measured inference steps.
-        warmup_frames: Number of initial environment steps excluded from environment-step timing.
+        warmup_steps: Number of initial environment steps excluded from environment-step timing.
         seed: Environment seed.
         measure_synchronized_step_breakdown: Whether to collect serialized synchronized
             environment/simulation step diagnostics.
@@ -241,7 +241,7 @@ class BenchmarkPlayRequest:
     agent: str | None = None
     num_envs: int | None = None
     num_frames: int = 100
-    warmup_frames: int = 1
+    warmup_steps: int = 1
     seed: int | None = None
     measure_synchronized_step_breakdown: bool = False
     presets: tuple[str, ...] = field(default_factory=tuple)

--- a/source/isaaclab/isaaclab/benchmark/builders.py
+++ b/source/isaaclab/isaaclab/benchmark/builders.py
@@ -132,6 +132,7 @@ def build_runtime(
     steps_per_iteration: int,
     aggregate_throughput: bool = False,
     frames_per_environment_step: int | None = None,
+    environment_step_warmup_steps: int = 0,
     environment_step_times_s: Sequence[float] | None = None,
     simulation_step_times_s: Sequence[float] | None = None,
     simulation_step_calls: int | None = None,
@@ -150,6 +151,7 @@ def build_runtime(
             remains the ordinary sample deviation of the per-iteration rates,
             and peak remains the maximum per-iteration throughput.
         frames_per_environment_step: Number of environment frames processed by each vectorized ``env.step()`` call.
+        environment_step_warmup_steps: Number of initial environment-step calls excluded from timing.
         environment_step_times_s: Positive per-environment-step wall times [s].
         simulation_step_times_s: Synchronized simulation wall times per environment step [s].
         simulation_step_calls: Number of measured simulation-step calls.
@@ -230,6 +232,7 @@ def build_runtime(
             environment_step_calls=len(environment_samples),
             simulation_step_calls=simulation_step_calls,
             measurement_mode=("serialized_synchronized" if simulation_step_times_s is not None else "host_return"),
+            warmup_steps=environment_step_warmup_steps,
         )
 
     return Runtime(

--- a/source/isaaclab/isaaclab/benchmark/dispatch.py
+++ b/source/isaaclab/isaaclab/benchmark/dispatch.py
@@ -130,7 +130,7 @@ def _request_argv(request: BenchmarkRequest) -> list[str]:
 
     if request.workflow == "runtime":
         _append_value(argv, "--num_frames", request.num_frames)
-        _append_value(argv, "--warmup_frames", request.warmup_frames)
+        _append_value(argv, "--warmup_steps", request.warmup_steps)
     elif request.workflow == "startup":
         _append_value(argv, "--top_n", request.top_n)
         _append_value(argv, "--whitelist_config", request.whitelist_config)
@@ -163,7 +163,7 @@ def _request_argv(request: BenchmarkRequest) -> list[str]:
         _append_value(argv, "--checkpoint", request.checkpoint)
         _append_value(argv, "--agent", request.agent)
         _append_value(argv, "--num_frames", request.num_frames)
-        _append_value(argv, "--warmup_frames", request.warmup_frames)
+        _append_value(argv, "--warmup_steps", request.warmup_steps)
 
     if getattr(request, "measure_synchronized_step_breakdown", False):
         argv.append("--measure_sync_step")

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -66,7 +66,7 @@ def _parse_args(argv: list[str]):
         help="Measure a serialized synchronized simulation and outside-simulation step breakdown.",
     )
     parser.add_argument(
-        "--warmup_frames",
+        "--warmup_steps",
         type=parse_non_negative_int,
         default=1,
         help="Exclude the first N env.step() calls from environment-step timing. Default 1 removes cold start.",
@@ -175,7 +175,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                             "name": "environment_step_measurement_mode",
                             "data": ("serialized_synchronized" if args_cli.measure_sync_step else "host_return"),
                         },
-                        {"name": "environment_step_warmup_frames", "data": args_cli.warmup_frames},
+                        {"name": "environment_step_warmup_steps", "data": args_cli.warmup_steps},
                         {"name": "presets", "data": ",".join(cfg.presets)},
                     ]
                 },
@@ -243,14 +243,14 @@ def run(argv: list[str]) -> BenchmarkResult:
             environment_step_timer = stepping.EnvironmentStepTimingRecorder(
                 env,
                 measure_synchronized_step_breakdown=args_cli.measure_sync_step,
-                warmup_steps=args_cli.warmup_frames,
+                warmup_steps=args_cli.warmup_steps,
             )
-            total_frames = args_cli.warmup_frames + args_cli.num_frames
+            total_frames = args_cli.warmup_steps + args_cli.num_frames
             with environment_step_timer, BenchmarkMonitor(benchmark, interval=1.0):
                 all_step_times, reward, ep_length, success_rate = stepping.run_play_loop(env, policy, total_frames)
 
             first_step_s = all_step_times[0]
-            step_times = all_step_times[args_cli.warmup_frames :]
+            step_times = all_step_times[args_cli.warmup_steps :]
 
             benchmark.update_manual_recorders()
 
@@ -268,6 +268,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=fps,
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
@@ -306,6 +306,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=total_fps_series,
                 steps_per_iteration=steps_per_iteration,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -67,7 +67,7 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         help="Measure a serialized synchronized simulation and outside-simulation step breakdown.",
     )
     parser.add_argument(
-        "--warmup_frames",
+        "--warmup_steps",
         type=parse_non_negative_int,
         default=1,
         help="Exclude the first N env.step() calls from environment-step timing. Default 1 removes cold start.",
@@ -172,7 +172,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                             "name": "environment_step_measurement_mode",
                             "data": ("serialized_synchronized" if args.measure_sync_step else "host_return"),
                         },
-                        {"name": "environment_step_warmup_frames", "data": args.warmup_frames},
+                        {"name": "environment_step_warmup_steps", "data": args.warmup_steps},
                         {"name": "presets", "data": ",".join(cfg.presets)},
                     ]
                 },
@@ -200,14 +200,14 @@ def run(argv: list[str]) -> BenchmarkResult:
             environment_step_timer = stepping.EnvironmentStepTimingRecorder(
                 env,
                 measure_synchronized_step_breakdown=args.measure_sync_step,
-                warmup_steps=args.warmup_frames,
+                warmup_steps=args.warmup_steps,
             )
-            total_frames = args.warmup_frames + args.num_frames
+            total_frames = args.warmup_steps + args.num_frames
             with environment_step_timer, BenchmarkMonitor(benchmark, interval=1.0):
                 all_step_times, reward, ep_length, success_rate = stepping.run_play_loop(env, policy, total_frames)
 
             first_step_s = all_step_times[0]
-            step_times = all_step_times[args.warmup_frames :]
+            step_times = all_step_times[args.warmup_steps :]
 
             benchmark.update_manual_recorders()
 
@@ -225,6 +225,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=fps,
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
@@ -281,6 +281,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=total_fps_series,
                 steps_per_iteration=env.unwrapped.num_envs * agent_cfg.num_steps_per_env,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -73,7 +73,7 @@ def _parse_args(argv: list[str]):
         help="Measure a serialized synchronized simulation and outside-simulation step breakdown.",
     )
     parser.add_argument(
-        "--warmup_frames",
+        "--warmup_steps",
         type=parse_non_negative_int,
         default=1,
         help="Exclude the first N env.step() calls from environment-step timing. Default 1 removes cold start.",
@@ -175,7 +175,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                             "name": "environment_step_measurement_mode",
                             "data": ("serialized_synchronized" if args_cli.measure_sync_step else "host_return"),
                         },
-                        {"name": "environment_step_warmup_frames", "data": args_cli.warmup_frames},
+                        {"name": "environment_step_warmup_steps", "data": args_cli.warmup_steps},
                         {"name": "presets", "data": ",".join(cfg.presets)},
                     ]
                 },
@@ -230,14 +230,14 @@ def run(argv: list[str]) -> BenchmarkResult:
             environment_step_timer = stepping.EnvironmentStepTimingRecorder(
                 env,
                 measure_synchronized_step_breakdown=args_cli.measure_sync_step,
-                warmup_steps=args_cli.warmup_frames,
+                warmup_steps=args_cli.warmup_steps,
             )
-            total_frames = args_cli.warmup_frames + args_cli.num_frames
+            total_frames = args_cli.warmup_steps + args_cli.num_frames
             with environment_step_timer, BenchmarkMonitor(benchmark, interval=1.0):
                 all_step_times, reward, ep_length, success_rate = stepping.run_play_loop(env, policy, total_frames)
 
             first_step_s = all_step_times[0]
-            step_times = all_step_times[args_cli.warmup_frames :]
+            step_times = all_step_times[args_cli.warmup_steps :]
 
             benchmark.update_manual_recorders()
 
@@ -255,6 +255,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=fps,
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_train_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_train_sb3.py
@@ -367,6 +367,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=total_fps,
                 steps_per_iteration=steps_per_iteration,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -85,7 +85,7 @@ def _parse_args(argv: list[str]):
         help="Measure a serialized synchronized simulation and outside-simulation step breakdown.",
     )
     parser.add_argument(
-        "--warmup_frames",
+        "--warmup_steps",
         type=parse_non_negative_int,
         default=1,
         help="Exclude the first N env.step() calls from environment-step timing. Default 1 removes cold start.",
@@ -204,7 +204,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                             "name": "environment_step_measurement_mode",
                             "data": ("serialized_synchronized" if args_cli.measure_sync_step else "host_return"),
                         },
-                        {"name": "environment_step_warmup_frames", "data": args_cli.warmup_frames},
+                        {"name": "environment_step_warmup_steps", "data": args_cli.warmup_steps},
                         {"name": "presets", "data": ",".join(cfg.presets)},
                     ]
                 },
@@ -252,14 +252,14 @@ def run(argv: list[str]) -> BenchmarkResult:
             environment_step_timer = stepping.EnvironmentStepTimingRecorder(
                 env,
                 measure_synchronized_step_breakdown=args_cli.measure_sync_step,
-                warmup_steps=args_cli.warmup_frames,
+                warmup_steps=args_cli.warmup_steps,
             )
-            total_frames = args_cli.warmup_frames + args_cli.num_frames
+            total_frames = args_cli.warmup_steps + args_cli.num_frames
             with environment_step_timer, BenchmarkMonitor(benchmark, interval=1.0):
                 all_step_times, reward, ep_length, success_rate = stepping.run_play_loop(env, policy, total_frames)
 
             first_step_s = all_step_times[0]
-            step_times = all_step_times[args_cli.warmup_frames :]
+            step_times = all_step_times[args_cli.warmup_steps :]
 
             benchmark.update_manual_recorders()
 
@@ -277,6 +277,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=fps,
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
@@ -404,6 +404,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=total_fps,
                 steps_per_iteration=steps_per_iteration,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args_cli.warmup_steps,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
@@ -15,7 +15,7 @@ Usage example::
 
     uv run isaaclab benchmark runtime \\
         --task Isaac-Cartpole-Direct \\
-        --num_envs 16 --num_frames 1000 --warmup_frames 50 \\
+        --num_envs 16 --num_frames 1000 --warmup_steps 50 \\
         presets=newton_mjwarp --headless
 """
 
@@ -52,7 +52,7 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         "--num_frames", type=parse_positive_int, default=1000, help="Number of environment steps to benchmark."
     )
     parser.add_argument(
-        "--warmup_frames",
+        "--warmup_steps",
         type=parse_non_negative_int,
         default=50,
         help="Exact number of environment steps to exclude from timing; zero measures the first step.",
@@ -143,7 +143,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                     {"name": "task", "data": args.task},
                     {"name": "num_envs", "data": args.num_envs},
                     {"name": "num_frames", "data": args.num_frames},
-                    {"name": "warmup_frames", "data": args.warmup_frames},
+                    {"name": "environment_step_warmup_steps", "data": args.warmup_steps},
                     {
                         "name": "environment_step_measurement_mode",
                         "data": ("serialized_synchronized" if args.measure_sync_step else "host_return"),
@@ -159,7 +159,7 @@ def run(argv: list[str]) -> BenchmarkResult:
 
             num_envs = env.unwrapped.num_envs
 
-            warmup_step_times_s = stepping.run_runtime_warmup(env, args.warmup_frames)
+            warmup_step_times_s = stepping.run_runtime_warmup(env, args.warmup_steps)
             environment_step_timer = stepping.EnvironmentStepTimingRecorder(
                 env, measure_synchronized_step_breakdown=args.measure_sync_step
             )
@@ -186,6 +186,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 total_fps=fps,
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
+                environment_step_warmup_steps=args.warmup_steps,
                 aggregate_throughput=True,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
@@ -219,7 +220,6 @@ def run(argv: list[str]) -> BenchmarkResult:
                 hardware=hardware,
                 runtime=runtime,
                 resources=resources,
-                extra={"warmup_frames": args.warmup_frames},
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/schema.py
+++ b/source/isaaclab/isaaclab/benchmark/schema.py
@@ -231,6 +231,7 @@ class EnvironmentStepTiming:
         measurement_mode: Timing boundary semantics. ``host_return`` does not
             force device completion. ``serialized_synchronized`` explicitly
             synchronizes every measured boundary.
+        warmup_steps: Number of initial environment-step calls excluded from timing.
     """
 
     environment_step_time_s: MeanStd
@@ -241,9 +242,12 @@ class EnvironmentStepTiming:
     environment_step_calls: int
     simulation_step_calls: int | None
     measurement_mode: Literal["host_return", "serialized_synchronized"]
+    warmup_steps: int = 0
 
     def __post_init__(self) -> None:
         """Validate that the timing fields form one consistent measurement mode."""
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be non-negative")
         if self.environment_step_calls <= 0:
             raise ValueError("environment_step_calls must be greater than zero")
         if not (

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -121,7 +121,7 @@ def test_runtime_request_uses_runtime_defaults() -> None:
         "Isaac-Cartpole-Direct",
         "--num_frames",
         "1000",
-        "--warmup_frames",
+        "--warmup_steps",
         "50",
         "--output_path",
         ".",
@@ -131,16 +131,16 @@ def test_runtime_request_uses_runtime_defaults() -> None:
 
 
 @pytest.mark.parametrize("backend", ["rsl_rl", "rl_games", "skrl", "sb3"])
-def test_play_request_uses_backend_warmup_frames_argument(backend: str, monkeypatch) -> None:
-    request = BenchmarkPlayRequest(backend=backend, task="Isaac-Cartpole-Direct", warmup_frames=12)
+def test_play_request_uses_backend_warmup_steps_argument(backend: str, monkeypatch) -> None:
+    request = BenchmarkPlayRequest(backend=backend, task="Isaac-Cartpole-Direct", warmup_steps=12)
 
     argv = dispatch._request_argv(request)
     monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
     entrypoint = importlib.import_module(dispatch._workflow_module("play", backend))
     args, remaining_args = entrypoint._parse_args(argv)
 
-    assert argv[argv.index("--warmup_frames") + 1] == "12"
-    assert args.warmup_frames == 12
+    assert argv[argv.index("--warmup_steps") + 1] == "12"
+    assert args.warmup_steps == 12
     assert remaining_args == []
 
 
@@ -157,7 +157,7 @@ def test_task_workflow_help_does_not_require_task(workflow: str, monkeypatch, ca
 
 
 def test_request_dispatches_to_library_module(monkeypatch) -> None:
-    request = BenchmarkRuntimeRequest(task="Isaac-Cartpole-Direct", num_frames=1, warmup_frames=0)
+    request = BenchmarkRuntimeRequest(task="Isaac-Cartpole-Direct", num_frames=1, warmup_steps=0)
     expected = BenchmarkResult(bundle=object(), output_paths=(Path("result.json"),))
     received: list[str] = []
     caller_argv = ["caller.py", "--unrelated"]
@@ -185,7 +185,7 @@ def test_request_dispatches_to_library_module(monkeypatch) -> None:
         "Isaac-Cartpole-Direct",
         "--num_frames",
         "1",
-        "--warmup_frames",
+        "--warmup_steps",
         "0",
     ]
 

--- a/source/isaaclab/test/benchmark/test_builders.py
+++ b/source/isaaclab/test/benchmark/test_builders.py
@@ -124,12 +124,14 @@ def test_build_runtime_adds_environment_step_timing():
         total_fps=[4.0],
         steps_per_iteration=8,
         frames_per_environment_step=8,
+        environment_step_warmup_steps=3,
         environment_step_times_s=[1.0, 2.0],
         simulation_step_times_s=[0.5, 0.5],
         simulation_step_calls=8,
     )
 
     assert rt.environment_step_timing is not None
+    assert rt.environment_step_timing.warmup_steps == 3
     assert rt.environment_step_timing.environment_step_time_s.mean == pytest.approx(1.5)
     assert rt.environment_step_timing.environment_step_time_s.std == pytest.approx(2**-0.5)
     assert rt.environment_step_timing.environment_step_fps.mean == pytest.approx(16.0 / 3.0)
@@ -165,16 +167,32 @@ def test_build_runtime_adds_environment_step_timing_without_simulation_breakdown
         total_fps=[4.0],
         steps_per_iteration=8,
         frames_per_environment_step=8,
+        environment_step_warmup_steps=2,
         environment_step_times_s=[1.0, 2.0],
     )
 
     assert rt.environment_step_timing is not None
+    assert rt.environment_step_timing.warmup_steps == 2
     assert rt.environment_step_timing.environment_step_fps.mean == pytest.approx(16.0 / 3.0)
     assert rt.environment_step_timing.simulation_step_time_s is None
     assert rt.environment_step_timing.outside_simulation_step_time_s is None
     assert rt.environment_step_timing.outside_simulation_step_fraction is None
     assert rt.environment_step_timing.simulation_step_calls is None
     assert rt.environment_step_timing.measurement_mode == "host_return"
+
+
+def test_build_runtime_rejects_negative_environment_step_warmup_steps():
+    with pytest.raises(ValueError, match="warmup_steps must be non-negative"):
+        builders.build_runtime(
+            startup_time_s=StartupTime(0.1, 0.2, 0.3),
+            iteration_times_s=[2.0],
+            collection_fps=[4.0],
+            total_fps=[4.0],
+            steps_per_iteration=8,
+            frames_per_environment_step=8,
+            environment_step_warmup_steps=-1,
+            environment_step_times_s=[1.0],
+        )
 
 
 @pytest.mark.parametrize("simulation_step_times_s", [[], [0.0, 0.5], [-0.1, 0.5]])

--- a/source/isaaclab/test/benchmark/test_schema.py
+++ b/source/isaaclab/test/benchmark/test_schema.py
@@ -149,6 +149,7 @@ def test_training_bundle_round_trip(tmp_path):
     assert data["runtime"]["collection_fps"]["mean"] == pytest.approx(1_142_000.0)
     assert data["runtime"]["total_fps"]["mean"] == pytest.approx(1_071_780.0)
     timing = data["runtime"]["environment_step_timing"]
+    assert timing["warmup_steps"] == 0
     assert timing["outside_simulation_step_fraction"] == pytest.approx(0.375)
     assert timing["measurement_mode"] == "serialized_synchronized"
     assert "overhead_step_time_s" not in timing


### PR DESCRIPTION
## Summary

- rename runtime and play `--warmup_frames` interfaces to `--warmup_steps`
- expose the excluded count as `runtime.environment_step_timing.warmup_steps`
- use `environment_step_warmup_steps` consistently in flat benchmark metadata
- remove the duplicate runtime `extra.warmup_frames` value

## Dependency

Stacked on #6564. Merge #6564 first; the standalone change in this PR is commit `f895534e59`.

## Testing

- `./isaaclab.sh -p -m pytest source/isaaclab/test/benchmark source/isaaclab/test/cli/test_benchmark_entrypoint.py scripts/benchmarks/test/test_benchmark_smoke.py -k "not training_and_play_write_bundles" -q` (241 passed)
- runtime host-return and synchronized smoke tests (2 passed)
- RSL-RL training/play end-to-end smoke test (1 passed)
- `./isaaclab.sh -f`