### PR TITLE
[CI] Cut ARM CI cold start by persisting Isaac Sim caches across runs

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -81,6 +81,15 @@ inputs:
     description: 'Host path to bind-mount at /workspace/isaaclab (for deps-cache-hit mode)'
     default: ''
     required: false
+  persistent-cache-key:
+    description: >-
+      When set, Kit/OptiX/asset caches are bind-mounted from a stable per-key
+      directory that outlives the run, so the job skips Isaac Sim's ~6 min
+      first-launch warm-up. Key by Isaac Sim image tag so a base-image bump
+      starts cold. Needs volume-mount-source and a long-lived self-hosted
+      runner. Default '' — no persistence.
+    default: ''
+    required: false
   extra-pip-packages:
     description: 'Space-separated pip packages to install inside the Docker container before pytest starts'
     default: ''
@@ -152,10 +161,16 @@ runs:
           local standalone_script_scope="${22}"
           local standalone_script_visualizer="${23}"
           local standalone_script_runtime_group="${24}"
+          local persistent_cache_key="${25}"
           local logs_pid=""
           local wait_pid=""
           local docker_wait_file="/tmp/.docker_exit_${container_name}"
           local docker_runtime_dir=""
+          local cache_dir=""
+          local cache_root=""
+          local sanitized_cache_key=""
+          local cache_lock_fd=""
+          local persistent_cache_dir=""
 
           # Kill the container immediately if the runner is cancelled.
           # The GitHub Actions runner can deliver HUP, INT, or TERM on cancellation
@@ -332,30 +347,62 @@ runs:
             # host-uid test runs, mirroring the compose/singularity mounts.
             docker_runtime_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/isaaclab-docker-runtime.XXXXXX")"
             mkdir -p \
-              "${docker_runtime_dir}/home/.cache" \
               "${docker_runtime_dir}/home/.local/share/ov/data" \
               "${docker_runtime_dir}/home/.local/share/ov/pkg" \
-              "${docker_runtime_dir}/home/.nv/ComputeCache" \
               "${docker_runtime_dir}/home/.nvidia-omniverse/config" \
               "${docker_runtime_dir}/home/.nvidia-omniverse/logs" \
               "${docker_runtime_dir}/home/Documents/Kit/shared" \
-              "${docker_runtime_dir}/isaac-sim/kit/cache" \
               "${docker_runtime_dir}/isaac-sim/kit/data" \
               "${docker_runtime_dir}/isaac-sim/kit/logs" \
-              "${docker_runtime_dir}/isaac-sim/cache" \
-              "${docker_runtime_dir}/isaac-sim/computecache" \
               "${docker_runtime_dir}/isaac-sim/config" \
               "${docker_runtime_dir}/isaac-sim/data" \
               "${docker_runtime_dir}/isaac-sim/logs" \
               "${docker_runtime_dir}/isaac-sim/pkg"
+
+            # Caches are derived artifacts, so with a key they live outside
+            # docker_runtime_dir and survive the cleanup below; the per-run dirs
+            # above stay per-run.
+            cache_dir="${docker_runtime_dir}/cache"
+            if [ -n "$persistent_cache_key" ]; then
+              cache_root="${ISAACLAB_CI_CACHE_ROOT:-/var/tmp/isaaclab-ci-cache}"
+              sanitized_cache_key=$(echo "$persistent_cache_key" | sed 's/[^a-zA-Z0-9._-]/-/g')
+              mkdir -p "$cache_root"
+              exec {cache_lock_fd}>"${cache_root}/${sanitized_cache_key}.lock"
+              # Non-blocking: a job that loses the lock uses a per-run cache
+              # rather than interleaving writes or waiting out its timeout.
+              if flock -n "$cache_lock_fd"; then
+                cache_dir="${cache_root}/${sanitized_cache_key}"
+                persistent_cache_dir="$cache_dir"
+                # Same 14-day TTL as the deps tags in .github/actions/docker-build.
+                find "$cache_root" -mindepth 1 -maxdepth 1 -type d -mtime +14 \
+                  -exec rm -rf {} + 2>/dev/null || true
+                echo "🔵 Persistent cache: ${cache_dir}"
+              else
+                echo "::notice::Persistent cache ${sanitized_cache_key} is locked by another job - using a per-run cache"
+              fi
+            fi
+            mkdir -p \
+              "${cache_dir}/home-cache" \
+              "${cache_dir}/home-computecache" \
+              "${cache_dir}/kit-cache" \
+              "${cache_dir}/isaac-sim-cache" \
+              "${cache_dir}/computecache"
+            # Keep the active cache clear of the TTL sweep while it is in use.
+            touch "$cache_dir"
+
+            # Nested cache mounts follow the home mount they sit inside; Docker
+            # orders binds by destination depth. ComputeCache is persisted at
+            # both paths because which one CUDA writes depends on HOME.
             docker_volume_args="\
               -v ${volume_mount_source}:/workspace/isaaclab:rw \
               -v ${docker_runtime_dir}/home:/tmp/isaaclab-ci-home:rw \
-              -v ${docker_runtime_dir}/isaac-sim/kit/cache:/isaac-sim/kit/cache:rw \
+              -v ${cache_dir}/home-cache:/tmp/isaaclab-ci-home/.cache:rw \
+              -v ${cache_dir}/home-computecache:/tmp/isaaclab-ci-home/.nv/ComputeCache:rw \
+              -v ${cache_dir}/kit-cache:/isaac-sim/kit/cache:rw \
+              -v ${cache_dir}/isaac-sim-cache:/isaac-sim/.cache:rw \
+              -v ${cache_dir}/computecache:/isaac-sim/.nv/ComputeCache:rw \
               -v ${docker_runtime_dir}/isaac-sim/kit/data:/isaac-sim/kit/data:rw \
               -v ${docker_runtime_dir}/isaac-sim/kit/logs:/isaac-sim/kit/logs:rw \
-              -v ${docker_runtime_dir}/isaac-sim/cache:/isaac-sim/.cache:rw \
-              -v ${docker_runtime_dir}/isaac-sim/computecache:/isaac-sim/.nv/ComputeCache:rw \
               -v ${docker_runtime_dir}/isaac-sim/config:/isaac-sim/.nvidia-omniverse/config:rw \
               -v ${docker_runtime_dir}/isaac-sim/data:/isaac-sim/.local/share/ov/data:rw \
               -v ${docker_runtime_dir}/isaac-sim/logs:/isaac-sim/.nvidia-omniverse/logs:rw \
@@ -548,8 +595,13 @@ runs:
           # Clean up container
           echo "🔵 Cleaning up Docker container..."
           docker rm $container_name 2>/dev/null || echo "🟠 Container cleanup failed, but continuing..."
+          # A persistent cache_dir lives outside docker_runtime_dir and is left
+          # in place for the next run.
           if [ -n "$docker_runtime_dir" ]; then
             rm -rf "$docker_runtime_dir" || echo "🟠 Docker runtime storage cleanup failed, but continuing..."
+          fi
+          if [ -n "$persistent_cache_dir" ]; then
+            echo "🔵 Retained persistent cache: $(du -sh "$persistent_cache_dir" 2>/dev/null | cut -f1) at ${persistent_cache_dir}"
           fi
           echo "::endgroup::"
 
@@ -557,7 +609,7 @@ runs:
         }
 
         # Call the function with provided parameters
-        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}" "$TEST_K_EXPR_INPUT" "$CI_MARKER_INPUT" "${{ inputs.standalone-script-scope }}" "${{ inputs.standalone-script-visualizer }}" "${{ inputs.standalone-script-runtime-group }}"
+        run_tests "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}" "$TEST_K_EXPR_INPUT" "$CI_MARKER_INPUT" "${{ inputs.standalone-script-scope }}" "${{ inputs.standalone-script-visualizer }}" "${{ inputs.standalone-script-runtime-group }}" "${{ inputs.persistent-cache-key }}"
 
     - name: Kill container on cancellation
       if: cancelled()

--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -188,6 +188,9 @@ jobs:
         test-k-expr: not ovphysx
         ci-marker: arm_ci
         volume-mount-source: ${{ github.workspace }}
+        # The Spark runners are long-lived, so keep Isaac Sim's caches between
+        # runs; rebuilding them costs ~6 min of renderer warm-up.
+        persistent-cache-key: arm64-${{ needs.config.outputs.isaacsim_image_tag }}
 
     - name: Run shared Cartpole smoke
       uses: ./.github/actions/run-tests
@@ -197,6 +200,7 @@ jobs:
         container-name: isaac-lab-arm-ci-cartpole-${{ github.run_id }}-${{ github.run_attempt }}
         image-tag: ${{ needs.config.outputs.ci_image_tag }}-arm64
         volume-mount-source: ${{ github.workspace }}
+        persistent-cache-key: arm64-${{ needs.config.outputs.isaacsim_image_tag }}
 
     - name: Upload test reports
       if: always()

--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -183,23 +183,11 @@ jobs:
         result-file: arm-ci-report.xml
         container-name: isaac-lab-arm-ci-${{ github.run_id }}-${{ github.run_attempt }}
         image-tag: ${{ needs.config.outputs.ci_image_tag }}-arm64
-        extra-pip-packages: "${{ steps.ov_pins.outputs.ovrtx }} ${{ steps.ov_pins.outputs.ovphysx }}"
+        # ovphysx params run on x86 only; nothing left in this step imports it.
+        extra-pip-packages: "${{ steps.ov_pins.outputs.ovrtx }}"
         test-k-expr: not ovphysx
         ci-marker: arm_ci
         volume-mount-source: ${{ github.workspace }}
-
-    - name: Run arm_ci OVPhysX marker tests
-      uses: ./.github/actions/run-tests
-      with:
-        test-path: tools
-        result-file: arm-ci-ovphysx-report.xml
-        container-name: isaac-lab-arm-ci-ovphysx-${{ github.run_id }}-${{ github.run_attempt }}
-        image-tag: ${{ needs.config.outputs.ci_image_tag }}-arm64
-        extra-pip-packages: "${{ steps.ov_pins.outputs.ovrtx }} ${{ steps.ov_pins.outputs.ovphysx }}"
-        test-k-expr: ovphysx
-        ci-marker: arm_ci
-        volume-mount-source: ${{ github.workspace }}
-
 
     - name: Run shared Cartpole smoke
       uses: ./.github/actions/run-tests


### PR DESCRIPTION
## PR series map

| Part | PR | Scope | Base | Review diff |
|---|---|---|---|---|
| 1/2 | https://github.com/isaac-sim/IsaacLab/pull/6775 | Drop the duplicate OVPhysX step from ARM CI | `develop` | https://github.com/hujc7/IsaacLab/compare/cb129107e2aec855e392a1866657da7f7d873ece...20e105c27380b1f08fccd793bdab053f9c937e90 |
| 2/2 | **this PR** | Persist Isaac Sim caches across runs | Part 1 | https://github.com/hujc7/IsaacLab/compare/20e105c27380b1f08fccd793bdab053f9c937e90...f065bfd429905464c24a2db9cd80d11cb6278233 |

Stacked on https://github.com/isaac-sim/IsaacLab/pull/6775 — [CI] Halve ARM CI runtime by dropping the duplicate OVPhysX step. Both parts target `develop` because the series is cross-fork and a base branch cannot live on the fork, so this PR's diff contains Part 1's commit as well. **Use the Part 2 compare link above to review this change in isolation.**

## Summary

* Every `run-tests` invocation provisioned Isaac Sim's cache directories under a fresh `mktemp` dir and deleted them afterwards, so **every step of every run launched Isaac Sim against empty Kit, OptiX and asset caches**.
* That warm-up costs **~6 min of silence before the first rendering test reports**, and was discarded immediately afterwards.
* Adds an opt-in `persistent-cache-key` input that bind-mounts those caches from a stable per-key directory outliving the run. ARM CI keys on the Isaac Sim image tag.
* **Expected: ~15.9 min → ~10 min, with no test coverage removed.**

## 1. Evidence the cost is cache-resident

From run 30388296334:

| Observation | Time | What it shows |
|---|---|---|
| First rendering test in a container | **421 s** | Cold caches |
| First test of the *next* file, same container | **72 s** | Separate process and renderer; only the mounted dirs are shared — so ~350 s was one-time work now on disk |
| First rendering test of the *next step* (fresh `mktemp`) | **370 s** | The same work redone, because the dir was thrown away |

That third row is the direct proof: the expensive state is filesystem-resident and currently discarded between every step.

## 2. What changed

`.github/actions/run-tests/action.yml` splits the scratch dir by lifetime:

| Group | Paths | Lifetime |
|---|---|---|
| Persisted | `kit/cache`, `/isaac-sim/.cache`, `.nv/ComputeCache` (both `/isaac-sim` and `$HOME`), `$HOME/.cache` | across runs |
| Per-run | `logs`, `config`, `data`, `pkg`, `kit/data`, `kit/logs` | unchanged |

Only derived artifacts persist; persisting logs/config/data would leak state between runs without saving any work.

Two details worth flagging for review:

* **Nested bind mounts.** `$HOME` is mounted wholesale at `/tmp/isaaclab-ci-home`, so persisting only its `.cache` means mounting over a path inside an existing mount. Docker sorts bind mounts by destination depth, so the nested mounts land on top rather than being shadowed — they are ordered after the parent accordingly.
* **ComputeCache is persisted at two locations** (`/isaac-sim/.nv/ComputeCache` and `$HOME/.nv/ComputeCache`) because which one CUDA writes depends on `HOME`, which this action overrides. Persisting one alone would leave half the JIT cache cold.

**Concurrency:** a non-blocking `flock`. A job that cannot take the lock falls back to a per-run cache rather than interleaving writes into a shared Kit cache or waiting out its 60-minute timeout — slower, never wrong, and identical to today's behaviour.

**Disk growth:** stale cache roots are evicted on a 14-day TTL, mirroring the deps-tag eviction already in `.github/actions/docker-build`. The active cache is `touch`ed so it is never swept while in use, and its size is reported in the cleanup log group.

**Blast radius:** the whole cache-mount block is inside `if [ -n "$volume_mount_source" ]`, and `volume-mount-source` is passed **only** by `arm-ci.yml`. x86 jobs bake source into the image and never enter this branch. The input also defaults to `''` (no persistence), so unkeyed callers keep today's exact behaviour.

## 3. Verification

The shell logic was extracted from the action and exercised directly, each case in its own process:

| Case | Expected | Result |
|---|---|---|
| Key set, lock free | persistent dir, survives cleanup | pass |
| No key | per-run dir, deleted with runtime dir | pass |
| Lock held by another process | falls back to per-run dir | pass |
| 20-day-old sibling cache root | evicted by TTL sweep | pass |
| Second run with same key | reuses the warmed dir | pass |

Also: `uv run isaaclab -f` passes; `bash -n` on the embedded script passes; both YAML files parse; `python3 tools/changelog/cli.py check develop` passes (CI-only change).

**Not yet verified on hardware:** the actual saving on a Spark runner, and which of the persisted directories holds the bulk of the warm-up. The first green run on this branch will show both — worth confirming before merge.

## 4. Related

https://github.com/isaac-sim/IsaacLab/pull/6707 — Save warp cache for CI covers a different cache with the same intent; worth coordinating so the two do not diverge on where CI caches live.

