### PR TITLE
Fix GelSight Mini render data path

### DIFF
--- a/source/isaaclab_assets/changelog.d/kellyguo11-fix-gelsight-mini-background-path.rst
+++ b/source/isaaclab_assets/changelog.d/kellyguo11-fix-gelsight-mini-background-path.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed :data:`~isaaclab_assets.sensors.GELSIGHT_MINI_CFG` to use the available GelSight render data.

--- a/source/isaaclab_assets/isaaclab_assets/sensors/gelsight.py
+++ b/source/isaaclab_assets/isaaclab_assets/sensors/gelsight.py
@@ -30,7 +30,7 @@ Reference: https://www.gelsight.com/gelsightinc-products/
 """
 
 GELSIGHT_MINI_CFG = GelSightRenderCfg(
-    sensor_data_dir_name="gs_mini_data",
+    sensor_data_dir_name="gelsight_r15_data",
     background_path="bg.jpg",
     calib_path="polycalib.npz",
     real_background="real_bg.npy",

--- a/source/isaaclab_assets/test/test_gelsight.py
+++ b/source/isaaclab_assets/test/test_gelsight.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for predefined GelSight sensor configurations."""
+
+from isaaclab_assets.sensors import GELSIGHT_MINI_CFG
+
+
+def test_gelsight_mini_uses_available_background_path():
+    """Verify the GelSight Mini background resolves to the available render data."""
+    assert f"{GELSIGHT_MINI_CFG.sensor_data_dir_name}/{GELSIGHT_MINI_CFG.background_path}" == (
+        "gelsight_r15_data/bg.jpg"
+    )


### PR DESCRIPTION
# Description

Point `GELSIGHT_MINI_CFG` at the published `gelsight_r15_data` render-data
directory. The previous `gs_mini_data` background and calibration URLs return
404, causing GelSight Mini renderer initialization to fail with
`FileNotFoundError`.

This change preserves the existing public configuration symbol and makes its
background resolve to:

`IsaacLab/TacSL/gelsight_r15_data/bg.jpg`

No new dependencies are required.

Fixes #6182

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- Confirmed the regression test fails with the old `gs_mini_data/bg.jpg` path.
- `isaaclab.bat -p -m pytest source/isaaclab_assets/test/test_gelsight.py -q`
  (`1 passed`; one unrelated existing deprecation warning)
- `isaaclab.bat -p tools/changelog/cli.py check develop`
- `isaaclab.bat -f`

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `isaaclab.bat -f`.
- [x] Documentation changes are not required for this configuration correction.
- [x] My changes generate no new warnings.
- [x] I have added a regression test that proves the fix is effective.
- [x] I have added a changelog fragment for `isaaclab_assets`.
- [x] My name already exists in `CONTRIBUTORS.md`.
