### PR TITLE
Default task presets to Isaac Sim PhysX

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -249,7 +249,9 @@ override is given:
 
     @configclass
     class PhysicsCfg(PresetCfg):
-        default: PhysxCfg = PhysxCfg()
+        isaacsim_physx: PhysxCfg = PhysxCfg()
+        physx: PhysxCfg = isaacsim_physx
+        default: PhysxCfg = isaacsim_physx
         newton_mjwarp: NewtonCfg = NewtonCfg()
 
     @configclass
@@ -261,10 +263,10 @@ override is given:
     # Use Newton physics backend
     python train.py --task=Isaac-Reach-Franka env.physics=newton_mjwarp
 
-For tasks that expose automatic PhysX-family selection, ``physics=physx`` is
-resolved at launch time: Isaac Sim PhysX is used when a Kit renderer or Kit viewer
-is requested, and OvPhysX is used for fully kit-less runs. Use
-``physics=isaacsim_physx`` to force Isaac Sim PhysX.
+PhysX-backed task defaults select ``isaacsim_physx`` explicitly. For tasks that
+expose automatic PhysX-family selection, pass ``physics=physx`` to opt in: Isaac
+Sim PhysX is used when a Kit renderer or Kit viewer is requested, and OvPhysX is
+used for fully kit-less runs.
 
 The ``default`` field can be set to ``None`` to make an optional feature that is
 disabled unless explicitly selected:
@@ -313,7 +315,7 @@ Physics backend selection uses the same preset system. A task can define a
         physx: PhysxCfg = PhysxCfg()
         isaacsim_physx: PhysxCfg = PhysxCfg()
         ovphysx: OvPhysxCfg = OvPhysxCfg()
-        default = physx
+        default = isaacsim_physx
         newton_mjwarp: NewtonCfg = NewtonCfg(
             solver_cfg=MJWarpSolverCfg(njmax=5, nconmax=3),
             num_substeps=1,

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -91,9 +91,10 @@ modes. The **Presets** column in each table below is divided into three labeled 
 * **physics=** — physics-backend name passed as ``physics=NAME``
   (e.g. ``physx``, ``isaacsim_physx``, ``newton_mjwarp``,
   ``newton_kamino``, ``ovphysx``, ``newton_mjwarp_vbd``). On tasks that
-  expose automatic PhysX-family selection, ``physx`` uses Isaac Sim PhysX when
-  a Kit renderer or Kit viewer is requested and OvPhysX otherwise; use
-  ``isaacsim_physx`` to force Isaac Sim PhysX.
+  expose automatic PhysX-family selection, ``physx`` opts into launch-time
+  selection: it uses Isaac Sim PhysX when a Kit renderer or Kit viewer is
+  requested and OvPhysX otherwise. PhysX-backed task defaults use the explicit
+  ``isaacsim_physx`` preset.
 * **renderer=** — renderer-backend name passed as ``renderer=NAME``
   (e.g. ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``)
 * **presets=** — environment-specific (domain) preset name passed as

--- a/source/isaaclab_tasks/changelog.d/default-isaacsim-physx.rst
+++ b/source/isaaclab_tasks/changelog.d/default-isaacsim-physx.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed PhysX-backed task defaults to select ``isaacsim_physx`` explicitly.
+  Use ``physics=physx`` to opt into automatic Isaac Sim PhysX/OvPhysX selection.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -81,7 +81,8 @@ class DrLegsPhysicsCfg(PresetCfg):
 
     default: NewtonCfg = _kamino_newton_cfg()
     newton_kamino: NewtonCfg = _kamino_newton_cfg()
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    physx: PhysxCfg = isaacsim_physx
 
 
 ##
@@ -133,7 +134,8 @@ class DrLegsActionsCfg(PresetCfg):
 
     default: ActionsCfg = ActionsCfg()
     newton_kamino: ActionsCfg = ActionsCfg()
-    physx: ActionsCfg = _physx_actions_cfg()
+    isaacsim_physx: ActionsCfg = _physx_actions_cfg()
+    physx: ActionsCfg = isaacsim_physx
 
 
 @configclass
@@ -253,7 +255,8 @@ class DrLegsEventCfg(PresetCfg):
 
     default: EventCfg = EventCfg()
     newton_kamino: EventCfg = EventCfg()
-    physx: EventCfg = _physx_event_cfg()
+    isaacsim_physx: EventCfg = _physx_event_cfg()
+    physx: EventCfg = isaacsim_physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
@@ -51,11 +51,12 @@ class DrLegsContactSensorCfg(PresetCfg):
         track_air_time=True,
     )
     newton_kamino = default
-    physx = PhysXContactSensorCfg(
+    isaacsim_physx = PhysXContactSensorCfg(
         prim_path="{ENV_REGEX_NS}/Robot/foot_.*",
         history_length=3,
         track_air_time=True,
     )
+    physx = isaacsim_physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -176,12 +176,14 @@ class TerminationsCfg:
 class PhysicsCfg(PresetCfg):
     """Physics backend presets for Agibot place tasks."""
 
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
         gpu_total_aggregate_pairs_capacity=16 * 1024,
         friction_correlation_distance=0.00625,
     )
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             solver="newton",
@@ -202,7 +204,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
 
 
 # Robot USD assets whose gripper revolute joints are authored with reversed

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
@@ -61,8 +61,9 @@ class SO101StackPhysicsCfg(PhysicsCfg):
     object surface instead of letting it tunnel through grasped objects.
     """
 
-    default = PhysicsCfg().default.replace(solve_articulation_contact_last=True)
-    physx = default
+    isaacsim_physx = PhysicsCfg().isaacsim_physx.replace(solve_articulation_contact_last=True)
+    physx = isaacsim_physx
+    default = isaacsim_physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -290,12 +290,14 @@ class TerminationsCfg:
 class PhysicsCfg(PresetCfg):
     """Physics backend presets for stack tasks."""
 
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
         gpu_total_aggregate_pairs_capacity=2**21,
         friction_correlation_distance=0.00625,
     )
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             solver="newton",
@@ -316,7 +318,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
 
 
 def raise_if_surface_gripper_on_newton(env_cfg) -> None:

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import UnitreeA1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import AnymalBRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=75,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import AnymalCRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=120,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
@@ -22,4 +22,6 @@ class AnymalCRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         super().__post_init__()
         # switch robot to anymal-c
         self.scene.robot = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.01, physx=0.0)
+        self.scene.robot.actuators["legs"].armature = preset(
+            default=0.0, isaacsim_physx=0.0, physx=0.0, newton_mjwarp=0.01
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/digit/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/digit/rough_env_cfg.py
@@ -217,8 +217,9 @@ class DigitActionsCfg:
 class DigitPhysicsCfg(PresetCfg):
     """PhysX-only physics configuration for the Digit velocity environments."""
 
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
-    physx = default
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import UnitreeGo1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env_cfg.py
@@ -35,7 +35,7 @@ class CabinetDirectPhysicsCfg(PresetCfg):
         ),
         num_substeps=1,
     )
-    default = physx
+    default = isaacsim_physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -48,16 +48,13 @@ class CabinetSimCfg(PresetCfg):
     finer physics timestep (1/200 s) while PhysX keeps its default (1/60 s).
     """
 
-    default: SimulationCfg = SimulationCfg(
+    isaacsim_physx: SimulationCfg = SimulationCfg(
         dt=1 / 60,
         render_interval=1,
         physics=PhysxCfg(bounce_threshold_velocity=0.01, friction_correlation_distance=0.00625),
     )
-    physx: SimulationCfg = SimulationCfg(
-        dt=1 / 60,
-        render_interval=1,
-        physics=PhysxCfg(bounce_threshold_velocity=0.01, friction_correlation_distance=0.00625),
-    )
+    physx: SimulationCfg = isaacsim_physx
+    default: SimulationCfg = isaacsim_physx
     newton_mjwarp: SimulationCfg = SimulationCfg(
         dt=1 / 600,
         render_interval=1,
@@ -263,8 +260,9 @@ class _CabinetNewtonEventCfg:
 
 @configclass
 class CabinetEventCfg(PresetCfg):
-    default: EventCfg = EventCfg()
-    physx: EventCfg = EventCfg()
+    isaacsim_physx: EventCfg = EventCfg()
+    physx: EventCfg = isaacsim_physx
+    default: EventCfg = isaacsim_physx
     newton_mjwarp: _CabinetNewtonEventCfg = _CabinetNewtonEventCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -26,7 +26,7 @@ from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
 class CartpolePhysicsCfg(PresetCfg):
     physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
-    default = physx
+    default = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=5,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -34,8 +34,9 @@ from isaaclab_assets.robots.cartpole import CARTPOLE_CFG  # isort:skip
 
 @configclass
 class CartpolePhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg()
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    physx: PhysxCfg = isaacsim_physx
+    default: PhysxCfg = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=5,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/dexsuite_kuka_allegro_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/dexsuite_kuka_allegro_env_cfg.py
@@ -144,6 +144,7 @@ class KukaAllegroMixinCfg:
         ovphysx_events = default_events.replace(variable_gravity=None)
         self.events = preset(
             default=default_events,
+            isaacsim_physx=default_events,
             physx=default_events,
             newton_mjwarp=default_events,
             ovphysx=ovphysx_events,
@@ -153,6 +154,7 @@ class KukaAllegroMixinCfg:
             ovphysx_curriculum = default_curriculum.replace(gravity_adr=None)
             self.curriculum = preset(
                 default=default_curriculum,
+                isaacsim_physx=default_curriculum,
                 physx=default_curriculum,
                 newton_mjwarp=default_curriculum,
                 ovphysx=ovphysx_curriculum,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
@@ -466,11 +466,13 @@ class TerminationsCfg:
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_max_rigid_patch_count=4 * 5 * 2**15,
         gpu_found_lost_pairs_capacity=2**26,
     )
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             solver="newton",
@@ -490,7 +492,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
@@ -173,7 +173,13 @@ def _shadow_hand_cfg(
         spawn=SHADOW_HAND_CFG.spawn.replace(fixed_tendons_props=None),
         init_state=SHADOW_HAND_CFG.init_state.replace(pos=init_pos, rot=init_rot),
     )
-    return preset(default=newton_mjwarp_cfg, physx=physx_cfg, newton_mjwarp=newton_mjwarp_cfg, ovphysx=ovphysx_cfg)
+    return preset(
+        default=newton_mjwarp_cfg,
+        isaacsim_physx=physx_cfg,
+        physx=physx_cfg,
+        newton_mjwarp=newton_mjwarp_cfg,
+        ovphysx=ovphysx_cfg,
+    )
 
 
 # Per-hand presets shared by the Direct environment and the manager scene.
@@ -201,7 +207,7 @@ class ObjectCfg(PresetCfg):
     thresholds, max depenetration velocity, custom physics material).
     """
 
-    physx = RigidObjectCfg(
+    isaacsim_physx = RigidObjectCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.SphereCfg(
             radius=OBJECT_RADIUS,
@@ -222,6 +228,7 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
     )
+    physx = isaacsim_physx
     newton_mjwarp = RigidObjectCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.SphereCfg(
@@ -237,7 +244,7 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
     )
-    ovphysx = physx
+    ovphysx = isaacsim_physx
     default = newton_mjwarp
 
 
@@ -251,11 +258,12 @@ class PhysicsCfg(PresetCfg):
     tasks; tuning may be needed for handover-specific contact dynamics.
     """
 
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
         gpu_max_rigid_contact_count=2**23,
         gpu_max_rigid_patch_count=2**23,
     )
+    physx = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             solver="newton",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
@@ -85,7 +85,7 @@ class DeformableCfg(PresetCfg):
         ),
     )
 
-    physx: DeformableObjectCfg = DeformableObjectCfg(
+    isaacsim_physx: DeformableObjectCfg = DeformableObjectCfg(
         prim_path="{ENV_REGEX_NS}/Deformable",
         init_state=DeformableObjectCfg.InitialStateCfg(pos=(0.5, 0.0, 0.05)),
         spawn=sim_utils.MeshCuboidCfg(
@@ -101,6 +101,7 @@ class DeformableCfg(PresetCfg):
             ),
         ),
     )
+    physx: DeformableObjectCfg = isaacsim_physx
 
     newton_mjwarp_vbd_proxy = newton_mjwarp_vbd
 
@@ -180,7 +181,8 @@ class PhysicsCfg(PresetCfg):
         num_substeps=10,
     )
 
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    physx: PhysxCfg = isaacsim_physx
 
     default = newton_mjwarp_vbd_proxy
 
@@ -434,7 +436,8 @@ class FrankaSoftSceneCfg(PresetCfg):
     newton_mjwarp_vbd: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=True)
 
     # PhysX does not support replicating physics for deformable objects
-    physx: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
+    isaacsim_physx: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
+    physx: _FrankaSoftSceneCfg = isaacsim_physx
 
     newton_mjwarp_vbd_proxy = newton_mjwarp_vbd
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
@@ -27,7 +27,7 @@ class AntPhysicsCfg(PresetCfg):
     physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
     ovphysx: OvPhysxCfg = OvPhysxCfg()
-    default = physx
+    default = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=45,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
@@ -31,8 +31,9 @@ from isaaclab_assets.robots.ant import ANT_CFG  # isort: skip
 
 @configclass
 class AntPhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
-    physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    isaacsim_physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    physx: PhysxCfg = isaacsim_physx
+    default: PhysxCfg = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=38,
@@ -151,8 +152,9 @@ class ObservationsCfg:
 
 @configclass
 class AntObservationsCfg(PresetCfg):
-    default: ObservationsCfg = ObservationsCfg()
-    physx: ObservationsCfg = ObservationsCfg()
+    isaacsim_physx: ObservationsCfg = ObservationsCfg()
+    physx: ObservationsCfg = isaacsim_physx
+    default: ObservationsCfg = isaacsim_physx
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
@@ -27,7 +27,7 @@ class HumanoidPhysicsCfg(PresetCfg):
     physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
     ovphysx: OvPhysxCfg = OvPhysxCfg()
-    default = physx
+    default = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=80,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
@@ -28,8 +28,9 @@ from isaaclab_assets.robots.humanoid import HUMANOID_CFG  # isort:skip
 
 @configclass
 class HumanoidPhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
-    physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    isaacsim_physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    physx: PhysxCfg = isaacsim_physx
+    default: PhysxCfg = isaacsim_physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=80,
@@ -135,8 +136,9 @@ class ObservationsCfg:
 
 @configclass
 class HumanoidObservationsCfg(PresetCfg):
-    default: ObservationsCfg = ObservationsCfg()
-    physx: ObservationsCfg = ObservationsCfg()
+    isaacsim_physx: ObservationsCfg = ObservationsCfg()
+    physx: ObservationsCfg = isaacsim_physx
+    default: ObservationsCfg = isaacsim_physx
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_common.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_common.py
@@ -26,7 +26,7 @@ from isaaclab_assets.robots.allegro import ALLEGRO_HAND_CFG
 
 @configclass
 class ObjectCfg(PresetCfg):
-    physx = RigidObjectCfg(
+    isaacsim_physx = RigidObjectCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.UsdFileCfg(
             usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd",
@@ -45,6 +45,7 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.17, 0.56), rot=(0.0, 0.0, 0.0, 1.0)),
     )
+    physx = isaacsim_physx
     newton_mjwarp = ArticulationCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.UsdFileCfg(
@@ -82,9 +83,10 @@ class ObjectCfg(PresetCfg):
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
     )
+    physx = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             integrator="implicitfast",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_common.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_common.py
@@ -138,22 +138,24 @@ class PhysxEventCfg:
 
 @configclass
 class ShadowHandEventCfg(PresetCfg):
-    physx = PhysxEventCfg()
+    isaacsim_physx = PhysxEventCfg()
+    physx = isaacsim_physx
     newton_mjwarp = NewtonEventCfg()
-    ovphysx = physx  # OvPhysX is PhysX-based; reuse the PhysX randomization terms
+    ovphysx = isaacsim_physx  # OvPhysX is PhysX-based; reuse the PhysX randomization terms
     default = newton_mjwarp
     newton_kamino = newton_mjwarp
 
 
 @configclass
 class ShadowHandRobotCfg(PresetCfg):
-    physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot").replace(
+    isaacsim_physx = SHADOW_HAND_CFG.replace(prim_path="/World/envs/env_.*/Robot").replace(
         init_state=ArticulationCfg.InitialStateCfg(
             pos=(0.0, 0.0, 0.5),
             rot=(0.0, 0.0, 0.0, 1.0),
             joint_pos={".*": 0.0},
         )
     )
+    physx = isaacsim_physx
     # Newton robot lives in the asset (see isaaclab_assets.robots.shadow_hand); reorient
     # uses its default gains. The handover task consumes the same asset cfg and overrides
     # only the finger gains.
@@ -174,7 +176,7 @@ class ShadowHandRobotCfg(PresetCfg):
 
 @configclass
 class ObjectCfg(PresetCfg):
-    physx = RigidObjectCfg(
+    isaacsim_physx = RigidObjectCfg(
         prim_path="/World/envs/env_.*/object",
         spawn=sim_utils.UsdFileCfg(
             usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd",
@@ -193,6 +195,7 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.6), rot=(0.0, 0.0, 0.0, 1.0)),
     )
+    physx = isaacsim_physx
 
     newton_mjwarp = ArticulationCfg(
         prim_path="/World/envs/env_.*/object",
@@ -208,18 +211,19 @@ class ObjectCfg(PresetCfg):
         actuators={},
         articulation_root_prim_path="",
     )
-    ovphysx = physx  # OvPhysX is PhysX-based; use the rigid-body cube, not Newton's articulation
+    ovphysx = isaacsim_physx  # OvPhysX is PhysX-based; use the rigid-body cube, not Newton's articulation
     default = newton_mjwarp
     newton_kamino = newton_mjwarp
 
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
         gpu_max_rigid_contact_count=2**23,
         gpu_max_rigid_patch_count=2**23,
     )
+    physx = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             integrator="implicitfast",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
@@ -72,6 +72,7 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     # scene — clone_in_fabric is the only backend-varying field (Newton cannot use Fabric cloning)
     scene: InteractiveSceneCfg = preset(
         default=ShadowHandSceneCfg(clone_in_fabric=False),
+        isaacsim_physx=ShadowHandSceneCfg(clone_in_fabric=True),
         physx=ShadowHandSceneCfg(clone_in_fabric=True),
         ovphysx=ShadowHandSceneCfg(clone_in_fabric=True),
         newton_mjwarp=ShadowHandSceneCfg(clone_in_fabric=False),

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
@@ -17,7 +17,9 @@ from .rough_env_cfg import AnymalDRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     ovphysx = OvPhysxCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import CassieRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=52,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -17,7 +17,9 @@ from .rough_env_cfg import G1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=95,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import UnitreeGo2RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=65,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -16,7 +16,9 @@ from .rough_env_cfg import H1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=65,
@@ -28,7 +30,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
@@ -35,7 +35,9 @@ from isaaclab_tasks.utils import PresetCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=130,
@@ -228,9 +230,10 @@ class SpotPhysxEventCfg(SpotNewtonEventCfg, SpotStartupEventCfg):
 
 @configclass
 class SpotEventCfg(PresetCfg):
-    default = SpotPhysxEventCfg()
+    isaacsim_physx = SpotPhysxEventCfg()
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = SpotNewtonEventCfg()
-    physx = default
     newton_kamino = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -46,7 +46,9 @@ from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
 class RoughPhysicsCfg(PresetCfg):
     """Shared physics preset for all rough-terrain locomotion envs."""
 
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = isaacsim_physx
+    default = isaacsim_physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=200,
@@ -64,7 +66,6 @@ class RoughPhysicsCfg(PresetCfg):
         # on triangle-mesh terrain. See isaaclab_newton 0.5.22 changelog.
         default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
-    physx = default
     ovphysx = OvPhysxCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -112,7 +112,9 @@ class PresetCfg:
 
         @configclass
         class PhysicsCfg(PresetCfg):
-            default: PhysxCfg = PhysxCfg()
+            isaacsim_physx: PhysxCfg = PhysxCfg()
+            physx: PhysxCfg = isaacsim_physx
+            default: PhysxCfg = isaacsim_physx
             newton_mjwarp: NewtonCfg = NewtonCfg()
 
     The preset *name* (``newton_mjwarp``) is decoupled from the config class
@@ -213,8 +215,11 @@ def _record_preset_selection(value, preset_name: str, fields: dict):
     """Attach preset-selection metadata when a physics preset resolves to a concrete config."""
     if not isinstance(value, PhysicsCfg):
         return value
-    if preset_name == "default" and fields.get("physx") == value:
-        preset_name = "physx"
+    if preset_name == "default":
+        if fields.get("isaacsim_physx") == value:
+            preset_name = "isaacsim_physx"
+        elif fields.get("physx") == value:
+            preset_name = "physx"
     _set_physics_preset_selection(value, preset_name, fields)
     return value
 

--- a/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
+++ b/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
@@ -20,6 +20,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
 from isaaclab.app import scan
+from isaaclab.physics.physics_manager_cfg import _get_physics_preset_selection
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import resolve_task_config
@@ -27,6 +28,8 @@ from isaaclab_tasks.utils.preset_cli import enumerate_task_presets
 from isaaclab_tasks.utils.preset_target import PresetTarget
 
 _CAMERA_PRESETS_TASK = "Isaac-Cartpole-Camera-Direct"
+_MANAGER_TASK = "Isaac-Cartpole"
+_STATE_TASK = "Isaac-Cartpole-Direct"
 
 
 def _resolve_with_presets(presets: str):
@@ -78,14 +81,36 @@ def test_isaacsim_physx_is_physics_selector():
     assert "isaacsim_physx" in preset_map[PresetTarget.PHYSICS]
 
 
-def test_cartpole_physx_preset_is_plain_physx_cfg():
-    """Task configs expose ``physx`` as concrete PhysX, not a public auto wrapper."""
+def test_cartpole_default_is_explicit_isaacsim_physx():
+    """PhysX-backed task defaults select Isaac Sim PhysX instead of automatic PhysX."""
     from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpolePhysicsCfg
 
     physics_cfg = CartpolePhysicsCfg()
 
     assert isinstance(physics_cfg.physx, PhysxCfg)
-    assert isinstance(physics_cfg.default, PhysxCfg)
+    assert physics_cfg.default == physics_cfg.isaacsim_physx
+
+    env_cfg = _resolve_with_args()
+    assert _get_physics_preset_selection(env_cfg.sim.physics) == "isaacsim_physx"
+
+    old_argv = sys.argv.copy()
+    try:
+        sys.argv = [sys.argv[0]]
+        state_env_cfg, _ = resolve_task_config(_STATE_TASK, "rsl_rl_cfg_entry_point")
+    finally:
+        sys.argv = old_argv
+
+    state_scan = scan(state_env_cfg)
+    assert isinstance(state_env_cfg.sim.physics, PhysxCfg)
+    assert state_scan.needs_kit is True
+
+
+def test_manager_task_exposes_explicit_and_automatic_physx_selectors():
+    """Migrated manager tasks retain automatic PhysX as an explicit opt-in."""
+    preset_map = enumerate_task_presets(_MANAGER_TASK)
+
+    assert preset_map is not None
+    assert {"isaacsim_physx", "physx"} <= set(preset_map[PresetTarget.PHYSICS])
 
 
 def test_physx_and_isaacsim_physx_presets_conflict():
@@ -101,24 +126,24 @@ def test_preset_mjwarp_ovrtx_does_not_need_kit():
     assert needs_kit is False
 
 
-def test_preset_rtx_resolves_to_ovphysx_and_ovrtx_without_kit():
-    """The RTX preset uses kitless PhysX-family backends when no Kit runtime is requested."""
+def test_preset_rtx_uses_isaac_sim_backends_with_default_physics():
+    """Automatic RTX follows the explicit Isaac Sim PhysX task default."""
     env_cfg = _resolve_with_presets("rtx")
     config_scan = _resolve_runtime_renderer(env_cfg)
 
-    assert isinstance(env_cfg.sim.physics, OvPhysxCfg)
-    assert isinstance(env_cfg.tiled_camera.renderer_cfg, OVRTXRendererCfg)
-    assert config_scan.needs_kit is False
+    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.tiled_camera.renderer_cfg, IsaacRtxRendererCfg)
+    assert config_scan.needs_kit is True
 
 
-def test_renderer_selector_rtx_resolves_to_ovphysx_and_ovrtx_without_kit():
-    """The RTX renderer selector uses kitless PhysX-family backends without Kit signals."""
+def test_renderer_selector_rtx_uses_isaac_sim_backends_with_default_physics():
+    """The typed RTX selector follows the explicit Isaac Sim PhysX task default."""
     env_cfg = _resolve_with_args("renderer=rtx")
     config_scan = _resolve_runtime_renderer(env_cfg)
 
-    assert isinstance(env_cfg.sim.physics, OvPhysxCfg)
-    assert isinstance(env_cfg.tiled_camera.renderer_cfg, OVRTXRendererCfg)
-    assert config_scan.needs_kit is False
+    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.tiled_camera.renderer_cfg, IsaacRtxRendererCfg)
+    assert config_scan.needs_kit is True
 
 
 def test_renderer_selector_physx_rtx_resolves_to_ovphysx_without_kit():
@@ -201,7 +226,7 @@ def test_preset_physx_with_default_kit_camera_resolves_to_physx():
 
 
 def test_preset_default_needs_kit():
-    """Default automatic PhysX plus Isaac RTX requires Kit."""
+    """Default explicit Isaac Sim PhysX plus Isaac RTX requires Kit."""
     env_cfg = _resolve_with_presets("default")
     needs_kit = scan(env_cfg).needs_kit
     assert needs_kit is True

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -126,17 +126,17 @@ def test_newton_plus_ovrtx_is_valid():
     validate_runtime_compatibility(env_cfg)
 
 
-def test_default_auto_physx_plus_ovrtx_resolves_to_ovphysx():
-    """Default automatic PhysX uses OvPhysX when OVRTX is the only renderer signal."""
+def test_default_isaacsim_physx_plus_ovrtx_raises():
+    """The explicit Isaac Sim PhysX task default cannot be paired with OVRTX."""
     env_cfg = _resolve_with_presets("ovrtx")
 
     assert isinstance(env_cfg.sim.physics, PhysxCfg)
 
-    config_scan = validate_runtime_compatibility(env_cfg)
-
-    assert isinstance(env_cfg.sim.physics, OvPhysxCfg)
-    assert isinstance(env_cfg.tiled_camera.renderer_cfg, OVRTXRendererCfg)
-    assert config_scan.needs_kit is False
+    with pytest.raises(ValueError) as excinfo:
+        validate_runtime_compatibility(env_cfg)
+    msg = str(excinfo.value)
+    assert "PhysxCfg" in msg
+    assert "isaacsim_rtx" in msg
 
 
 def test_explicit_auto_physx_plus_ovrtx_resolves_to_ovphysx():
@@ -206,14 +206,14 @@ def test_default_preset_is_valid():
     validate_runtime_compatibility(env_cfg)
 
 
-def test_rtx_with_default_physx_is_valid_and_resolves_to_ovphysx_and_ovrtx():
-    """The RTX preset chooses kitless PhysX-family backends when no Kit runtime is needed."""
+def test_rtx_with_default_isaacsim_physx_uses_isaac_sim_backends():
+    """Automatic RTX follows the explicit Isaac Sim PhysX task default."""
     env_cfg = _resolve_with_presets("rtx")
     config_scan = validate_runtime_compatibility(env_cfg)
 
-    assert isinstance(env_cfg.sim.physics, OvPhysxCfg)
-    assert isinstance(env_cfg.tiled_camera.renderer_cfg, OVRTXRendererCfg)
-    assert config_scan.needs_kit is False
+    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.tiled_camera.renderer_cfg, IsaacRtxRendererCfg)
+    assert config_scan.needs_kit is True
 
 
 def test_renderer_selector_physx_rtx_is_valid_and_resolves_to_ovphysx_and_ovrtx():


### PR DESCRIPTION
## Summary

- make PhysX-backed task defaults select `isaacsim_physx` explicitly
- migrate backend-coupled task presets so `presets=isaacsim_physx` applies a consistent configuration
- retain `physics=physx` as the explicit opt-in to automatic Isaac Sim PhysX/OvPhysX selection
- document the behavior and add regression coverage for default and explicit-auto selection

## Root cause

The previous task defaults resolved through the `physx` preset. That preset represents automatic PhysX-family selection, so a launch without a Kit requirement could resolve to OvPhysX and attempt to import the optional `ovphysx` package even though the intended default was Isaac Sim PhysX.

Recording the default as `isaacsim_physx` makes the runtime requirement explicit while preserving the automatic selector for users who request it.

## User impact

Tasks that default to PhysX now launch with Isaac Sim PhysX when no physics override is provided. Users can retain the previous automatic backend selection behavior with `physics=physx`.

Newton-default tasks remain Newton-default; only their PhysX alternatives were given explicit Isaac Sim and automatic selectors where appropriate.

## Validation

- `pre-commit run --all-files`
- 152 task preset, Hydra, and runtime compatibility tests
- 41 focused preset/runtime tests rerun after formatting
- one-iteration `Isaac-Cartpole-Direct` RSL-RL smoke test with no `physics=` override
