### PR TITLE
[CI] Stabilize the Newton environment smoke tests and run them kit-less

### DIFF
--- a/source/isaaclab_tasks/changelog.d/jichuanh-newton-env-tests-kitless.skip
+++ b/source/isaaclab_tasks/changelog.d/jichuanh-newton-env-tests-kitless.skip
@@ -1,0 +1,3 @@
+Test-only: ran the Newton environment smoke tests kit-less, split the Kit-requiring tasks into
+their own file, and limited OpenUSD's work-thread pool to work around the usd-core<26.5 physics
+parser race that aborted the process during the Newton USD import.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -13,6 +13,7 @@ import inspect
 import os
 import re
 import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import gymnasium as gym
@@ -144,7 +145,11 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
 
 
 def parse_env_cfg(
-    task_name: str, device: str = "cuda:0", num_envs: int | None = None, use_fabric: bool | None = None
+    task_name: str,
+    device: str = "cuda:0",
+    num_envs: int | None = None,
+    use_fabric: bool | None = None,
+    presets: Sequence[str] = (),
 ) -> ManagerBasedRLEnvCfg | DirectRLEnvCfg:
     """Parse configuration for an environment and override based on inputs.
 
@@ -155,6 +160,10 @@ def parse_env_cfg(
         use_fabric: Whether to enable/disable fabric interface. If false, all read/write operations go through USD.
             This slows down the simulation but allows seeing the changes in the USD through the USD stage.
             Defaults to None, in which case it is left unchanged.
+        presets: Preset names to select while resolving :class:`PresetCfg` wrappers, mirroring the
+            Hydra ``presets=`` CLI tokens. Defaults to an empty selection, which resolves to each
+            wrapper's default. A selection must be passed here rather than applied afterwards,
+            because the returned config no longer carries the wrappers to choose from.
 
     Returns:
         The parsed configuration object.
@@ -171,12 +180,12 @@ def parse_env_cfg(
     if isinstance(cfg, dict):
         raise RuntimeError(f"Configuration for the task: '{task_name}' is not a class. Please provide a class.")
 
-    # Resolve any PresetCfg wrappers to their default preset so the config
-    # is usable without a Hydra CLI override (e.g. in tests).
+    # Resolve any PresetCfg wrappers, honoring the requested presets and otherwise falling back to
+    # each wrapper's default so the config is usable without a Hydra CLI override (e.g. in tests).
     # Must happen BEFORE attribute overrides, otherwise overrides on PresetCfg wrapper
     # fields (e.g. cfg.scene when scene is a PresetCfg) get discarded when the wrapper
     # is replaced by its .default.
-    cfg = resolve_presets(cfg)
+    cfg = resolve_presets(cfg, presets)
 
     # simulation device
     cfg.sim.device = device

--- a/source/isaaclab_tasks/test/core/test_environments_newton.py
+++ b/source/isaaclab_tasks/test/core/test_environments_newton.py
@@ -3,16 +3,22 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Launch Isaac Sim Simulator first."""
+"""Newton environment smoke tests.
 
-from isaaclab.app import AppLauncher
+The MJWarp preset is a kit-less backend, so this suite runs without ``AppLauncher``. Tasks carrying
+Kit camera sensors still need the Kit runtime and are filtered out; ``test_environments.py`` already
+smoke-tests each of them on its default backend.
+"""
 
-# launch the simulator
-app_launcher = AppLauncher(headless=True, enable_cameras=True)
-simulation_app = app_launcher.app
+import os
 
-
-"""Rest everything follows."""
+# Limit OpenUSD's work-thread pool to one thread to avoid a race condition in usd-core<26.5, which
+# corrupts native state while collecting collider descriptors and aborts the process during the
+# Newton USD import. Set at module scope rather than in a fixture, unlike the same workaround in
+# rendering_test_utils.py: kit-less, OpenUSD builds its task arena while tests are collected, and
+# WorkSetConcurrencyLimit does not shrink an arena that already exists.
+# TODO: Remove once usd-core>=26.5 is the minimum - that release fixes the race condition.
+os.environ.setdefault("PXR_WORK_THREAD_LIMIT", "1")
 
 import pytest
 
@@ -30,6 +36,8 @@ from env_test_utils import _run_environments, setup_environment  # isort: skip
         multi_agent=False,
         newton_mjwarp_envs=True,
         tier="core",
+        needs_kit=False,
+        physics_preset_name="newton_mjwarp",
     ),
 )
 @pytest.mark.newton_ci

--- a/source/isaaclab_tasks/test/core/test_parse_env_cfg_presets.py
+++ b/source/isaaclab_tasks/test/core/test_parse_env_cfg_presets.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests that :func:`parse_env_cfg` honors a requested preset selection.
+
+A selection has to be supplied while the ``PresetCfg`` wrappers are being resolved: the returned
+config no longer carries the alternatives, so applying a preset afterwards silently keeps the
+default. These cases use tasks whose default backend is *not* the requested one, so a dropped
+selection fails instead of coincidentally matching.
+"""
+
+import pytest
+from isaaclab_newton.physics import NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+
+pytestmark = pytest.mark.unit
+
+# Defaults to PhysX and offers a newton_mjwarp preset, so the selection has to do real work.
+_PHYSX_DEFAULT_TASK = "Isaac-Velocity-Flat-G1"
+
+
+def test_parse_env_cfg_defaults_to_the_preset_default() -> None:
+    """Without a selection, a wrapper still resolves to its default."""
+    env_cfg = parse_env_cfg(_PHYSX_DEFAULT_TASK)
+
+    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+
+
+def test_parse_env_cfg_applies_requested_physics_preset() -> None:
+    """A requested preset must win over the task's default backend."""
+    env_cfg = parse_env_cfg(_PHYSX_DEFAULT_TASK, presets=("newton_mjwarp",))
+
+    assert isinstance(env_cfg.sim.physics, NewtonCfg)
+
+
+def test_parse_env_cfg_applies_preset_alongside_other_overrides() -> None:
+    """Selecting a preset must not discard the device and num_envs overrides."""
+    env_cfg = parse_env_cfg(_PHYSX_DEFAULT_TASK, device="cuda:0", num_envs=3, presets=("newton_mjwarp",))
+
+    assert isinstance(env_cfg.sim.physics, NewtonCfg)
+    assert env_cfg.sim.device == "cuda:0"
+    assert env_cfg.scene.num_envs == 3

--- a/source/isaaclab_tasks/test/env_test_utils.py
+++ b/source/isaaclab_tasks/test/env_test_utils.py
@@ -19,7 +19,6 @@ from isaaclab.envs.utils.spaces import sample_space
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.version import get_isaac_sim_version
 
-from isaaclab_tasks.utils.hydra import apply_overrides, collect_presets
 from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry, parse_env_cfg
 
 # Map of task IDs to the reason for marking the corresponding parametrized
@@ -103,6 +102,26 @@ def _has_physics_preset(raw_cfg, preset_name: str) -> bool:
     return physics is not None and hasattr(physics, preset_name)
 
 
+def _task_needs_kit(task_id: str, physics_preset_name: str | None = None) -> bool:
+    """Check whether a task's resolved config requires the Isaac Sim Kit runtime.
+
+    Derived from the same scan :func:`~isaaclab.app.launch_simulation` performs, so the
+    kit-less split follows the launcher instead of a hand-maintained task list.
+
+    Args:
+        task_id: Registered task ID.
+        physics_preset_name: Physics preset applied before scanning, since the backend
+            selection decides whether Kit is needed.
+
+    Returns:
+        True if the task needs the Kit runtime.
+    """
+    from isaaclab.app import sim_launcher
+
+    env_cfg = parse_env_cfg(task_id, presets=(physics_preset_name,) if physics_preset_name else ())
+    return bool(sim_launcher.scan(env_cfg, {}).needs_kit)
+
+
 def setup_environment(
     include_play: bool = False,
     factory_envs: bool | None = None,
@@ -112,6 +131,8 @@ def setup_environment(
     pickplace_stack_envs: bool | None = None,
     newton_mjwarp_envs: bool | None = None,
     tier: str | None = None,
+    needs_kit: bool | None = None,
+    physics_preset_name: str | None = None,
 ) -> list[str]:
     """
     Acquire all registered Isaac environment task IDs with optional filters.
@@ -146,6 +167,12 @@ def setup_environment(
             - "core": include only core environments (registered under ``isaaclab_tasks.core``).
             - "contrib": include only contributed environments (registered under ``isaaclab_tasks.contrib``).
             - None: include all environments regardless of tier.
+        needs_kit:
+            - True: include only environments whose resolved config needs the Kit runtime.
+            - False: include only environments that run kit-less.
+            - None: include all environments regardless of Kit requirement.
+        physics_preset_name: Physics preset applied before deciding the Kit requirement, since the
+            backend selection determines whether Kit is needed. Only used with ``needs_kit``.
 
     Returns:
         A sorted list of task IDs matching the selected filters.
@@ -222,6 +249,11 @@ def setup_environment(
                 continue
         # if None: no filter
 
+        # apply Kit-runtime filter
+        if needs_kit is not None and _task_needs_kit(task_spec.id, physics_preset_name) != needs_kit:
+            continue
+        # if None: no filter
+
         registered_tasks.append(task_spec.id)
 
     # sort environments alphabetically
@@ -290,8 +322,10 @@ def _run_environments(
             If None, uses the environment's default physics.
     """
 
-    # skip test if stage in memory is not supported
-    if get_isaac_sim_version().major < 5 and create_stage_in_memory:
+    # skip test if stage in memory is not supported. Only query the Isaac Sim version when the
+    # answer can matter: get_isaac_sim_version() imports isaacsim, which a kit-less caller does
+    # not have.
+    if create_stage_in_memory and get_isaac_sim_version().major < 5:
         pytest.skip("Stage in memory is not supported in this version of Isaac Sim")
 
     # skip suction gripper environments as they require CPU simulation and cannot be run with GPU simulation
@@ -370,20 +404,13 @@ def _check_random_actions(
     get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
     env = None
     try:
-        # parse config
-        env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)
-        # apply physics preset override before creating the environment
-        if physics_preset_name is not None:
-            # parse_env_cfg already resolved PresetCfg wrappers to their default,
-            # so we load the raw config to retrieve preset alternatives.
-            raw_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
-            presets = {"env": collect_presets(raw_cfg), "agent": {}}
-            hydra_cfg = {"env": env_cfg.to_dict(), "agent": None}
-            apply_overrides(env_cfg, None, hydra_cfg, [physics_preset_name], [], [], presets)
-            # Re-apply num_envs since apply_overrides may have replaced
-            # the scene config with the preset's default num_envs.
-            if num_envs is not None:
-                env_cfg.scene.num_envs = num_envs
+        # parse config, selecting the requested physics preset as it is resolved
+        env_cfg = parse_env_cfg(
+            task_name,
+            device=device,
+            num_envs=num_envs,
+            presets=(physics_preset_name,) if physics_preset_name else (),
+        )
         # set config args
         env_cfg.sim.create_stage_in_memory = create_stage_in_memory
         if disable_clone_in_fabric:


### PR DESCRIPTION
# Description

The `isaaclab_tasks` shards intermittently aborted with `SIGSEGV` or `SIGABRT` while creating a
Newton environment — measured at **~5% per environment build**. The abort is glibc catching a
corrupted heap (`malloc(): unaligned tcache chunk detected`) at an unrelated later allocation, so
pytest recorded `CRASHED` with no Python traceback and no failing node.

Root cause is a race in OpenUSD's physics parser: collecting collider descriptors for several
colliders under one rigid body reallocates a shared `std::vector` across worker threads.

> *"Fixed a bug in UsdPhysicsParsingUtility which could cause a race condition and crash when parsing
> multiple colliders under the same rigid body in a multi-threaded context"* — OpenUSD CHANGELOG
> `[26.05] - 2026-04-24`, upstream issue 4002

This PR contains three related changes.

## 1. Work around the parser race

Limit OpenUSD's work-thread pool for this suite, mirroring the workaround already in
`source/isaaclab_tasks/test/rendering_test_utils.py` and carrying the same removal note.

Applied at **module scope** rather than in a fixture: kit-less, OpenUSD builds its task arena while
tests are collected, and `WorkSetConcurrencyLimit` does not shrink an arena that already exists
(measured — it still reported 128 workers and still crashed).

## 2. Run the suite kit-less

The MJWarp preset is a kit-less backend, so `AppLauncher` is dropped and the suite filters to tasks
that run without Kit. The split is derived from `scan(...).needs_kit` — the same decision
`launch_simulation()` makes — so a task follows its own config instead of a hand-maintained list.

Tasks carrying Kit camera sensors are excluded; `test_environments.py` already smoke-tests each of
them on its default backend, so no task loses coverage.

`get_isaac_sim_version()` in `_run_environments` is now called only when `create_stage_in_memory` is
set, since it imports `isaacsim` — that unconditional call was what previously forced Kit.

## 3. Make the physics preset selection actually apply

Selecting a preset in this suite had no effect. `parse_env_cfg` resolves every `PresetCfg` wrapper to
its `default` before returning, and the follow-up `apply_overrides` call had no choice node left to
act on, so each task ran whichever backend it defaulted to.

`parse_env_cfg` now takes the selection and applies it *while* the wrappers are resolved, which is
what `register_task_to_hydra` already does. Default `presets=()` keeps every existing caller
unchanged. The raw-config / `collect_presets` / `apply_overrides` dance in the test util collapses to
a single `parse_env_cfg(...)` call.

Consequence: `Isaac-Velocity-Flat-G1` and `Isaac-Velocity-Flat-Spot` now run **Newton** in this
suite rather than PhysX. Both pass.

## Evidence

Standalone reproducer — `pxr` only, no Isaac Lab, Newton, CUDA or Kit; 15 processes x 40 parses of
the Franka Reach stage:

| usd-core | Has the 26.05 fix | Crashed processes |
|---|---|---|
| 25.11 (current pin) | no | **14 / 15** |
| 26.3 | no | 10 / 15 |
| 26.8 | yes | **0 / 15** |

Crash rate against OpenUSD's thread count, which is what this PR limits:

| `PXR_WORK_THREAD_LIMIT` | 1 | 2 | 4 | 8 | 16 | 32 | 128 |
|---|---|---|---|---|---|---|---|
| crashed procs (of 15) | **0** | **0** | 10 | 10 | 12 | 11 | 14 |

Captured stack, previously unavailable because the process died without a Python traceback:

```
#0  moveDescsToDict<UsdPhysicsRigidBodyDesc>(...)        pxr/UsdPhysics/_usdPhysics.so
#1  LoadUsdPhysicsFromRange(stage, paths, callback, ...) libusd_ms
    newton/_src/utils/import_usd.py:546  parse_usd
    isaaclab_newton/cloner/newton_clone_utils.py:188  _build_source_builder
    isaaclab/scene/interactive_scene.py:187  __init__
```

Local verification:

| Check | Result |
|---|---|
| `test_parse_env_cfg_presets.py` (new) | 3 passed — fails on develop |
| kit-less collection, no `isaacsim` import | 58 tests in 7.3s |
| `Isaac-Reach-Franka`, `-OSC`, `Isaac-Reorient-Cube-Shadow-Direct` | 6 passed |
| `Isaac-Velocity-Flat-G1`, `-Spot` on Newton for the first time | 4 passed |

## Why not raise the usd-core pin

`usd-core>=26.5` is the real fix, but it cannot be delivered yet: `newton[importers]` declares
`usd-core>=25.5,<26.5`, whose exclusive bound excludes the fixing release. `[tool.uv]
override-dependencies` gets `uv sync` past that, but `isaaclab.sh --install` resolves
`[project.dependencies]` with **pip**, which has no override mechanism (see the comment at
`source/isaaclab/isaaclab/cli/commands/install.py:341`), so the Docker image build fails with
`ResolutionImpossible`.

**Raising `usd-core<26.5` to `<27` in `newton[importers]` is the prerequisite.** Once that lands, the
pin can move and both this workaround and the one in `rendering_test_utils.py` can be removed.

## Notes for review

- This is a mitigation for the crash, not a fix. Users creating Newton environments outside this
  suite remain exposed until the pin can move.
- Change 3 alters what CI exercises: any task whose default is not `newton_mjwarp` now genuinely runs
  Newton in this suite. G1 and Spot pass; other suites are unaffected because `presets` defaults to
  an empty selection.
- `apply_overrides` still accepts a `presets` argument that it never reads. It no longer has callers
  in `env_test_utils.py`, but `rendering_test_utils.py` and `test_hydra.py` still pass it. Removing
  it is a separate cleanup across those call sites.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Pre-commit hooks pass
- [x] Changelog fragment added
- [ ] Full CI validation
