### PR TITLE
Restore explicit automatic PhysX configs

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -245,11 +245,14 @@ override is given:
 
 .. code-block:: python
 
+    from isaaclab.physics import PhysxAutoCfg
     from isaaclab_tasks.utils import PresetCfg
 
     @configclass
     class PhysicsCfg(PresetCfg):
-        default: PhysxCfg = PhysxCfg()
+        isaacsim_physx: PhysxCfg = PhysxCfg()
+        physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+        default: PhysxAutoCfg = physx
         newton_mjwarp: NewtonCfg = NewtonCfg()
 
     @configclass
@@ -263,8 +266,9 @@ override is given:
 
 For tasks that expose automatic PhysX-family selection, ``physics=physx`` is
 resolved at launch time: Isaac Sim PhysX is used when a Kit renderer or Kit viewer
-is requested, and OvPhysX is used for fully kit-less runs. Use
-``physics=isaacsim_physx`` to force Isaac Sim PhysX.
+is requested. For fully kit-less runs, OvPhysX is used when the task configures
+an OvPhysX alternative; otherwise selection falls back to Isaac Sim PhysX and
+requires Kit. Use ``physics=isaacsim_physx`` to force Isaac Sim PhysX.
 
 The ``default`` field can be set to ``None`` to make an optional feature that is
 disabled unless explicitly selected:
@@ -304,15 +308,19 @@ Physics backend selection uses the same preset system. A task can define a
     from isaaclab_ovphysx.physics import OvPhysxCfg
     from isaaclab_physx.physics import PhysxCfg
 
+    from isaaclab.physics import PhysxAutoCfg
     from isaaclab.utils.configclass import configclass
 
     from isaaclab_tasks.utils import PresetCfg
 
     @configclass
     class CartpolePhysicsCfg(PresetCfg):
-        physx: PhysxCfg = PhysxCfg()
         isaacsim_physx: PhysxCfg = PhysxCfg()
         ovphysx: OvPhysxCfg = OvPhysxCfg()
+        physx: PhysxAutoCfg = PhysxAutoCfg(
+            isaacsim_physx=isaacsim_physx,
+            ovphysx=ovphysx,
+        )
         default = physx
         newton_mjwarp: NewtonCfg = NewtonCfg(
             solver_cfg=MJWarpSolverCfg(njmax=5, nconmax=3),

--- a/docs/source/overview/core-concepts/physical-backends/newton/kamino-solver.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/kamino-solver.rst
@@ -72,8 +72,8 @@ Then add a ``newton_kamino`` entry beside the existing ``default``, ``physx``, a
 .. literalinclude:: ../../../../../../source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
     :language: python
     :start-at: class CartpolePhysicsCfg
-    :end-at: ovphysx: OvPhysxCfg = OvPhysxCfg()
-    :emphasize-lines: 17-38
+    :end-before: class CartpoleEnvCfg
+    :emphasize-lines: 18-39
 
 The important pieces are:
 

--- a/docs/source/overview/environments.rst
+++ b/docs/source/overview/environments.rst
@@ -92,8 +92,9 @@ modes. The **Presets** column in each table below is divided into three labeled 
   (e.g. ``physx``, ``isaacsim_physx``, ``newton_mjwarp``,
   ``newton_kamino``, ``ovphysx``, ``newton_mjwarp_vbd``). On tasks that
   expose automatic PhysX-family selection, ``physx`` uses Isaac Sim PhysX when
-  a Kit renderer or Kit viewer is requested and OvPhysX otherwise; use
-  ``isaacsim_physx`` to force Isaac Sim PhysX.
+  Kit is required and OvPhysX otherwise when the task supports it. Tasks
+  without an OvPhysX alternative fall back to Isaac Sim PhysX; use
+  ``isaacsim_physx`` to force Isaac Sim PhysX directly.
 * **renderer=** — renderer-backend name passed as ``renderer=NAME``
   (e.g. ``isaacsim_rtx``, ``newton_renderer``, ``ovrtx``, ``rtx``)
 * **presets=** — environment-specific (domain) preset name passed as

--- a/docs/source/setup/quickstart_details.rst
+++ b/docs/source/setup/quickstart_details.rst
@@ -80,7 +80,7 @@ Available Presets
 
 **Physics backends** (``physics=NAME``):
 
-- ``physx`` — automatic PhysX-family selection: Isaac Sim PhysX when a Kit renderer or Kit viewer is requested, otherwise OvPhysX
+- ``physx`` — automatic PhysX-family selection: Isaac Sim PhysX when Kit is required, otherwise OvPhysX when the task supports it; tasks without OvPhysX support fall back to Isaac Sim PhysX
 - ``isaacsim_physx`` — force PhysX via Isaac Sim / Kit
 - ``newton_mjwarp`` — Newton with the MuJoCo-Warp solver
 - ``newton_kamino`` — Newton with the Kamino solver (beta, limited tasks)
@@ -117,13 +117,14 @@ Then use ``renderer=rtx`` to select the RTX implementation required by the runti
    * - Requires Isaac Sim/Kit, such as ``physics=isaacsim_physx``, ``--visualizer kit``,
        livestreaming, or another Kit camera
      - :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg`
-   * - Fully kit-less, such as ``physics=physx``, ``physics=newton_mjwarp``, or
-       ``physics=ovphysx`` without a Kit visualizer or camera
+   * - Fully kit-less, such as ``physics=physx`` on a task that supports OvPhysX,
+       ``physics=newton_mjwarp``, or ``physics=ovphysx`` without a Kit visualizer or camera
      - :class:`~isaaclab_ov.renderers.OVRTXRendererCfg`
 
 For example, ``physics=newton_mjwarp renderer=rtx`` selects OVRTX for a
 fully kit-less run, while ``physics=physx renderer=rtx`` selects OvPhysX
-+ OVRTX unless combined with ``--visualizer kit``.
++ OVRTX when the task supports OvPhysX. Otherwise, automatic PhysX falls back
+to Isaac Sim PhysX and ``rtx`` resolves to Isaac RTX.
 
 A camera configured directly with ``renderer_cfg=IsaacRtxRendererCfg()`` does
 not participate in automatic selection and is not overridden by

--- a/source/isaaclab/changelog.d/antoiner-restore-physx-auto.minor.rst
+++ b/source/isaaclab/changelog.d/antoiner-restore-physx-auto.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab.physics.PhysxAutoCfg` for explicit launch-time
+  selection between configured Isaac Sim PhysX and OvPhysX alternatives.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -28,12 +28,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
 from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
-from isaaclab.physics.physics_manager_cfg import (
-    PhysicsCfg,
-    _get_physics_preset_selection,
-    _resolve_auto_physx_cfg,
-    _set_physics_preset_selection,
-)
+from isaaclab.physics.physics_manager_cfg import PhysicsCfg, PhysxAutoCfg, resolve_physx_auto_cfg
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.sensors.camera.camera_cfg import CameraCfg
 from isaaclab.utils._device import set_cuda_device
@@ -72,13 +67,9 @@ def make_physics_cfg(physics_cfg_str: str) -> PhysicsCfg:
         ValueError: If *physics_cfg_str* does not name a known backend.
     """
     if physics_cfg_str == "physx":
-        physics_cfg = PhysxCfg()
-        _set_physics_preset_selection(physics_cfg, "physx")
-        return physics_cfg
+        return PhysxAutoCfg(isaacsim_physx=PhysxCfg(), ovphysx=OvPhysxCfg())
     if physics_cfg_str == "isaacsim_physx":
-        physics_cfg = PhysxCfg()
-        _set_physics_preset_selection(physics_cfg, "isaacsim_physx")
-        return physics_cfg
+        return PhysxCfg()
     if physics_cfg_str == "newton_mjwarp":
         return NewtonCfg()
     if physics_cfg_str == "newton_vbd":
@@ -116,8 +107,8 @@ def _is_auto_rtx_renderer(node) -> bool:
 
 
 def _is_auto_physx_physics(node) -> bool:
-    """True when the node is the automatic ``physx`` preset selection."""
-    return isinstance(node, PhysicsCfg) and _get_physics_preset_selection(node) == "physx"
+    """True when the node is an automatic PhysX placeholder."""
+    return isinstance(node, PhysxAutoCfg)
 
 
 def _is_kit_camera(node) -> bool:
@@ -333,12 +324,12 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
     )
     _refresh_physics_scan_flags(config_scan, concrete_physics_cfgs, has_physics)
 
-    # Resolve recorded auto PhysX selections first. Automatic RTX resolution
+    # Resolve automatic PhysX placeholders first. Automatic RTX resolution
     # then sees the concrete physics backend selected for this runtime.
     if has_auto_physx:
         use_isaac_sim = _has_kit_runtime_intent(config_scan, launcher_args)
         for node, parent, key, is_first_physics in auto_physx_locations:
-            physics_cfg = _resolve_auto_physx_cfg(node, use_isaac_sim)
+            physics_cfg = resolve_physx_auto_cfg(node, use_isaac_sim)
             concrete_physics_cfgs.append(physics_cfg)
             if parent is None:
                 effective_cfg = physics_cfg

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -28,7 +28,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
 from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
-from isaaclab.physics.physics_manager_cfg import PhysicsCfg, PhysxAutoCfg, resolve_physx_auto_cfg
+from isaaclab.physics.physics_manager_cfg import PhysicsCfg, PhysxAutoCfg, _resolve_physx_auto_cfg
 from isaaclab.renderers.renderer_cfg import RendererCfg
 from isaaclab.sensors.camera.camera_cfg import CameraCfg
 from isaaclab.utils._device import set_cuda_device
@@ -254,7 +254,7 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
     When the ``physics`` key is present in *launcher_args*, every physics config is
     replaced by the requested backend (see :func:`make_physics_cfg`): nested configs
     in place, a root config via :attr:`Scan.effective_cfg` (it cannot be mutated in
-    place). Automatic PhysX preset selections (``physics=physx``) and RTX
+    place). Automatic PhysX configurations and RTX
     renderer placeholders (``renderer_type="auto_rtx"``) are also resolved
     at this stage using the full *launcher_args* context.
     """
@@ -324,12 +324,11 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
     )
     _refresh_physics_scan_flags(config_scan, concrete_physics_cfgs, has_physics)
 
-    # Resolve automatic PhysX placeholders first. Automatic RTX resolution
-    # then sees the concrete physics backend selected for this runtime.
+    # RTX selection depends on the resolved physics backend.
     if has_auto_physx:
         use_isaac_sim = _has_kit_runtime_intent(config_scan, launcher_args)
         for node, parent, key, is_first_physics in auto_physx_locations:
-            physics_cfg = resolve_physx_auto_cfg(node, use_isaac_sim)
+            physics_cfg = _resolve_physx_auto_cfg(node, use_isaac_sim)
             concrete_physics_cfgs.append(physics_cfg)
             if parent is None:
                 effective_cfg = physics_cfg

--- a/source/isaaclab/isaaclab/physics/__init__.pyi
+++ b/source/isaaclab/isaaclab/physics/__init__.pyi
@@ -8,7 +8,9 @@ __all__ = [
     "PhysicsEvent",
     "PhysicsManager",
     "PhysicsCfg",
+    "PhysxAutoCfg",
+    "resolve_physx_auto_cfg",
 ]
 
 from .physics_manager import CallbackHandle, PhysicsEvent, PhysicsManager
-from .physics_manager_cfg import PhysicsCfg
+from .physics_manager_cfg import PhysicsCfg, PhysxAutoCfg, resolve_physx_auto_cfg

--- a/source/isaaclab/isaaclab/physics/__init__.pyi
+++ b/source/isaaclab/isaaclab/physics/__init__.pyi
@@ -9,8 +9,7 @@ __all__ = [
     "PhysicsManager",
     "PhysicsCfg",
     "PhysxAutoCfg",
-    "resolve_physx_auto_cfg",
 ]
 
 from .physics_manager import CallbackHandle, PhysicsEvent, PhysicsManager
-from .physics_manager_cfg import PhysicsCfg, PhysxAutoCfg, resolve_physx_auto_cfg
+from .physics_manager_cfg import PhysicsCfg, PhysxAutoCfg

--- a/source/isaaclab/isaaclab/physics/physics_manager_cfg.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager_cfg.py
@@ -37,40 +37,20 @@ class PhysicsCfg:
 
 @configclass
 class PhysxAutoCfg(PhysicsCfg):
-    """Automatic PhysX-family physics placeholder.
-
-    The simulation launcher resolves this placeholder to Isaac Sim PhysX when
-    Kit is required or when no OvPhysX alternative is configured. Otherwise,
-    it resolves to the configured OvPhysX alternative for a kitless run.
-    """
+    """PhysX configuration resolved to a concrete backend at launch."""
 
     class_type: Any = None
-    """Placeholder manager type; resolved before simulation construction."""
-
-    physics_type: str = "auto_physx"
-    """Physics placeholder marker consumed by :func:`isaaclab.app.scan`."""
+    """Unused because this configuration is resolved before simulation construction."""
 
     isaacsim_physx: PhysxCfg | None = None
-    """Concrete Isaac Sim PhysX configuration."""
+    """Concrete Isaac Sim PhysX configuration, or ``None`` when unavailable."""
 
     ovphysx: OvPhysxCfg | None = None
     """Concrete OvPhysX configuration, or ``None`` when OvPhysX is unsupported."""
 
 
-def resolve_physx_auto_cfg(physics_cfg: PhysicsCfg, use_isaac_sim: bool) -> PhysicsCfg:
-    """Resolve an automatic PhysX placeholder to a concrete backend.
-
-    Args:
-        physics_cfg: Physics configuration to resolve.
-        use_isaac_sim: Whether the run already requires Isaac Sim and Kit.
-
-    Returns:
-        The selected concrete physics configuration. Non-automatic
-        configurations are returned unchanged.
-
-    Raises:
-        ValueError: If the selected alternative has the wrong concrete type.
-    """
+def _resolve_physx_auto_cfg(physics_cfg: PhysicsCfg, use_isaac_sim: bool) -> PhysicsCfg:
+    """Resolve a :class:`PhysxAutoCfg` to a concrete backend."""
     if not isinstance(physics_cfg, PhysxAutoCfg):
         return physics_cfg
 
@@ -83,7 +63,7 @@ def resolve_physx_auto_cfg(physics_cfg: PhysicsCfg, use_isaac_sim: bool) -> Phys
     else:
         from isaaclab_physx.physics import PhysxCfg
 
-        selected = physics_cfg.isaacsim_physx if physics_cfg.isaacsim_physx is not None else PhysxCfg()
+        selected = physics_cfg.isaacsim_physx
         expected_type = PhysxCfg
         field_name = "isaacsim_physx"
 

--- a/source/isaaclab/isaaclab/physics/physics_manager_cfg.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager_cfg.py
@@ -7,14 +7,15 @@
 
 from __future__ import annotations
 
-import weakref
-from collections.abc import Callable
 from dataclasses import MISSING
 from typing import TYPE_CHECKING, Any
 
 from isaaclab.utils.configclass import configclass
 
 if TYPE_CHECKING:
+    from isaaclab_ovphysx.physics import OvPhysxCfg
+    from isaaclab_physx.physics import PhysxCfg
+
     from .physics_manager import PhysicsManager
 
 
@@ -34,67 +35,60 @@ class PhysicsCfg:
     """The physics manager class to use. Must be set by subclasses."""
 
 
-_PhysicsPresetSelection = tuple[Callable[[], PhysicsCfg | None], str, dict[str, Any]]
-_PHYSICS_PRESET_SELECTIONS: dict[int, _PhysicsPresetSelection] = {}
+@configclass
+class PhysxAutoCfg(PhysicsCfg):
+    """Automatic PhysX-family physics placeholder.
+
+    The simulation launcher resolves this placeholder to Isaac Sim PhysX when
+    Kit is required or when no OvPhysX alternative is configured. Otherwise,
+    it resolves to the configured OvPhysX alternative for a kitless run.
+    """
+
+    class_type: Any = None
+    """Placeholder manager type; resolved before simulation construction."""
+
+    physics_type: str = "auto_physx"
+    """Physics placeholder marker consumed by :func:`isaaclab.app.scan`."""
+
+    isaacsim_physx: PhysxCfg | None = None
+    """Concrete Isaac Sim PhysX configuration."""
+
+    ovphysx: OvPhysxCfg | None = None
+    """Concrete OvPhysX configuration, or ``None`` when OvPhysX is unsupported."""
 
 
-def _set_physics_preset_selection(
-    physics_cfg: PhysicsCfg,
-    preset_name: str,
-    alternatives: dict[str, Any] | None = None,
-) -> None:
-    """Record which physics preset selected a concrete physics config."""
-    physics_cfg_id = id(physics_cfg)
-    try:
-        physics_cfg_ref = weakref.ref(
-            physics_cfg,
-            lambda _ref, cfg_id=physics_cfg_id: _PHYSICS_PRESET_SELECTIONS.pop(cfg_id, None),
+def resolve_physx_auto_cfg(physics_cfg: PhysicsCfg, use_isaac_sim: bool) -> PhysicsCfg:
+    """Resolve an automatic PhysX placeholder to a concrete backend.
+
+    Args:
+        physics_cfg: Physics configuration to resolve.
+        use_isaac_sim: Whether the run already requires Isaac Sim and Kit.
+
+    Returns:
+        The selected concrete physics configuration. Non-automatic
+        configurations are returned unchanged.
+
+    Raises:
+        ValueError: If the selected alternative has the wrong concrete type.
+    """
+    if not isinstance(physics_cfg, PhysxAutoCfg):
+        return physics_cfg
+
+    if not use_isaac_sim and physics_cfg.ovphysx is not None:
+        from isaaclab_ovphysx.physics import OvPhysxCfg
+
+        selected = physics_cfg.ovphysx
+        expected_type = OvPhysxCfg
+        field_name = "ovphysx"
+    else:
+        from isaaclab_physx.physics import PhysxCfg
+
+        selected = physics_cfg.isaacsim_physx if physics_cfg.isaacsim_physx is not None else PhysxCfg()
+        expected_type = PhysxCfg
+        field_name = "isaacsim_physx"
+
+    if not isinstance(selected, expected_type):
+        raise ValueError(
+            f"Invalid PhysxAutoCfg.{field_name}: expected {expected_type.__name__}, got {type(selected).__name__}."
         )
-    except TypeError:
-
-        def physics_cfg_ref() -> PhysicsCfg:
-            return physics_cfg
-
-    physics_alternatives = {}
-    if alternatives is not None and "ovphysx" in alternatives:
-        physics_alternatives["ovphysx"] = alternatives["ovphysx"]
-    _PHYSICS_PRESET_SELECTIONS[physics_cfg_id] = (physics_cfg_ref, preset_name, physics_alternatives)
-
-
-def _get_physics_preset_metadata(physics_cfg: PhysicsCfg) -> tuple[str | None, dict[str, Any]]:
-    """Return preset metadata for a concrete physics config, if any."""
-    metadata = _PHYSICS_PRESET_SELECTIONS.get(id(physics_cfg))
-    if metadata is None:
-        return None, {}
-    physics_cfg_ref, preset_name, alternatives = metadata
-    if physics_cfg_ref() is not physics_cfg:
-        _PHYSICS_PRESET_SELECTIONS.pop(id(physics_cfg), None)
-        return None, {}
-    return preset_name, alternatives
-
-
-def _get_physics_preset_selection(physics_cfg: PhysicsCfg) -> str | None:
-    """Return the preset name that selected a concrete physics config, if any."""
-    preset_name, _ = _get_physics_preset_metadata(physics_cfg)
-    return preset_name
-
-
-def _resolve_auto_physx_cfg(physics_cfg: PhysicsCfg, use_isaac_sim: bool) -> PhysicsCfg:
-    """Resolve the automatic ``physx`` preset selection to a concrete backend."""
-    if _get_physics_preset_selection(physics_cfg) != "physx":
-        return physics_cfg
-
-    from isaaclab_physx.physics import PhysxCfg
-
-    if not isinstance(physics_cfg, PhysxCfg):
-        raise ValueError(f"Invalid physics preset 'physx': expected PhysxCfg, got {type(physics_cfg).__name__}.")
-    if use_isaac_sim:
-        return physics_cfg
-
-    from isaaclab_ovphysx.physics import OvPhysxCfg
-
-    _, alternatives = _get_physics_preset_metadata(physics_cfg)
-    selected = alternatives.get("ovphysx") or OvPhysxCfg()
-    if not isinstance(selected, OvPhysxCfg):
-        raise ValueError(f"Invalid physics preset 'ovphysx': expected OvPhysxCfg, got {type(selected).__name__}.")
     return selected

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -21,7 +21,7 @@ from isaaclab.app.settings_manager import SettingsManager
 from isaaclab.envs.utils.recording_hooks import run_recording_hooks_after_visualizers
 from isaaclab.markers.vis_marker_registry import VisMarkerRegistry
 from isaaclab.physics import PhysicsEvent, PhysicsManager
-from isaaclab.physics.physics_manager_cfg import _resolve_auto_physx_cfg, _set_physics_preset_selection
+from isaaclab.physics.physics_manager_cfg import resolve_physx_auto_cfg
 from isaaclab.physics.scene_data_requirements import (
     SceneDataRequirement,
     resolve_scene_data_requirements,
@@ -170,24 +170,9 @@ class SimulationContext:
         # If physics is a PresetCfg wrapper (has a 'default' field but no 'class_type'),
         # resolve to the default preset so downstream code always sees a concrete PhysicsCfg.
         if not hasattr(self._physics, "class_type") and hasattr(self._physics, "default"):
-            physics_preset = self._physics
-            self._physics = physics_preset.default
-            default_is_physx = getattr(physics_preset, "physx", None) is self._physics
-            class_default_is_physx = getattr(type(physics_preset), "default", None) is getattr(
-                type(physics_preset), "physx", None
-            )
-            if default_is_physx or class_default_is_physx:
-                _set_physics_preset_selection(
-                    self._physics,
-                    "physx",
-                    {
-                        name: getattr(physics_preset, name)
-                        for name in ("physx", "isaacsim_physx", "ovphysx")
-                        if hasattr(physics_preset, name)
-                    },
-                )
+            self._physics = self._physics.default
             self.cfg.physics = self._physics
-        self._physics = _resolve_auto_physx_cfg(self._physics, use_isaac_sim=has_kit())
+        self._physics = resolve_physx_auto_cfg(self._physics, use_isaac_sim=has_kit())
         self.cfg.physics = self._physics
         self.physics_manager: type[PhysicsManager] = self._physics.class_type
         self.physics_manager.initialize(self)

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -21,7 +21,7 @@ from isaaclab.app.settings_manager import SettingsManager
 from isaaclab.envs.utils.recording_hooks import run_recording_hooks_after_visualizers
 from isaaclab.markers.vis_marker_registry import VisMarkerRegistry
 from isaaclab.physics import PhysicsEvent, PhysicsManager
-from isaaclab.physics.physics_manager_cfg import resolve_physx_auto_cfg
+from isaaclab.physics.physics_manager_cfg import _resolve_physx_auto_cfg
 from isaaclab.physics.scene_data_requirements import (
     SceneDataRequirement,
     resolve_scene_data_requirements,
@@ -172,7 +172,7 @@ class SimulationContext:
         if not hasattr(self._physics, "class_type") and hasattr(self._physics, "default"):
             self._physics = self._physics.default
             self.cfg.physics = self._physics
-        self._physics = resolve_physx_auto_cfg(self._physics, use_isaac_sim=has_kit())
+        self._physics = _resolve_physx_auto_cfg(self._physics, use_isaac_sim=has_kit())
         self.cfg.physics = self._physics
         self.physics_manager: type[PhysicsManager] = self._physics.class_type
         self.physics_manager.initialize(self)

--- a/source/isaaclab_tasks/changelog.d/antoiner-restore-physx-auto.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-restore-physx-auto.minor.rst
@@ -2,5 +2,5 @@ Changed
 ^^^^^^^
 
 * Changed task ``physics=physx`` presets to use explicit automatic PhysX
-  configurations. Use ``physics=isaacsim_physx`` or ``physics=ovphysx`` to
-  force a concrete implementation.
+  configurations. Use ``physics=isaacsim_physx`` or, when exposed by the task,
+  ``physics=ovphysx`` to force a concrete implementation.

--- a/source/isaaclab_tasks/changelog.d/antoiner-restore-physx-auto.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-restore-physx-auto.minor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed task ``physics=physx`` presets to use explicit automatic PhysX
+  configurations. Use ``physics=isaacsim_physx`` or ``physics=ovphysx`` to
+  force a concrete implementation.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -20,6 +20,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -81,7 +82,8 @@ class DrLegsPhysicsCfg(PresetCfg):
 
     default: NewtonCfg = _kamino_newton_cfg()
     newton_kamino: NewtonCfg = _kamino_newton_cfg()
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
 
 
 ##
@@ -134,6 +136,7 @@ class DrLegsActionsCfg(PresetCfg):
     default: ActionsCfg = ActionsCfg()
     newton_kamino: ActionsCfg = ActionsCfg()
     physx: ActionsCfg = _physx_actions_cfg()
+    isaacsim_physx: ActionsCfg = physx
 
 
 @configclass
@@ -254,6 +257,7 @@ class DrLegsEventCfg(PresetCfg):
     default: EventCfg = EventCfg()
     newton_kamino: EventCfg = EventCfg()
     physx: EventCfg = _physx_event_cfg()
+    isaacsim_physx: EventCfg = physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/walk_env_cfg.py
@@ -56,6 +56,7 @@ class DrLegsContactSensorCfg(PresetCfg):
         history_length=3,
         track_air_time=True,
     )
+    isaacsim_physx = physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -20,6 +20,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sensors import ContactSensorCfg, FrameTransformerCfg
 from isaaclab.sim.schemas.schemas_cfg import MassPropertiesCfg, RigidBodyPropertiesCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
@@ -176,7 +177,7 @@ class TerminationsCfg:
 class PhysicsCfg(PresetCfg):
     """Physics backend presets for Agibot place tasks."""
 
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
         gpu_total_aggregate_pairs_capacity=16 * 1024,
@@ -202,7 +203,8 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
 
 
 # Robot USD assets whose gripper revolute joints are authored with reversed

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
@@ -61,8 +62,9 @@ class SO101StackPhysicsCfg(PhysicsCfg):
     object surface instead of letting it tunnel through grasped objects.
     """
 
-    default = PhysicsCfg().default.replace(solve_articulation_contact_last=True)
-    physx = default
+    isaacsim_physx = PhysicsCfg().isaacsim_physx.replace(solve_articulation_contact_last=True)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.markers.config import FRAME_MARKER_CFG
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg, OffsetCfg
 from isaaclab.sim.schemas.schemas_cfg import RigidBodyPropertiesCfg
@@ -290,7 +291,7 @@ class TerminationsCfg:
 class PhysicsCfg(PresetCfg):
     """Physics backend presets for stack tasks."""
 
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_found_lost_aggregate_pairs_capacity=1024 * 1024 * 4,
         gpu_total_aggregate_pairs_capacity=2**21,
@@ -316,7 +317,8 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
 
 
 def raise_if_surface_gripper_on_newton(env_cfg) -> None:

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/a1/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import UnitreeA1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_b/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import AnymalBRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=75,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import AnymalCRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=120,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
@@ -22,4 +22,6 @@ class AnymalCRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         super().__post_init__()
         # switch robot to anymal-c
         self.scene.robot = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.01, physx=0.0)
+        self.scene.robot.actuators["legs"].armature = preset(
+            default=0.0, newton_mjwarp=0.01, physx=0.0, isaacsim_physx=0.0
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/digit/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/digit/rough_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.managers import ObservationGroupCfg, ObservationTermCfg, RewardTermCfg, SceneEntityCfg, TerminationTermCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
@@ -217,8 +218,9 @@ class DigitActionsCfg:
 class DigitPhysicsCfg(PresetCfg):
     """PhysX-only physics configuration for the Digit velocity environments."""
 
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
-    physx = default
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import UnitreeGo1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_direct_env_cfg.py
@@ -15,6 +15,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -26,9 +27,9 @@ from isaaclab_tasks.utils import PresetCfg
 
 @configclass
 class CabinetDirectPhysicsCfg(PresetCfg):
-    physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
     ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             integrator="implicitfast",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -19,6 +19,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer import OffsetCfg
@@ -45,19 +46,16 @@ class CabinetSimCfg(PresetCfg):
     """Simulation configuration presets for the cabinet environment.
 
     Wraps the full :class:`~isaaclab.sim.SimulationCfg` so that Newton can run at a
-    finer physics timestep (1/200 s) while PhysX keeps its default (1/60 s).
+    finer physics timestep (1/600 s) while PhysX keeps its default (1/60 s).
     """
 
-    default: SimulationCfg = SimulationCfg(
+    isaacsim_physx: SimulationCfg = SimulationCfg(
         dt=1 / 60,
         render_interval=1,
         physics=PhysxCfg(bounce_threshold_velocity=0.01, friction_correlation_distance=0.00625),
     )
-    physx: SimulationCfg = SimulationCfg(
-        dt=1 / 60,
-        render_interval=1,
-        physics=PhysxCfg(bounce_threshold_velocity=0.01, friction_correlation_distance=0.00625),
-    )
+    physx: SimulationCfg = isaacsim_physx.replace(physics=PhysxAutoCfg(isaacsim_physx=isaacsim_physx.physics))
+    default: SimulationCfg = physx
     newton_mjwarp: SimulationCfg = SimulationCfg(
         dt=1 / 600,
         render_interval=1,
@@ -265,6 +263,7 @@ class _CabinetNewtonEventCfg:
 class CabinetEventCfg(PresetCfg):
     default: EventCfg = EventCfg()
     physx: EventCfg = EventCfg()
+    isaacsim_physx: EventCfg = physx
     newton_mjwarp: _CabinetNewtonEventCfg = _CabinetNewtonEventCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -13,6 +13,7 @@ from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg, ViewerCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
@@ -24,8 +25,9 @@ from isaaclab_assets.robots.cartpole import CARTPOLE_CFG
 
 @configclass
 class CartpolePhysicsCfg(PresetCfg):
-    physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
+    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
@@ -61,7 +63,6 @@ class CartpolePhysicsCfg(PresetCfg):
         debug_mode=False,
         use_cuda_graph=True,
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils.configclass import configclass
 
@@ -34,8 +35,10 @@ from isaaclab_assets.robots.cartpole import CARTPOLE_CFG  # isort:skip
 
 @configclass
 class CartpolePhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg()
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
+    default: PhysxAutoCfg = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=5,
@@ -70,7 +73,6 @@ class CartpolePhysicsCfg(PresetCfg):
         debug_mode=False,
         use_cuda_graph=True,
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
 
 
 ##

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/dexsuite_kuka_allegro_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/config/kuka_allegro/dexsuite_kuka_allegro_env_cfg.py
@@ -9,6 +9,7 @@ from isaaclab.assets import ArticulationCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sensors import CameraCfg, ContactSensorCfg
 from isaaclab.utils.configclass import configclass
 
@@ -40,6 +41,8 @@ class KukaAllegroPhysicsCfg(dexsuite.PhysicsCfg):
         gpu_max_rigid_patch_count=4 * 5 * 2**15,
         gpu_found_lost_pairs_capacity=2**26,
     )
+    physx = PhysxAutoCfg(isaacsim_physx=dexsuite.PhysicsCfg().isaacsim_physx, ovphysx=ovphysx)
+    default = physx
 
 
 @configclass
@@ -145,6 +148,7 @@ class KukaAllegroMixinCfg:
         self.events = preset(
             default=default_events,
             physx=default_events,
+            isaacsim_physx=default_events,
             newton_mjwarp=default_events,
             ovphysx=ovphysx_events,
         )
@@ -154,6 +158,7 @@ class KukaAllegroMixinCfg:
             self.curriculum = preset(
                 default=default_curriculum,
                 physx=default_curriculum,
+                isaacsim_physx=default_curriculum,
                 newton_mjwarp=default_curriculum,
                 ovphysx=ovphysx_curriculum,
             )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/dexsuite/dexsuite_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import MeshCapsuleCfg, MeshConeCfg, MeshCuboidCfg, MeshSphereCfg, RigidBodyMaterialCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
@@ -466,7 +467,7 @@ class TerminationsCfg:
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.01,
         gpu_max_rigid_patch_count=4 * 5 * 2**15,
         gpu_found_lost_pairs_capacity=2**26,
@@ -490,7 +491,8 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
         debug_mode=False,
     )
-    physx = default
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
@@ -16,6 +16,7 @@ from isaaclab.envs import DirectMARLEnvCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialBaseCfg
@@ -173,7 +174,13 @@ def _shadow_hand_cfg(
         spawn=SHADOW_HAND_CFG.spawn.replace(fixed_tendons_props=None),
         init_state=SHADOW_HAND_CFG.init_state.replace(pos=init_pos, rot=init_rot),
     )
-    return preset(default=newton_mjwarp_cfg, physx=physx_cfg, newton_mjwarp=newton_mjwarp_cfg, ovphysx=ovphysx_cfg)
+    return preset(
+        default=newton_mjwarp_cfg,
+        physx=physx_cfg,
+        isaacsim_physx=physx_cfg,
+        newton_mjwarp=newton_mjwarp_cfg,
+        ovphysx=ovphysx_cfg,
+    )
 
 
 # Per-hand presets shared by the Direct environment and the manager scene.
@@ -238,6 +245,7 @@ class ObjectCfg(PresetCfg):
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.54), rot=(0.0, 0.0, 0.0, 1.0)),
     )
     ovphysx = physx
+    isaacsim_physx = physx
     default = newton_mjwarp
 
 
@@ -251,7 +259,7 @@ class PhysicsCfg(PresetCfg):
     tasks; tuning may be needed for handover-specific contact dynamics.
     """
 
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
         gpu_max_rigid_contact_count=2**23,
         gpu_max_rigid_patch_count=2**23,
@@ -273,6 +281,7 @@ class PhysicsCfg(PresetCfg):
         debug_mode=False,
     )
     ovphysx = OvPhysxCfg()
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
@@ -27,6 +27,7 @@ from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
@@ -101,6 +102,7 @@ class DeformableCfg(PresetCfg):
             ),
         ),
     )
+    isaacsim_physx = physx
 
     newton_mjwarp_vbd_proxy = newton_mjwarp_vbd
 
@@ -180,7 +182,8 @@ class PhysicsCfg(PresetCfg):
         num_substeps=10,
     )
 
-    physx: PhysxCfg = PhysxCfg()
+    isaacsim_physx: PhysxCfg = PhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
 
     default = newton_mjwarp_vbd_proxy
 
@@ -435,6 +438,7 @@ class FrankaSoftSceneCfg(PresetCfg):
 
     # PhysX does not support replicating physics for deformable objects
     physx: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
+    isaacsim_physx = physx
 
     newton_mjwarp_vbd_proxy = newton_mjwarp_vbd
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
@@ -12,6 +12,7 @@ from isaaclab_physx.physics import PhysxCfg
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -24,9 +25,9 @@ from isaaclab_assets.robots.ant import ANT_CFG
 
 @configclass
 class AntPhysicsCfg(PresetCfg):
-    physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
     ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
@@ -15,6 +15,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -31,8 +32,9 @@ from isaaclab_assets.robots.ant import ANT_CFG  # isort: skip
 
 @configclass
 class AntPhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
-    physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    isaacsim_physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default: PhysxAutoCfg = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=38,
@@ -153,6 +155,7 @@ class ObservationsCfg:
 class AntObservationsCfg(PresetCfg):
     default: ObservationsCfg = ObservationsCfg()
     physx: ObservationsCfg = ObservationsCfg()
+    isaacsim_physx: ObservationsCfg = physx
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
@@ -12,6 +12,7 @@ from isaaclab_physx.physics import PhysxCfg
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from isaaclab.envs import DirectRLEnvCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -24,9 +25,9 @@ from isaaclab_assets import HUMANOID_CFG
 
 @configclass
 class HumanoidPhysicsCfg(PresetCfg):
-    physx: PhysxCfg = PhysxCfg()
     isaacsim_physx: PhysxCfg = PhysxCfg()
     ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
@@ -15,6 +15,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -28,8 +29,9 @@ from isaaclab_assets.robots.humanoid import HUMANOID_CFG  # isort:skip
 
 @configclass
 class HumanoidPhysicsCfg(PresetCfg):
-    default: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
-    physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    isaacsim_physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default: PhysxAutoCfg = physx
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=80,
@@ -137,6 +139,7 @@ class ObservationsCfg:
 class HumanoidObservationsCfg(PresetCfg):
     default: ObservationsCfg = ObservationsCfg()
     physx: ObservationsCfg = ObservationsCfg()
+    isaacsim_physx: ObservationsCfg = physx
     newton_mjwarp: ObservationsCfg = ObservationsCfg()
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -21,6 +21,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils.configclass import configclass
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
@@ -35,6 +36,8 @@ from isaaclab_tasks.utils import PresetCfg
 @configclass
 class ReachPhysicsCfg(PresetCfg):
     isaacsim_physx: PhysxCfg = PhysxCfg(bounce_threshold_velocity=0.2)
+    ovphysx: OvPhysxCfg = OvPhysxCfg()
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
 
     newton_mjwarp: NewtonCfg = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
@@ -52,7 +55,6 @@ class ReachPhysicsCfg(PresetCfg):
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(max_contacts_per_world=32),
     )
-    ovphysx: OvPhysxCfg = OvPhysxCfg()
     default: NewtonCfg = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_common.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_common.py
@@ -16,6 +16,7 @@ from isaaclab_physx.physics import PhysxCfg
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
@@ -77,12 +78,13 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.17, 0.56), rot=(0.0, 0.0, 0.0, 1.0)),
     )
+    isaacsim_physx = physx
     default = newton_mjwarp
 
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
     )
     newton_mjwarp = NewtonCfg(
@@ -97,6 +99,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
     )
     ovphysx = OvPhysxCfg()
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_common.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_common.py
@@ -20,6 +20,7 @@ from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 from isaaclab.utils.noise import GaussianNoiseCfg, NoiseModelWithAdditiveBiasCfg
@@ -139,6 +140,7 @@ class PhysxEventCfg:
 @configclass
 class ShadowHandEventCfg(PresetCfg):
     physx = PhysxEventCfg()
+    isaacsim_physx = physx
     newton_mjwarp = NewtonEventCfg()
     ovphysx = physx  # OvPhysX is PhysX-based; reuse the PhysX randomization terms
     default = newton_mjwarp
@@ -154,6 +156,7 @@ class ShadowHandRobotCfg(PresetCfg):
             joint_pos={".*": 0.0},
         )
     )
+    isaacsim_physx = physx
     # Newton robot lives in the asset (see isaaclab_assets.robots.shadow_hand); reorient
     # uses its default gains. The handover task consumes the same asset cfg and overrides
     # only the finger gains.
@@ -193,6 +196,7 @@ class ObjectCfg(PresetCfg):
         ),
         init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, -0.39, 0.6), rot=(0.0, 0.0, 0.0, 1.0)),
     )
+    isaacsim_physx = physx
 
     newton_mjwarp = ArticulationCfg(
         prim_path="/World/envs/env_.*/object",
@@ -215,7 +219,7 @@ class ObjectCfg(PresetCfg):
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    physx = PhysxCfg(
+    isaacsim_physx = PhysxCfg(
         bounce_threshold_velocity=0.2,
         gpu_max_rigid_contact_count=2**23,
         gpu_max_rigid_patch_count=2**23,
@@ -232,6 +236,7 @@ class PhysicsCfg(PresetCfg):
         num_substeps=2,
     )
     ovphysx = OvPhysxCfg()
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     default = newton_mjwarp
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=128))
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
@@ -73,6 +73,7 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
     scene: InteractiveSceneCfg = preset(
         default=ShadowHandSceneCfg(clone_in_fabric=False),
         physx=ShadowHandSceneCfg(clone_in_fabric=True),
+        isaacsim_physx=ShadowHandSceneCfg(clone_in_fabric=True),
         ovphysx=ShadowHandSceneCfg(clone_in_fabric=True),
         newton_mjwarp=ShadowHandSceneCfg(clone_in_fabric=False),
         newton_kamino=ShadowHandSceneCfg(clone_in_fabric=False),

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/flat_env_cfg.py
@@ -7,6 +7,7 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -17,7 +18,10 @@ from .rough_env_cfg import AnymalDRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    ovphysx = OvPhysxCfg()
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=60,
@@ -28,8 +32,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
-    ovphysx = OvPhysxCfg()
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import CassieRoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=52,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/g1/flat_env_cfg.py
@@ -7,6 +7,7 @@ from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
 from isaaclab.managers import SceneEntityCfg
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -17,7 +18,9 @@ from .rough_env_cfg import G1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=95,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import UnitreeGo2RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=65,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/flat_env_cfg.py
@@ -6,6 +6,7 @@
 from isaaclab_newton.physics import KaminoSolverCfg, MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils.configclass import configclass
 
@@ -16,7 +17,9 @@ from .rough_env_cfg import H1RoughEnvCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=65,
@@ -28,7 +31,6 @@ class PhysicsCfg(PresetCfg):
         num_substeps=1,
         debug_mode=False,
     )
-    physx = default
     newton_kamino = NewtonCfg(solver_cfg=KaminoSolverCfg(max_contacts_per_world=64))
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/spot/flat_env_cfg.py
@@ -21,6 +21,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg, SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
@@ -35,7 +36,9 @@ from isaaclab_tasks.utils import PresetCfg
 
 @configclass
 class PhysicsCfg(PresetCfg):
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=130,
@@ -231,6 +234,7 @@ class SpotEventCfg(PresetCfg):
     default = SpotPhysxEventCfg()
     newton_mjwarp = SpotNewtonEventCfg()
     physx = default
+    isaacsim_physx = physx
     newton_kamino = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -20,6 +20,7 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import ContactSensorCfg, RayCasterCfg, patterns
 from isaaclab.sim import SimulationCfg
@@ -46,7 +47,10 @@ from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
 class RoughPhysicsCfg(PresetCfg):
     """Shared physics preset for all rough-terrain locomotion envs."""
 
-    default = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    isaacsim_physx = PhysxCfg(gpu_max_rigid_patch_count=10 * 2**15)
+    ovphysx = OvPhysxCfg()
+    physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
+    default = physx
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
             njmax=200,
@@ -64,8 +68,6 @@ class RoughPhysicsCfg(PresetCfg):
         # on triangle-mesh terrain. See isaaclab_newton 0.5.22 changelog.
         default_shape_cfg=NewtonShapeCfg(margin=0.01),
     )
-    physx = default
-    ovphysx = OvPhysxCfg()
 
 
 ##

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -38,7 +38,6 @@ from hydra.core.config_store import ConfigStore
 from omegaconf import OmegaConf
 
 from isaaclab.envs.utils.spaces import replace_env_cfg_spaces_with_strings, replace_strings_with_env_cfg_spaces
-from isaaclab.physics.physics_manager_cfg import PhysicsCfg, _set_physics_preset_selection
 from isaaclab.utils import replace_slices_with_strings, replace_strings_with_slices
 from isaaclab.utils.configclass import configclass
 
@@ -209,25 +208,6 @@ def _preset_fields(preset_obj) -> dict:
     return d
 
 
-def _record_preset_selection(value, preset_name: str, fields: dict):
-    """Attach preset-selection metadata when a physics preset resolves to a concrete config."""
-    if not isinstance(value, PhysicsCfg):
-        return value
-    if preset_name == "default" and fields.get("physx") == value:
-        preset_name = "physx"
-    _set_physics_preset_selection(value, preset_name, fields)
-    return value
-
-
-def _preset_values_conflict(first, second) -> bool:
-    """Return whether two selected preset values conflict on the same path."""
-    if first is second:
-        return False
-    if isinstance(first, PhysicsCfg) and isinstance(second, PhysicsCfg):
-        return True
-    return first != second
-
-
 def _iter_cfg_items(cfg):
     if isinstance(cfg, Mapping):
         return cfg.items()
@@ -316,7 +296,7 @@ def _pick_alternative(
     if explicit_name is not None:
         explicit_name = _normalize_preset_name(explicit_name, field_names)
         if explicit_name in fields:
-            return _record_preset_selection(fields[explicit_name], explicit_name, fields)
+            return fields[explicit_name]
         avail = list(fields)
         hint = ""
         if explicit_name in PresetTarget.all_legacy_aliases():
@@ -344,15 +324,15 @@ def _pick_alternative(
                 typed_hits.setdefault(raw_name, set()).update(targets)
                 typed_hits.setdefault(name, set()).update(targets)
         if match_name is not None:
-            if _preset_values_conflict(match_value, val):
+            if match_value is not val and match_value != val:
                 raise ValueError(
                     f"Conflicting global presets: '{match_name}' and '{name}' both define preset for '{path}'"
                 )
         match_name, match_value = name, val
     if match_name is not None:
-        return _record_preset_selection(match_value, match_name, fields)
+        return match_value
     if "default" in fields:
-        return _record_preset_selection(fields["default"], "default", fields)
+        return fields["default"]
     raise ValueError(
         f"PresetCfg {type(preset_obj).__name__} at '{path}' has no 'default' field "
         f"and none of the selected presets {selected} match its fields {set(fields.keys())}."

--- a/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
@@ -28,7 +28,6 @@ def test_preset_enables_contact_last_and_keeps_stack_tuning():
     assert preset.default == preset.physx
     for physx in (preset.isaacsim_physx, preset.physx.isaacsim_physx):
         assert physx.solve_articulation_contact_last is True
-        # stack-family tuning must be preserved (values from PhysicsCfg.default)
         assert physx.bounce_threshold_velocity == 0.01
         assert physx.friction_correlation_distance == 0.00625
 

--- a/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/stack/test_so101_stack_physics_cfg.py
@@ -25,7 +25,8 @@ from isaaclab_tasks.contrib.stack.config.so101.stack_joint_pos_env_cfg import (
 
 def test_preset_enables_contact_last_and_keeps_stack_tuning():
     preset = SO101StackPhysicsCfg()
-    for physx in (preset.default, preset.physx):
+    assert preset.default == preset.physx
+    for physx in (preset.isaacsim_physx, preset.physx.isaacsim_physx):
         assert physx.solve_articulation_contact_last is True
         # stack-family tuning must be preserved (values from PhysicsCfg.default)
         assert physx.bounce_threshold_velocity == 0.01
@@ -36,4 +37,4 @@ def test_both_so101_stack_tasks_carry_the_preset():
     for cfg_cls in (SO101CubeStackEnvCfg, SO101CubeStackIKAbsEnvCfg):
         cfg = cfg_cls()
         assert isinstance(cfg.sim.physics, SO101StackPhysicsCfg)
-        assert cfg.sim.physics.physx.solve_articulation_contact_last is True
+        assert cfg.sim.physics.physx.isaacsim_physx.solve_articulation_contact_last is True

--- a/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
+++ b/source/isaaclab_tasks/test/core/test_dr_legs_physics_presets.py
@@ -9,6 +9,8 @@ from isaaclab_newton.physics import KaminoSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.sensors import ContactSensorCfg as PhysXContactSensorCfg
 
+from isaaclab.physics import PhysxAutoCfg
+
 from isaaclab_tasks.contrib.dr_legs.hold_pose_env_cfg import DrLegsHoldPoseEnvCfg, DrLegsPhysicsCfg
 from isaaclab_tasks.contrib.dr_legs.walk_env_cfg import DrLegsWalkEnvCfg
 from isaaclab_tasks.utils.hydra import resolve_presets
@@ -20,7 +22,8 @@ def test_dr_legs_physx_uses_assembled_joint_reset_and_bounded_joint_velocity() -
     """PhysX must assemble the joints and apply the asset's solver velocity limit."""
     env_cfg = resolve_presets(DrLegsWalkEnvCfg(), selected=("physx",))
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
+    assert isinstance(env_cfg.sim.physics.isaacsim_physx, PhysxCfg)
     assert isinstance(env_cfg.scene.contact_forces, PhysXContactSensorCfg)
     assert env_cfg.actions.joint_pos.scale == 0.1
     assert env_cfg.scene.robot == DR_LEGS_IMPLICIT_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -1450,7 +1450,11 @@ def test_resolve_presets_errors_on_cyclic_preset_at_root():
 # Tests: typed-selector validation (physics=/renderer= must hit their type)
 # =============================================================================
 
+from isaaclab_ovphysx.physics import OvPhysxCfg  # noqa: E402
+from isaaclab_physx.physics import PhysxCfg as IsaacSimPhysxCfg  # noqa: E402
+
 from isaaclab.physics import PhysicsCfg as _RealPhysicsCfg  # noqa: E402
+from isaaclab.physics import PhysxAutoCfg  # noqa: E402
 
 from isaaclab_tasks.utils.preset_target import PresetTarget  # noqa: E402
 
@@ -1465,6 +1469,28 @@ class _NewtonPhysicsCfg(_RealPhysicsCfg):
 @configclass
 class _PhysxPhysicsCfg(_RealPhysicsCfg):
     dt: float = 0.005
+
+
+def test_pick_physx_auto_alternative_does_not_attach_hidden_metadata():
+    """Selecting ``physx`` returns the explicit placeholder without out-of-band state."""
+
+    @configclass
+    class PhysicsPresetCfg(PresetCfg):
+        isaacsim_physx: IsaacSimPhysxCfg = IsaacSimPhysxCfg()
+        ovphysx: OvPhysxCfg = OvPhysxCfg()
+        physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
+        default: PhysxAutoCfg = physx
+
+    presets = PhysicsPresetCfg()
+    selected = hydra_mod._pick_alternative(presets, [], explicit_name="physx")
+    metadata_reader = getattr(
+        __import__("isaaclab.physics.physics_manager_cfg", fromlist=["_get_physics_preset_selection"]),
+        "_get_physics_preset_selection",
+        lambda _cfg: None,
+    )
+
+    assert selected is presets.physx
+    assert metadata_reader(selected) is None
 
 
 def test_validate_typed_presets_passes_when_selector_hits_its_type():

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -1450,11 +1450,7 @@ def test_resolve_presets_errors_on_cyclic_preset_at_root():
 # Tests: typed-selector validation (physics=/renderer= must hit their type)
 # =============================================================================
 
-from isaaclab_ovphysx.physics import OvPhysxCfg  # noqa: E402
-from isaaclab_physx.physics import PhysxCfg as IsaacSimPhysxCfg  # noqa: E402
-
 from isaaclab.physics import PhysicsCfg as _RealPhysicsCfg  # noqa: E402
-from isaaclab.physics import PhysxAutoCfg  # noqa: E402
 
 from isaaclab_tasks.utils.preset_target import PresetTarget  # noqa: E402
 
@@ -1469,28 +1465,6 @@ class _NewtonPhysicsCfg(_RealPhysicsCfg):
 @configclass
 class _PhysxPhysicsCfg(_RealPhysicsCfg):
     dt: float = 0.005
-
-
-def test_pick_physx_auto_alternative_does_not_attach_hidden_metadata():
-    """Selecting ``physx`` returns the explicit placeholder without out-of-band state."""
-
-    @configclass
-    class PhysicsPresetCfg(PresetCfg):
-        isaacsim_physx: IsaacSimPhysxCfg = IsaacSimPhysxCfg()
-        ovphysx: OvPhysxCfg = OvPhysxCfg()
-        physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
-        default: PhysxAutoCfg = physx
-
-    presets = PhysicsPresetCfg()
-    selected = hydra_mod._pick_alternative(presets, [], explicit_name="physx")
-    metadata_reader = getattr(
-        __import__("isaaclab.physics.physics_manager_cfg", fromlist=["_get_physics_preset_selection"]),
-        "_get_physics_preset_selection",
-        lambda _cfg: None,
-    )
-
-    assert selected is presets.physx
-    assert metadata_reader(selected) is None
 
 
 def test_validate_typed_presets_passes_when_selector_hits_its_type():

--- a/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
+++ b/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
@@ -13,6 +13,7 @@ No Kit/GPU required — safe for CI and beginners.
 import sys
 from argparse import Namespace
 
+import gymnasium as gym
 import pytest
 from isaaclab_ov.renderers import OVRTXRendererCfg
 from isaaclab_ovphysx.physics import OvPhysxCfg
@@ -20,9 +21,13 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
 from isaaclab.app import scan
+from isaaclab.physics import PhysxAutoCfg, resolve_physx_auto_cfg
+from isaaclab.sim import SimulationCfg
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import resolve_task_config
+from isaaclab_tasks.utils.hydra import collect_presets
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 from isaaclab_tasks.utils.preset_cli import enumerate_task_presets
 from isaaclab_tasks.utils.preset_target import PresetTarget
 
@@ -78,14 +83,78 @@ def test_isaacsim_physx_is_physics_selector():
     assert "isaacsim_physx" in preset_map[PresetTarget.PHYSICS]
 
 
-def test_cartpole_physx_preset_is_plain_physx_cfg():
-    """Task configs expose ``physx`` as concrete PhysX, not a public auto wrapper."""
+def test_physics_api_exposes_auto_placeholder():
+    """The public physics API exposes the explicit automatic PhysX placeholder."""
+    import isaaclab.physics as physics
+
+    assert hasattr(physics, "PhysxAutoCfg")
+
+
+def test_cartpole_physx_preset_is_explicit_auto_cfg():
+    """Task configs expose automatic PhysX through an explicit placeholder."""
     from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpolePhysicsCfg
 
     physics_cfg = CartpolePhysicsCfg()
 
-    assert isinstance(physics_cfg.physx, PhysxCfg)
-    assert isinstance(physics_cfg.default, PhysxCfg)
+    assert isinstance(physics_cfg.physx, PhysxAutoCfg)
+    assert isinstance(physics_cfg.physx.isaacsim_physx, PhysxCfg)
+    assert isinstance(physics_cfg.physx.ovphysx, OvPhysxCfg)
+    assert physics_cfg.default == physics_cfg.physx
+
+
+def test_registered_task_physx_presets_use_explicit_auto_cfg():
+    """Every registered task with Isaac Sim PhysX exposes the same explicit auto shape."""
+    invalid_presets = []
+
+    for task_id, task_spec in gym.registry.items():
+        if not task_id.startswith(("Isaac-", "IsaacContrib-")) or "env_cfg_entry_point" not in task_spec.kwargs:
+            continue
+        env_cfg = load_cfg_from_registry(task_id, "env_cfg_entry_point")
+        presets = collect_presets(env_cfg)
+        has_auto_physx = any(isinstance(fields.get("physx"), PhysxAutoCfg) for fields in presets.values())
+        for path, fields in presets.items():
+            if not any(isinstance(value, PhysxCfg) for value in fields.values()):
+                if has_auto_physx and "physx" in fields and fields.get("isaacsim_physx") != fields["physx"]:
+                    invalid_presets.append(f"{task_id}:{path}")
+            else:
+                auto_cfg = fields.get("physx")
+                isaacsim_cfg = fields.get("isaacsim_physx")
+                ovphysx_cfg = fields.get("ovphysx")
+                if (
+                    not isinstance(auto_cfg, PhysxAutoCfg)
+                    or not isinstance(isaacsim_cfg, PhysxCfg)
+                    or auto_cfg.isaacsim_physx != isaacsim_cfg
+                    or auto_cfg.ovphysx != ovphysx_cfg
+                ):
+                    invalid_presets.append(f"{task_id}:{path}")
+
+    assert invalid_presets == [], "\n".join(sorted(set(invalid_presets)))
+
+
+def test_auto_physx_without_ovphysx_falls_back_to_isaac_sim():
+    """Automatic PhysX keeps Isaac Sim when a task does not support OvPhysX."""
+    cfg = SimulationCfg(physics=PhysxAutoCfg(isaacsim_physx=PhysxCfg()))
+
+    config_scan = scan(cfg)
+
+    assert isinstance(cfg.physics, PhysxCfg)
+    assert config_scan.needs_kit is True
+
+
+def test_auto_physx_rejects_wrong_isaac_sim_alternative_type():
+    """Selecting a malformed Isaac Sim alternative reports its expected type."""
+    cfg = PhysxAutoCfg(isaacsim_physx=OvPhysxCfg())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match=r"PhysxAutoCfg\.isaacsim_physx.*PhysxCfg.*OvPhysxCfg"):
+        resolve_physx_auto_cfg(cfg, use_isaac_sim=True)
+
+
+def test_auto_physx_rejects_wrong_ovphysx_alternative_type():
+    """Selecting a malformed OvPhysX alternative reports its expected type."""
+    cfg = PhysxAutoCfg(ovphysx=PhysxCfg())  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match=r"PhysxAutoCfg\.ovphysx.*OvPhysxCfg.*PhysxCfg"):
+        resolve_physx_auto_cfg(cfg, use_isaac_sim=False)
 
 
 def test_physx_and_isaacsim_physx_presets_conflict():
@@ -125,7 +194,7 @@ def test_renderer_selector_physx_rtx_resolves_to_ovphysx_without_kit():
     """Automatic PhysX and RTX selectors use kitless backends when no Kit runtime is requested."""
     env_cfg = _resolve_with_args("physics=physx", "renderer=rtx")
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
 
     config_scan = _resolve_runtime_renderer(env_cfg)
 
@@ -138,7 +207,7 @@ def test_renderer_selector_physx_rtx_resolves_to_physx_with_kit_visualizer():
     """Automatic PhysX and RTX selectors use Isaac Sim backends when the Kit visualizer is requested."""
     env_cfg = _resolve_with_args("physics=physx", "renderer=rtx")
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
 
     config_scan = _resolve_runtime_renderer(env_cfg, Namespace(visualizer="kit"))
 

--- a/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
+++ b/source/isaaclab_tasks/test/core/test_preset_kit_decision.py
@@ -21,7 +21,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
 from isaaclab.app import scan
-from isaaclab.physics import PhysxAutoCfg, resolve_physx_auto_cfg
+from isaaclab.physics import PhysicsCfg, PhysxAutoCfg
 from isaaclab.sim import SimulationCfg
 
 import isaaclab_tasks  # noqa: F401
@@ -32,6 +32,10 @@ from isaaclab_tasks.utils.preset_cli import enumerate_task_presets
 from isaaclab_tasks.utils.preset_target import PresetTarget
 
 _CAMERA_PRESETS_TASK = "Isaac-Cartpole-Camera-Direct"
+
+
+def _physics_cfg(value):
+    return value if isinstance(value, PhysicsCfg) else getattr(value, "physics", None)
 
 
 def _resolve_with_presets(presets: str):
@@ -83,52 +87,27 @@ def test_isaacsim_physx_is_physics_selector():
     assert "isaacsim_physx" in preset_map[PresetTarget.PHYSICS]
 
 
-def test_physics_api_exposes_auto_placeholder():
-    """The public physics API exposes the explicit automatic PhysX placeholder."""
-    import isaaclab.physics as physics
-
-    assert hasattr(physics, "PhysxAutoCfg")
-
-
-def test_cartpole_physx_preset_is_explicit_auto_cfg():
-    """Task configs expose automatic PhysX through an explicit placeholder."""
-    from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpolePhysicsCfg
-
-    physics_cfg = CartpolePhysicsCfg()
-
-    assert isinstance(physics_cfg.physx, PhysxAutoCfg)
-    assert isinstance(physics_cfg.physx.isaacsim_physx, PhysxCfg)
-    assert isinstance(physics_cfg.physx.ovphysx, OvPhysxCfg)
-    assert physics_cfg.default == physics_cfg.physx
-
-
 def test_registered_task_physx_presets_use_explicit_auto_cfg():
-    """Every registered task with Isaac Sim PhysX exposes the same explicit auto shape."""
-    invalid_presets = []
+    """Every task with Isaac Sim PhysX exposes automatic and concrete presets."""
 
     for task_id, task_spec in gym.registry.items():
         if not task_id.startswith(("Isaac-", "IsaacContrib-")) or "env_cfg_entry_point" not in task_spec.kwargs:
             continue
         env_cfg = load_cfg_from_registry(task_id, "env_cfg_entry_point")
         presets = collect_presets(env_cfg)
-        has_auto_physx = any(isinstance(fields.get("physx"), PhysxAutoCfg) for fields in presets.values())
+        has_auto_physx = any(isinstance(_physics_cfg(fields.get("physx")), PhysxAutoCfg) for fields in presets.values())
         for path, fields in presets.items():
-            if not any(isinstance(value, PhysxCfg) for value in fields.values()):
-                if has_auto_physx and "physx" in fields and fields.get("isaacsim_physx") != fields["physx"]:
-                    invalid_presets.append(f"{task_id}:{path}")
-            else:
-                auto_cfg = fields.get("physx")
-                isaacsim_cfg = fields.get("isaacsim_physx")
-                ovphysx_cfg = fields.get("ovphysx")
-                if (
-                    not isinstance(auto_cfg, PhysxAutoCfg)
-                    or not isinstance(isaacsim_cfg, PhysxCfg)
-                    or auto_cfg.isaacsim_physx != isaacsim_cfg
-                    or auto_cfg.ovphysx != ovphysx_cfg
-                ):
-                    invalid_presets.append(f"{task_id}:{path}")
-
-    assert invalid_presets == [], "\n".join(sorted(set(invalid_presets)))
+            location = f"{task_id}:{path}"
+            physics_fields = {name: _physics_cfg(value) for name, value in fields.items()}
+            if any(isinstance(value, PhysxCfg) for value in physics_fields.values()):
+                auto_cfg = physics_fields.get("physx")
+                isaacsim_cfg = physics_fields.get("isaacsim_physx")
+                assert isinstance(auto_cfg, PhysxAutoCfg), location
+                assert isinstance(isaacsim_cfg, PhysxCfg), location
+                assert auto_cfg.isaacsim_physx == isaacsim_cfg, location
+                assert auto_cfg.ovphysx == physics_fields.get("ovphysx"), location
+            elif has_auto_physx and "physx" in fields:
+                assert fields.get("isaacsim_physx") == fields["physx"], location
 
 
 def test_auto_physx_without_ovphysx_falls_back_to_isaac_sim():
@@ -139,22 +118,6 @@ def test_auto_physx_without_ovphysx_falls_back_to_isaac_sim():
 
     assert isinstance(cfg.physics, PhysxCfg)
     assert config_scan.needs_kit is True
-
-
-def test_auto_physx_rejects_wrong_isaac_sim_alternative_type():
-    """Selecting a malformed Isaac Sim alternative reports its expected type."""
-    cfg = PhysxAutoCfg(isaacsim_physx=OvPhysxCfg())  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match=r"PhysxAutoCfg\.isaacsim_physx.*PhysxCfg.*OvPhysxCfg"):
-        resolve_physx_auto_cfg(cfg, use_isaac_sim=True)
-
-
-def test_auto_physx_rejects_wrong_ovphysx_alternative_type():
-    """Selecting a malformed OvPhysX alternative reports its expected type."""
-    cfg = PhysxAutoCfg(ovphysx=PhysxCfg())  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match=r"PhysxAutoCfg\.ovphysx.*OvPhysxCfg.*PhysxCfg"):
-        resolve_physx_auto_cfg(cfg, use_isaac_sim=False)
 
 
 def test_physx_and_isaacsim_physx_presets_conflict():

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -25,6 +25,7 @@ import isaaclab.app.sim_launcher as sim_launcher_module
 import isaaclab.utils as isaaclab_utils
 from isaaclab.app import scan
 from isaaclab.app.sim_launcher import _validate_runtime, launch_simulation
+from isaaclab.physics import PhysxAutoCfg
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import resolve_task_config
@@ -130,7 +131,7 @@ def test_default_auto_physx_plus_ovrtx_resolves_to_ovphysx():
     """Default automatic PhysX uses OvPhysX when OVRTX is the only renderer signal."""
     env_cfg = _resolve_with_presets("ovrtx")
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
 
     config_scan = validate_runtime_compatibility(env_cfg)
 
@@ -143,7 +144,7 @@ def test_explicit_auto_physx_plus_ovrtx_resolves_to_ovphysx():
     """The ``physx`` preset remains automatic when paired with OVRTX."""
     env_cfg = _resolve_with_presets("physx,ovrtx")
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
 
     config_scan = validate_runtime_compatibility(env_cfg)
 
@@ -220,7 +221,7 @@ def test_renderer_selector_physx_rtx_is_valid_and_resolves_to_ovphysx_and_ovrtx(
     """The automatic PhysX and RTX selectors choose kitless backends without Kit signals."""
     env_cfg = _resolve_with_args("physics=physx", "renderer=rtx")
 
-    assert isinstance(env_cfg.sim.physics, PhysxCfg)
+    assert isinstance(env_cfg.sim.physics, PhysxAutoCfg)
 
     config_scan = validate_runtime_compatibility(env_cfg)
 


### PR DESCRIPTION
# Description

This PR replaces hidden preset metadata with `PhysxAutoCfg`.

- use Isaac Sim PhysX when Kit is required;
- use OvPhysX for a kitless run when the task supports it;
- fall back to Isaac Sim PhysX when the task does not support OvPhysX.

Registered task physics presets use this shape. Coupled presets expose matching
`isaacsim_physx` aliases. Explicit `physics=isaacsim_physx` and
`physics=ovphysx` selections remain concrete.

No new dependencies are required.

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Screenshots

Not applicable.

## Testing

- `./isaaclab.sh -f`
- `./isaaclab.sh -d`
- Targeted Hydra, runtime compatibility, and task preset tests: 156 passed

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there