### PR TITLE
Report rendering XFAIL reasons in HTML

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-kitless-xfail-stabilization-patch.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-kitless-xfail-stabilization-patch.skip
@@ -1,0 +1,1 @@
+Test-only: reported expected rendering failures and their ticketed reasons in the golden-image HTML artifact.

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -722,18 +722,20 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
 
     os.makedirs(_COMPARISON_IMAGES_DIR, exist_ok=True)
     report_path = os.path.join(_COMPARISON_IMAGES_DIR, report_filename)
-    sorted_scores = sorted(comparison_scores, key=lambda e: -e["diff_pct"])
+    sorted_scores = sorted(
+        comparison_scores, key=lambda entry: (0 if entry.get("xfail_reason") else 1, -entry["diff_pct"])
+    )
 
     rows = []
     for entry in sorted_scores:
         xfail_reason = entry.get("xfail_reason") or ""
         if xfail_reason:
-            if entry["passed"]:
-                status_class = "xpass"
-                status_text = "XPASS (REVIEW XFAIL)"
-            else:
+            if entry.get("xfail_observed", not entry["passed"]):
                 status_class = "unreliable"
                 status_text = "UNRELIABLE (XFAIL)"
+            else:
+                status_class = "xpass"
+                status_text = "XPASS (REVIEW XFAIL)"
         else:
             status_class = "pass" if entry["passed"] else "fail"
             status_text = status_class.upper()
@@ -868,9 +870,12 @@ def record_comparison_outcomes(
     """Record expected outcomes for HTML and attach comparison properties to JUnit XML."""
     xfail_marker = request.node.get_closest_marker("xfail")
     xfail_reason = xfail_marker.kwargs.get("reason") if xfail_marker is not None else None
-    for entry in comparison_scores[initial_count:]:
+    entries = comparison_scores[initial_count:]
+    xfail_observed = any(not entry["passed"] for entry in entries)
+    for entry in entries:
         if xfail_reason:
             entry["xfail_reason"] = xfail_reason
+            entry["xfail_observed"] = xfail_observed
         label = f"{entry['backend']}-{entry['renderer']}-{entry['aov']}"
         request.node.user_properties.append((f"diff_pct:{label}", f"{entry['diff_pct']:.2f}"))
         ssim_value = f"{entry['ssim']:.4f}" if entry.get("ssim_checked", True) else f"{entry['ssim']:.4f} (N/A)"
@@ -925,14 +930,14 @@ def make_attach_comparison_properties_fixture(comparison_scores: list[dict]):
     """
 
     @pytest.fixture(autouse=True)
-    def _attach_comparison_properties(request):
+    def _record_comparison_outcomes(request):
         """Record expected outcomes and attach image-comparison properties."""
         initial_count = len(comparison_scores)
         yield
         # Function-scoped teardown runs before the session-scoped HTML report is generated.
         record_comparison_outcomes(request, comparison_scores, initial_count)
 
-    return _attach_comparison_properties
+    return _record_comparison_outcomes
 
 
 def make_require_ovlibs_install_fixture():

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -10,6 +10,7 @@ import os
 import re
 import tempfile
 from datetime import datetime
+from html import escape
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -725,8 +726,13 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
 
     rows = []
     for entry in sorted_scores:
-        status_class = "pass" if entry["passed"] else "fail"
-        status_text = status_class.upper()
+        if entry.get("xfail_reason") and not entry["passed"]:
+            status_class = "unreliable"
+            status_text = "UNRELIABLE (XFAIL)"
+        else:
+            status_class = "pass" if entry["passed"] else "fail"
+            status_text = status_class.upper()
+        reason = escape(entry.get("xfail_reason", ""))
 
         actual_img_html = ""
         golden_img_html = ""
@@ -763,6 +769,7 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
             f"<td{ssim_cell_class}{ssim_title}>{entry['ssim']:.4f}</td>"
             f"<td{ssim_cell_class}{ssim_title}>{ssim_threshold_cell}</td>"
             f'<td class="status-{status_class}">{status_text}</td>'
+            f"<td>{reason}</td>"
             f"<td>{actual_img_html}</td>"
             f"<td>{golden_img_html}</td>"
             f'<td class="compare-cell">{compare_html}</td>'
@@ -783,9 +790,11 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
         "  th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; vertical-align: middle; }\n"
         "  th { background: #f0f0f0; white-space: nowrap; }\n"
         "  tr.fail { background: #fff0f0; }\n"
-        "  tr.pass:hover, tr.fail:hover { filter: brightness(0.96); }\n"
+        "  tr.unreliable { background: #fff8e1; }\n"
+        "  tr.pass:hover, tr.fail:hover, tr.unreliable:hover { filter: brightness(0.96); }\n"
         "  .status-pass { color: #2a7a2a; font-weight: bold; }\n"
         "  .status-fail { color: #cc0000; font-weight: bold; }\n"
+        "  .status-unreliable { color: #a15c00; font-weight: bold; }\n"
         "  .ssim-disabled { color: #999; font-style: italic; }\n"
         "  img { display: block; max-width: 120px; height: auto; }\n"
         "  .compare-cell { max-width: 420px; }\n"
@@ -831,6 +840,7 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
         "<th>SSIM</th>"
         "<th>SSIM Threshold</th>"
         "<th>Status</th>"
+        "<th>Reason</th>"
         "<th>ACTUAL</th>"
         "<th>GOLDEN</th>"
         "<th>Beyond Compare Command</th>"
@@ -849,7 +859,11 @@ def attach_comparison_properties(
     request: pytest.FixtureRequest, comparison_scores: list[dict], initial_count: int
 ) -> None:
     """Attach pixel-diff, SSIM scores, and failure images as JUnit XML properties."""
+    xfail_marker = request.node.get_closest_marker("xfail")
+    xfail_reason = xfail_marker.kwargs.get("reason") if xfail_marker is not None else None
     for entry in comparison_scores[initial_count:]:
+        if xfail_reason and not entry["passed"]:
+            entry["xfail_reason"] = xfail_reason
         label = f"{entry['backend']}-{entry['renderer']}-{entry['aov']}"
         request.node.user_properties.append((f"diff_pct:{label}", f"{entry['diff_pct']:.2f}"))
         ssim_value = f"{entry['ssim']:.4f}" if entry.get("ssim_checked", True) else f"{entry['ssim']:.4f} (N/A)"

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -864,10 +864,10 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
         file.write(report_html)
 
 
-def record_comparison_outcomes(
+def attach_comparison_properties(
     request: pytest.FixtureRequest, comparison_scores: list[dict], initial_count: int
 ) -> None:
-    """Record expected outcomes for HTML and attach comparison properties to JUnit XML."""
+    """Annotate expected HTML outcomes and attach comparison properties to JUnit XML."""
     xfail_marker = request.node.get_closest_marker("xfail")
     xfail_reason = xfail_marker.kwargs.get("reason") if xfail_marker is not None else None
     entries = comparison_scores[initial_count:]
@@ -923,21 +923,21 @@ def make_generate_html_report_fixture(comparison_scores: list[dict], report_file
 
 
 def make_attach_comparison_properties_fixture(comparison_scores: list[dict]):
-    """Create a fixture that records HTML outcomes and JUnit properties for one module.
+    """Create a fixture that annotates HTML outcomes and attaches JUnit properties.
 
     Args:
         comparison_scores: Module-local comparison score storage.
     """
 
     @pytest.fixture(autouse=True)
-    def _record_comparison_outcomes(request):
-        """Record expected outcomes and attach image-comparison properties."""
+    def _attach_comparison_properties(request):
+        """Annotate expected HTML outcomes and attach image-comparison properties."""
         initial_count = len(comparison_scores)
         yield
         # Function-scoped teardown runs before the session-scoped HTML report is generated.
-        record_comparison_outcomes(request, comparison_scores, initial_count)
+        attach_comparison_properties(request, comparison_scores, initial_count)
 
-    return _record_comparison_outcomes
+    return _attach_comparison_properties
 
 
 def make_require_ovlibs_install_fixture():

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -726,13 +726,18 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
 
     rows = []
     for entry in sorted_scores:
-        if entry.get("xfail_reason") and not entry["passed"]:
-            status_class = "unreliable"
-            status_text = "UNRELIABLE (XFAIL)"
+        xfail_reason = entry.get("xfail_reason") or ""
+        if xfail_reason:
+            if entry["passed"]:
+                status_class = "xpass"
+                status_text = "XPASS (REVIEW XFAIL)"
+            else:
+                status_class = "unreliable"
+                status_text = "UNRELIABLE (XFAIL)"
         else:
             status_class = "pass" if entry["passed"] else "fail"
             status_text = status_class.upper()
-        reason = escape(entry.get("xfail_reason", ""))
+        reason = escape(xfail_reason)
 
         actual_img_html = ""
         golden_img_html = ""
@@ -791,10 +796,12 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
         "  th { background: #f0f0f0; white-space: nowrap; }\n"
         "  tr.fail { background: #fff0f0; }\n"
         "  tr.unreliable { background: #fff8e1; }\n"
-        "  tr.pass:hover, tr.fail:hover, tr.unreliable:hover { filter: brightness(0.96); }\n"
+        "  tr.xpass { background: #eef5ff; }\n"
+        "  tr.pass:hover, tr.fail:hover, tr.unreliable:hover, tr.xpass:hover { filter: brightness(0.96); }\n"
         "  .status-pass { color: #2a7a2a; font-weight: bold; }\n"
         "  .status-fail { color: #cc0000; font-weight: bold; }\n"
         "  .status-unreliable { color: #a15c00; font-weight: bold; }\n"
+        "  .status-xpass { color: #0969da; font-weight: bold; }\n"
         "  .ssim-disabled { color: #999; font-style: italic; }\n"
         "  img { display: block; max-width: 120px; height: auto; }\n"
         "  .compare-cell { max-width: 420px; }\n"
@@ -855,14 +862,14 @@ def generate_html_report(comparison_scores: list[dict], report_filename: str) ->
         file.write(report_html)
 
 
-def attach_comparison_properties(
+def record_comparison_outcomes(
     request: pytest.FixtureRequest, comparison_scores: list[dict], initial_count: int
 ) -> None:
-    """Attach pixel-diff, SSIM scores, and failure images as JUnit XML properties."""
+    """Record expected outcomes for HTML and attach comparison properties to JUnit XML."""
     xfail_marker = request.node.get_closest_marker("xfail")
     xfail_reason = xfail_marker.kwargs.get("reason") if xfail_marker is not None else None
     for entry in comparison_scores[initial_count:]:
-        if xfail_reason and not entry["passed"]:
+        if xfail_reason:
             entry["xfail_reason"] = xfail_reason
         label = f"{entry['backend']}-{entry['renderer']}-{entry['aov']}"
         request.node.user_properties.append((f"diff_pct:{label}", f"{entry['diff_pct']:.2f}"))
@@ -911,7 +918,7 @@ def make_generate_html_report_fixture(comparison_scores: list[dict], report_file
 
 
 def make_attach_comparison_properties_fixture(comparison_scores: list[dict]):
-    """Create an autouse fixture that attaches JUnit properties for one module.
+    """Create a fixture that records HTML outcomes and JUnit properties for one module.
 
     Args:
         comparison_scores: Module-local comparison score storage.
@@ -919,10 +926,11 @@ def make_attach_comparison_properties_fixture(comparison_scores: list[dict]):
 
     @pytest.fixture(autouse=True)
     def _attach_comparison_properties(request):
-        """Attach pixel-diff, SSIM scores, and failure images as JUnit XML properties."""
+        """Record expected outcomes and attach image-comparison properties."""
         initial_count = len(comparison_scores)
         yield
-        attach_comparison_properties(request, comparison_scores, initial_count)
+        # Function-scoped teardown runs before the session-scoped HTML report is generated.
+        record_comparison_outcomes(request, comparison_scores, initial_count)
 
     return _attach_comparison_properties
 

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -125,8 +125,8 @@ def test_franka_factory_adds_cloth_only_motion_policy() -> None:
 
 
 def test_html_report_labels_xfail_and_xpass_outcomes(monkeypatch, tmp_path: Path) -> None:
-    """Expected failures and stale expected-failure marks should be distinct in HTML."""
-    reason = "Known rendering regression (NVBUG#1234567)."
+    """Expected failures and unexpected passes should be distinct in HTML."""
+    reason = "Known <b>rendering</b> regression (NVBUG#1234567)."
     comparison_scores = [
         {
             "test": "cartpole",
@@ -161,10 +161,44 @@ def test_html_report_labels_xfail_and_xpass_outcomes(monkeypatch, tmp_path: Path
     request = Mock(node=node)
 
     record_comparison_outcomes(request, comparison_scores, initial_count=0)
+    comparison_scores.append(
+        {
+            "test": "shadow_hand",
+            "backend": "newton",
+            "renderer": "ovrtx_renderer",
+            "ovstage_variant": "Yes",
+            "aov": "albedo",
+            "diff_pct": 0.0,
+            "threshold": 5.0,
+            "ssim": 1.0,
+            "ssim_threshold": 0.985,
+            "ssim_checked": True,
+            "passed": True,
+        }
+    )
+    record_comparison_outcomes(request, comparison_scores, initial_count=2)
+    comparison_scores.append(
+        {
+            "test": "ordinary",
+            "backend": "newton",
+            "renderer": "ovrtx_renderer",
+            "ovstage_variant": "Yes",
+            "aov": "depth",
+            "diff_pct": 50.0,
+            "threshold": 5.0,
+            "ssim": 0.5,
+            "ssim_threshold": 0.985,
+            "ssim_checked": False,
+            "passed": False,
+        }
+    )
     monkeypatch.setattr(rendering_test_utils, "_COMPARISON_IMAGES_DIR", str(tmp_path))
     generate_html_report(comparison_scores, "report.html")
 
     report = (tmp_path / "report.html").read_text(encoding="utf-8")
-    assert '<td class="status-unreliable">UNRELIABLE (XFAIL)</td>' in report
-    assert '<td class="status-xpass">XPASS (REVIEW XFAIL)</td>' in report
-    assert report.count(reason) == 2
+    escaped_reason = "Known &lt;b&gt;rendering&lt;/b&gt; regression (NVBUG#1234567)."
+    assert report.count('<td class="status-unreliable">UNRELIABLE (XFAIL)</td>') == 2
+    assert report.count('<td class="status-xpass">XPASS (REVIEW XFAIL)</td>') == 1
+    assert report.count(escaped_reason) == 3
+    assert reason not in report
+    assert report.index(escaped_reason) < report.index("<td>ordinary</td>")

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -11,13 +11,13 @@ from unittest.mock import Mock
 import pytest
 import rendering_test_utils
 from rendering_test_utils import (
+    attach_comparison_properties,
     generate_html_report,
     make_kitless_rendering_params,
     make_kitless_rendering_params_dexsuite,
     make_kitless_rendering_params_franka,
     make_skip_rendering_params,
     make_xfail_rendering_params,
-    record_comparison_outcomes,
 )
 
 
@@ -160,7 +160,7 @@ def test_html_report_labels_xfail_and_xpass_outcomes(monkeypatch, tmp_path: Path
     node.get_closest_marker.return_value = pytest.mark.xfail(reason=reason, strict=False).mark
     request = Mock(node=node)
 
-    record_comparison_outcomes(request, comparison_scores, initial_count=0)
+    attach_comparison_properties(request, comparison_scores, initial_count=0)
     comparison_scores.append(
         {
             "test": "shadow_hand",
@@ -176,7 +176,7 @@ def test_html_report_labels_xfail_and_xpass_outcomes(monkeypatch, tmp_path: Path
             "passed": True,
         }
     )
-    record_comparison_outcomes(request, comparison_scores, initial_count=2)
+    attach_comparison_properties(request, comparison_scores, initial_count=2)
     comparison_scores.append(
         {
             "test": "ordinary",

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -11,13 +11,13 @@ from unittest.mock import Mock
 import pytest
 import rendering_test_utils
 from rendering_test_utils import (
-    attach_comparison_properties,
     generate_html_report,
     make_kitless_rendering_params,
     make_kitless_rendering_params_dexsuite,
     make_kitless_rendering_params_franka,
     make_skip_rendering_params,
     make_xfail_rendering_params,
+    record_comparison_outcomes,
 )
 
 
@@ -124,8 +124,8 @@ def test_franka_factory_adds_cloth_only_motion_policy() -> None:
         assert "NVBUG#6489754" in cloth_params[motion_id].marks[0].kwargs["reason"]
 
 
-def test_html_report_labels_expected_failure_as_unreliable(monkeypatch, tmp_path: Path) -> None:
-    """Expected image-comparison failures should include their ticketed reason in HTML."""
+def test_html_report_labels_xfail_and_xpass_outcomes(monkeypatch, tmp_path: Path) -> None:
+    """Expected failures and stale expected-failure marks should be distinct in HTML."""
     reason = "Known rendering regression (NVBUG#1234567)."
     comparison_scores = [
         {
@@ -140,17 +140,31 @@ def test_html_report_labels_expected_failure_as_unreliable(monkeypatch, tmp_path
             "ssim_threshold": 0.985,
             "ssim_checked": True,
             "passed": False,
-        }
+        },
+        {
+            "test": "cartpole",
+            "backend": "newton",
+            "renderer": "ovrtx_renderer",
+            "ovstage_variant": "Yes",
+            "aov": "rgb",
+            "diff_pct": 0.0,
+            "threshold": 1.5,
+            "ssim": 1.0,
+            "ssim_threshold": 0.985,
+            "ssim_checked": True,
+            "passed": True,
+        },
     ]
     node = Mock()
     node.user_properties = []
     node.get_closest_marker.return_value = pytest.mark.xfail(reason=reason, strict=False).mark
     request = Mock(node=node)
 
-    attach_comparison_properties(request, comparison_scores, initial_count=0)
+    record_comparison_outcomes(request, comparison_scores, initial_count=0)
     monkeypatch.setattr(rendering_test_utils, "_COMPARISON_IMAGES_DIR", str(tmp_path))
     generate_html_report(comparison_scores, "report.html")
 
     report = (tmp_path / "report.html").read_text(encoding="utf-8")
     assert '<td class="status-unreliable">UNRELIABLE (XFAIL)</td>' in report
-    assert reason in report
+    assert '<td class="status-xpass">XPASS (REVIEW XFAIL)</td>' in report
+    assert report.count(reason) == 2

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -5,8 +5,14 @@
 
 """Tests for rendering correctness parameter helpers."""
 
+from pathlib import Path
+from unittest.mock import Mock
+
 import pytest
+import rendering_test_utils
 from rendering_test_utils import (
+    attach_comparison_properties,
+    generate_html_report,
     make_kitless_rendering_params,
     make_kitless_rendering_params_dexsuite,
     make_kitless_rendering_params_franka,
@@ -116,3 +122,35 @@ def test_franka_factory_adds_cloth_only_motion_policy() -> None:
         assert "xfail" not in [mark.name for mark in soft_params[motion_id].marks]
         assert [mark.name for mark in cloth_params[motion_id].marks] == ["xfail"]
         assert "NVBUG#6489754" in cloth_params[motion_id].marks[0].kwargs["reason"]
+
+
+def test_html_report_labels_expected_failure_as_unreliable(monkeypatch, tmp_path: Path) -> None:
+    """Expected image-comparison failures should include their ticketed reason in HTML."""
+    reason = "Known rendering regression (NVBUG#1234567)."
+    comparison_scores = [
+        {
+            "test": "cartpole",
+            "backend": "newton",
+            "renderer": "ovrtx_renderer",
+            "ovstage_variant": "Yes",
+            "aov": "albedo",
+            "diff_pct": 12.5,
+            "threshold": 1.5,
+            "ssim": 0.9,
+            "ssim_threshold": 0.985,
+            "ssim_checked": True,
+            "passed": False,
+        }
+    ]
+    node = Mock()
+    node.user_properties = []
+    node.get_closest_marker.return_value = pytest.mark.xfail(reason=reason, strict=False).mark
+    request = Mock(node=node)
+
+    attach_comparison_properties(request, comparison_scores, initial_count=0)
+    monkeypatch.setattr(rendering_test_utils, "_COMPARISON_IMAGES_DIR", str(tmp_path))
+    generate_html_report(comparison_scores, "report.html")
+
+    report = (tmp_path / "report.html").read_text(encoding="utf-8")
+    assert '<td class="status-unreliable">UNRELIABLE (XFAIL)</td>' in report
+    assert reason in report


### PR DESCRIPTION
# Description

- Follow-up to #6767: reports image-comparison XFAILs as `UNRELIABLE` and XPASSes as `XPASS (REVIEW XFAIL)` with ticketed reasons in the HTML artifact.  
- Skipped or crashed tests that never reach image comparison remain out of scope.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there