### PR TITLE
[Newton] Drop the unused lockfile input from the kit-less build

### DIFF
--- a/.github/workflows/kitless-docker.yml
+++ b/.github/workflows/kitless-docker.yml
@@ -53,7 +53,6 @@ jobs:
           ^docker/utils/volume_mounts\.py$ :: Container volume helper
           ^isaaclab\.sh$ :: Install CLI wrapper
           ^pyproject\.toml$ :: Root dependency manifest
-          ^uv\.lock$ :: Locked dependency graph
           ^source/[^/]+/pyproject\.toml$ :: Package manifests
           ^source/isaaclab/isaaclab/cli/ :: Install CLI implementation
           ^source/isaaclab_newton/isaaclab_newton/test/mock_interfaces/ :: Mock-interface implementation

--- a/docker/Dockerfile.kitless
+++ b/docker/Dockerfile.kitless
@@ -41,7 +41,7 @@ WORKDIR ${ISAACLAB_PATH}
 
 # Copy the install inputs before the rest of the runtime tree so dependency
 # installation remains cached when only scripts or application code changes.
-COPY pyproject.toml uv.lock VERSION LICENSE LICENSE-mimic README.md ./
+COPY pyproject.toml VERSION LICENSE LICENSE-mimic README.md ./
 COPY source/ source/
 COPY isaaclab.sh ./
 


### PR DESCRIPTION
## 1. Summary

- Stops copying `uv.lock` into the kit-less build context, and stops gating the kit-less CI job on it.
- Two files, +1 / -2.

## 2. Background

https://github.com/isaac-sim/IsaacLab/pull/6355 — "[Newton] Add a kitless training container" — installs through `"${ISAACLAB_PATH}/isaaclab.sh" --install newton,rl[all],ov[ovrtx]`, matching `Dockerfile.base` and `Dockerfile.curobo`. That path goes through `uv pip`, which does not read `uv.lock`; there is no `uv sync` or `--frozen` left in the Dockerfile.

## 3. Details

`uv.lock` was still copied in the same layer as `pyproject.toml`. Nothing reads it, but a `COPY` makes a file part of the build cache key regardless, so every lockfile change invalidated that layer and forced a full dependency reinstall.

The workflow's change-detection pattern had the same problem in reverse: a lockfile-only change triggered a GPU build that could not produce a different image.

`pyproject.toml` and the per-package manifests still gate the build, which is what `uv pip install --editable` actually resolves from.

## 4. Test plan

- [x] Confirmed nothing in `isaaclab.sh`, the install CLI, `Dockerfile.kitless` or `validate-kitless-image` reads `uv.lock`, `uv sync`, `uv run` or `--frozen`.
- [x] `docker/test/test_container_profiles.py` + `docker/test/test_dockerfile_nonroot.py`: 30 passed.
- [x] `uv run isaaclab -f` on all files.
- [x] `tools/changelog/cli.py check` — no `source/<pkg>/` touched, no fragment required.
