### PR TITLE
Set convex hull collision meshes for DR Legs

### DIFF
--- a/source/isaaclab_assets/changelog.d/aserifi-set-drlegs-convexhull.rst
+++ b/source/isaaclab_assets/changelog.d/aserifi-set-drlegs-convexhull.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the DR Legs feet colliding as bounding boxes by setting an explicit ``convexHull`` mesh
+  approximation on :data:`~isaaclab_assets.robots.dr_legs.DR_LEGS_IMPLICIT_PD_CFG`.

--- a/source/isaaclab_assets/isaaclab_assets/robots/dr_legs.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/dr_legs.py
@@ -80,6 +80,7 @@ DR_LEGS_IMPLICIT_PD_CFG = ArticulationCfg(
     spawn=sim_utils.UsdFileCfg(
         usd_path=_DR_LEGS_USD_PATH,
         activate_contact_sensors=True,
+        collision_props=sim_utils.UsdPhysicsMeshCollisionCfg(mesh_approximation_name="convexHull"),
         rigid_props=sim_utils.RigidBodyPropertiesCfg(
             disable_gravity=False,
             max_depenetration_velocity=10.0,


### PR DESCRIPTION
# Description

Until #6596 the Newton cloner imported with `skip_mesh_approximation=True` and convex-hulled every collision mesh, so DR Legs implicitly ran with convex-hull feet even though the USD authors `boundingCube` on the foot collision meshes. Now that authored approximations are fixed and the feet load as boxes, changing the contact geometry the task was tuned against, so this sets `convexHull` explicitly on the DR Legs spawn to keep the previous behavior.
 