### PR TITLE
Zero the Newton shape margin for ANYmal-D physX-Newton sim2sim

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -97,6 +97,7 @@ Guidelines for modifications:
 * Grzegorz Malczyk
 * Haoran Zhou
 * Harsh Patel
+* Henry Hu
 * HoJin Jeon
 * Hongwei Xiong
 * Hongyu Li

--- a/source/isaaclab_tasks/changelog.d/henry-anymald-newton-margin.rst
+++ b/source/isaaclab_tasks/changelog.d/henry-anymald-newton-margin.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed ANYmal-D rough-terrain locomotion terminating on spurious base contacts under the
+  Newton MJWarp backend by setting the Newton shape margin to zero in
+  :class:`~isaaclab_tasks.core.velocity.config.anymal_d.rough_env_cfg.AnymalDRoughEnvCfg`.
+  Other robots keep the shared default.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
+from isaaclab_newton.physics import NewtonShapeCfg
+
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
@@ -21,3 +23,10 @@ class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         super().__post_init__()
         # switch robot to anymal-d
         self.scene.robot = ANYMAL_D_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+        # ANYmal-D's base capsule passes within a few millimetres of the thigh colliders, so
+        # the shared 1 cm Newton shape margin inflates them into constant overlap and trips
+        # the base_contact termination. Other robots keep the default.
+        newton_cfg = getattr(self.sim.physics, "newton_mjwarp", None)
+        if newton_cfg is not None:
+            newton_cfg.default_shape_cfg = NewtonShapeCfg(margin=0.0)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-from isaaclab_newton.physics import NewtonShapeCfg
-
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
@@ -29,4 +27,4 @@ class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         # the base_contact termination. Other robots keep the default.
         newton_cfg = getattr(self.sim.physics, "newton_mjwarp", None)
         if newton_cfg is not None:
-            newton_cfg.default_shape_cfg = NewtonShapeCfg(margin=0.0)
+            newton_cfg.default_shape_cfg = newton_cfg.default_shape_cfg.replace(margin=0.0)


### PR DESCRIPTION
## Description
  
  ANYmal-D fails on rough terrain under the Newton MJWarp backend: the robot is
  terminated by the 1 N `base_contact` check while it is still upright and walking
  normally.
  
  The cause is a collision-geometry interaction. ANYmal-D's base collider is a
  rotationally-symmetric capsule of radius 0.12 m, which leaves only a few millimetres
  of clearance to the thigh colliders during normal gait. Newton's shape margin extends
  the collision surface outward and the margins of both shapes are summed, so the shared
  1 cm default turns that clearance into near-constant base↔thigh overlap.

  Measured under Newton MJWarp with a PhysX-trained checkpoint (4096 envs, 3000 steps,
  ~12k episodes):

  | shape margin | success rate |
  |---|---|
  | 0.01 (current default) | 28.9% |
  | 0.005 | 71.2% |
  | **0.0 (this PR)** | **93.1%** |
 
  PhysX reference on the same checkpoint: 96.2%.
  
   
  The override is scoped to `AnymalDRoughEnvCfg`. Other robots keep the shared 1 cm
  default, which they need for stable contact on triangle-mesh terrain. Verified at
  runtime that ANYmal-D resolves to margin 0.0 while Go2, H1 and Cassie still resolve to
  0.01, including when several tasks are constructed in the same process.
 
  The root cause is really the asset — a rotationally-symmetric capsule is a poor
  approximation of a flat chassis. Shrinking the capsule to r = 0.10 m recovers the same
  policy to 95.6%, and margin 0.005 on top of that reaches 96.1%. That is the better
  long-term fix, but it changes a shipped asset and would affect existing checkpoints, so
  this PR takes the minimal config-only mitigation. 

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (existing functionality will not work without user modification)
  - [ ] Documentation update
  
  ## Checklist
  - [x] I have read and understood the contribution guidelines
  - [x] I have run the pre-commit checks with `./isaaclab.sh --format`
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do not edit CHANGELOG.rst
  or bump extension.toml — CI handles that)
  - [x] I have added my name to the CONTRIBUTORS.md or my name already exists there

