### PR TITLE
Fix release multi-version docs dependencies

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [doc-build-type]
     # run on deploy branches to create multi-version docs
-    if: needs.doc-build-type.outputs.trigger-deploy == 'true' || github.event_name == 'pull_request'
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [doc-build-type]
     # run on deploy branches to create multi-version docs
-    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true' || github.event_name == 'pull_request'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -89,15 +89,15 @@ jobs:
         # including when manually dispatched from the release landing branch.
         ref: develop
 
-    - name: Setup python
-      uses: actions/setup-python@v5
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
-        architecture: x64
 
-    - name: Install dev requirements
-      working-directory: ./docs
-      run: pip install -r requirements.txt
+    - name: Install docs dependencies
+      run: |
+        uv sync --extra test
+        echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     - name: Generate multi-version docs
       working-directory: ./docs


### PR DESCRIPTION
# Description

Fix the scheduled multi-version documentation job on `release/3.0.0-beta2`.

The release workflow checks out `develop` before generating the multi-version site, but it still tried to install `docs/requirements.txt`. That file was removed from `develop` when documentation dependencies moved into the root UV `test` extra, so the job failed before Sphinx started.

Update only the multi-version job to use `astral-sh/setup-uv@v6` and `uv sync --extra test`, matching the dependency setup on `develop` while leaving release-branch current-doc builds unchanged.

Failed nightly job: https://github.com/isaac-sim/IsaacLab/actions/runs/30600776364/job/91062748798

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Verification

- Confirmed the old command cannot find `docs/requirements.txt` on the current `develop` tip.
- Ran `uv sync --extra test` successfully in a clean checkout of the current `develop` tip (468 packages resolved and the documentation toolchain installed).
- Temporarily enabled the multi-version job for this pull request and ran it end to end: https://github.com/isaac-sim/IsaacLab/actions/runs/30652411009/job/91228818769
  - `Install docs dependencies` passed.
  - All selected documentation versions built successfully.
  - Default-version validation and the GitHub Pages artifact upload passed.
  - The job completed successfully in 1h 3m 56s, and deployment remained skipped.
- Reverted the temporary pull-request trigger after the successful run; the aggregate diff contains only the release dependency fix.
- Ran the full repository pre-commit suite before each commit and push; all hooks passed, including YAML validation.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with the repository formatting command.
- [x] No user-facing documentation update is required for this workflow-only fix.
- [x] The change generates no new static-check warnings.
- [x] I verified the replacement dependency command and the full multi-version job.
- [x] No package changelog fragment is required because no `source/<pkg>/` package is touched.
- [x] My name already exists in `CONTRIBUTORS.md`.
