### PR TITLE
[Deps] Bump USD Core to 26.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     # OpenUSD (kit-less mode). Both packages vendor a complete ``pxr`` runtime, so
     # they must never co-install: usd-core supplies pxr where it has wheels (x86_64),
     # usd-exchange supplies it on aarch64 (where usd-core has no wheel).
-    "usd-core>=25.11,<26.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
+    "usd-core>=26.5,<27.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
     "usd-exchange>=2.2 ; platform_machine == 'aarch64'",
     # avoid broken hf-xet pre-release cached on NVIDIA Artifactory
     "hf-xet>=1.4.1,<2.0.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64' or platform_machine == 'aarch64'",
@@ -381,6 +381,8 @@ environments = [
 # Torch routes through [tool.uv.sources]. Values mirror [tool.isaaclab.versions] where applicable.
 override-dependencies = [
     "numpy>=2",
+    # Override Newton's stale <26.5 importer bound; OpenUSD 26.5 fixes concurrent collider parsing.
+    "usd-core>=26.5,<27.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
     "mujoco~=3.10.0",
     "mujoco-warp~=3.10.0,>=3.10.0.2",
     "newton[sim,importers] @ git+https://github.com/newton-physics/newton.git@831076f52f14612aecace894c81270c1e0ed9479",

--- a/source/isaaclab/changelog.d/antoiner-usd-core-26-5.major.rst
+++ b/source/isaaclab/changelog.d/antoiner-usd-core-26-5.major.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Raised the minimum kit-less OpenUSD version to 26.5 to fix
+  crashes when parsing colliders concurrently. Extensions built against USD 25
+  must be rebuilt against USD 26.

--- a/source/isaaclab/test/cli/test_source_package_metadata.py
+++ b/source/isaaclab/test/cli/test_source_package_metadata.py
@@ -23,8 +23,8 @@ def _repo_root() -> Path:
     raise RuntimeError("Could not find Isaac Lab repository root.")
 
 
-def test_isaaclab_usd_core_pin_stays_on_isaacsim_compatible_usd25_abi():
-    """The kit-less USD package must stay on the Isaac Sim compatible USD 25 ABI."""
+def test_isaaclab_usd_core_pin_requires_usd26_abi():
+    """The kit-less USD package must require the USD 26 ABI."""
     with (_repo_root() / "pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
@@ -33,7 +33,7 @@ def test_isaaclab_usd_core_pin_stays_on_isaacsim_compatible_usd25_abi():
     ]
 
     assert usd_core_dependencies == [
-        "usd-core>=25.11,<26.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64'"
+        "usd-core>=26.5,<27.0 ; platform_machine == 'x86_64' or platform_machine == 'AMD64'"
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,7 @@ overrides = [
     { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", marker = "sys_platform == 'win32'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "usd-core", marker = "platform_machine == 'AMD64' or platform_machine == 'x86_64'", specifier = ">=26.5,<27.0" },
 ]
 
 [[package]]
@@ -2846,7 +2847,7 @@ requires-dist = [
     { name = "transformers", specifier = "==4.57.6" },
     { name = "trimesh" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
-    { name = "usd-core", marker = "platform_machine == 'AMD64' or platform_machine == 'x86_64'", specifier = ">=25.11,<26.0" },
+    { name = "usd-core", marker = "platform_machine == 'AMD64' or platform_machine == 'x86_64'", specifier = ">=26.5,<27.0" },
     { name = "usd-exchange", marker = "platform_machine == 'aarch64'", specifier = ">=2.2" },
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.16" },
     { name = "warp-lang", specifier = "==1.16.0.dev20260723" },
@@ -7413,12 +7414,11 @@ wheels = [
 
 [[package]]
 name = "usd-core"
-version = "25.11"
+version = "26.8"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/a4/92db335084f0de14b5d4e1800b847057e3ef36bdbb211e5617f3d9940e92/usd_core-25.11-cp312-none-macosx_10_9_universal2.whl", hash = "sha256:bbf89d0671e0773b957a5a3a3e0178e13d4318d46fd8201fcf1d87e3d5501556", size = 38511379, upload-time = "2025-10-24T19:01:24.506Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f1/dbf18bee5b569a06119f0cde798daeef4837887594a0caf415eb1d75112a/usd_core-25.11-cp312-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c05c05150f6c4598e0738677f0b7c8f82ff9fc492d040ed78147eb1ad5ce8545", size = 27393145, upload-time = "2025-10-24T19:01:27.841Z" },
-    { url = "https://files.pythonhosted.org/packages/48/34/dd9883f27526288de19741100cb5b75f2725423367a999c055a677d1d88a/usd_core-25.11-cp312-none-win_amd64.whl", hash = "sha256:7bc5aaad20287bfc821e73e2ced99123e448e40ffd018acf99b09975eab4012d", size = 13061673, upload-time = "2025-10-24T19:01:30.396Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0b/efe5c0d7c273149ac94083831e5b36649925a621a73cd2ddf9616e160c8c/usd_core-26.8-cp312-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:204fb1ef1fc977b827c491f4e9fa39b57518504ed0cacfe12e026e95123cacf1", size = 29530957, upload-time = "2026-07-20T14:32:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/749edc4d2eea3ffb94aa0526d5da6f4a3f185ef7004ceeb6b5ecdb6a0c68/usd_core-26.8-cp312-none-win_amd64.whl", hash = "sha256:6db0031224b718cae53e4b19ecd80aea0a7ed4348e330fd82ccfbdc9b8b311ed", size = 13887898, upload-time = "2026-07-20T14:32:27.452Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Raises the kit-less `usd-core` dependency from `>=25.11,<26.0` to
`>=26.5,<27.0` so Isaac Lab picks up the upstream fix for crashes while
parsing colliders concurrently.

Newton's pinned importer metadata still declares `usd-core<26.5`, so this PR
adds a narrow uv override for x86_64/AMD64 until that metadata catches up. The
lock resolves `usd-core 26.8` for the supported Linux x86_64 and Windows
platforms. This intentionally excludes the unrelated Newton runtime changes
from #6301.

## Type of change

- Breaking change (extensions built against USD 25 must be rebuilt against
  USD 26)

## Screenshots

Not applicable.

## Verification

- `./isaaclab.sh -p -m pytest source/isaaclab/test/cli/test_source_package_metadata.py`
  (`2 passed`)
- `./isaaclab.sh -p tools/changelog/cli.py check develop`
- `./isaaclab.sh -f`
- Fresh uv resolution (`472 packages`, `usd-core 26.8`)

No new test was added; the existing hard-coded USD dependency guard was
updated for the new ABI range.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made the corresponding changelog update
- [x] My changes generate no new warnings
- [x] I have added a changelog fragment for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
