### PR TITLE
Reject OvPhysX physics paired with a Kit-based renderer

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.rst
@@ -1,7 +1,7 @@
 Fixed
 ^^^^^
 
-* Fixed OvPhysX physics paired with a Kit-based renderer failing inside the OvPhysX
-  library with ``Failed to initialize Carbonite and load PhysX plugins``. The kitless
-  backend guard only covered the Kit visualizer, so the combination is now rejected up
-  front with the supported alternatives, matching the existing OVRTX renderer check.
+* Fixed kitless OvPhysX physics and OVRTX renderers accepting some configurations
+  that also require Isaac Sim / Kit, then failing during runtime initialization.
+  Compatibility validation now reports every component that requires Kit and the
+  supported alternatives.

--- a/source/isaaclab/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed OvPhysX physics paired with a Kit-based renderer failing inside the OvPhysX
+  library with ``Failed to initialize Carbonite and load PhysX plugins``. The kitless
+  backend guard only covered the Kit visualizer, so the combination is now rejected up
+  front with the supported alternatives, matching the existing OVRTX renderer check.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -6,8 +6,8 @@
 """Utilities for detecting and launching the appropriate simulation backend.
 
 The flow is intentionally simple: walk the config tree **once** to collect its
-signals into a :class:`Scan`, resolve those signals and launcher inputs into one
-runtime plan, then validate and launch from that plan.
+signals into a :class:`Scan`, resolve the Kit runtime sources from that scan and
+the launcher inputs, then validate and launch.
 """
 
 from __future__ import annotations
@@ -326,7 +326,7 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
 
     # RTX selection depends on the resolved physics backend.
     if has_auto_physx:
-        use_isaac_sim = _resolve_runtime_plan(config_scan, launcher_args).uses_kit
+        use_isaac_sim = bool(_get_kit_runtime_sources(config_scan, launcher_args))
         for node, parent, key, is_first_physics in auto_physx_locations:
             physics_cfg = _resolve_physx_auto_cfg(node, use_isaac_sim)
             concrete_physics_cfgs.append(physics_cfg)
@@ -376,22 +376,8 @@ def _has_kit_visualizer(config_scan: Scan, launcher_args: argparse.Namespace | d
     return "kit" in visualizer_types or config_scan.visualizer_intent["has_kit_visualizer"]
 
 
-@dataclass(frozen=True)
-class _RuntimePlan:
-    """Resolved process plan after config and launcher inputs are combined."""
-
-    has_ovphysx_physics: bool
-    has_ovrtx_renderer: bool
-    kit_sources: tuple[str, ...]
-
-    @property
-    def uses_kit(self) -> bool:
-        """Whether any resolved runtime component requires Isaac Sim / Kit."""
-        return bool(self.kit_sources)
-
-
-def _resolve_runtime_plan(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> _RuntimePlan:
-    """Combine scanned config facts and launcher inputs into one runtime plan."""
+def _get_kit_runtime_sources(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> tuple[str, ...]:
+    """Return the config and launcher components that require Isaac Sim / Kit."""
     kit_sources = []
     if config_scan.has_kit_physics:
         kit_sources.append("Isaac Sim PhysX physics (`PhysxCfg`)")
@@ -406,16 +392,12 @@ def _resolve_runtime_plan(config_scan: Scan, launcher_args: argparse.Namespace |
     if config_scan.needs_kit and not kit_sources:
         kit_sources.append("the default Isaac Sim / Kit runtime")
 
-    return _RuntimePlan(
-        has_ovphysx_physics=config_scan.has_ovphysx_physics,
-        has_ovrtx_renderer=config_scan.has_ovrtx,
-        kit_sources=tuple(kit_sources),
-    )
+    return tuple(kit_sources)
 
 
 def _uses_isaac_sim_runtime(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> bool:
     """Return whether the scanned config or launcher arguments require Isaac Sim / Kit."""
-    return _resolve_runtime_plan(config_scan, launcher_args).uses_kit
+    return bool(_get_kit_runtime_sources(config_scan, launcher_args))
 
 
 def _format_runtime_sources(sources: tuple[str, ...]) -> str:
@@ -425,18 +407,18 @@ def _format_runtime_sources(sources: tuple[str, ...]) -> str:
     return f"{', '.join(sources[:-1])}, and {sources[-1]}"
 
 
-def _validate_runtime(plan: _RuntimePlan) -> None:
-    """Raise if the resolved runtime plan contains an unsupported combination.
+def _validate_runtime(scan: Scan, kit_sources: tuple[str, ...]) -> None:
+    """Raise if the scan and resolved Kit sources form an unsupported combination.
 
     OVRTX is kitless and cannot share a process with Kit-based runtimes (PhysX physics
     or any other Kit source); OvPhysX physics is subject to the same process boundary.
     """
-    if plan.has_ovphysx_physics and plan.uses_kit:
+    if scan.has_ovphysx_physics and kit_sources:
         # both would initialize Carbonite in one process; without this guard OvPhysX fails
         # deep inside its own library with "Failed to initialize Carbonite and load PhysX plugins"
         raise ValueError(
             "Invalid backend combination: OvPhysX physics (`OvPhysxCfg`) is kitless and cannot be used together "
-            f"with Isaac Sim / Kit ({_format_runtime_sources(plan.kit_sources)}).\n"
+            f"with Isaac Sim / Kit ({_format_runtime_sources(kit_sources)}).\n"
             "\n"
             "To fix this, pick one of the following supported combinations:\n"
             "  * Keep OvPhysX physics and switch to a kitless renderer/visualizer:\n"
@@ -447,13 +429,13 @@ def _validate_runtime(plan: _RuntimePlan) -> None:
             "      presets=isaacsim_physx,isaacsim_rtx\n"
         )
 
-    if not plan.has_ovrtx_renderer or not plan.uses_kit:
+    if not scan.has_ovrtx or not kit_sources:
         return
 
     raise ValueError(
         "Invalid backend combination: the OVRTX renderer (`OVRTXRendererCfg`,"
         ' `renderer_type="ovrtx"`) is a kitless renderer and cannot be used together'
-        f" with Isaac Sim / Kit ({_format_runtime_sources(plan.kit_sources)}).\n"
+        f" with Isaac Sim / Kit ({_format_runtime_sources(kit_sources)}).\n"
         "\n"
         "To fix this, pick one of the following supported combinations:\n"
         "  * Keep Isaac Sim / Kit and switch the renderer:\n"
@@ -527,9 +509,9 @@ def launch_simulation(
     physics_cfg = config_scan.resolved_physics_cfg
     visualizer_types = _get_visualizer_types(launcher_args)
 
-    runtime_plan = _resolve_runtime_plan(config_scan, launcher_args)
-    _validate_runtime(runtime_plan)
-    needs_kit = runtime_plan.uses_kit
+    kit_sources = _get_kit_runtime_sources(config_scan, launcher_args)
+    _validate_runtime(config_scan, kit_sources)
+    needs_kit = bool(kit_sources)
     _set_arg(launcher_args, "visualizer_intent", config_scan.visualizer_intent)
 
     # Kit-based backends apply the Python logging level inside AppLauncher; kitless backends

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -5,9 +5,9 @@
 
 """Utilities for detecting and launching the appropriate simulation backend.
 
-The flow is intentionally simple: walk the config tree **once** to collect every
-signal we care about (physics backend, OVRTX renderer, Kit cameras, visualizer
-intent) into a :class:`Scan`, then decide how to launch from that scan.
+The flow is intentionally simple: walk the config tree **once** to collect its
+signals into a :class:`Scan`, resolve those signals and launcher inputs into one
+runtime plan, then validate and launch from that plan.
 """
 
 from __future__ import annotations
@@ -326,7 +326,7 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
 
     # RTX selection depends on the resolved physics backend.
     if has_auto_physx:
-        use_isaac_sim = _has_kit_runtime_intent(config_scan, launcher_args)
+        use_isaac_sim = _resolve_runtime_plan(config_scan, launcher_args).uses_kit
         for node, parent, key, is_first_physics in auto_physx_locations:
             physics_cfg = _resolve_physx_auto_cfg(node, use_isaac_sim)
             concrete_physics_cfgs.append(physics_cfg)
@@ -376,43 +376,67 @@ def _has_kit_visualizer(config_scan: Scan, launcher_args: argparse.Namespace | d
     return "kit" in visualizer_types or config_scan.visualizer_intent["has_kit_visualizer"]
 
 
-def _has_kit_runtime_intent(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> bool:
-    """Return whether explicit runtime signals require Isaac Sim / Kit."""
-    explicit_experience = bool(_get_arg(launcher_args, "experience", ""))
-    return (
-        explicit_experience
-        or config_scan.has_kit_camera
-        or config_scan.has_kit_physics
-        or _has_kit_visualizer(config_scan, launcher_args)
-        or _get_livestream_mode(launcher_args) > 0
+@dataclass(frozen=True)
+class _RuntimePlan:
+    """Resolved process plan after config and launcher inputs are combined."""
+
+    has_ovphysx_physics: bool
+    has_ovrtx_renderer: bool
+    kit_sources: tuple[str, ...]
+
+    @property
+    def uses_kit(self) -> bool:
+        """Whether any resolved runtime component requires Isaac Sim / Kit."""
+        return bool(self.kit_sources)
+
+
+def _resolve_runtime_plan(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> _RuntimePlan:
+    """Combine scanned config facts and launcher inputs into one runtime plan."""
+    kit_sources = []
+    if config_scan.has_kit_physics:
+        kit_sources.append("Isaac Sim PhysX physics (`PhysxCfg`)")
+    if config_scan.has_kit_camera:
+        kit_sources.append('a Kit-based renderer (`IsaacRtxRendererCfg`, `renderer_type="isaac_rtx"`)')
+    if _has_kit_visualizer(config_scan, launcher_args):
+        kit_sources.append('the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`)')
+    if _get_arg(launcher_args, "experience", ""):
+        kit_sources.append("an explicit Kit experience")
+    if _get_livestream_mode(launcher_args) > 0:
+        kit_sources.append("livestreaming")
+    if config_scan.needs_kit and not kit_sources:
+        kit_sources.append("the default Isaac Sim / Kit runtime")
+
+    return _RuntimePlan(
+        has_ovphysx_physics=config_scan.has_ovphysx_physics,
+        has_ovrtx_renderer=config_scan.has_ovrtx,
+        kit_sources=tuple(kit_sources),
     )
 
 
 def _uses_isaac_sim_runtime(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> bool:
     """Return whether the scanned config or launcher arguments require Isaac Sim / Kit."""
-    return config_scan.needs_kit or _has_kit_runtime_intent(config_scan, launcher_args)
+    return _resolve_runtime_plan(config_scan, launcher_args).uses_kit
 
 
-def _validate_runtime(scan: Scan, launcher_args: argparse.Namespace | dict | None) -> None:
-    """Raise if *scan*'s physics/renderer/visualizer combination is unsupported.
+def _format_runtime_sources(sources: tuple[str, ...]) -> str:
+    """Format runtime sources as a readable list."""
+    if len(sources) < 3:
+        return " and ".join(sources)
+    return f"{', '.join(sources[:-1])}, and {sources[-1]}"
+
+
+def _validate_runtime(plan: _RuntimePlan) -> None:
+    """Raise if the resolved runtime plan contains an unsupported combination.
 
     OVRTX is kitless and cannot share a process with Kit-based runtimes (PhysX physics
-    or the Kit visualizer); OvPhysX physics likewise cannot run with the Kit visualizer
-    or a Kit-based renderer.
+    or any other Kit source); OvPhysX physics is subject to the same process boundary.
     """
-    has_kit_visualizer = _has_kit_visualizer(scan, launcher_args)
-
-    if scan.has_ovphysx_physics and (has_kit_visualizer or scan.has_kit_camera):
+    if plan.has_ovphysx_physics and plan.uses_kit:
         # both would initialize Carbonite in one process; without this guard OvPhysX fails
         # deep inside its own library with "Failed to initialize Carbonite and load PhysX plugins"
-        kit_sources = []
-        if has_kit_visualizer:
-            kit_sources.append('the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`)')
-        if scan.has_kit_camera:
-            kit_sources.append('a Kit-based renderer (`IsaacRtxRendererCfg`, `renderer_type="isaac_rtx"`)')
         raise ValueError(
             "Invalid backend combination: OvPhysX physics (`OvPhysxCfg`) is kitless and cannot be used together "
-            f"with Isaac Sim / Kit ({' and '.join(kit_sources)}).\n"
+            f"with Isaac Sim / Kit ({_format_runtime_sources(plan.kit_sources)}).\n"
             "\n"
             "To fix this, pick one of the following supported combinations:\n"
             "  * Keep OvPhysX physics and switch to a kitless renderer/visualizer:\n"
@@ -423,19 +447,13 @@ def _validate_runtime(scan: Scan, launcher_args: argparse.Namespace | dict | Non
             "      presets=isaacsim_physx,isaacsim_rtx\n"
         )
 
-    if not scan.has_ovrtx or (not scan.has_kit_physics and not has_kit_visualizer):
+    if not plan.has_ovrtx_renderer or not plan.uses_kit:
         return
-
-    sources = []
-    if scan.has_kit_physics:
-        sources.append("Isaac Sim PhysX physics (`PhysxCfg`)")
-    if has_kit_visualizer:
-        sources.append('the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`)')
 
     raise ValueError(
         "Invalid backend combination: the OVRTX renderer (`OVRTXRendererCfg`,"
         ' `renderer_type="ovrtx"`) is a kitless renderer and cannot be used together'
-        f" with Isaac Sim / Kit ({' and '.join(sources)}).\n"
+        f" with Isaac Sim / Kit ({_format_runtime_sources(plan.kit_sources)}).\n"
         "\n"
         "To fix this, pick one of the following supported combinations:\n"
         "  * Keep Isaac Sim / Kit and switch the renderer:\n"
@@ -509,20 +527,9 @@ def launch_simulation(
     physics_cfg = config_scan.resolved_physics_cfg
     visualizer_types = _get_visualizer_types(launcher_args)
 
-    # ovrtx + Kit visualizer share conflicting RTX hydra libraries under different USD
-    # namespaces; loading both in one process crashes the dynamic linker. Fail early
-    # with a targeted hint (_validate_runtime covers the broader ovrtx-vs-Kit cases).
-    if "kit" in visualizer_types and config_scan.has_ovrtx:
-        raise ValueError(
-            "[launch_simulation] '--visualizer kit' is incompatible with 'ovrtx'. "
-            "Both Kit (Isaac Sim) and ovrtx ship conflicting RTX hydra libraries "
-            "(librtx.hydra.so, liblegacy.hydra.so) compiled against different USD namespaces, "
-            "which causes a dynamic-linker crash when loaded into the same process. "
-            "Use '--visualizer newton' instead, which is fully compatible with ovrtx presets."
-        )
-
-    _validate_runtime(config_scan, launcher_args)
-    needs_kit = _uses_isaac_sim_runtime(config_scan, launcher_args)
+    runtime_plan = _resolve_runtime_plan(config_scan, launcher_args)
+    _validate_runtime(runtime_plan)
+    needs_kit = runtime_plan.uses_kit
     _set_arg(launcher_args, "visualizer_intent", config_scan.visualizer_intent)
 
     # Kit-based backends apply the Python logging level inside AppLauncher; kitless backends

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -397,16 +397,30 @@ def _validate_runtime(scan: Scan, launcher_args: argparse.Namespace | dict | Non
     """Raise if *scan*'s physics/renderer/visualizer combination is unsupported.
 
     OVRTX is kitless and cannot share a process with Kit-based runtimes (PhysX physics
-    or the Kit visualizer); OvPhysX physics likewise cannot run with the Kit visualizer.
+    or the Kit visualizer); OvPhysX physics likewise cannot run with the Kit visualizer
+    or a Kit-based renderer.
     """
     has_kit_visualizer = _has_kit_visualizer(scan, launcher_args)
 
-    if scan.has_ovphysx_physics and has_kit_visualizer:
+    if scan.has_ovphysx_physics and (has_kit_visualizer or scan.has_kit_camera):
+        # both would initialize Carbonite in one process; without this guard OvPhysX fails
+        # deep inside its own library with "Failed to initialize Carbonite and load PhysX plugins"
+        kit_sources = []
+        if has_kit_visualizer:
+            kit_sources.append('the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`)')
+        if scan.has_kit_camera:
+            kit_sources.append('a Kit-based renderer (`IsaacRtxRendererCfg`, `renderer_type="isaac_rtx"`)')
         raise ValueError(
             "Invalid backend combination: OvPhysX physics (`OvPhysxCfg`) is kitless and cannot be used together "
-            'with the Kit visualizer (`--visualizer kit` / `visualizer_type="kit"`). Use a kitless visualizer '
-            "such as `--visualizer newton`, `--visualizer rerun`, or `--visualizer viser`, or omit the visualizer "
-            "argument for headless execution."
+            f"with Isaac Sim / Kit ({' and '.join(kit_sources)}).\n"
+            "\n"
+            "To fix this, pick one of the following supported combinations:\n"
+            "  * Keep OvPhysX physics and switch to a kitless renderer/visualizer:\n"
+            "      presets=ovphysx,ovrtx\n"
+            "    (and use `--visualizer newton`, `--visualizer rerun`, or `--visualizer viser`, or omit\n"
+            "    the visualizer argument for headless execution.)\n"
+            "  * Keep Isaac Sim / Kit and switch to a Kit-compatible physics backend:\n"
+            "      presets=isaacsim_physx,isaacsim_rtx\n"
         )
 
     if not scan.has_ovrtx or (not scan.has_kit_physics and not has_kit_visualizer):

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -344,7 +344,7 @@ def scan(cfg, launcher_args: argparse.Namespace | dict | None = None) -> Scan:
     if not has_auto_rtx:
         return config_scan
 
-    use_isaac_sim = _uses_isaac_sim_runtime(config_scan, launcher_args)
+    use_isaac_sim = bool(_get_kit_runtime_sources(config_scan, launcher_args))
     renderer_factory = IsaacRtxRendererCfg if use_isaac_sim else OVRTXRendererCfg
 
     # Resolve every auto RTX placeholder in place, tracking camera renderers that may require Kit.
@@ -393,11 +393,6 @@ def _get_kit_runtime_sources(config_scan: Scan, launcher_args: argparse.Namespac
         kit_sources.append("the default Isaac Sim / Kit runtime")
 
     return tuple(kit_sources)
-
-
-def _uses_isaac_sim_runtime(config_scan: Scan, launcher_args: argparse.Namespace | dict | None) -> bool:
-    """Return whether the scanned config or launcher arguments require Isaac Sim / Kit."""
-    return bool(_get_kit_runtime_sources(config_scan, launcher_args))
 
 
 def _format_runtime_sources(sources: tuple[str, ...]) -> str:

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -13,7 +13,7 @@ import isaaclab.app.app_launcher as app_launcher_module
 import isaaclab.app.sim_launcher as sim_launcher
 import isaaclab.utils as utils_module
 from isaaclab.app import AppLauncher
-from isaaclab.app.sim_launcher import Scan, _ensure_livestream_kit_visualizer, _uses_isaac_sim_runtime
+from isaaclab.app.sim_launcher import Scan, _ensure_livestream_kit_visualizer, _get_kit_runtime_sources
 
 pytestmark = pytest.mark.integration
 
@@ -61,7 +61,7 @@ def test_explicit_experience_requires_isaac_sim_runtime():
     )
     args = argparse.Namespace(experience="isaaclab.python.kit", visualizer=None)
 
-    assert _uses_isaac_sim_runtime(scan, args)
+    assert _get_kit_runtime_sources(scan, args)
 
 
 def test_launch_simulation_preserves_failure_exit_code(monkeypatch: pytest.MonkeyPatch):

--- a/source/isaaclab_tasks/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.skip
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-ovphysx-kit-renderer-guard.skip
@@ -1,0 +1,1 @@
+Test-only: cover centralized runtime-plan compatibility validation.

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -13,6 +13,8 @@ No Kit/GPU required — safe for CI and beginners.
 """
 
 import argparse
+import ast
+import inspect
 import sys
 
 import pytest
@@ -24,7 +26,7 @@ from isaaclab_physx.renderers import IsaacRtxRendererCfg
 import isaaclab.app.sim_launcher as sim_launcher_module
 import isaaclab.utils as isaaclab_utils
 from isaaclab.app import scan
-from isaaclab.app.sim_launcher import _validate_runtime, launch_simulation
+from isaaclab.app.sim_launcher import _resolve_runtime_plan, _validate_runtime, launch_simulation
 from isaaclab.physics import PhysxAutoCfg
 
 import isaaclab_tasks  # noqa: F401
@@ -36,7 +38,7 @@ _CAMERA_PRESETS_TASK = "Isaac-Cartpole-Camera-Direct"
 def validate_runtime_compatibility(env_cfg, launcher_args=None):
     """Run the single-scan runtime validation for *env_cfg* (test adapter)."""
     config_scan = scan(env_cfg, launcher_args)
-    _validate_runtime(config_scan, launcher_args)
+    _validate_runtime(_resolve_runtime_plan(config_scan, launcher_args))
     return config_scan
 
 
@@ -54,6 +56,31 @@ def _resolve_with_args(*args: str):
         return env_cfg
     finally:
         sys.argv = old_argv
+
+
+# ---------------------------------------------------------------------------
+# Architecture: validation consumes one resolved owner
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_validation_consumes_only_resolved_plan():
+    """Keep config and launcher interpretation outside the compatibility validator."""
+    assert list(inspect.signature(_validate_runtime).parameters) == ["plan"]
+
+    tree = ast.parse(inspect.getsource(_validate_runtime))
+    forbidden_scan_fields = {
+        "has_kit_camera",
+        "has_kit_physics",
+        "needs_kit",
+        "visualizer_intent",
+    }
+    accessed_attributes = {node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)}
+    assert accessed_attributes.isdisjoint(forbidden_scan_fields)
+
+    called_helpers = {
+        node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "_has_kit_visualizer" not in called_helpers
 
 
 # ---------------------------------------------------------------------------
@@ -93,8 +120,45 @@ def test_kit_visualizer_dict_args_plus_ovrtx_raises():
         validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
 
 
+def test_kit_renderer_plus_ovrtx_raises():
+    """A Kit renderer and OVRTX cannot initialize in the same process."""
+    env_cfg = _resolve_with_presets("newton,isaacsim_rtx")
+    mixed_cfg = argparse.Namespace(
+        physics=env_cfg.sim.physics,
+        kit_camera=env_cfg.tiled_camera,
+        ovrtx_renderer=OVRTXRendererCfg(),
+    )
+
+    with pytest.raises(ValueError, match="Kit-based renderer"):
+        validate_runtime_compatibility(mixed_cfg)
+
+
+@pytest.mark.parametrize(
+    ("launcher_args", "source"),
+    [
+        (argparse.Namespace(experience="custom.kit"), "explicit Kit experience"),
+        (argparse.Namespace(livestream=2), "livestreaming"),
+    ],
+)
+def test_launcher_kit_source_plus_ovrtx_raises(launcher_args, source):
+    """Every launcher-side Kit source must conflict with OVRTX."""
+    env_cfg = _resolve_with_presets("newton,ovrtx")
+
+    with pytest.raises(ValueError, match=source):
+        validate_runtime_compatibility(env_cfg, launcher_args)
+
+
+def test_default_kit_runtime_plus_ovrtx_raises(monkeypatch: pytest.MonkeyPatch):
+    """A config without physics defaults to Kit, which cannot share OVRTX."""
+    monkeypatch.delenv("LIVESTREAM", raising=False)
+    renderer_only_cfg = argparse.Namespace(renderer=OVRTXRendererCfg())
+
+    with pytest.raises(ValueError, match="default Isaac Sim / Kit runtime"):
+        validate_runtime_compatibility(renderer_only_cfg)
+
+
 # ---------------------------------------------------------------------------
-# Invalid: OvPhysX physics + Kit visualizer
+# Invalid: OvPhysX physics + Isaac Sim / Kit
 # ---------------------------------------------------------------------------
 
 
@@ -116,9 +180,24 @@ def test_ovphysx_dict_args_plus_kit_visualizer_raises():
         validate_runtime_compatibility(env_cfg, {"visualizer": "kit,newton"})
 
 
-# ---------------------------------------------------------------------------
-# Invalid: OvPhysX physics + Kit renderer, with no Kit visualizer requested
-# ---------------------------------------------------------------------------
+def test_ovphysx_plus_kit_physics_raises():
+    """Two physics configs cannot pull OvPhysX and Kit into the same process."""
+    mixed_cfg = argparse.Namespace(
+        ovphysx_physics=OvPhysxCfg(),
+        kit_physics=PhysxCfg(),
+    )
+
+    with pytest.raises(ValueError, match="PhysxCfg"):
+        validate_runtime_compatibility(mixed_cfg)
+
+
+def test_explicit_kit_experience_plus_ovphysx_raises():
+    """An explicit Kit experience must conflict with OvPhysX."""
+    env_cfg = _resolve_with_presets("ovphysx,ovrtx")
+    launcher_args = argparse.Namespace(experience="custom.kit")
+
+    with pytest.raises(ValueError, match="explicit Kit experience"):
+        validate_runtime_compatibility(env_cfg, launcher_args)
 
 
 def test_ovphysx_plus_kit_camera_without_visualizer_raises():

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -117,6 +117,25 @@ def test_ovphysx_dict_args_plus_kit_visualizer_raises():
 
 
 # ---------------------------------------------------------------------------
+# Invalid: OvPhysX physics + Kit renderer, with no Kit visualizer requested
+# ---------------------------------------------------------------------------
+
+
+def test_ovphysx_plus_kit_camera_without_visualizer_raises():
+    """A Kit-based renderer pulls in Kit even with no visualizer, which OvPhysX cannot share.
+
+    Without a visualizer the only Kit signal is the camera, so this is the case the visualizer-only
+    guard missed: it previously reached OvPhysX's own initialization and failed there instead.
+    """
+    env_cfg = _resolve_with_presets("ovphysx,isaacsim_rtx")
+    with pytest.raises(ValueError) as excinfo:
+        validate_runtime_compatibility(env_cfg, argparse.Namespace(visualizer=None))
+    msg = str(excinfo.value)
+    assert "OvPhysX" in msg
+    assert "renderer" in msg
+
+
+# ---------------------------------------------------------------------------
 # Valid combinations: must NOT raise
 # ---------------------------------------------------------------------------
 

--- a/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
+++ b/source/isaaclab_tasks/test/core/test_runtime_compatibility.py
@@ -26,7 +26,7 @@ from isaaclab_physx.renderers import IsaacRtxRendererCfg
 import isaaclab.app.sim_launcher as sim_launcher_module
 import isaaclab.utils as isaaclab_utils
 from isaaclab.app import scan
-from isaaclab.app.sim_launcher import _resolve_runtime_plan, _validate_runtime, launch_simulation
+from isaaclab.app.sim_launcher import _get_kit_runtime_sources, _validate_runtime, launch_simulation
 from isaaclab.physics import PhysxAutoCfg
 
 import isaaclab_tasks  # noqa: F401
@@ -38,7 +38,8 @@ _CAMERA_PRESETS_TASK = "Isaac-Cartpole-Camera-Direct"
 def validate_runtime_compatibility(env_cfg, launcher_args=None):
     """Run the single-scan runtime validation for *env_cfg* (test adapter)."""
     config_scan = scan(env_cfg, launcher_args)
-    _validate_runtime(_resolve_runtime_plan(config_scan, launcher_args))
+    kit_sources = _get_kit_runtime_sources(config_scan, launcher_args)
+    _validate_runtime(config_scan, kit_sources)
     return config_scan
 
 
@@ -59,13 +60,13 @@ def _resolve_with_args(*args: str):
 
 
 # ---------------------------------------------------------------------------
-# Architecture: validation consumes one resolved owner
+# Architecture: validation consumes one resolved Kit-source value
 # ---------------------------------------------------------------------------
 
 
-def test_runtime_validation_consumes_only_resolved_plan():
+def test_runtime_validation_consumes_resolved_kit_sources():
     """Keep config and launcher interpretation outside the compatibility validator."""
-    assert list(inspect.signature(_validate_runtime).parameters) == ["plan"]
+    assert list(inspect.signature(_validate_runtime).parameters) == ["scan", "kit_sources"]
 
     tree = ast.parse(inspect.getsource(_validate_runtime))
     forbidden_scan_fields = {


### PR DESCRIPTION
# Description

OvPhysX is kitless and cannot share a process with Kit. The runtime guard covered the Kit
*visualizer*, but not Kit-based *renderers*, so `presets=ovphysx,isaacsim_rtx` with no visualizer
passed validation and then failed deep inside the OvPhysX library:

```
RuntimeError: ovphysx_create_instance() failed: Failed to initialize Carbonite and load PhysX plugins
```

The check now also treats a Kit camera as a Kit runtime signal, so the combination is rejected up
front with the supported alternatives, matching the existing OVRTX renderer check in the same
function.

Found while validating dexsuite camera presets across renderer/physics combinations. Split out of
#6835 so it can be reviewed and tested on its own.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

`test_ovphysx_plus_kit_camera_without_visualizer_raises` covers the case the previous guard missed.
Both existing OvPhysX tests pass `visualizer="kit"`, so they passed before this change and never
exercised `scan.has_kit_camera`. Verified the new test fails when the condition is reverted to the
old form and passes with it: `23 passed` on
`source/isaaclab_tasks/test/core/test_runtime_compatibility.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
