### PR TITLE
Skip Warp adjoint codegen in entry scripts

### DIFF
--- a/scripts/environments/random_agent.py
+++ b/scripts/environments/random_agent.py
@@ -7,7 +7,15 @@
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 
-from isaaclab_rl.entrypoints import run_random_agent_cli
+# Warp captures ``enable_backward`` when a module is created, which happens at import
+# time, so it has to be set before importing anything that defines Warp kernels.
+# Isaac Lab does not use Warp autodiff; skipping adjoint codegen roughly halves the
+# time spent building kernels on a cold kernel cache.
+import warp as wp
+
+wp.config.enable_backward = False
+
+from isaaclab_rl.entrypoints import run_random_agent_cli  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/environments/zero_agent.py
+++ b/scripts/environments/zero_agent.py
@@ -7,7 +7,15 @@
 
 # PLACEHOLDER: Extension template (do not remove this comment)
 
-from isaaclab_rl.entrypoints import run_zero_agent_cli
+# Warp captures ``enable_backward`` when a module is created, which happens at import
+# time, so it has to be set before importing anything that defines Warp kernels.
+# Isaac Lab does not use Warp autodiff; skipping adjoint codegen roughly halves the
+# time spent building kernels on a cold kernel cache.
+import warp as wp
+
+wp.config.enable_backward = False
+
+from isaaclab_rl.entrypoints import run_zero_agent_cli  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/reinforcement_learning/play.py
+++ b/scripts/reinforcement_learning/play.py
@@ -5,7 +5,15 @@
 
 """Unified playback executable for Isaac Lab reinforcement learning workflows."""
 
-from isaaclab_rl.entrypoints import run_play_cli
+# Warp captures ``enable_backward`` when a module is created, which happens at import
+# time, so it has to be set before importing anything that defines Warp kernels.
+# Isaac Lab does not use Warp autodiff; skipping adjoint codegen roughly halves the
+# time spent building kernels on a cold kernel cache.
+import warp as wp
+
+wp.config.enable_backward = False
+
+from isaaclab_rl.entrypoints import run_play_cli  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/reinforcement_learning/train.py
+++ b/scripts/reinforcement_learning/train.py
@@ -5,7 +5,15 @@
 
 """Unified training executable for Isaac Lab reinforcement learning workflows."""
 
-from isaaclab_rl.entrypoints import run_train_cli
+# Warp captures ``enable_backward`` when a module is created, which happens at import
+# time, so it has to be set before importing anything that defines Warp kernels.
+# Isaac Lab does not use Warp autodiff; skipping adjoint codegen roughly halves the
+# time spent building kernels on a cold kernel cache.
+import warp as wp
+
+wp.config.enable_backward = False
+
+from isaaclab_rl.entrypoints import run_train_cli  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/source/isaaclab/test/test_scripts_warp_backward_ordering.py
+++ b/source/isaaclab/test/test_scripts_warp_backward_ordering.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Static scanner ensuring entry scripts disable Warp adjoint codegen early enough.
+
+``warp.config.enable_backward`` is captured when a Warp module is created, which happens at
+import time. Setting it after an Isaac Lab import has no effect on modules already created,
+and nothing fails loudly when that happens -- the kernels are simply built with adjoints
+again. These tests pin the ordering so a future import reshuffle cannot silently undo it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_ENTRY_SCRIPTS = [
+    "scripts/reinforcement_learning/train.py",
+    "scripts/reinforcement_learning/play.py",
+    "scripts/environments/zero_agent.py",
+    "scripts/environments/random_agent.py",
+]
+
+_SETTING = "wp.config.enable_backward = False"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("script", _ENTRY_SCRIPTS)
+def test_entry_script_disables_warp_backward_before_isaaclab_imports(script: str):
+    lines = (_REPO_ROOT / script).read_text().splitlines()
+
+    setting_at = next((i for i, line in enumerate(lines) if line.strip() == _SETTING), None)
+    assert setting_at is not None, f"{script} does not set '{_SETTING}'"
+
+    first_isaaclab_import = next(
+        (i for i, line in enumerate(lines) if line.startswith(("import isaaclab", "from isaaclab"))),
+        None,
+    )
+    assert first_isaaclab_import is not None, f"{script} imports no Isaac Lab module"
+    assert setting_at < first_isaaclab_import, (
+        f"{script} sets enable_backward on line {setting_at + 1}, after the Isaac Lab import on line"
+        f" {first_isaaclab_import + 1}; Warp modules created by that import keep adjoint codegen."
+    )


### PR DESCRIPTION
# Description

Warp generates an adjoint (backward) kernel for every kernel it compiles. Isaac Lab does not use Warp's tape-based autodiff, so those adjoint kernels are compiled and never launched — pure cold-start cost.

`warp.config.enable_backward` is captured when a Warp module is first created, which happens at import time, so it has to be set before importing anything that defines Warp kernels. This sets it at the top of the four entry scripts the `isaaclab` CLI dispatches to (`train`, `play`, `zero_agent`, `random_agent`), which precedes `newton`, `mujoco_warp` and `isaaclab_newton`.

Fixes # (no issue)

## Measurements

Through `isaaclab train` on a cold Warp kernel cache (`Isaac-Cartpole-Direct`, 16 envs, `presets=newton_mjwarp`, RTX 5090): **68.8s → 43.2s**.

Time from process start to the end of the first `env.step()`, same settings, isolated GPU, arms interleaved within every rep:

**Cold Warp kernel cache** — fresh container, warp/newton bump, CI:

| task | before | after | saved | speedup |
|---|---|---|---|---|
| Cartpole | 57.69s | 36.31s | −21.38s | 1.59x |
| Humanoid | 59.14s | 41.06s | −18.09s | 1.44x |
| AnymalD-Rough | 76.39s | 53.91s | −22.48s | 1.42x |
| KukaAllegro | 204.90s | 182.99s | −21.91s | 1.12x |

**Partial cache** — a Warp kernel was edited, so those modules rebuild:

| task | before | after | speedup |
|---|---|---|---|
| Cartpole | 27.17s | 12.30s | 2.21x |
| Humanoid | 27.12s | 12.49s | 2.17x |
| AnymalD-Rough | 32.06s | 17.50s | 1.83x |
| KukaAllegro | 166.56s | 152.93s | 1.09x |

The absolute saving is near-constant (~20s cold, ~14s partial) because it is the same newton/mujoco_warp module set compiling regardless of which task loads it; only the denominator changes. KukaAllegro spends ~141s on asset and mesh processing before Warp is relevant — its fully-warm startup is still 142s — hence the smaller ratio.

**Fully warm cache:** unchanged (≤1%, both signs).

**Steady-state step time:** unchanged — 1.010x / 1.018x / 1.013x / 0.990x across the four tasks.

Savings are concentrated in newton rather than mujoco_warp:

| module | before | after |
|---|---|---|
| `newton._src.sim.articulation` | 8.58s | 1.38s |
| `newton._src.solvers.mujoco.kernels` | 8.14s | 2.57s |
| `newton._src.utils.selection` | 5.24s | 2.76s |
| `isaaclab_newton.assets.kernels` | 3.30s | 1.13s |
| `mujoco_warp._src.smooth` | 3.57s | 3.47s |

## Correctness

- Cartpole observation SHA-256 and reward sum are **bit-identical** with and without the change over a 100-step fixed-seed rollout.
- AnymalD-Rough differs, but it is non-deterministic run-to-run regardless of this change (reward sums −29.157 / −28.557 / −29.239 across three unmodified runs), so the difference is not attributable to it.
- Isaac Lab has no `wp.Tape` usage.

## Notes

The setting is per-script rather than in `isaaclab/__init__.py` deliberately: importing the library should not mutate a third-party global as a side effect. The tradeoff is that it has to be repeated per entry point, and scripts not listed above (tutorials, demos, benchmarks) do not get it.

`test_scripts_warp_backward_ordering.py` pins the ordering. This matters because the failure is silent — setting the flag after an Isaac Lab import does not raise, it just rebuilds the adjoints — so an import reshuffle could quietly undo the change. The test is a static scanner in the same style as the existing `test_scripts_torcharray_patterns.py`.

The one autodiff consumer reachable from Isaac Lab is `newton.ik.IKSolver`, which defaults to `jacobian_mode=AUTODIFF`. `NewtonIKSolverCfg` defaults to `"analytic"` and `Isaac-Reach-Franka-Newton-IK-Rel` pins `"analytic"`, so no shipped task is affected. A user who selects `autodiff` through one of these scripts would get a Warp `UserWarning` and zero gradients; removing the two lines from that script is the workaround.

A cleaner long-term fix likely belongs upstream in newton: `SolverBase._set_module_options` already exists and is used for `deterministic`, so gating `enable_backward` on `model.requires_grad` there would cover every entry point automatically. Happy to pursue that instead.

Changelog fragment is `.skip`: the behavior change lives in `scripts/`, and the only `source/` change is the test.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation — none needed; the change has no user-facing API or configuration surface.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
