### PR TITLE
fix: compare joint_ids against None when exporting LeAPP PD gains

### DIFF
--- a/source/isaaclab/changelog.d/fix-leapp-joint-ids-truthiness.rst
+++ b/source/isaaclab/changelog.d/fix-leapp-joint-ids-truthiness.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.utils.leapp.export_annotator.ExportPatcher` raising
+  ``RuntimeError: Boolean value of Tensor with more than one value is ambiguous``
+  when exporting PD gains for action terms whose ``joint_ids`` is a tensor.

--- a/source/isaaclab/changelog.d/fix-leapp-joint-ids-truthiness.rst
+++ b/source/isaaclab/changelog.d/fix-leapp-joint-ids-truthiness.rst
@@ -1,6 +1,8 @@
 Fixed
 ^^^^^
 
-* Fixed :class:`~isaaclab.utils.leapp.export_annotator.ExportPatcher` raising
-  ``RuntimeError: Boolean value of Tensor with more than one value is ambiguous``
-  when exporting PD gains for action terms whose ``joint_ids`` is a tensor.
+* Fixed :class:`~isaaclab.utils.leapp.export_annotator.ExportPatcher` failing to export PD
+  gains for action terms whose ``joint_ids`` is a tensor or a ``wp.array``, which raised
+  ``RuntimeError: Boolean value of Tensor with more than one value is ambiguous`` and
+  ``RuntimeError: Item indexing is not supported on wp.array objects``. Joint names are now
+  also resolved for ``wp.array`` selections instead of being silently dropped.

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -712,7 +712,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kp_gains",
-                            ref=kp_gains[:, joint_ids] if joint_ids else kp_gains,
+                            ref=kp_gains[:, joint_ids] if joint_ids is not None else kp_gains,
                             kind="kp",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_stiffness_to_sim_index"),
@@ -722,7 +722,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kd_gains",
-                            ref=kd_gains[:, joint_ids] if joint_ids else kd_gains,
+                            ref=kd_gains[:, joint_ids] if joint_ids is not None else kd_gains,
                             kind="kd",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_damping_to_sim_index"),

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -39,6 +39,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 import torch
+import warp as wp
 from leapp import annotate
 from leapp.utils.tensor_description import TensorSemantics
 
@@ -58,6 +59,18 @@ if TYPE_CHECKING:
 
 
 VARIABLE_IMPEDANCE_MODES = frozenset({"variable", "variable_kp"})
+
+
+def _normalize_joint_ids(joint_ids: Any) -> Any:
+    """Return ``joint_ids`` in a form that supports torch indexing and name selection.
+
+    Action terms resolve their joint selection to different types: a ``slice``, a
+    :class:`torch.Tensor`, a list, or -- for :class:`BinaryJointAction` -- a ``wp.array``,
+    which supports neither torch fancy indexing nor ``tolist``.
+    """
+    if isinstance(joint_ids, wp.array):
+        return wp.to_torch(joint_ids)
+    return joint_ids
 
 
 def _effective_joint_gains(real_asset) -> tuple[torch.Tensor | None, torch.Tensor | None]:
@@ -609,7 +622,7 @@ class ExportPatcher:
             if osc and hasattr(osc, "cfg") and osc.cfg.impedance_mode in VARIABLE_IMPEDANCE_MODES:
                 asset = getattr(term, "_asset", None)
                 real_asset = getattr(asset, "_real_asset", asset)
-                joint_ids = getattr(term, "_joint_ids", None)
+                joint_ids = _normalize_joint_ids(getattr(term, "_joint_ids", None))
                 joint_names = getattr(real_asset, "joint_names", None) if real_asset else None
                 scene_key = self._action_term_scene_keys.get(term_name, "ego")
                 tensors.append(
@@ -700,7 +713,7 @@ class ExportPatcher:
             asset = getattr(term, "_asset", None)
             real_asset = getattr(asset, "_real_asset", asset)
             if real_asset and hasattr(real_asset, "data"):
-                joint_ids = getattr(term, "_joint_ids", None)
+                joint_ids = _normalize_joint_ids(getattr(term, "_joint_ids", None))
                 joint_names = getattr(real_asset, "joint_names", None)
                 scene_key = self._action_term_scene_keys.get(term_name, "ego")
                 # Source the PD gains from the actuators so they are correct for every actuator

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -68,9 +68,7 @@ def _normalize_joint_ids(joint_ids: Any) -> Any:
     :class:`torch.Tensor`, a list, or -- for :class:`BinaryJointAction` -- a ``wp.array``,
     which supports neither torch fancy indexing nor ``tolist``.
     """
-    if isinstance(joint_ids, wp.array):
-        return wp.to_torch(joint_ids)
-    return joint_ids
+    return wp.to_torch(joint_ids) if isinstance(joint_ids, wp.array) else joint_ids
 
 
 def _effective_joint_gains(real_asset) -> tuple[torch.Tensor | None, torch.Tensor | None]:


### PR DESCRIPTION
# Description

LeAPP export crashed when collecting PD gains, for two reasons in the same code path.

`ExportPatcher._collect_action_static_outputs` selected the gain columns with a truthiness test:

```python
ref=kp_gains[:, joint_ids] if joint_ids else kp_gains,
```

Action terms resolve `_joint_ids` to several different types. Since #6784:

* `JointAction` and `JointPositionToLimitsAction` store a `torch.Tensor`, so `if joint_ids` calls
  `Tensor.__bool__` and raises `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`.
* `BinaryJointAction` stores a `wp.array`, which raises
  `RuntimeError: Item indexing is not supported on wp.array objects` when used as a torch index, and which
  `select_element_names()` silently rejects (it has no `tolist`), dropping the exported joint names.

Other terms still use `slice(None)` or a list, both of which already worked.

This adds `_normalize_joint_ids()`, converting a `wp.array` selection to a tensor via `wp.to_torch()`, and
compares against `None` instead of relying on truthiness. Both gain call sites use it, so the variable-impedance
path resolves joint names for `wp.array` selections too.

Fixes the `isaaclab_rl` job, which fails on `develop`:
`test_leapp_export_flow[rsl_rl-Isaac-Lift-Cube-Franka]`, `[rsl_rl-Isaac-Open-Drawer-Franka]` and
`[rsl_rl-Isaac-Reach-Franka]`.

Note that pushes to `develop` skip the `test-*` matrix jobs (`if: github.event_name != 'push'`), so this
regression could not be caught on the merge commit that introduced it.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

No new test is included because #6779 already added `source/isaaclab_rl/test/export/test_leapp_export_flow.py`,
which covers all three failing cases.
