### PR TITLE
Fix joint id type

### DIFF
--- a/source/isaaclab/changelog.d/mh-fix-leapp-tests.rst
+++ b/source/isaaclab/changelog.d/mh-fix-leapp-tests.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.envs.mdp.actions.BinaryJointAction` resolving its joint
+  indices to a Warp array while every other action term resolves them to a
+  :class:`torch.Tensor`, which broke consumers that index tensors with them.
+* Fixed LEAPP export failing with ``RuntimeError: Boolean value of Tensor with
+  more than one value is ambiguous`` when an action term selects a subset of
+  joints.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
@@ -56,7 +56,7 @@ class BinaryJointAction(ActionTerm):
         # resolve the joints over which the action term is applied
         joint_ids, self._joint_names = self._asset.find_joints(self.cfg.joint_names, as_proxy=True)
         self._num_joints = len(joint_ids)
-        self._joint_ids = joint_ids.warp
+        self._joint_ids = joint_ids.torch
         # log the resolved joint names for debugging
         logger.info(
             f"Resolved joint names for the action term {self.__class__.__name__}:"

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -712,7 +712,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kp_gains",
-                            ref=kp_gains[:, joint_ids] if joint_ids else kp_gains,
+                            ref=kp_gains if joint_ids is None else kp_gains[:, joint_ids],
                             kind="kp",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_stiffness_to_sim_index"),
@@ -722,7 +722,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kd_gains",
-                            ref=kd_gains[:, joint_ids] if joint_ids else kd_gains,
+                            ref=kd_gains if joint_ids is None else kd_gains[:, joint_ids],
                             kind="kd",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_damping_to_sim_index"),


### PR DESCRIPTION
# Description

Fixes incorrect joint type (supposed to be torch not warp) for binary joint action, and stengthens the check on leapp export

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
