### PR TITLE
fixed error caused by joint_ids becoming tensors

### DIFF
--- a/source/isaaclab/changelog.d/frlai-fix-failing-export-tests.rst
+++ b/source/isaaclab/changelog.d/frlai-fix-failing-export-tests.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed LEAPP export for action terms that store joint selectors as tensor indices.

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -88,6 +88,17 @@ def _effective_joint_gains(real_asset) -> tuple[torch.Tensor | None, torch.Tenso
     return kp, kd
 
 
+def _has_joint_ids(joint_ids) -> bool:
+    """Return whether a joint-id selection should index per-joint tensors."""
+    if joint_ids is None:
+        return False
+    if isinstance(joint_ids, slice):
+        return joint_ids != slice(None)
+    if isinstance(joint_ids, torch.Tensor):
+        return joint_ids.numel() > 0
+    return bool(joint_ids)
+
+
 # ══════════════════════════════════════════════════════════════════
 # ExportPatcher
 # ══════════════════════════════════════════════════════════════════
@@ -701,7 +712,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kp_gains",
-                            ref=kp_gains[:, joint_ids] if joint_ids else kp_gains,
+                            ref=kp_gains[:, joint_ids] if _has_joint_ids(joint_ids) else kp_gains,
                             kind="kp",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_stiffness_to_sim_index"),
@@ -711,7 +722,7 @@ class ExportPatcher:
                     static_values.append(
                         TensorSemantics(
                             name=f"{term_name}_kd_gains",
-                            ref=kd_gains[:, joint_ids] if joint_ids else kd_gains,
+                            ref=kd_gains[:, joint_ids] if _has_joint_ids(joint_ids) else kd_gains,
                             kind="kd",
                             element_names=select_element_names(joint_names, joint_ids),
                             extra=build_write_connection(scene_key, "write_joint_damping_to_sim_index"),

--- a/source/isaaclab_rl/test/export/test_leapp_proxy.py
+++ b/source/isaaclab_rl/test/export/test_leapp_proxy.py
@@ -49,6 +49,34 @@ def _capture_leapp_inputs(monkeypatch: pytest.MonkeyPatch) -> list:
     return annotated_inputs
 
 
+def test_static_action_outputs_select_tensor_joint_ids():
+    """Test static action gains can be selected with tensor joint ids."""
+
+    class _Buffer:
+        def __init__(self, tensor: torch.Tensor):
+            self.torch = tensor
+
+    real_asset = SimpleNamespace(
+        data=SimpleNamespace(
+            default_joint_stiffness=_Buffer(torch.arange(6.0).reshape(1, 6)),
+            default_joint_damping=_Buffer(torch.arange(10.0, 16.0).reshape(1, 6)),
+        ),
+        actuators={},
+        joint_names=[f"j{index}" for index in range(6)],
+    )
+    term = SimpleNamespace(_asset=real_asset, _joint_ids=torch.tensor([0, 2, 4], dtype=torch.long))
+    action_manager = SimpleNamespace(_terms={"joint_pos": term})
+
+    patcher = ExportPatcher(export_method="onnx-dynamo")
+    values = patcher._collect_action_static_outputs(action_manager)
+
+    assert [value.name for value in values] == ["joint_pos_kp_gains", "joint_pos_kd_gains"]
+    assert torch.equal(values[0].ref, torch.tensor([[0.0, 2.0, 4.0]]))
+    assert torch.equal(values[1].ref, torch.tensor([[10.0, 12.0, 14.0]]))
+    assert values[0].element_names == [["j0", "j2", "j4"]]
+    assert values[1].element_names == [["j0", "j2", "j4"]]
+
+
 def test_direct_projected_gravity_b_read_preserves_vector3d_input(monkeypatch: pytest.MonkeyPatch):
     """Test direct data proxy reads keep projected gravity as its own semantic input."""
     annotated_inputs = _capture_leapp_inputs(monkeypatch)


### PR DESCRIPTION
Fixes # (issue)

fixed error caused by joint_ids becoming tensors. Previously joint_ids were either list or None. there was a check in the patching that relied on something like ```if joint_ids``` which fails with the new joint_id contract where it is a tensor. Fixed it by explicitly checking if it is None or empty and added a fast to make the error clearer.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
