### PR TITLE
Fix LEAPP selector ownership and show all test results

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-fix-leapp-selector-boundary.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-fix-leapp-selector-boundary.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed LEAPP gain export for Torch, Warp, and list joint selectors without
+  changing the selector backend owned by action terms.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
@@ -56,7 +56,7 @@ class BinaryJointAction(ActionTerm):
         # resolve the joints over which the action term is applied
         joint_ids, self._joint_names = self._asset.find_joints(self.cfg.joint_names, as_proxy=True)
         self._num_joints = len(joint_ids)
-        self._joint_ids = joint_ids.torch
+        self._joint_ids = joint_ids.warp
         # log the resolved joint names for debugging
         logger.info(
             f"Resolved joint names for the action term {self.__class__.__name__}:"

--- a/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
+++ b/source/isaaclab/isaaclab/utils/leapp/export_annotator.py
@@ -44,6 +44,7 @@ from leapp.utils.tensor_description import TensorSemantics
 
 from isaaclab.assets.articulation.base_articulation import BaseArticulation
 from isaaclab.managers import ManagerTermBase
+from isaaclab.utils.array import convert_to_torch
 
 from .leapp_semantics import select_element_names
 from .proxy import _ArticulationWriteProxy, _DataProxy, _EnvProxy, _ManagerTermProxy
@@ -708,6 +709,10 @@ class ExportPatcher:
                 # exports zero gains for explicit actuators (DCMotor, IdealPDActuator, ...), which
                 # keep their gains on the actuator rather than in the sim. See _effective_joint_gains.
                 kp_gains, kd_gains = _effective_joint_gains(real_asset)
+                gain_reference = kp_gains if kp_gains is not None else kd_gains
+                if joint_ids is not None and not isinstance(joint_ids, slice) and gain_reference is not None:
+                    joint_ids = convert_to_torch(joint_ids, dtype=torch.long, device=gain_reference.device)
+
                 if kp_gains is not None:
                     static_values.append(
                         TensorSemantics(

--- a/source/isaaclab/isaaclab/utils/leapp/leapp_semantics.py
+++ b/source/isaaclab/isaaclab/utils/leapp/leapp_semantics.py
@@ -12,6 +12,10 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 
+import warp as wp
+
+from isaaclab.utils.array import convert_to_torch
+
 try:
     from leapp import InputKindEnum, OutputKindEnum
 except ImportError:
@@ -58,6 +62,8 @@ def select_element_names(names: list[str] | None, indices: Any = None) -> list[s
         return list(names)
     if isinstance(indices, slice):
         return list(names[indices])
+    if isinstance(indices, wp.array):
+        indices = convert_to_torch(indices)
     with suppress(AttributeError):
         indices = indices.tolist()
     if isinstance(indices, (list, tuple)):

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -212,3 +212,28 @@ def test_module_importorskip_is_not_a_failure(monkeypatch, tmp_path: Path) -> No
     assert status["skipped"] == 1
     assert status["tests"] == 1
     assert not was_failure
+
+
+def test_result_summary_includes_fast_failure_after_thirty_slower_files():
+    """The summary must print failures even when at least 30 files ran longer."""
+    orchestrator = _load_orchestrator_module()
+    test_files = ["fast_failure.py", *(f"slow_pass_{index:02d}.py" for index in range(30))]
+    test_status = {
+        test_path: {
+            "result": "FAILED" if test_path == "fast_failure.py" else "passed",
+            "time_elapsed": 0.1 if test_path == "fast_failure.py" else float(index + 1),
+            "wall_time": 0.1 if test_path == "fast_failure.py" else float(index + 1),
+            "tests": 1,
+            "failures": int(test_path == "fast_failure.py"),
+            "errors": 0,
+            "skipped": 0,
+        }
+        for index, test_path in enumerate(test_files)
+    }
+
+    summary = orchestrator._format_test_file_results(test_files, test_status, "cuda:0")
+
+    assert "All Test File Results" in summary
+    assert "Slowest 30 Test Files" not in summary
+    assert "fast_failure.py" in summary
+    assert all(test_path in summary for test_path in test_files)

--- a/source/isaaclab_rl/changelog.d/zhengyuz-fix-leapp-selector-boundary.skip
+++ b/source/isaaclab_rl/changelog.d/zhengyuz-fix-leapp-selector-boundary.skip
@@ -1,0 +1,1 @@
+Selector-representation regression coverage lives in this package.

--- a/source/isaaclab_rl/test/export/test_leapp_selectors.py
+++ b/source/isaaclab_rl/test/export/test_leapp_selectors.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for selector representations at LEAPP export boundaries."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import warp as wp
+
+pytest.importorskip("leapp")
+
+from isaaclab.utils.leapp.export_annotator import ExportPatcher
+from isaaclab.utils.leapp.leapp_semantics import select_element_names
+
+
+def _make_warp_selector():
+    """Create a CPU Warp selector for a fresh parameterized test case."""
+    return wp.array([0, 2], dtype=wp.int32, device="cpu")
+
+
+@pytest.mark.parametrize(
+    ("selector_factory", "expected_indices"),
+    [
+        pytest.param(lambda: torch.tensor([0, 2], dtype=torch.int32), [0, 2], id="torch"),
+        pytest.param(_make_warp_selector, [0, 2], id="warp"),
+        pytest.param(lambda: [0, 2], [0, 2], id="list"),
+        pytest.param(list, [], id="empty-list"),
+        pytest.param(lambda: slice(1, None), [1, 2], id="slice"),
+        pytest.param(lambda: None, [0, 1, 2], id="none"),
+    ],
+)
+def test_static_action_gains_accept_selector_representations(selector_factory, expected_indices):
+    """Test gain tensors and element names use the same normalized selector."""
+    selector = selector_factory()
+    kp_gains = torch.tensor([[10.0, 20.0, 30.0]])
+    kd_gains = torch.tensor([[1.0, 2.0, 3.0]])
+    asset = SimpleNamespace(
+        data=SimpleNamespace(
+            default_joint_stiffness=SimpleNamespace(torch=kp_gains),
+            default_joint_damping=SimpleNamespace(torch=kd_gains),
+        ),
+        actuators={},
+        joint_names=["joint_0", "joint_1", "joint_2"],
+    )
+    term = SimpleNamespace(_asset=asset, _joint_ids=selector)
+    action_manager = SimpleNamespace(_terms={"binary_gripper": term})
+
+    outputs = ExportPatcher("onnx-dynamo")._collect_action_static_outputs(action_manager)
+    outputs_by_name = {output.name: output for output in outputs}
+
+    assert term._joint_ids is selector
+    assert torch.equal(outputs_by_name["binary_gripper_kp_gains"].ref, kp_gains[:, expected_indices])
+    assert torch.equal(outputs_by_name["binary_gripper_kd_gains"].ref, kd_gains[:, expected_indices])
+    expected_names = [[asset.joint_names[index] for index in expected_indices]]
+    assert outputs_by_name["binary_gripper_kp_gains"].element_names == expected_names
+    assert outputs_by_name["binary_gripper_kd_gains"].element_names == expected_names
+
+
+def test_element_names_accept_warp_selector():
+    """Test LEAPP write semantics resolve names from a Warp selector."""
+    assert select_element_names(["joint_0", "joint_1", "joint_2"], _make_warp_selector()) == [
+        "joint_0",
+        "joint_2",
+    ]

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1199,6 +1199,34 @@ def _write_empty_report():
     logger.info(f"Wrote empty report to tests/{result_file}")
 
 
+def _format_test_file_results(test_files: list[str], test_status: dict[str, dict], run_device: str) -> str:
+    """Format all per-file test results as a table."""
+    summary = "\n\n=====================\n"
+    summary += "All Test File Results\n"
+    summary += "=====================\n"
+
+    table = PrettyTable(field_names=["Test Path", "GPU", "Result", "Test (s)", "Wall (s)", "# Tests"])
+    table.align["Test Path"] = "l"
+    table.align["Test (s)"] = "r"
+    table.align["Wall (s)"] = "r"
+    sorted_test_files = sorted(test_files, key=lambda path: test_status[path]["wall_time"], reverse=True)
+    for test_path in sorted_test_files:
+        status = test_status[test_path]
+        num_tests_passed = status["tests"] - status["failures"] - status["errors"] - status["skipped"]
+        table.add_row(
+            [
+                test_path,
+                run_device,
+                status["result"],
+                f"{status['time_elapsed']:0.2f}",
+                f"{status['wall_time']:0.2f}",
+                f"{num_tests_passed}/{status['tests']}",
+            ]
+        )
+
+    return summary + table.get_string()
+
+
 def pytest_sessionstart(session):
     """Intercept pytest startup to execute tests in the correct order."""
     # Get the workspace root directory (one level up from tools)
@@ -1394,34 +1422,7 @@ def pytest_sessionstart(session):
     # device mask is unset.
     run_device = resolve_test_sim_device()
 
-    summary_str += "\n\n=====================\n"
-    summary_str += "Slowest 30 Test Files\n"
-    summary_str += "=====================\n"
-
-    per_file_result_table = PrettyTable(field_names=["Test Path", "GPU", "Result", "Test (s)", "Wall (s)", "# Tests"])
-    per_file_result_table.align["Test Path"] = "l"
-    per_file_result_table.align["Test (s)"] = "r"
-    per_file_result_table.align["Wall (s)"] = "r"
-    slowest_test_files = sorted(test_files, key=lambda path: test_status[path]["wall_time"], reverse=True)[:30]
-    for test_path in slowest_test_files:
-        num_tests_passed = (
-            test_status[test_path]["tests"]
-            - test_status[test_path]["failures"]
-            - test_status[test_path]["errors"]
-            - test_status[test_path]["skipped"]
-        )
-        per_file_result_table.add_row(
-            [
-                test_path,
-                run_device,
-                test_status[test_path]["result"],
-                f"{test_status[test_path]['time_elapsed']:0.2f}",
-                f"{test_status[test_path]['wall_time']:0.2f}",
-                f"{num_tests_passed}/{test_status[test_path]['tests']}",
-            ]
-        )
-
-    summary_str += per_file_result_table.get_string()
+    summary_str += _format_test_file_results(test_files, test_status, run_device)
 
     # Print summary to console and log file
     logger.info(summary_str)


### PR DESCRIPTION
# Description

Repairs the ownership regression introduced by #6846 and makes the failing test file visible in the final CI summary.

- Restores BinaryJointAction to the cached Warp selector required by the indexed articulation write path.
- Normalizes Torch, Warp, list, empty, slice, and None selectors at the LEAPP export boundary before gain-tensor indexing.
- Resolves LEAPP element names from Warp selectors without changing the action term selector.
- Prints every per-file test result, ordered by wall time, instead of truncating the table to the slowest 30 files.

The original core failure was hidden because test_mock_assets.py finished too quickly to appear in the slowest-30 table: https://github.com/isaac-sim/IsaacLab/actions/runs/30725622913/job/91454200516

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- 28 passed: source/isaaclab/test/test_mock_interfaces/test_mock_assets.py
- 9 passed: LEAPP proxy and selector tests
- 5 passed: test orchestrator result handling
- Changelog fragment validation passed against current develop.
- All pre-commit hooks pass for the eight files in this PR.
- The repository-wide formatter was run twice; its only failure is the pre-existing Git LFS metadata issue for golden images outside this diff.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] Documentation changes are not required for this internal bug fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added changelog fragments for every touched package
- [x] My name already exists in CONTRIBUTORS.md