### PR TITLE
Remove local imports from schema config exports

### DIFF
--- a/source/isaaclab/isaaclab/sim/__init__.py
+++ b/source/isaaclab/isaaclab/sim/__init__.py
@@ -26,7 +26,7 @@ To make it convenient to use the module, we recommend importing the module as fo
 
 """
 
-from isaaclab.utils.module import lazy_export
+from isaaclab.utils.module import deferred_import, lazy_export
 
 _stub_getattr, _stub_dir, __all__ = lazy_export()
 
@@ -94,38 +94,39 @@ _NEWTON_FORWARDS = frozenset(
     }
 )
 
+_PHYSX_CFG = deferred_import("isaaclab_physx.sim.schemas.schemas_cfg")
+_PHYSX_MATERIAL_CFG = deferred_import("isaaclab_physx.sim.spawners.materials.physics_materials_cfg")
+_NEWTON_CFG = deferred_import("isaaclab_newton.sim.schemas.schemas_cfg")
+
 
 def __getattr__(name):
     if name in _PHYSX_FORWARDS_SCHEMAS:
         try:
-            from isaaclab_physx.sim.schemas import schemas_cfg as _physx_cfg
+            return getattr(_PHYSX_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.{name}' has moved to 'isaaclab_physx.sim.schemas'."
                 " Install the isaaclab_physx extension or update your import. This forwarding"
                 " shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_physx_cfg, name)
     if name in _PHYSX_FORWARDS_MATERIALS:
         try:
-            from isaaclab_physx.sim.spawners.materials import physics_materials_cfg as _physx_mat_cfg
+            return getattr(_PHYSX_MATERIAL_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.{name}' has moved to 'isaaclab_physx.sim.spawners.materials'."
                 " Install the isaaclab_physx extension or update your import. This forwarding"
                 " shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_physx_mat_cfg, name)
     if name in _NEWTON_FORWARDS:
         try:
-            from isaaclab_newton.sim.schemas import schemas_cfg as _newton_cfg
+            return getattr(_NEWTON_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.{name}' has moved to 'isaaclab_newton.sim.schemas'."
                 " Install the isaaclab_newton extension or update your import. This forwarding"
                 " shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_newton_cfg, name)
     return _stub_getattr(name)
 
 

--- a/source/isaaclab/isaaclab/sim/schemas/__init__.py
+++ b/source/isaaclab/isaaclab/sim/schemas/__init__.py
@@ -32,7 +32,7 @@ Locally, the schemas are defined in the following files:
 
 """
 
-from isaaclab.utils.module import lazy_export
+from isaaclab.utils.module import deferred_import, lazy_export
 
 _stub_getattr, _stub_dir, __all__ = lazy_export()
 
@@ -86,28 +86,29 @@ _NEWTON_FORWARDS = frozenset(
     }
 )
 
+_PHYSX_CFG = deferred_import("isaaclab_physx.sim.schemas.schemas_cfg")
+_NEWTON_CFG = deferred_import("isaaclab_newton.sim.schemas.schemas_cfg")
+
 
 def __getattr__(name):
     if name in _PHYSX_FORWARDS:
         try:
-            from isaaclab_physx.sim.schemas import schemas_cfg as _physx_cfg
+            return getattr(_PHYSX_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.schemas.{name}' has moved to 'isaaclab_physx.sim.schemas'."
                 " Install the isaaclab_physx extension or update your import. This forwarding"
                 " shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_physx_cfg, name)
     if name in _NEWTON_FORWARDS:
         try:
-            from isaaclab_newton.sim.schemas import schemas_cfg as _newton_cfg
+            return getattr(_NEWTON_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.schemas.{name}' has moved to 'isaaclab_newton.sim.schemas'."
                 " Install the isaaclab_newton extension or update your import. This forwarding"
                 " shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_newton_cfg, name)
     return _stub_getattr(name)
 
 

--- a/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas_cfg.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from typing import ClassVar, Literal
 
 from isaaclab.utils.configclass import configclass
+from isaaclab.utils.module import deferred_import
 
 # Names that moved out of this submodule into ``isaaclab_physx.sim.schemas.schemas_cfg``.
 # Resolved lazily so callers using ``from isaaclab.sim.schemas.schemas_cfg import
@@ -59,11 +60,14 @@ _NEWTON_FORWARDS = frozenset(
     }
 )
 
+_PHYSX_CFG = deferred_import("isaaclab_physx.sim.schemas.schemas_cfg")
+_NEWTON_CFG = deferred_import("isaaclab_newton.sim.schemas.schemas_cfg")
+
 
 def __getattr__(name):
     if name in _PHYSX_FORWARDS:
         try:
-            from isaaclab_physx.sim.schemas import schemas_cfg as _physx_cfg
+            return getattr(_PHYSX_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.schemas.schemas_cfg.{name}' has moved to"
@@ -71,10 +75,9 @@ def __getattr__(name):
                 " extension or update your import. This forwarding shim is scheduled for"
                 " removal in 4.0."
             ) from e
-        return getattr(_physx_cfg, name)
     if name in _NEWTON_FORWARDS:
         try:
-            from isaaclab_newton.sim.schemas import schemas_cfg as _newton_cfg
+            return getattr(_NEWTON_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.schemas.schemas_cfg.{name}' has moved to"
@@ -82,7 +85,6 @@ def __getattr__(name):
                 " extension or update your import. This forwarding shim is scheduled for"
                 " removal in 4.0."
             ) from e
-        return getattr(_newton_cfg, name)
     raise AttributeError(f"module 'isaaclab.sim.schemas.schemas_cfg' has no attribute {name!r}")
 
 

--- a/source/isaaclab/isaaclab/sim/spawners/materials/__init__.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/__init__.py
@@ -52,7 +52,7 @@ Usage:
 .. _Physics Scene: https://openusd.org/dev/api/usd_physics_page_front.html
 """
 
-from isaaclab.utils.module import lazy_export
+from isaaclab.utils.module import deferred_import, lazy_export
 
 _stub_getattr, _stub_dir, __all__ = lazy_export()
 
@@ -68,18 +68,19 @@ _PHYSX_FORWARDS = frozenset({
     "PhysxSurfaceDeformableBodyMaterialCfg",
 })
 
+_PHYSX_CFG = deferred_import("isaaclab_physx.sim.spawners.materials.physics_materials_cfg")
+
 
 def __getattr__(name):
     if name in _PHYSX_FORWARDS:
         try:
-            from isaaclab_physx.sim.spawners.materials import physics_materials_cfg as _physx_cfg
+            return getattr(_PHYSX_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.spawners.materials.{name}' has moved to"
                 " 'isaaclab_physx.sim.spawners.materials'. Install the isaaclab_physx extension"
                 " or update your import. This forwarding shim is scheduled for removal in 4.0."
             ) from e
-        return getattr(_physx_cfg, name)
     return _stub_getattr(name)
 
 

--- a/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/physics_materials_cfg.py
@@ -11,6 +11,7 @@ from typing import ClassVar
 
 from isaaclab.sim.schemas.schemas_cfg import SchemaFragment
 from isaaclab.utils.configclass import configclass
+from isaaclab.utils.module import deferred_import
 
 # Names that moved out of this submodule into ``isaaclab_physx.sim.spawners.materials.physics_materials_cfg``.
 # Resolved lazily so callers using ``from isaaclab.sim.spawners.materials.physics_materials_cfg
@@ -27,11 +28,13 @@ _PHYSX_FORWARDS = frozenset(
     }
 )
 
+_PHYSX_CFG = deferred_import("isaaclab_physx.sim.spawners.materials.physics_materials_cfg")
+
 
 def __getattr__(name):
     if name in _PHYSX_FORWARDS:
         try:
-            from isaaclab_physx.sim.spawners.materials import physics_materials_cfg as _physx_mat_cfg
+            return getattr(_PHYSX_CFG, name)
         except ImportError as e:
             raise ImportError(
                 f"'isaaclab.sim.spawners.materials.physics_materials_cfg.{name}' has moved to"
@@ -39,7 +42,6 @@ def __getattr__(name):
                 " isaaclab_physx extension or update your import. This forwarding shim is scheduled"
                 " for removal in 4.0."
             ) from e
-        return getattr(_physx_mat_cfg, name)
     raise AttributeError(f"module 'isaaclab.sim.spawners.materials.physics_materials_cfg' has no attribute {name!r}")
 
 

--- a/source/isaaclab/isaaclab/utils/module.py
+++ b/source/isaaclab/isaaclab/utils/module.py
@@ -14,8 +14,39 @@ import sys
 import tempfile
 import warnings
 from collections.abc import Callable
+from types import ModuleType
 
 import lazy_loader as lazy
+
+
+class _DeferredModule(ModuleType):
+    """Module proxy that imports its target on first attribute access."""
+
+    def __init__(self, module_name: str):
+        super().__init__(module_name)
+        self._module_name = module_name
+        self._module: ModuleType | None = None
+
+    def __getattr__(self, name: str):
+        if self._module is None:
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+
+def deferred_import(module_name: str) -> ModuleType:
+    """Create a module proxy that imports an optional dependency on first use.
+
+    Unlike :func:`lazy_loader.load`, constructing this proxy does not inspect the module spec or
+    import parent packages. This allows dependency-free configuration modules to declare optional
+    backend forwarding targets at module scope without importing those backends eagerly.
+
+    Args:
+        module_name: Fully qualified module name to load on first attribute access.
+
+    Returns:
+        A module proxy for the deferred import.
+    """
+    return _DeferredModule(module_name)
 
 
 def _parse_stub(

--- a/source/isaaclab/test/sim/test_schema_import_boundaries.py
+++ b/source/isaaclab/test/sim/test_schema_import_boundaries.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests that schema configuration modules do not import backends inside functions."""
+
+import ast
+from pathlib import Path
+
+_ISAACLAB_ROOT = Path(__file__).parents[2] / "isaaclab"
+_CONFIG_EXPORT_MODULES = (
+    _ISAACLAB_ROOT / "sim" / "__init__.py",
+    _ISAACLAB_ROOT / "sim" / "schemas" / "__init__.py",
+    _ISAACLAB_ROOT / "sim" / "schemas" / "schemas_cfg.py",
+    _ISAACLAB_ROOT / "sim" / "spawners" / "materials" / "__init__.py",
+    _ISAACLAB_ROOT / "sim" / "spawners" / "materials" / "physics_materials_cfg.py",
+)
+_BACKEND_PREFIXES = ("isaaclab_newton", "isaaclab_physx", "isaaclab_ovphysx")
+
+
+def test_config_export_modules_have_no_function_local_backend_imports():
+    """Keep backend resolution declarative and out of function bodies."""
+    violations = []
+    for path in _CONFIG_EXPORT_MODULES:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for function in (node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))):
+            for node in ast.walk(function):
+                module = node.module if isinstance(node, ast.ImportFrom) else None
+                names = [alias.name for alias in node.names] if isinstance(node, ast.Import) else []
+                imported_modules = ([module] if module is not None else []) + names
+                if any(name.startswith(_BACKEND_PREFIXES) for name in imported_modules):
+                    violations.append(f"{path.relative_to(_ISAACLAB_ROOT.parent)}:{function.name}")
+
+    assert not violations, f"function-local backend imports found in: {', '.join(violations)}"

--- a/source/isaaclab/test/utils/test_module.py
+++ b/source/isaaclab/test/utils/test_module.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for module loading utilities."""
+
+import sys
+
+import pytest
+
+from isaaclab.utils.module import deferred_import
+
+
+def test_deferred_import_delays_module_loading():
+    """Delay importing a module until one of its attributes is requested."""
+    module_name = "email.quoprimime"
+    sys.modules.pop(module_name, None)
+
+    module = deferred_import(module_name)
+    assert module_name not in sys.modules
+
+    assert callable(module.header_check)
+    assert module_name in sys.modules
+
+
+def test_deferred_import_delays_missing_dependency_error():
+    """Create a proxy for a missing optional dependency without raising eagerly."""
+    module = deferred_import("isaaclab_missing_optional_dependency")
+
+    with pytest.raises(ModuleNotFoundError, match="isaaclab_missing_optional_dependency"):
+        module.some_attribute


### PR DESCRIPTION
# Description

Removes function-local optional-backend imports from schema and physics-material configuration exports.

- Adds a deferred module proxy that does not inspect or import optional backend packages until first attribute access.
- Uses module-scope deferred targets in the top-level simulation, schema, and physics-material compatibility shims.
- Adds regression coverage for all five configuration-export modules and for deferred import behavior.

Addresses [IsaacLab-Internal#902](https://github.com/isaac-sim/IsaacLab-Internal/issues/902). The backend-specific file-spawner operations and imports shown in the issue are moved to their owning backends by [PR #6856](https://github.com/isaac-sim/IsaacLab/pull/6856).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- ``uv run --frozen --extra test python -m pytest source/isaaclab/test/sim/test_schema_import_boundaries.py source/isaaclab/test/utils/test_module.py source/isaaclab/test/sim/test_schemas_shim.py -q`` — 145 passed.
- ``uv run --frozen isaaclab -f`` — passed.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the all-files pre-commit checks.
- [x] Documentation changes are not required for this internal refactor.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] I have added a changelog fragment for the touched package.
- [x] My name already exists in ``CONTRIBUTORS.md``.
