### PR TITLE
Train rough locomotion at zero shape margin

### DIFF
--- a/source/isaaclab_tasks/changelog.d/zhengyuz-locomotion-zero-margin.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-locomotion-zero-margin.minor.rst
@@ -1,0 +1,23 @@
+Changed
+^^^^^^^
+
+* Changed the shared rough-locomotion Newton preset
+  :class:`~isaaclab_tasks.core.velocity.velocity_env_cfg.RoughPhysicsCfg` to raise the MuJoCo
+  constraint budget from ``njmax=200``/``nconmax=100`` to ``njmax=1000``/``nconmax=300``. Rough
+  terrain needs far more constraint rows than the old budget allowed, and MuJoCo drops the excess
+  rows silently, so the overflow presented as unstable contact rather than as a resource limit.
+* Changed the same preset's ``default_shape_cfg`` margin from ``0.01`` to ``0.0``, and removed the
+  per-robot ``margin = 0.001`` override from
+  :class:`~isaaclab_tasks.core.velocity.config.anymal_d.rough_env_cfg.AnymalDRoughEnvCfg`.
+  ``margin`` is a rest offset that inflates every collider, so a shared non-zero value changes the
+  shape of every asset using the preset: at ``margin=0.01`` opposing surfaces engage across a 20 mm
+  cushion and never touch, which breaks sim2real transfer. The margin was previously believed to be
+  required for non-AnymalD robots on triangle-mesh terrain, but it was masking the constraint
+  overflow addressed above; with the budgets raised, every robot in the suite trains at
+  ``margin=0``.
+* Changed the Cassie, Unitree Go2, and H1 rough environments to set contact stiffness
+  ``ke=10000`` with ``kd=200`` on the Newton MJWarp shape config. The shared ``ke=2500`` leaves the
+  contact time constant at ``4 * sim.dt``, which corrects penetration too slowly on mesh terrain.
+  ``kd = 2*sqrt(ke)`` keeps the contact critically damped; the damping ratio matters considerably
+  more than the stiffness itself. The stiffness is set per robot rather than in the shared preset
+  because it does not help every robot in the suite.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -19,8 +19,5 @@ class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
 
-        # sim
-        # lower margin to avoid self-collision
-        self.sim.physics.newton_mjwarp.default_shape_cfg.margin = 0.001
         # scene
         self.scene.robot = ANYMAL_D_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
@@ -58,6 +58,13 @@ class CassieRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
 
+        # sim
+        # Stiffen contacts. The shared ke=2500 puts the contact time constant at 4 * sim.dt, so
+        # penetration is corrected over several steps and the terrain feels soft. kd = 2*sqrt(ke)
+        # keeps the contact critically damped -- the damping ratio matters far more than the
+        # stiffness itself, and an under- or over-damped pair destabilizes training.
+        self.sim.physics.newton_mjwarp.default_shape_cfg.ke = 10000.0
+        self.sim.physics.newton_mjwarp.default_shape_cfg.kd = 200.0
         # scene
         self.scene.robot = CASSIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.02)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
@@ -20,6 +20,13 @@ class UnitreeGo2RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
 
+        # sim
+        # Stiffen contacts. The shared ke=2500 puts the contact time constant at 4 * sim.dt, so
+        # penetration is corrected over several steps and the terrain feels soft. kd = 2*sqrt(ke)
+        # keeps the contact critically damped -- the damping ratio matters far more than the
+        # stiffness itself, and an under- or over-damped pair destabilizes training.
+        self.sim.physics.newton_mjwarp.default_shape_cfg.ke = 10000.0
+        self.sim.physics.newton_mjwarp.default_shape_cfg.kd = 200.0
         # scene
         self.scene.robot = UNITREE_GO2_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
@@ -78,6 +78,13 @@ class H1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
 
+        # sim
+        # Stiffen contacts. The shared ke=2500 puts the contact time constant at 4 * sim.dt, so
+        # penetration is corrected over several steps and the terrain feels soft. kd = 2*sqrt(ke)
+        # keeps the contact critically damped -- the damping ratio matters far more than the
+        # stiffness itself, and an under- or over-damped pair destabilizes training.
+        self.sim.physics.newton_mjwarp.default_shape_cfg.ke = 10000.0
+        self.sim.physics.newton_mjwarp.default_shape_cfg.kd = 200.0
         # scene
         self.scene.robot = H1_MINIMAL_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/torso_link"

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -52,8 +52,12 @@ class RoughPhysicsCfg(PresetCfg):
     physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
     newton_mjwarp = NewtonCfg(
         solver_cfg=MJWarpSolverCfg(
-            njmax=200,
-            nconmax=100,
+            # Rough terrain needs far more constraint rows than the solver defaults allow.
+            # At njmax=200 the budget overflows on every robot here (G1 alone needs 218) and
+            # MuJoCo silently drops the excess rows, which reads as unstable contact rather
+            # than as an overflow. njmax=500 is still not enough for Go2; 1000 leaves headroom.
+            njmax=1000,
+            nconmax=300,
             cone="pyramidal",
             impratio=1.0,
             integrator="implicitfast",
@@ -62,10 +66,16 @@ class RoughPhysicsCfg(PresetCfg):
         collision_cfg=NewtonCollisionPipelineCfg(max_triangle_pairs=2_500_000),
         num_substeps=1,
         debug_mode=False,
-        # 1 cm shape margin is the single most important Newton setting for rough
-        # terrain — without it, non-AnymalD robots fail to learn stable contact
-        # on triangle-mesh terrain. See isaaclab_newton 0.5.22 changelog.
-        default_shape_cfg=NewtonShapeCfg(margin=0.01),
+        # Keep the shape margin at 0. ``margin`` is a rest offset: it inflates every collider,
+        # so a non-zero value here changes the shape of every asset that uses this preset --
+        # at margin=0.01 opposing surfaces engage across a 20 mm cushion and never actually
+        # touch (measured: zero penetrating contacts, versus 100% at margin=0). That silently
+        # breaks sim2real transfer. The margin was previously believed to be load-bearing for
+        # non-AnymalD robots on triangle-mesh terrain; it was in fact masking the constraint
+        # overflow fixed by njmax/nconmax above. With the budgets raised, every robot in this
+        # suite trains at margin=0. If a specific asset ever needs a rest offset, set it on
+        # that asset rather than here.
+        default_shape_cfg=NewtonShapeCfg(margin=0.0),
     )
     default = physx
 


### PR DESCRIPTION
## Description

The shared rough-terrain Newton preset carried a 1 cm shape margin, documented as *"the single most important Newton setting for rough terrain"*. `margin` is a **rest offset**: it inflates every collider, so opposing surfaces engage across a 20 mm cushion and never actually touch — measured zero penetrating contacts at `margin=0.01`, versus 100% at `margin=0`. A shared non-zero value silently changes the shape of every asset using the preset, and that phantom gap is what breaks sim2real transfer.

The margin turned out not to be load-bearing. It was **masking a constraint-budget overflow**: rough terrain needs far more constraint rows than `njmax=200` allows (G1 alone needs 218), and MuJoCo drops the excess rows silently — so the overflow presented as unstable contact rather than as a resource limit. `njmax=500` is still not enough for Go2; 1000 leaves headroom.

With the budgets raised, every robot in the suite trains at `margin=0`:

| robot | shipped (`margin=0.01`) | this PR (`margin=0` + budgets + per-robot `ke`) |
|---|---|---|
| Cassie | 5.828 | 5.875 |
| Go2 | 5.986 | 5.980 |
| H1 | 5.799 | 5.857 |
| AnymalD | 5.61 | 5.45 |

Measured on `Curriculum/terrain_levels`, `physics=newton_mjwarp`, 4096 envs. All runs verified overflow-free — earlier low-margin results in this campaign were invalid because they silently overflowed and NaN'd.

Contact stiffness is set **per robot** on Cassie, Go2 and H1 rather than in the shared preset, because it does not help every robot in the suite. The shared `ke=2500` leaves the contact time constant at `4 * sim.dt`, correcting penetration too slowly on mesh terrain. `kd = 2*sqrt(ke)` holds critical damping — the damping ratio dominates the stiffness itself (a run at ζ=0.63 finished at terrain 0.62, versus 5.81 at ζ=1.0 with a tenth the stiffness).

Note `ke=1e4` sits exactly at the MuJoCo REFSAFE floor for the 5 ms step (`timeconst >= 2*dt` implies `dt <= 1/(2*sqrt(ke))`), so it is the stiffest critically-damped contact this step size supports.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added a changelog entry
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works