### PR TITLE
[CI] Publish Isaac Lab images to the Isaac Sim NGC org

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -5,9 +5,9 @@
 
 # Shared image config for CI workflows. Loaded by the `config` job in each
 # workflow via yq and exposed as job outputs (see e.g. .github/workflows/build.yaml).
-# The `nvidian/isaac-sim` mirror stopped receiving nightly develop builds on 2026-06-24
-# (frozen at 6.1.0-alpha.2). Isaac Sim publishes to its own NGC org, which is current.
+# The `nvidian` org is retired: it stopped serving nightly develop builds on 2026-06-24
+# (frozen at 6.1.0-alpha.2) and now denies pushes. Both images use Isaac Sim's NGC org.
 isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
 isaacsim_image_tag: latest-develop
-isaaclab_image_name: nvcr.io/nvidian/isaac-lab
+isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""

--- a/docs/source/features/include/docker_details.inc
+++ b/docs/source/features/include/docker_details.inc
@@ -283,19 +283,16 @@ and their profile-specific environment file, if any. The standalone ``kitless`` 
 
 .. rubric:: Published Kit-less Image
 
-Building the kit-less image locally is not required. It is published alongside the Isaac Lab base image
-in the same registry repository, distinguished by a ``-kitless`` tag suffix, and follows the same branch
-tagging scheme: a moving tag per branch (``latest`` for ``main``, ``v<version>`` for a tagged release,
-``latest-develop``, ``latest-release-<branch>``) alongside an immutable per-commit tag that appends the
-full commit hash. Pin the immutable tag for reproducible runs and use the moving tag to follow a branch.
+Building the kit-less image locally is not required. It is published alongside the Isaac Lab release
+image in the same registry repository, distinguished by a ``-kitless`` tag suffix and carrying the same
+release version tag.
 
 .. code:: bash
 
-    # moving tag, follows the newest develop build
-    docker pull nvcr.io/nvidian/isaac-lab:latest-develop-kitless
+    docker pull nvcr.io/nvidia/isaac-lab:<version>-kitless
 
     docker run --rm --gpus all --network host \
-        nvcr.io/nvidian/isaac-lab:latest-develop-kitless \
+        nvcr.io/nvidia/isaac-lab:<version>-kitless \
         isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct \
         --num_envs 16 presets=newton_mjwarp --max_iterations 5
 


### PR DESCRIPTION
# Description

The nightly `Publish Docker Images` cron has failed every night since 2026-08-01.
Both legs build fine, then die on the push:

```
ERROR: failed to push nvcr.io/nvidian/isaac-lab:latest-develop:
failed to authorize: failed to fetch oauth token: denied: Access Denied
```

Not the base image: the `kitless` leg fails identically, and it builds
`FROM ubuntu:24.04` without resolving the Isaac Sim base. The same runs pull the
Isaac Sim base for amd64 and arm64, so the credential already reads the org that
image moved to in #6815. This points `isaaclab_image_name` at that org.

`develop` only — the cron runs from the default branch but checks out `develop` and
reads `config.yaml` from that tree.

Docs: the published kit-less section named an internal org and a develop-nightly tag
on a public page. It now describes the release image location, with a `<version>`
placeholder rather than a concrete tag — the kit-less image postdates every published
release, so no existing version tag has a `-kitless` counterpart.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
