### PR TITLE
Remove Newton Warp missing-table xfail from Franka tests

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-missing-table-xfail-reenable.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-missing-table-xfail-reenable.skip
@@ -1,0 +1,1 @@
+Test-only: removed the Newton Warp missing-table xfail from the kitless Franka rendering tests (OMPE-103086).

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -160,7 +160,6 @@ _OVRTX_TEXTURE_READINESS_DATA_TYPES = (
 _OVRTX_TEXTURE_READINESS_XFAIL_REASON = "OVRTX 0.4 may return before textured materials are ready (NVBUG#6505191)."
 _KITLESS_STAGE_VARIANTS = ("legacy", "ovstage")
 _LIFT_RENDERER_CRASH_SKIP_REASON = "Lift kitless OVRTX rendering may crash or time out (NVBUG#6524987)."
-_NEWTON_WARP_MISSING_TABLE_XFAIL_REASON = "Missing table in Newton Warp renderer (OMPE-103086)."
 _OVRTX_CLOTH_MOTION_XFAIL_REASON = "Missing cloth in OVRTX 0.4 motion vectors (NVBUG#6489754)."
 
 
@@ -329,21 +328,17 @@ def make_kitless_rendering_params_lift() -> list[pytest.param]:
 
 
 def make_kitless_rendering_params_franka(*, include_cloth_motion_vectors: bool = False) -> list[pytest.param]:
-    """Create kitless Franka parameters with known content regressions marked."""
+    """Create kitless Franka parameters with the cloth-only motion-vector regression optionally marked."""
     params = make_kitless_rendering_params(KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)
-    expected_failures = {
-        tuple(param.values): _NEWTON_WARP_MISSING_TABLE_XFAIL_REASON
-        for param in params
-        if param.values[1] == "newton" and param.values[2] == "newton_renderer"
-    }
-    if include_cloth_motion_vectors:
-        expected_failures.update(
-            {
-                (variant, "newton", "ovrtx_renderer", "motion_vectors"): _OVRTX_CLOTH_MOTION_XFAIL_REASON
-                for variant in _KITLESS_STAGE_VARIANTS
-            }
-        )
-    return make_xfail_rendering_params(params, expected_failures)
+    if not include_cloth_motion_vectors:
+        return params
+    return make_xfail_rendering_params(
+        params,
+        {
+            (variant, "newton", "ovrtx_renderer", "motion_vectors"): _OVRTX_CLOTH_MOTION_XFAIL_REASON
+            for variant in _KITLESS_STAGE_VARIANTS
+        },
+    )
 
 
 # Tolerances for the numeric transform comparison. Transform entries mix unit-scale rotation

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -106,16 +106,17 @@ def test_lift_factory_applies_shared_native_crash_policy() -> None:
 
 
 def test_franka_factory_adds_cloth_only_motion_policy() -> None:
-    """Franka suites should share table xfails while cloth adds motion-vector xfails."""
+    """Newton Warp cases should run unmarked while cloth adds motion-vector xfails."""
     soft_params = {param.id: param for param in make_kitless_rendering_params_franka()}
     cloth_params = {
         param.id: param for param in make_kitless_rendering_params_franka(include_cloth_motion_vectors=True)
     }
 
-    table_id = "legacy-newton-newton_warp-rgb"
-    assert [mark.name for mark in soft_params[table_id].marks] == ["xfail"]
-    assert [mark.name for mark in cloth_params[table_id].marks] == ["xfail"]
-    assert "OMPE-103086" in soft_params[table_id].marks[0].kwargs["reason"]
+    newton_warp_ids = [param_id for param_id in soft_params if param_id.startswith("legacy-newton-newton_warp-")]
+    assert newton_warp_ids
+    for param_id in newton_warp_ids:
+        assert [mark.name for mark in soft_params[param_id].marks] == []
+        assert [mark.name for mark in cloth_params[param_id].marks] == []
 
     for variant in ("legacy", "ovstage"):
         motion_id = f"{variant}-newton-ovrtx-motion_vectors"

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -106,17 +106,11 @@ def test_lift_factory_applies_shared_native_crash_policy() -> None:
 
 
 def test_franka_factory_adds_cloth_only_motion_policy() -> None:
-    """Newton Warp cases should run unmarked while cloth adds motion-vector xfails."""
+    """Only the cloth suite should carry the motion-vector xfail."""
     soft_params = {param.id: param for param in make_kitless_rendering_params_franka()}
     cloth_params = {
         param.id: param for param in make_kitless_rendering_params_franka(include_cloth_motion_vectors=True)
     }
-
-    newton_warp_ids = [param_id for param_id in soft_params if param_id.startswith("legacy-newton-newton_warp-")]
-    assert newton_warp_ids
-    for param_id in newton_warp_ids:
-        assert [mark.name for mark in soft_params[param_id].marks] == []
-        assert [mark.name for mark in cloth_params[param_id].marks] == []
 
     for variant in ("legacy", "ovstage"):
         motion_id = f"{variant}-newton-ovrtx-motion_vectors"


### PR DESCRIPTION
# Description

Drop the xfail mark so all seven Newton Warp AOV cases per suite (on every kitless Franka soft and cloth run) gate normally.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there