### PR TITLE
Expose cable demo backend option

### DIFF
--- a/docs/source/overview/core-concepts/physical-backends/newton/using-cables.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/using-cables.rst
@@ -29,8 +29,21 @@ in your environment:
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/demos/cables.py
-    ./isaaclab.sh -p scripts/demos/cables.py --num_cables 40 --num_segments 15
+    # Default Newton VBD physics with the Kit visualizer.
+    uv run python scripts/demos/cables.py
+
+    # Explicit Newton VBD physics with the Newton visualizer.
+    uv run python scripts/demos/cables.py --physics newton_vbd --visualizer newton
+
+    # No visualizer and a larger cable pile.
+    uv run python scripts/demos/cables.py --visualizer none --num_cables 40 --num_segments 15
+
+The demo accepts ``newton_vbd`` as its only ``--physics`` option. Its
+``--visualizer`` option accepts ``kit``, ``newton``, ``rerun``, ``viser``, and
+``none``; when omitted, the demo uses ``kit``. Use ``--num_cables`` and
+``--num_segments`` to change the pile size and cable resolution. Use
+``--max_steps`` to stop after a fixed number of simulation steps; its negative
+default runs until the selected visualizer closes or the process is interrupted.
 
 The demo spawns a pile of randomly oriented cables onto a ground plane under
 standalone Newton VBD, lets them collide and settle, and periodically restores

--- a/docs/source/overview/showroom.rst
+++ b/docs/source/overview/showroom.rst
@@ -125,8 +125,9 @@ A few quick showroom scripts to run and checkout:
 
             isaaclab.bat -p scripts\demos\cables.py
 
-   Use ``--num_cables`` and ``--num_segments`` to change the pile size and cable resolution.
-   Cables are a Newton-only asset; see :doc:`core-concepts/physical-backends/newton/using-cables`.
+   Select the listed options with ``--physics`` and ``--visualizer``. Use ``--num_cables`` and
+   ``--num_segments`` to change the pile size and cable resolution. Cables are a Newton-only asset;
+   see :doc:`core-concepts/physical-backends/newton/using-cables`.
 
    .. image:: ../_static/demos/cables.jpg
       :width: 100%

--- a/scripts/demos/cables.py
+++ b/scripts/demos/cables.py
@@ -7,8 +7,14 @@
 
 .. code-block:: bash
 
-    ./isaaclab.sh -p scripts/demos/cables.py
-    ./isaaclab.sh -p scripts/demos/cables.py --num_cables 40 --num_segments 15
+    # Usage with default Newton VBD physics and Kit visualizer.
+    uv run python scripts/demos/cables.py
+
+    # Usage with explicit Newton VBD physics and Newton visualizer.
+    uv run python scripts/demos/cables.py --physics newton_vbd --visualizer newton
+
+    # Usage without a visualizer and with a larger cable pile.
+    uv run python scripts/demos/cables.py --visualizer none --num_cables 40 --num_segments 15
 
 """
 
@@ -20,10 +26,11 @@ import random
 
 from isaaclab.app import add_launcher_args, launch_simulation
 
-parser = argparse.ArgumentParser(description="Spawn a pile of cables with Newton VBD.")
+parser = argparse.ArgumentParser(description="Spawn a pile of cables with Newton VBD.", conflict_handler="resolve")
 parser.add_argument("--num_cables", type=int, default=25, help="Number of cables to spawn.")
 parser.add_argument("--num_segments", type=int, default=20, help="Number of segments per cable.")
 parser.add_argument("--max_steps", type=int, default=-1, help="Stop after this many steps; negative runs forever.")
+parser.add_argument("--physics", default="newton_vbd", choices=["newton_vbd"], help="Physics backend.")
 add_launcher_args(parser)
 parser.set_defaults(visualizer=["kit"])
 args_cli = parser.parse_args()
@@ -35,6 +42,7 @@ if args_cli.num_segments < 2:
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import CableObject, CableObjectCfg
+from isaaclab.physics import PhysicsCfg
 
 
 def design_scene(num_cables: int, num_segments: int, colorize: bool) -> dict[str, CableObject]:
@@ -126,16 +134,10 @@ def run_simulator(sim: sim_utils.SimulationContext, entities: dict[str, CableObj
 
 def main() -> None:
     """Launch and run the cable pile demo."""
-    from isaaclab_newton.physics import NewtonCfg
-
-    from isaaclab_contrib.deformable import VBDSolverCfg
-
-    sim_cfg = sim_utils.SimulationCfg(
-        dt=0.01,
-        device=args_cli.device,
-        physics=NewtonCfg(solver_cfg=VBDSolverCfg(iterations=20), num_substeps=8),
-    )
-    with launch_simulation(sim_cfg, args_cli):
+    with launch_simulation(cfg=PhysicsCfg(), launcher_args=args_cli) as physics_cfg:
+        physics_cfg.solver_cfg.iterations = 20
+        physics_cfg.num_substeps = 8
+        sim_cfg = sim_utils.SimulationCfg(dt=0.01, device=args_cli.device, physics=physics_cfg)
         sim = sim_utils.SimulationContext(sim_cfg)
         sim.set_camera_view(eye=(2.0, 2.0, 1.0), target=(0.0, 0.0, 0.25))
         colorize = bool(args_cli.visualizer and "kit" in args_cli.visualizer)

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -136,10 +136,6 @@ class SmokeResult:
 
 OVERRIDES = {
     "scripts/demos/arl_robot_1.py": ScriptOverride(readiness_pattern=r"Starting demo with Lee Position Controller"),
-    "scripts/demos/cables.py": ScriptOverride(
-        # Cables are a Newton-only asset, so the demo exposes no --physics flag.
-        fixed_physics_backend="newton_vbd",
-    ),
     "scripts/demos/h1_locomotion.py": ScriptOverride(
         skip_reason="downloads a published policy and requires interactive viewport input",
         visualizers=("kit",),

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -253,6 +253,12 @@ def test_physx_only_sensor_demos_accept_explicit_physics_selector(relative_path)
     assert spec.physics_backends == (("--physics", "isaacsim_physx"),)
 
 
+def test_cable_demo_accepts_explicit_newton_vbd_selector():
+    """The Newton-only cable demo must accept its documented backend explicitly."""
+    spec = next(spec for spec in SPECS if spec.relative_path == "scripts/demos/cables.py")
+    assert spec.physics_backends == (("--physics", "newton_vbd"),)
+
+
 def test_multi_mesh_raycaster_opens_requested_rerun_viewer():
     """The interactive raycaster demo must open Rerun when the user explicitly requests it."""
     path = script_cases.ROOT / "scripts/demos/sensors/multi_mesh_raycaster.py"


### PR DESCRIPTION
# Description

The cable demo used the common visualizer launcher arguments but hard-coded its Newton VBD configuration, so it did not accept the explicit `--physics` selector used by other demo scripts.

This change:

- exposes `--physics newton_vbd` as the demo's single supported physics option;
- resolves the backend through `launch_simulation()` and then reapplies the demo-specific VBD tuning;
- preserves the Kit default and the standard `kit`, `newton`, `rerun`, `viser`, and `none` visualizer choices;
- documents the available physics, visualizer, and cable-demo options;
- removes the fixed-backend test override and adds a regression assertion for the explicit selector.

The default launch behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Screenshots

Not applicable; the demo's rendered output is unchanged.

## Validation

- `uv run --extra test python -m pytest source/isaaclab/test/app/test_standalone_scripts.py` — 40 passed, 295 runtime cases skipped
- `uv run python scripts/demos/cables.py --physics newton_vbd --visualizer none --num_cables 1 --num_segments 2 --max_steps 1`
- `uv run isaaclab -d` — warning-free documentation build
- `uv run --frozen isaaclab -f`
- `uv run --extra test python tools/changelog/cli.py check cable-demo-pr-base` against `upstream/develop`

The regression test was also verified to fail against the pre-fix cable script.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
