### PR TITLE
Fix coupled MPM reset handling

### DIFF
--- a/source/isaaclab_contrib/changelog.d/hong-nvidia-fix-coupled-mpm-reset.rst
+++ b/source/isaaclab_contrib/changelog.d/hong-nvidia-fix-coupled-mpm-reset.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_contrib.coupling.NewtonCouplerManager` resets for coupled implicit MPM entries.

--- a/source/isaaclab_contrib/changelog.d/hong-nvidia-fix-coupled-mpm-reset.rst
+++ b/source/isaaclab_contrib/changelog.d/hong-nvidia-fix-coupled-mpm-reset.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed :class:`~isaaclab_contrib.coupling.NewtonCouplerManager` resets for coupled implicit MPM entries.

--- a/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import partial
 
+import warp as wp
 from isaaclab_newton.physics import (
     KaminoSolverCfg,
     MJWarpSolverCfg,
@@ -208,6 +209,41 @@ class NewtonCouplerManager(NewtonVBDManager):
         super()._initialize_contacts()
         if cls._contacts is not None and hasattr(NewtonManager._solver, "prepare_contacts"):
             NewtonManager._solver.prepare_contacts(cls._contacts)
+
+    @classmethod
+    def _reset_solver_internals(cls, world_mask: wp.array | None) -> None:
+        """Reset compatible coupled entries while preserving implicit MPM history.
+
+        :meth:`SolverCoupled.reset` applies the same world mask to every
+        nested solver. :class:`SolverImplicitMPM` rejects Isaac Lab's
+        per-world mask for its shared topology, and resetting it without a
+        mask would also clear particle history for worlds that did not reset.
+        Reset the remaining entries through the coupled solver's reset
+        lifecycle so their per-world solver state and coupled transient state
+        remain synchronized.
+
+        Args:
+            world_mask: Per-world reset mask, or ``None`` when no simulation
+                state is available.
+        """
+        if world_mask is None:
+            return
+
+        solver = NewtonManager._solver
+        solver._distribute_state(cls._state_0, iteration_restart=True)
+        solver_cfg = PhysicsManager._cfg.solver_cfg
+        for entry_cfg in solver_cfg.entries:
+            if isinstance(entry_cfg.solver_cfg, MPMSolverCfg):
+                continue
+            entry = solver._entries[entry_cfg.name]
+            entry.solver.reset(entry.state_0, world_mask=world_mask, flags=0)
+            solver._sync_entry_reset_state(entry)
+
+        solver._reconcile_state(cls._state_0)
+        solver._reset_coupling_state(cls._state_0, world_mask=world_mask, flags=0)
+        solver._clear_entry_contact_buffers()
+        solver._rebuild_entry_solver_state_caches()
+        solver._entry_output_state_valid = False
 
     @classmethod
     def _supports_cuda_graph_capture(cls) -> bool:

--- a/source/isaaclab_contrib/test/coupling/test_coupler.py
+++ b/source/isaaclab_contrib/test/coupling/test_coupler.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -31,6 +32,8 @@ from isaaclab_newton.physics.newton_manager import NewtonManager
 from newton import ShapeFlags
 from newton.solvers.experimental.coupled import SolverCoupledADMM, SolverCoupledProxy
 
+from isaaclab.physics import PhysicsManager
+
 from isaaclab_contrib.coupling import (
     CouplerAdmmCfg,
     CouplerCfg,
@@ -41,6 +44,48 @@ from isaaclab_contrib.coupling import (
     coupler,
 )
 from isaaclab_contrib.deformable.newton_manager_cfg import NewtonModelCfg, VBDSolverCfg
+
+
+def test_reset_skips_mpm_entry_but_resets_rigid_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep coupled MPM history while resetting compatible entries per world."""
+    world_mask = object()
+    state = object()
+    rigid_solver = MagicMock()
+    mpm_solver = MagicMock()
+    rigid_entry = SimpleNamespace(solver=rigid_solver, state_0=object())
+    mpm_entry = SimpleNamespace(solver=mpm_solver, state_0=object())
+    coupled_solver = SimpleNamespace(
+        _entries={"rigid": rigid_entry, "mpm": mpm_entry},
+        _distribute_state=MagicMock(),
+        _sync_entry_reset_state=MagicMock(),
+        _reconcile_state=MagicMock(),
+        _reset_coupling_state=MagicMock(),
+        _clear_entry_contact_buffers=MagicMock(),
+        _rebuild_entry_solver_state_caches=MagicMock(),
+        _entry_output_state_valid=True,
+    )
+    solver_cfg = CouplerProxyCfg(
+        entries=[
+            CouplerEntryCfg(name="rigid", solver_cfg=XPBDSolverCfg()),
+            CouplerEntryCfg(name="mpm", solver_cfg=MPMSolverCfg(), in_place=True),
+        ]
+    )
+
+    monkeypatch.setattr(NewtonManager, "_solver", coupled_solver, raising=False)
+    monkeypatch.setattr(NewtonCouplerManager, "_state_0", state, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(solver_cfg=solver_cfg), raising=False)
+
+    NewtonCouplerManager._reset_solver_internals(world_mask)
+
+    coupled_solver._distribute_state.assert_called_once_with(state, iteration_restart=True)
+    rigid_solver.reset.assert_called_once_with(rigid_entry.state_0, world_mask=world_mask, flags=0)
+    mpm_solver.reset.assert_not_called()
+    coupled_solver._sync_entry_reset_state.assert_called_once_with(rigid_entry)
+    coupled_solver._reconcile_state.assert_called_once_with(state)
+    coupled_solver._reset_coupling_state.assert_called_once_with(state, world_mask=world_mask, flags=0)
+    coupled_solver._clear_entry_contact_buffers.assert_called_once_with()
+    coupled_solver._rebuild_entry_solver_state_caches.assert_called_once_with()
+    assert coupled_solver._entry_output_state_valid is False
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Reset compatible entries in coupled Newton solvers while skipping implicit MPM entries.
- Preserve MPM particle history and retain per-world reset behavior for rigid entries.
- Add a regression test covering a coupled rigid/MPM configuration.

## Root cause

`SolverCoupled.reset` forwards Isaac Lab's per-world reset mask to every nested solver. `SolverImplicitMPM` rejects that mask for its shared topology, causing the coupled scene to fail on its first step.

Fixes #6874

## Validation

- `uv run --extra test python -m pytest source/isaaclab_contrib/test/coupling/test_coupler.py`
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.
- [x] I have added a changelog fragment for the touched package.
- [x] I have added my name to `CONTRIBUTORS.md` or it is already present.
