### PR TITLE
Fix Franka Reach gains and IK backend support

### DIFF
--- a/source/isaaclab_assets/changelog.d/maximiliank-use-franka-usd-gains.rst
+++ b/source/isaaclab_assets/changelog.d/maximiliank-use-franka-usd-gains.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Updated the Menagerie Franka configuration to use its corrected USD-authored arm drive gains.

--- a/source/isaaclab_assets/isaaclab_assets/robots/franka.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/franka.py
@@ -81,10 +81,9 @@ FRANKA_PANDA_MENAGERIE_CFG.spawn.usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Robots/Fran
 FRANKA_PANDA_MENAGERIE_CFG.actuators = {
     "panda_arm": ImplicitActuatorCfg(
         joint_names_expr=["panda_joint[1-7]"],
-        # Override the converter-authored angular drives with SI gains until the USD is corrected.
         velocity_limit_sim={"panda_joint[1-4]": 20.0, "panda_joint[5-7]": 25.0},
-        stiffness={"panda_joint[1-2]": 1000.0, "panda_joint[3-4]": 750.0, "panda_joint[5-7]": 300.0},
-        damping={"panda_joint[1-2]": 20.0, "panda_joint[3-4]": 4.0, "panda_joint[5-7]": 2.0},
+        stiffness=None,
+        damping=None,
     ),
     "panda_hand": ImplicitActuatorCfg(
         joint_names_expr=["panda_finger_joint.*"],
@@ -95,8 +94,8 @@ FRANKA_PANDA_MENAGERIE_CFG.actuators = {
 """Configuration of the MuJoCo Menagerie-derived Franka Emika Panda robot.
 
 The converted model has different inertial and drive authoring from the legacy asset used by
-:attr:`FRANKA_PANDA_CFG`. The explicit arm gains and solver velocity limits provide consistent
-resolved drives across physics backends, while the hand retains its USD-authored drives.
+:attr:`FRANKA_PANDA_CFG`. The solver velocity limits provide consistent behavior across physics
+backends, while the arm and hand retain their USD-authored drives.
 """
 
 

--- a/source/isaaclab_tasks/changelog.d/maximiliank-newton-diffik-abs.rst
+++ b/source/isaaclab_tasks/changelog.d/maximiliank-newton-diffik-abs.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Enabled the Franka absolute differential IK preset on Newton and OVPhysX with aligned command frames, stabilized joint corrections, and task-appropriate action regularization.
+* Improved Franka Newton IK training convergence by reducing the rotational action scale.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/franka/ik_abs_env_cfg.py
@@ -20,4 +20,5 @@ class FrankaReachEnvCfg(franka_reach_env_cfg.FrankaReachEnvCfg):
         self.scene.robot.spawn.rigid_props.disable_gravity = (
             self.scene.robot.spawn.rigid_props.disable_gravity.diffik_abs
         )
+        self.rewards.action_magnitude.weight = self.rewards.action_magnitude.weight.diffik_abs
         self.actions.arm_action = self.actions.arm_action.diffik_abs

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -11,7 +11,6 @@ from isaaclab_newton.envs.mdp.actions.newton_ik_actions_cfg import NewtonInverse
 from isaaclab_newton.ik.newton_ik_objectives_cfg import NewtonIKJointLimitObjectiveCfg, NewtonIKPoseObjectiveCfg
 from isaaclab_newton.ik.newton_ik_solver_cfg import NewtonIKSolverCfg
 from isaaclab_newton.physics import NewtonCfg
-from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.envs.mdp as mdp
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
@@ -53,7 +52,11 @@ class FrankaArmActionCfg(PresetCfg):
         body_offset=DifferentialInverseKinematicsActionCfg.OffsetCfg(pos=[0.0, 0.0, 0.107]),
     )
     diffik_abs: DifferentialInverseKinematicsActionCfg = diffik.replace(
-        controller=diffik.controller.replace(use_relative_mode=False),
+        controller=diffik.controller.replace(
+            use_relative_mode=False,
+            ik_params={"lambda_val": 0.45},
+        ),
+        body_offset=None,
         scale=1.0,
     )
     newton_ik: NewtonInverseKinematicsActionCfg = NewtonInverseKinematicsActionCfg(
@@ -66,7 +69,7 @@ class FrankaArmActionCfg(PresetCfg):
                 body_offset_pos=(0.0, 0.0, 0.107),
                 command_type="pose",
                 use_relative_mode=True,
-                scale=(0.05, 0.05, 0.05, 0.5, 0.5, 0.5),
+                scale=(0.05, 0.05, 0.05, 0.25, 0.25, 0.25),
                 rotation_weight=2.0,
             ),
             NewtonIKJointLimitObjectiveCfg(weight=0.1),
@@ -86,12 +89,6 @@ class FrankaReachEnvCfg(ReachEnvCfg):
             self.sim.physics, NewtonCfg
         ):
             raise ValueError("The 'newton_ik' action preset requires a Newton physics preset.")
-        if (
-            isinstance(self.actions.arm_action, DifferentialInverseKinematicsActionCfg)
-            and not self.actions.arm_action.controller.use_relative_mode
-            and not isinstance(self.sim.physics, PhysxCfg)
-        ):
-            raise ValueError("The 'diffik_abs' action preset requires the 'isaacsim_physx' physics preset.")
 
     def __post_init__(self) -> None:
         # post init of parent
@@ -104,6 +101,10 @@ class FrankaReachEnvCfg(ReachEnvCfg):
         self.rewards.end_effector_position_tracking.params["asset_cfg"].body_names = ["panda_hand"]
         self.rewards.end_effector_orientation_tracking.params["asset_cfg"].body_names = ["panda_hand"]
         self.rewards.joint_vel.params["asset_cfg"].joint_names = ["panda_joint.*"]
+        self.rewards.action_magnitude.weight = preset(
+            default=self.rewards.action_magnitude.weight,
+            diffik_abs=0.0,
+        )
 
         # override actions
         self.actions.arm_action = FrankaArmActionCfg()

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -182,16 +182,8 @@ def test_reach_uses_menagerie_franka():
         "panda_joint[1-4]": 20.0,
         "panda_joint[5-7]": 25.0,
     }
-    assert robot.actuators["panda_arm"].stiffness == {
-        "panda_joint[1-2]": 1000.0,
-        "panda_joint[3-4]": 750.0,
-        "panda_joint[5-7]": 300.0,
-    }
-    assert robot.actuators["panda_arm"].damping == {
-        "panda_joint[1-2]": 20.0,
-        "panda_joint[3-4]": 4.0,
-        "panda_joint[5-7]": 2.0,
-    }
+    assert robot.actuators["panda_arm"].stiffness is None
+    assert robot.actuators["panda_arm"].damping is None
     assert robot.actuators["panda_arm"].armature is None
     assert robot.actuators["panda_hand"].stiffness is None
     assert robot.actuators["panda_hand"].damping is None

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -67,6 +67,8 @@ def test_reach_diffik_abs_legacy_task_is_a_deprecated_alias():
         (("diffik", "isaacsim_physx"), "DifferentialInverseKinematicsActionCfg", "PhysxCfg"),
         (("diffik", "newton_mjwarp"), "DifferentialInverseKinematicsActionCfg", "NewtonCfg"),
         (("diffik_abs", "isaacsim_physx"), "DifferentialInverseKinematicsActionCfg", "PhysxCfg"),
+        (("diffik_abs", "newton_mjwarp"), "DifferentialInverseKinematicsActionCfg", "NewtonCfg"),
+        (("diffik_abs", "ovphysx"), "DifferentialInverseKinematicsActionCfg", "OvPhysxCfg"),
         (("newton_ik", "newton_mjwarp"), "NewtonInverseKinematicsActionCfg", "NewtonCfg"),
     ],
 )
@@ -121,6 +123,15 @@ def test_reach_penalizes_action_magnitude_rate_and_physical_joint_motion():
     assert "end_effector_position_tracking_fine_grained" not in rewards.to_dict()
 
 
+def test_reach_diffik_abs_does_not_penalize_absolute_pose_magnitude():
+    absolute_rewards = _load_env_cfg("diffik_abs", "newton_mjwarp").rewards
+    relative_rewards = _load_env_cfg("diffik", "newton_mjwarp").rewards
+
+    assert absolute_rewards.action_magnitude.weight == 0.0
+    assert relative_rewards.action_magnitude.weight == pytest.approx(-0.005)
+    assert absolute_rewards.action_rate.weight == relative_rewards.action_rate.weight == pytest.approx(-0.0001)
+
+
 def test_reach_success_requires_position_and_orientation():
     cfg = _load_env_cfg()
     success = cfg.terminations.success
@@ -171,22 +182,6 @@ def test_reach_success_requires_position_and_orientation():
     position_only_succeeded = mdp.pose_command_success(env, **success.params)
 
     assert torch.equal(position_only_succeeded, torch.tensor([True, False, True]))
-
-
-def test_reach_uses_menagerie_franka():
-    robot = _load_env_cfg().scene.robot
-
-    assert robot.spawn.usd_path.endswith("/Robots/FrankaEmika/franka_panda.usda")
-    assert list(robot.actuators) == ["panda_arm", "panda_hand"]
-    assert robot.actuators["panda_arm"].velocity_limit_sim == {
-        "panda_joint[1-4]": 20.0,
-        "panda_joint[5-7]": 25.0,
-    }
-    assert robot.actuators["panda_arm"].stiffness is None
-    assert robot.actuators["panda_arm"].damping is None
-    assert robot.actuators["panda_arm"].armature is None
-    assert robot.actuators["panda_hand"].stiffness is None
-    assert robot.actuators["panda_hand"].damping is None
 
 
 def test_reach_osc_uses_menagerie_franka_effort_actuator():
@@ -248,18 +243,12 @@ def test_reach_diffik_abs_action_configuration():
     controller = DifferentialIKController(action.controller, num_envs=1, device="cpu")
 
     assert action.controller.use_relative_mode is False
+    assert action.controller.ik_params == {"lambda_val": 0.45}
     assert controller.action_dim == 7
+    assert action.body_offset is None
     assert action.scale == 1.0
     assert _load_env_cfg("joint_pos", "isaacsim_physx").scene.robot.spawn.rigid_props.disable_gravity is False
     assert cfg.scene.robot.spawn.rigid_props.disable_gravity is True
-
-
-@pytest.mark.parametrize("physics", ["newton_mjwarp", "ovphysx"])
-def test_reach_diffik_abs_rejects_unsupported_physics(physics):
-    cfg = _load_env_cfg("diffik_abs", physics)
-
-    with pytest.raises(ValueError, match="requires the 'isaacsim_physx' physics preset"):
-        cfg.validate()
 
 
 def test_reach_newton_ik_action_configuration():
@@ -277,7 +266,8 @@ def test_reach_newton_ik_action_configuration():
     assert action.objectives[0].body_offset_pos == (0.0, 0.0, 0.107)
     assert action.objectives[0].command_type == "pose"
     assert action.objectives[0].use_relative_mode is True
-    assert action.objectives[0].scale == diffik_action.scale == (0.05, 0.05, 0.05, 0.5, 0.5, 0.5)
+    assert action.objectives[0].scale == (0.05, 0.05, 0.05, 0.25, 0.25, 0.25)
+    assert diffik_action.scale == (0.05, 0.05, 0.05, 0.5, 0.5, 0.5)
     assert action.objectives[0].rotation_weight == 2.0
     assert action.objectives[1].weight == 0.1
     assert action.clip is None


### PR DESCRIPTION
## Summary

- Use corrected USD-authored Franka drive gains while retaining solver velocity limits.
- Enable absolute DiffIK on Isaac Sim PhysX, Newton MJWarp, and OVPhysX.
- Reduce the NewtonIK rotational action scale for more reliable MJWarp training.

The corrected `franka_panda.usda` and `payloads/Physics/physics.usda` must be promoted to production before merge.

## Validation

- Franka preset tests: 25 passed
- Absolute DiffIK: train/play on PhysX, Newton MJWarp, and OVPhysX
- OVPhysX: stable 1,000-iteration training and exact play
- Targeted pre-commit checks passed

## Type of change

- Bug fix (non-breaking change)