### PR TITLE
Add OSMO workflow for multi-GPU cluster training

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: check-yaml
         # OSMO workflow specs are Jinja templates, so they only become valid
         # YAML once the submission-time parameters have been substituted.
-        exclude: '^docker/cluster/multi_gpu\.yaml$'
+        exclude: '^docker/cluster/osmo_multi_gpu_workflow\.yaml$'
       - id: check-merge-conflict
         # These verbatim license headings contain a literal "=======" separator.
         exclude: '^docs/licenses/dependencies/(mujoco|llvmlite|numba)-license\.txt$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,9 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=2000"]  # restrict files more than 2 MB. Should use git-lfs instead.
       - id: check-yaml
+        # OSMO workflow specs are Jinja templates, so they only become valid
+        # YAML once the submission-time parameters have been substituted.
+        exclude: '^docker/cluster/multi_gpu\.yaml$'
       - id: check-merge-conflict
         # These verbatim license headings contain a literal "=======" separator.
         exclude: '^docs/licenses/dependencies/(mujoco|llvmlite|numba)-license\.txt$'

--- a/docker/cluster/multi_gpu.yaml
+++ b/docker/cluster/multi_gpu.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# NVIDIA OSMO workflow for single-node, multi-GPU Isaac Lab training.
+#
+# Submit with:
+#   osmo workflow submit docker/cluster/multi_gpu.yaml \
+#     --set num_gpu=4 \
+#     --set args="--task Isaac-Reorient-KukaAllegro --num_envs 4096"
+#
+# When ``num_gpu`` is 1 the workflow falls back to the single-process ``train``
+# entry point, so the same file covers both cases. No visualizer is requested,
+# so training runs headless.
+
+workflow:
+  name: isaac-lab
+  resources:
+    default:
+      gpu: {{ num_gpu }}
+      cpu: {{ num_cpu }}
+      memory: {{ memory }}Gi
+      storage: {{ storage }}Gi
+      platform: {{ platform }}
+
+  groups:
+  - name: training
+    tasks:
+    - name: trainer
+      lead: true
+      image: {{ image }}
+      command: ["bash"]
+      args: ["/tmp/run.sh"]
+      environment:
+        ACCEPT_EULA: Y
+        NCCL_DEBUG: WARN
+        NCCL_ASYNC_ERROR_HANDLING: "1"
+        TORCH_NCCL_ASYNC_ERROR_HANDLING: "1"
+      files:
+      - path: /tmp/run.sh
+        contents: |
+          set -euo pipefail
+
+          # Isaac Sim images ship their own Vulkan ICDs. Hide the system ones so the
+          # loader does not pick up a conflicting driver on the compute node.
+          if [ -e "/usr/share/vulkan" ] && [ -e "/etc/vulkan" ]; then
+            mv /usr/share/vulkan /usr/share/vulkan_hidden
+          fi
+
+          # Split the allocated CPUs across the per-GPU worker processes, otherwise
+          # every worker spawns a thread pool sized for the whole node.
+          export OMP_NUM_THREADS=$(( {{ num_cpu }} / {{ num_gpu }} ))
+          if [ "${OMP_NUM_THREADS}" -lt 1 ]; then
+            export OMP_NUM_THREADS=1
+          fi
+          export MKL_NUM_THREADS="${OMP_NUM_THREADS}"
+          export OPENBLAS_NUM_THREADS="${OMP_NUM_THREADS}"
+
+          {% if num_gpu > 1 %}
+          /workspace/isaaclab/isaaclab.sh train_multigpu \
+            --rl_library {{ rl_library }} \
+            --nproc_per_node {{ num_gpu }} \
+            --master_port {{ master_port }} \
+            {{ args }}
+          {% else %}
+          /workspace/isaaclab/isaaclab.sh train \
+            --rl_library {{ rl_library }} \
+            {{ args }}
+          {% endif %}
+
+default-values:
+  image: nvcr.io/nvidia/isaac-lab:latest
+  rl_library: rsl_rl
+  num_gpu: 1
+  num_cpu: 16
+  memory: 64
+  storage: 256
+  platform: dgx-h100
+  master_port: 29400
+  args:

--- a/docker/cluster/osmo_multi_gpu_workflow.yaml
+++ b/docker/cluster/osmo_multi_gpu_workflow.yaml
@@ -43,8 +43,10 @@ workflow:
           set -euo pipefail
 
           # Isaac Sim images ship their own Vulkan ICDs. Hide the system ones so the
-          # loader does not pick up a conflicting driver on the compute node.
-          if [ -e "/usr/share/vulkan" ] && [ -e "/etc/vulkan" ]; then
+          # loader does not pick up a conflicting driver on the compute node. The
+          # published images run as an unprivileged user and cannot write to
+          # /usr/share, so skip the rename there instead of failing the job.
+          if [ -e "/usr/share/vulkan" ] && [ -e "/etc/vulkan" ] && [ -w "/usr/share" ]; then
             mv /usr/share/vulkan /usr/share/vulkan_hidden
           fi
 
@@ -78,4 +80,5 @@ default-values:
   storage: 256
   platform: dgx-h100
   master_port: 29400
-  args:
+  # Empty rather than null: a null default renders as the literal string "None".
+  args: ""

--- a/docker/cluster/osmo_multi_gpu_workflow.yaml
+++ b/docker/cluster/osmo_multi_gpu_workflow.yaml
@@ -6,7 +6,7 @@
 # NVIDIA OSMO workflow for single-node, multi-GPU Isaac Lab training.
 #
 # Submit with:
-#   osmo workflow submit docker/cluster/multi_gpu.yaml \
+#   osmo workflow submit docker/cluster/osmo_multi_gpu_workflow.yaml \
 #     --set num_gpu=4 \
 #     --set args="--task Isaac-Reorient-KukaAllegro --num_envs 4096"
 #
@@ -70,7 +70,7 @@ workflow:
           {% endif %}
 
 default-values:
-  image: nvcr.io/nvidia/isaac-lab:latest
+  image: nvcr.io/nvidia/isaac-lab:3.0.0-beta2
   rl_library: rsl_rl
   num_gpu: 1
   num_cpu: 16

--- a/docs/source/features/include/cluster_details.inc
+++ b/docs/source/features/include/cluster_details.inc
@@ -195,9 +195,58 @@ ANYmal rough terrain locomotion training can be executed with the following comm
 
 The above will, in addition, also render videos of the training progress and store them under ``isaaclab/logs`` directory.
 
+
+.. rubric:: For OSMO
+
+`NVIDIA OSMO`_ is a cloud-native orchestration platform for scheduling robotics workloads. Unlike the
+SLURM and PBS workflows above, it runs the Isaac Lab Docker image directly, so no singularity
+conversion is needed and there is no code copy step -- the image is the unit of deployment.
+
+The workflow definition lives in ``docker/cluster/multi_gpu.yaml``. It requests a single node and
+scales training across the GPUs on that node through the
+:ref:`train_multigpu <train-multigpu-command>` command. The following parameters can be overridden
+at submission time:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Parameter
+     - Description
+   * - image
+     - The Isaac Lab container image to run. Defaults to ``nvcr.io/nvidia/isaac-lab:latest``.
+   * - rl_library
+     - The RL library used for training. Defaults to ``rsl_rl``.
+   * - num_gpu
+     - The number of GPUs to train on. When set to ``1``, the single-process ``train`` entry point
+       is used instead of ``train_multigpu``.
+   * - num_cpu
+     - The number of CPUs requested for the node. These are split evenly across the per-GPU worker
+       processes via ``OMP_NUM_THREADS``.
+   * - memory
+     - The amount of memory requested for the node, in GiB.
+   * - storage
+     - The amount of scratch storage requested for the node, in GiB.
+   * - platform
+     - The OSMO platform (node type) to schedule on, e.g. ``dgx-h100``.
+   * - master_port
+     - The port used by the torchrun rendezvous. Only relevant when ``num_gpu`` is greater than 1.
+   * - args
+     - The arguments forwarded to the training script, e.g. ``--task <task-name> --num_envs 4096``.
+       No visualizer is requested by the workflow, so training runs headless.
+
+To submit a job, use the ``osmo`` CLI:
+
+.. code:: bash
+
+    osmo workflow submit docker/cluster/multi_gpu.yaml \
+      --set num_gpu=4 \
+      --set args="--task Isaac-Reorient-KukaAllegro --num_envs 4096"
+
 .. _Singularity: https://docs.sylabs.io/guides/2.6/user-guide/index.html
 .. _ETH Zurich Euler: https://www.gdc-docs.ethz.ch/EulerManual/site/overview/
 .. _PBS Official Site: https://openpbs.org/
 .. _apptainer: https://apptainer.org/
 .. _documentation: https://www.apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages
 .. _SLURM documentation: https://www.slurm.schedmd.com/sbatch.html
+.. _NVIDIA OSMO: https://developer.nvidia.com/osmo

--- a/docs/source/features/include/cluster_details.inc
+++ b/docs/source/features/include/cluster_details.inc
@@ -202,8 +202,8 @@ The above will, in addition, also render videos of the training progress and sto
 SLURM and PBS workflows above, it runs the Isaac Lab Docker image directly, so no singularity
 conversion is needed and there is no code copy step -- the image is the unit of deployment.
 
-The workflow definition lives in ``docker/cluster/multi_gpu.yaml``. It requests a single node and
-scales training across the GPUs on that node through the
+The workflow definition lives in ``docker/cluster/osmo_multi_gpu_workflow.yaml``. It requests a
+single node and scales training across the GPUs on that node through the
 :ref:`train_multigpu <train-multigpu-command>` command. The following parameters can be overridden
 at submission time:
 
@@ -214,7 +214,9 @@ at submission time:
    * - Parameter
      - Description
    * - image
-     - The Isaac Lab container image to run. Defaults to ``nvcr.io/nvidia/isaac-lab:latest``.
+     - The Isaac Lab container image to run. Defaults to the released
+       ``nvcr.io/nvidia/isaac-lab:3.0.0-beta2`` image. Note that the repository does not publish a
+       ``latest`` tag, so this must name an explicit version.
    * - rl_library
      - The RL library used for training. Defaults to ``rsl_rl``.
    * - num_gpu
@@ -239,7 +241,7 @@ To submit a job, use the ``osmo`` CLI:
 
 .. code:: bash
 
-    osmo workflow submit docker/cluster/multi_gpu.yaml \
+    osmo workflow submit docker/cluster/osmo_multi_gpu_workflow.yaml \
       --set num_gpu=4 \
       --set args="--task Isaac-Reorient-KukaAllegro --num_envs 4096"
 


### PR DESCRIPTION
# Description

Isaac Lab's cluster tooling currently only covers SLURM and PBS via singularity. Both paths require converting the Docker image to a `.sif` and copying the source tree to the cluster on every submission.

This PR adds an [NVIDIA OSMO](https://developer.nvidia.com/osmo) workflow spec at `docker/cluster/multi_gpu.yaml`. OSMO runs the published Isaac Lab container image directly, so there is no singularity conversion and no code copy step — the image is the unit of deployment.

The workflow requests a single node and scales training across that node's GPUs through the existing `train_multigpu` command. Everything site-specific is a submission-time parameter (`image`, `rl_library`, `num_gpu`, `num_cpu`, `memory`, `storage`, `platform`, `master_port`, `args`), so the file carries no cluster- or user-specific defaults. When `num_gpu` is `1` it falls back to the single-process `train` entry point, so one file covers both cases.

Submitting a 4-GPU run:

```bash
osmo workflow submit docker/cluster/multi_gpu.yaml \
  --set num_gpu=4 \
  --set args="--task Isaac-Reorient-KukaAllegro --num_envs 4096"
```

The container startup script does two things beyond launching training:

- Hides the system Vulkan ICDs when the image ships its own, which otherwise makes the loader pick up a conflicting driver on the compute node.
- Splits the allocated CPUs across the per-GPU workers via `OMP_NUM_THREADS`, so each worker does not size its thread pool for the whole node.

The spec is a Jinja template and only becomes valid YAML after parameter substitution, so it is excluded from the `check-yaml` pre-commit hook. Rendering was verified for both the `num_gpu=1` and `num_gpu>1` branches.

Fixes # (issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<sub>No changelog fragment is included because this PR does not touch any package under `source/`; `tools/changelog/cli.py check` passes as-is. No tests are included because the change is a cluster job spec plus documentation.</sub>