### PR TITLE
Configure RSL-RL episode initialization

### DIFF
--- a/source/isaaclab/changelog.d/maximiliank-rsl-episode-initialization.rst
+++ b/source/isaaclab/changelog.d/maximiliank-rsl-episode-initialization.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the RSL-RL benchmark runner to honor the configured
+  ``init_at_random_ep_len`` value.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
@@ -247,7 +247,10 @@ def run(argv: list[str]) -> BenchmarkResult:
                 warmup_steps=args_cli.warmup_steps,
             )
             with early, environment_step_timer, BenchmarkMonitor(benchmark, interval=1.0):
-                runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
+                runner.learn(
+                    num_learning_iterations=agent_cfg.max_iterations,
+                    init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
+                )
 
             benchmark.update_manual_recorders()
 

--- a/source/isaaclab_rl/changelog.d/maximiliank-rsl-episode-initialization.minor.rst
+++ b/source/isaaclab_rl/changelog.d/maximiliank-rsl-episode-initialization.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_rl.rsl_rl.RslRlBaseRunnerCfg.init_at_random_ep_len`
+  for configuring initial episode-length randomization.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -206,7 +206,10 @@ def _run(args_cli: argparse.Namespace) -> None:
         dump_train_configs(log_dir, env_cfg, agent_cfg)
 
         try:
-            runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
+            runner.learn(
+                num_learning_iterations=agent_cfg.max_iterations,
+                init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
+            )
             print(f"Training time: {round(time.time() - start_time, 2)} seconds")
             env.close()
         except KeyboardInterrupt:

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -239,6 +239,13 @@ class RslRlBaseRunnerCfg:
     num_steps_per_env: int = MISSING
     """The number of steps per environment per update."""
 
+    init_at_random_ep_len: bool = True
+    """Whether to randomize each environment's episode length before learning.
+
+    Defaults to True. Disable this for curricula whose first recorded outcomes must come from
+    complete episodes.
+    """
+
     max_iterations: int = MISSING
     """The maximum number of iterations."""
 


### PR DESCRIPTION
## Summary

- add `init_at_random_ep_len` to the RSL-RL runner configuration
- preserve randomized initial episode progress as the default
- honor the same setting in normal and benchmark training

## Motivation

Reset-dataset curricula need the first sampled states to complete a real episode before they contribute outcomes. Tasks can now opt out of randomized initial episode progress without an environment wrapper or rollout-boundary synchronization hook.

The MPM Pour and Push tasks in #6875 are the initial consumers.

## Scope and compatibility

This PR contains one commit and only changes RSL-RL configuration and its two Isaac Lab entrypoints. It adds no distributed collective, training-state synchronization, environment wrapper, or MPM-specific behavior. Existing tasks remain unchanged unless they explicitly set `init_at_random_ep_len = False`.

## Validation

- focused RSL-RL configuration and entrypoint tests passed
- benchmark configuration coverage passed
- full pre-commit passed on head `0bb84af6d571d61491f898c3a5b08384f3262088`
