### PR TITLE
Add scoped Newton world builder hooks

### DIFF
--- a/docs/source/api/lab_newton/isaaclab_newton.cloner.rst
+++ b/docs/source/api/lab_newton/isaaclab_newton.cloner.rst
@@ -2,3 +2,16 @@
 =======================
 
 .. automodule:: isaaclab_newton.cloner
+
+  .. rubric:: Functions
+
+  .. autosummary::
+
+    newton_builder_world_hook
+
+.. currentmodule:: isaaclab_newton.cloner
+
+Builder Utilities
+-----------------
+
+.. autofunction:: newton_builder_world_hook

--- a/source/isaaclab_newton/changelog.d/maximiliank-newton-cloner-hooks.minor.rst
+++ b/source/isaaclab_newton/changelog.d/maximiliank-newton-cloner-hooks.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab_newton.cloner.newton_builder_world_hook` for scoped
+  extensions to replicated Newton worlds.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/__init__.pyi
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/__init__.pyi
@@ -6,11 +6,13 @@
 __all__ = [
     "NewtonReplicateContext",
     "PHYSICS_CONTEXT",
+    "newton_builder_world_hook",
     "newton_physics_replicate",
 ]
 
 from .replicate import (
     NewtonReplicateContext,
     PHYSICS_CONTEXT,
+    newton_builder_world_hook,
     newton_physics_replicate,
 )

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, TypeAlias
 
 import torch
@@ -32,6 +33,36 @@ if TYPE_CHECKING:
     ]
 else:
     _MappingBatch = tuple
+
+
+@contextlib.contextmanager
+def newton_builder_world_hook(
+    hook: Callable[[ModelBuilder, int, list[float], list[float]], None],
+) -> Iterator[None]:
+    """Temporarily extend every world built by Newton replication.
+
+    The callback must not already be registered. On exit, the context removes
+    only its callback and preserves hooks owned by other callers.
+
+    Args:
+        hook: Callback receiving the builder, world index, world position [m],
+            and world orientation quaternion in xyzw order during replication.
+
+    Yields:
+        Control while the callback is registered.
+
+    Raises:
+        RuntimeError: If the callback is already registered.
+    """
+    hooks = NewtonManager._per_world_builder_hooks
+    if hook in hooks:
+        raise RuntimeError("Newton world-builder hook is already registered.")
+    hooks.append(hook)
+    try:
+        yield
+    finally:
+        if hook in hooks:
+            hooks.remove(hook)
 
 
 def _build_newton_builder_from_mapping(

--- a/source/isaaclab_newton/test/cloner/test_newton_builder_world_hook.py
+++ b/source/isaaclab_newton/test/cloner/test_newton_builder_world_hook.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for scoped Newton per-world builder hooks."""
+
+import pytest
+from isaaclab_newton.cloner import newton_builder_world_hook
+from isaaclab_newton.physics import NewtonManager
+
+
+def test_newton_builder_world_hook_owns_one_registration(monkeypatch):
+    """The scope rejects duplicates and preserves unrelated hooks during cleanup."""
+
+    def existing(*_args):
+        pass
+
+    def temporary(*_args):
+        pass
+
+    def added_later(*_args):
+        pass
+
+    hooks = [existing]
+    monkeypatch.setattr(NewtonManager, "_per_world_builder_hooks", hooks)
+
+    with pytest.raises(ValueError, match="stop"):
+        with newton_builder_world_hook(temporary):
+            assert hooks == [existing, temporary]
+            with pytest.raises(RuntimeError, match="already registered"):
+                with newton_builder_world_hook(temporary):
+                    pass
+            assert hooks == [existing, temporary]
+            hooks.append(added_later)
+            raise ValueError("stop")
+
+    assert hooks == [existing, added_later]
+
+    with pytest.raises(RuntimeError, match="already registered"):
+        with newton_builder_world_hook(existing):
+            pass
+    assert hooks == [existing, added_later]


### PR DESCRIPTION
## Summary

- add a context-managed `newton_builder_world_hook` for temporary per-world Newton builder authoring
- restore the previous hook safely for nested contexts and exceptions
- expose and document the single scoped API

## Motivation

Solver-specific scenes such as coupled MPM tasks need to augment each replicated Newton world during construction. A scoped hook provides that extension point without task-local mutation of retained clone sources or permanent global hook state.

## Scope and compatibility

This PR contains one commit and is limited to the Newton cloner API, its documentation, one focused lifecycle test, and a changelog fragment. It does not add a clone-source helper and does not change existing replication unless a caller explicitly enters the context.

## Validation

- focused nested-context, exception-cleanup, and lifecycle coverage passed
- documentation built without warnings
- full pre-commit passed on head `3550028fd1439779876c46c3ac762f885d385b96`
