### PR TITLE
pref: FabricFrameView selection cache

### DIFF
--- a/scripts/benchmarks/benchmark_view_comparison.py
+++ b/scripts/benchmarks/benchmark_view_comparison.py
@@ -70,6 +70,7 @@ from pxr import Gf
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim.views import FrameView
+from isaaclab.utils.warp import ProxyArray
 
 try:
     from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
@@ -78,6 +79,25 @@ try:
     HAS_NEWTON = True
 except ImportError:
     HAS_NEWTON = False
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _warp(array: ProxyArray | wp.array) -> wp.array:
+    """Return the underlying ``wp.array``; ``FrameView`` getters return :class:`ProxyArray`."""
+    return array.warp if isinstance(array, ProxyArray) else array
+
+
+def _torch(array: ProxyArray | wp.array | torch.Tensor) -> torch.Tensor:
+    """Return a zero-copy torch view of a ``ProxyArray``, ``wp.array`` or tensor."""
+    if isinstance(array, ProxyArray):
+        return array.torch
+    if isinstance(array, wp.array):
+        return wp.to_torch(array)
+    return array
 
 
 # ------------------------------------------------------------------
@@ -268,8 +288,8 @@ def _run_pose_benchmarks(
     num_prims: int,
     num_iterations: int,
     timing_results: dict,
-    positions: wp.array,
-    orientations: wp.array,
+    positions: ProxyArray | wp.array,
+    orientations: ProxyArray | wp.array,
 ):
     """Shared benchmark loop for get/set world poses on any FrameView."""
     start_time = time.perf_counter()
@@ -277,7 +297,8 @@ def _run_pose_benchmarks(
         view.get_world_poses()
     timing_results["get_world_poses"] = (time.perf_counter() - start_time) / num_iterations
 
-    new_positions = wp.clone(positions)
+    orientations = _warp(orientations)
+    new_positions = wp.clone(_warp(positions))
     new_positions_t = wp.to_torch(new_positions)
     new_positions_t[:, 2] += 0.5
     expected_positions = new_positions_t.clone()
@@ -289,8 +310,8 @@ def _run_pose_benchmarks(
     timing_results["set_world_poses"] = (time.perf_counter() - start_time) / num_iterations
 
     ret_pos, ret_quat = view.get_world_poses()
-    ret_pos_t = wp.to_torch(ret_pos)
-    ret_quat_t = wp.to_torch(ret_quat)
+    ret_pos_t = _torch(ret_pos)
+    ret_quat_t = _torch(ret_quat)
     ori_t = wp.to_torch(orientations)
 
     pos_ok = torch.allclose(ret_pos_t, expected_positions, atol=1e-4, rtol=0)

--- a/source/isaaclab_physx/changelog.d/pv-fabric-frameview-selection-cache.rst
+++ b/source/isaaclab_physx/changelog.d/pv-fabric-frameview-selection-cache.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Changed the PhysX Fabric frame view to reuse its view-to-Fabric slot mapping
+  across accesses while Fabric reports no topology change, instead of rebuilding
+  it on every access. Set the ``ISAACLAB_DISABLE_FABRIC_VIEW_CACHE=1`` environment
+  variable to restore the previous rebuild-on-every-access behavior when
+  diagnosing suspected stale-mapping issues.

--- a/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/views/fabric_frame_view.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import itertools
 import logging
+import os
 import sys
 
 import torch
@@ -166,12 +167,17 @@ class FabricFrameView(BaseFrameView):
       collection timing is up to the interpreter, so relying on it can remove
       the tags at an arbitrary point in the frame (or, on a leaked reference,
       not at all).
-    * **Topology changes are absorbed, with no cache to invalidate.**  The
-      view-to-Fabric mapping is re-derived from live Fabric data on every
-      access, so prims moving between Fabric buckets can never leave a stale
-      mapping behind.  If a managed prim disappears (prim or attribute removed)
-      the next access raises :class:`RuntimeError` and the view must be
-      recreated.  See ``_refresh_child_selection`` for how this is done.
+    * **Topology changes are absorbed, keyed on Fabric's own change tracking.**
+      The view-to-Fabric mapping is cached and reused while
+      ``PrepareForReuse()`` reports the selection's batch view unchanged; any
+      Fabric topology change (which is what can move prims between buckets)
+      makes it return ``True`` and the mapping is re-derived from live Fabric
+      data, so bucket reorders can never leave a stale mapping behind.  Set
+      the ``ISAACLAB_DISABLE_FABRIC_VIEW_CACHE=1`` environment variable to
+      rebuild on every access instead when diagnosing suspected stale-mapping
+      issues.  If a managed prim disappears (prim or attribute removed) the
+      next access raises :class:`RuntimeError` and the view must be
+      recreated.  See ``_get_child_ifas`` for how this is done.
 
     Pose getters return :class:`~isaaclab.utils.warp.ProxyArray`; the
     convenience :meth:`set_world_poses` / :meth:`set_local_poses` helpers accept
@@ -240,15 +246,26 @@ class FabricFrameView(BaseFrameView):
         # View-side indices array.
         self._view_indices: wp.array | None = None
 
-        # Kernel-built view->fabric slot mappings, refreshed on every selection
-        # access (see ``_refresh_child_selection``).  ``_child_parent_map`` holds
-        # view-side indices (uint32, like the Fabric ``UInt`` index attributes);
-        # the ``*_slots_buf`` buffers hold Fabric slots and must be int32, the
-        # only dtype ``wp.indexedfabricarray`` accepts for indices.
+        # Kernel-built view->fabric slot mappings, rebuilt whenever a selection
+        # access finds the Fabric topology changed (see ``_get_child_ifas``).
+        # ``_child_parent_map`` holds view-side indices (uint32, like the
+        # Fabric ``UInt`` index attributes); the ``*_slots_buf`` buffers hold
+        # Fabric slots and must be int32, the only dtype
+        # ``wp.indexedfabricarray`` accepts for indices.
         self._child_parent_map: wp.array | None = None
         self._child_slots_buf: wp.array | None = None
         self._parent_slots_buf: wp.array | None = None
         self._parent_slot_of_child_buf: wp.array | None = None
+
+        # Cached indexed fabric arrays, valid while ``PrepareForReuse`` keeps
+        # returning ``False`` (no Fabric topology change, so the selection's
+        # batch view -- and with it the slot mapping -- is unchanged).
+        # ``_cached_child_sel`` records which selection (RO or RW) the child
+        # arrays were built for, so an RO<->RW flip forces a rebuild.
+        self._cache_enabled = os.environ.get("ISAACLAB_DISABLE_FABRIC_VIEW_CACHE", "0") != "1"
+        self._cached_child_sel = None
+        self._cached_child_ifas: tuple[wp.indexedfabricarray, wp.indexedfabricarray] | None = None
+        self._cached_parent_ifa: wp.indexedfabricarray | None = None
 
         # Sentinel passed to compose/decompose kernels for unused slots.
         self._fabric_empty_2d_array_sentinel: wp.array | None = None
@@ -547,50 +564,32 @@ class FabricFrameView(BaseFrameView):
     # ------------------------------------------------------------------
 
     def _get_world_ifa(self) -> wp.indexedfabricarray:
-        sel = self._refresh_child_selection()
-        return wp.indexedfabricarray(fa=wp.fabricarray(sel, self._WORLD_MATRIX_NAME), indices=self._child_slots_buf)
+        return self._get_child_ifas()[0]
 
     def _get_local_ifa(self) -> wp.indexedfabricarray:
-        sel = self._refresh_child_selection()
-        return wp.indexedfabricarray(fa=wp.fabricarray(sel, self._LOCAL_MATRIX_NAME), indices=self._child_slots_buf)
+        return self._get_child_ifas()[1]
 
     def _get_child_ifas(self) -> tuple[wp.indexedfabricarray, wp.indexedfabricarray]:
-        """Return ``(world, local)`` child arrays from a single selection refresh.
+        """Return ``(world, local)`` child arrays for the active selection.
 
-        Callers that need both spaces must use this instead of calling
-        :meth:`_get_world_ifa` and :meth:`_get_local_ifa`, which would refresh
-        the same selection -- and re-run its mapping kernel -- twice.
-        """
-        sel = self._refresh_child_selection()
-        return (
-            wp.indexedfabricarray(fa=wp.fabricarray(sel, self._WORLD_MATRIX_NAME), indices=self._child_slots_buf),
-            wp.indexedfabricarray(fa=wp.fabricarray(sel, self._LOCAL_MATRIX_NAME), indices=self._child_slots_buf),
-        )
-
-    def _get_parent_world_ifa(self) -> wp.indexedfabricarray:
-        self._refresh_parent_selection()
-        return wp.indexedfabricarray(
-            fa=wp.fabricarray(self._sel_parent, self._WORLD_MATRIX_NAME),
-            indices=self._parent_slot_of_child_buf,
-        )
-
-    def _refresh_child_selection(self):
-        """Refresh the active child selection and rebuild its slot mapping on device.
-
-        Runs on every accessor call.  ``PrepareForReuse`` lets the persistent
-        selection absorb Fabric bucket changes (and notifies the renderer for
-        the RW selection); a single Warp kernel launch over the selection's
-        index attribute then rebuilds ``_child_slots_buf`` so that entry ``i``
-        is the fabric-side slot of view prim ``i``.  Re-deriving the mapping
-        from live Fabric data on each access means bucket reorders can never
-        leave a stale mapping behind, with no host-side path resolution and no
-        cache to invalidate.
-
-        Returns:
-            The active (RO or RW) child prim selection.
+        Runs on every accessor call.  ``PrepareForReuse`` must be called even
+        when the cache hits: it lets the persistent selection absorb Fabric
+        bucket changes and marks the RW selection's attributes dirty for
+        downstream change tracking (the renderer).  Its return value is the
+        cache key: ``False`` guarantees the selection's batch view -- and with
+        it the slot layout -- is unchanged since the previous call, so the
+        cached arrays are returned as-is.  On a topology change (or an RO<->RW
+        flip, tracked via ``_cached_child_sel``) a single Warp kernel launch
+        over the selection's index attribute rebuilds ``_child_slots_buf`` so
+        that entry ``i`` is the fabric-side slot of view prim ``i``.  The count
+        check only needs to run on rebuilds: the index tag is authored by this
+        view alone, so the selection can only change through a topology change,
+        which ``PrepareForReuse`` reports.
         """
         sel = self._sel_rw if self._is_rw else self._sel_ro
-        sel.PrepareForReuse()
+        topology_changed = sel.PrepareForReuse()
+        if self._cache_enabled and not topology_changed and sel is self._cached_child_sel:
+            return self._cached_child_ifas
         self._check_selection_count(sel.GetCount(), self.count, self._child_index_attr)
         wp.launch(
             kernel=fabric_utils.map_view_indices_to_fabric_slots,
@@ -598,18 +597,26 @@ class FabricFrameView(BaseFrameView):
             inputs=[wp.fabricarray(sel, self._child_index_attr), self._child_slots_buf],
             device=self._device,
         )
-        return sel
+        self._cached_child_ifas = (
+            wp.indexedfabricarray(fa=wp.fabricarray(sel, self._WORLD_MATRIX_NAME), indices=self._child_slots_buf),
+            wp.indexedfabricarray(fa=wp.fabricarray(sel, self._LOCAL_MATRIX_NAME), indices=self._child_slots_buf),
+        )
+        self._cached_child_sel = sel
+        return self._cached_child_ifas
 
-    def _refresh_parent_selection(self) -> None:
-        """Refresh the parent selection and rebuild the per-child parent-slot mapping.
+    def _get_parent_world_ifa(self) -> wp.indexedfabricarray:
+        """Return the per-child parent world array, rebuilt on topology changes.
 
-        Two kernel launches: the first inverts the parent index attribute into
+        Same caching contract as :meth:`_get_child_ifas`.  A rebuild is two
+        kernel launches: the first inverts the parent index attribute into
         per-ordinal fabric slots, the second gathers those slots per child
         through ``_child_parent_map`` (children sharing a parent read the same
         slot).
         """
+        topology_changed = self._sel_parent.PrepareForReuse()
+        if self._cache_enabled and not topology_changed and self._cached_parent_ifa is not None:
+            return self._cached_parent_ifa
         num_parents = self._parent_slots_buf.shape[0]
-        self._sel_parent.PrepareForReuse()
         self._check_selection_count(self._sel_parent.GetCount(), num_parents, self._parent_index_attr)
         wp.launch(
             kernel=fabric_utils.map_view_indices_to_fabric_slots,
@@ -623,6 +630,11 @@ class FabricFrameView(BaseFrameView):
             inputs=[self._parent_slots_buf, self._child_parent_map, self._parent_slot_of_child_buf],
             device=self._device,
         )
+        self._cached_parent_ifa = wp.indexedfabricarray(
+            fa=wp.fabricarray(self._sel_parent, self._WORLD_MATRIX_NAME),
+            indices=self._parent_slot_of_child_buf,
+        )
+        return self._cached_parent_ifa
 
     def _check_selection_count(self, found: int, expected: int, index_attr: str) -> None:
         """Raise if a selection stopped matching exactly the view's tagged prims."""

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -207,13 +207,13 @@ def test_fabric_rebuild_after_topology_change(device, view_factory):
 
     # Simulate topology change: refresh both child selections and the parent
     # selection, mirroring the accessor paths.
-    view._refresh_child_selection()  # RO (steady state)
+    view._get_child_ifas()  # RO (steady state)
     view._is_rw = True
     try:
-        view._refresh_child_selection()  # RW (writer scope)
+        view._get_child_ifas()  # RW (writer scope)
     finally:
         view._is_rw = False
-    view._refresh_parent_selection()
+    view._get_parent_world_ifa()
 
     # Trigger another write through the rebuilt arrays.
     new = wp.zeros((2, 3), dtype=wp.float32, device=device)
@@ -226,6 +226,52 @@ def test_fabric_rebuild_after_topology_change(device, view_factory):
     expected = torch.tensor([[4.0, 5.0, 6.0], [4.0, 5.0, 6.0]], device=device)
     # 1e-5 ≈ 20 ULP at magnitudes ~4-6; absorbs float32 SRT compose/decompose drift.
     assert torch.allclose(pos_torch, expected, atol=1e-5), f"Read after rebuild failed on {device}: {pos_torch}"
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_child_arrays_cached_until_selection_flips(device, view_factory):
+    """Repeated reads reuse the cached arrays; an RO<->RW flip forces a rebuild.
+
+    ``PrepareForReuse`` returns ``False`` while Fabric topology is unchanged,
+    so back-to-back accesses on the same selection must return the identical
+    cached tuple; switching to the RW selection must not.
+    """
+    bundle = view_factory(2, device)
+    view = bundle.view
+    view.get_world_poses()  # ensure Fabric is initialized
+
+    first = view._get_child_ifas()
+    assert view._get_child_ifas() is first, "steady-state access should return the cached arrays"
+    assert view._get_parent_world_ifa() is view._get_parent_world_ifa(), (
+        "steady-state access should return the cached parent array"
+    )
+
+    view._is_rw = True
+    try:
+        assert view._get_child_ifas() is not first, "RO->RW flip should rebuild the arrays"
+    finally:
+        view._is_rw = False
+    assert view._get_child_ifas() is not first, "RW->RO flip should rebuild the arrays"
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_cache_disabled_by_environment_variable(device, view_factory, monkeypatch):
+    """``ISAACLAB_DISABLE_FABRIC_VIEW_CACHE=1`` rebuilds on every access, reads stay correct."""
+    monkeypatch.setenv("ISAACLAB_DISABLE_FABRIC_VIEW_CACHE", "1")
+    bundle = view_factory(2, device)
+    view = bundle.view
+
+    positions = wp.zeros((2, 3), dtype=wp.float32, device=device)
+    wp.launch(kernel=_fill_position, dim=2, inputs=[positions, 7.0, 8.0, 9.0], device=device)
+    with view.xform_world_space_writer() as w:
+        w.set_poses(positions=positions)
+
+    assert view._get_child_ifas() is not view._get_child_ifas(), "disabled cache should rebuild on every access"
+
+    ret_pos, _ = view.get_world_poses()
+    pos_torch = torch.as_tensor(ret_pos, device=device)
+    expected = torch.tensor([[7.0, 8.0, 9.0], [7.0, 8.0, 9.0]], device=device)
+    assert torch.allclose(pos_torch, expected, atol=1e-5), f"Read with cache disabled failed on {device}: {pos_torch}"
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])


### PR DESCRIPTION
# Description

Follow-up to #6805. That PR rebuilds the view-to-Fabric slot mapping on every accessor call. That is always correct, but it does work that is usually unnecessary: in steady-state stepping nothing moves between Fabric buckets, so the mapping from the previous call is still valid.

This PR caches the indexed fabric arrays and reuses them until Fabric itself says they might be stale. The signal is the return value of `PrepareForReuse()`, which #6805 already called but ignored:

> If Fabric topology has changed since the last call to this method this will re-generate the internally-held Batch view and return true. If Fabric topology was not changed since the last call to this method, this will just mark the selected attributes as dirty in Fabric and return false.

`False` guarantees the selection's batch view — and with it the slot layout — is unchanged, so the cached arrays are returned as-is. `True` (or a flip between the read-only and read-write child selections) triggers the same rebuild as before: one Warp kernel launch over the view's index attribute.

Why this is not the cache that #6554 had to remove: that cache was keyed on the selection's prim count, and an equal count does not mean the prims or their order stayed the same — a bucket reorder preserves the count but shuffles slots, silently mapping cameras to the wrong prims. This cache is keyed on Fabric's own change tracking instead of a fingerprint we reconstruct: any event that could shuffle slots is a topology change, and every topology change makes `PrepareForReuse()` return `True`.

Two details worth noting:

- `PrepareForReuse()` is still called on every access, even on a cache hit. Its side effect (marking the RW selection's attributes dirty for downstream change tracking) is load-bearing for the renderer.
- The `GetCount()` error check (a managed prim disappeared → clear `RuntimeError`) moves to the rebuild path. This detects the same failures at the same time: the index tag is authored by this view alone, so its selection can only change through a topology change, and any topology change forces a rebuild.

## Escape hatch

Set `ISAACLAB_DISABLE_FABRIC_VIEW_CACHE=1` to rebuild on every access again (the exact #6805 behavior). If a pose ever looks stale, this gives a one-variable A/B test that separates "the cache key is wrong" from "the data is wrong": if the flag changes the result, `PrepareForReuse()` under-reported a topology change and that is a Fabric bug to escalate.

## Drive-by fix

`scripts/benchmarks/benchmark_view_comparison.py` crashed on every `FrameView` backend: its shared
`_run_pose_benchmarks` still passed the getter results straight into `wp.clone()` / `wp.to_torch()`, but
`get_world_poses()` returns `ProxyArray` since #5677. The script now unwraps to `.warp` / `.torch`.
`benchmark_xform_prim_view.py` already did this; only this script was missed.

Verified: `--num_envs 128 --num_iterations 10 --backends usd fabric` runs to completion, round-trip
verification PASS on both backends (Fabric `get_world_poses` 0.061 ms vs USD 2.131 ms).

## Type of change

- New feature (non-breaking change which adds functionality)

## Benchmark

RTX A6000, `cuda:0`, 1024-prim view, mean of 200 steady-state calls:

| accessor | rebuild every access (#6805) | cached (this PR) |
| --- | ---: | ---: |
| `get_world_poses` | 0.198 ms | 0.071 ms |
| `get_local_poses` | 0.197 ms | 0.045 ms |

This removes the one regime where #6805 was slower than the code it replaced: per-operation cost on a static stage. End-to-end at high environment counts the accessor path was already negligible (~0.01% of step time), so no change is expected there.

## Tests

`isaaclab_physx/test/sim/test_views_xform_prim_fabric.py`: 83 passed, 4 skipped (environmental: empty device parameter sets, headless Fabric hierarchy bindings).

New tests:

- `test_child_arrays_cached_until_selection_flips` — back-to-back accesses return the identical cached arrays; an RO↔RW flip forces a rebuild.
- `test_cache_disabled_by_environment_variable` — with `ISAACLAB_DISABLE_FABRIC_VIEW_CACHE=1` every access rebuilds and reads stay correct.

The existing `test_fabric_rebuild_after_topology_change` now exercises the rebuild path through the cached accessors.

## Screenshots

Not applicable — no visual change.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

