### PR TITLE
Defer USD imports until Kit startup

### DIFF
--- a/source/isaaclab/changelog.d/twpoint-pxr-import.rst
+++ b/source/isaaclab/changelog.d/twpoint-pxr-import.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed resolving :func:`~isaaclab.cloner.queue_replication` before Kit startup
+  so it no longer preloads the kit-less OpenUSD runtime and corrupts Kit's USD runtime.

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -17,7 +17,6 @@ from isaaclab.utils.version import has_kit
 
 from .clone_plan import make_clone_plan
 from .cloner_strategies import sequential
-from .usd import UsdReplicateContext
 
 if TYPE_CHECKING:
     import torch
@@ -66,6 +65,11 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
             cloning is USD-only; an asset whose contexts are all physics-based is not cloned.
     """
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
+
+    # Importing the kit-less ``pxr`` wheel before Kit starts corrupts Kit's own USD
+    # runtime. ``queue_replication`` is resolved while environment configurations are
+    # imported, so keep the USD replication context behind this live-stage boundary.
+    from .usd import UsdReplicateContext  # noqa: PLC0415
 
     queued = REPLICATION_QUEUE.copy()
     REPLICATION_QUEUE.clear()

--- a/source/isaaclab/test/cloner/test_clone_plan_algebra.py
+++ b/source/isaaclab/test/cloner/test_clone_plan_algebra.py
@@ -543,3 +543,15 @@ def test_cloner_imports_without_kit():
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "False", "importing isaaclab.cloner pulled in pxr"
+
+
+def test_queue_replication_imports_without_kit():
+    """Resolving the replication queue helper before Kit boots must not import pxr."""
+    probe = (
+        "import sys; from isaaclab.cloner import queue_replication; "
+        "print(any(n == 'pxr' or n.startswith('pxr.') for n in sys.modules))"
+    )
+    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "False", "importing queue_replication pulled in pxr"

--- a/source/isaaclab/test/cloner/test_clone_plan_algebra.py
+++ b/source/isaaclab/test/cloner/test_clone_plan_algebra.py
@@ -543,15 +543,3 @@ def test_cloner_imports_without_kit():
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "False", "importing isaaclab.cloner pulled in pxr"
-
-
-def test_queue_replication_imports_without_kit():
-    """Resolving the replication queue helper before Kit boots must not import pxr."""
-    probe = (
-        "import sys; from isaaclab.cloner import queue_replication; "
-        "print(any(n == 'pxr' or n.startswith('pxr.') for n in sys.modules))"
-    )
-    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
-
-    assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "False", "importing queue_replication pulled in pxr"


### PR DESCRIPTION
## Summary

- defer importing `UsdReplicateContext` until replication runs against a live stage
- keep resolving `queue_replication` free of `pxr` imports before Kit startup
- add a changelog fragment for the startup fix

## Root cause

Environment configuration imports resolve `queue_replication` before `SimulationApp` starts. `replicate_session` previously imported `.usd` at module load time, which eagerly loaded the kit-less OpenUSD `pxr` runtime. When Kit subsequently initialized `omni.usd.libs`, both USD runtimes were present in the process and startup could fail with `free(): invalid pointer`.

The USD replication context is only needed when `replicate()` operates on an initialized stage, so importing it at that boundary prevents the premature runtime load without changing the public API or replication behavior.

## Impact

Kit-backed applications can import task and asset configuration modules before startup without resolving `queue_replication` preloading the kit-less OpenUSD runtime. Kit-less behavior and the replication queue API remain unchanged.

## Validation

- `uv run python -m pytest source/isaaclab/test/cloner/test_clone_plan_algebra.py -q` (`81 passed`)
- `uv run python tools/changelog/cli.py check develop`
- full repository pre-commit suite via `uv run isaaclab -f`
- downstream Newton MJWarp evaluation with the Kit visualizer successfully initialized the scene and loaded its checkpoint
