### PR TITLE
Resync the vendored omni-github result schema with upstream

### DIFF
--- a/.github/actions/upload-omni-github-test-results/result-json.schema.json
+++ b/.github/actions/upload-omni-github-test-results/result-json.schema.json
@@ -221,7 +221,7 @@
       }
     },
     "customValue": {
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string",
           "maxLength": 1024
@@ -242,7 +242,7 @@
           "type": "array",
           "maxItems": 100,
           "items": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "string",
                 "maxLength": 1024

--- a/.github/actions/upload-omni-github-test-results/result-json.schema.json
+++ b/.github/actions/upload-omni-github-test-results/result-json.schema.json
@@ -47,6 +47,11 @@
       "type": ["string", "null"],
       "maxLength": 4096
     },
+    "profileDetailString": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 1024
+    },
     "artifactRelativePath": {
       "type": "string",
       "minLength": 1,
@@ -135,6 +140,10 @@
           "type": ["boolean", "null"],
           "default": false
         },
+        "error": {
+          "type": ["boolean", "null"],
+          "default": false
+        },
         "unreliable": {
           "type": ["boolean", "null"],
           "default": false
@@ -152,6 +161,47 @@
           "minimum": 0,
           "maximum": 100,
           "default": 0
+        },
+        "failure_layer": {
+          "type": ["string", "null"],
+          "enum": [
+            "code",
+            "infrastructure",
+            "environment",
+            "upstream",
+            "downstream",
+            null
+          ]
+        },
+        "failure_component": {
+          "$ref": "#/$defs/profileDetailString"
+        },
+        "test_category": {
+          "type": ["string", "null"],
+          "enum": ["unit", "integration", "e2e", "smoke", null]
+        },
+        "reliability_class": {
+          "type": ["string", "null"],
+          "enum": [
+            "stable",
+            "flaky",
+            "known-failure-rate",
+            "experimental",
+            null
+          ]
+        },
+        "retry_kind": {
+          "type": ["string", "null"],
+          "enum": [
+            "infrastructure",
+            "environment",
+            "reliability_policy",
+            "explicit",
+            null
+          ]
+        },
+        "retry_reason": {
+          "$ref": "#/$defs/profileDetailString"
         },
         "owner": {
           "$ref": "#/$defs/nullableShortString"
@@ -241,23 +291,24 @@
         {
           "type": "array",
           "maxItems": 100,
-          "items": {
-            "anyOf": [
-              {
+          "anyOf": [
+            {
+              "items": {
                 "type": "string",
                 "maxLength": 1024
-              },
-              {
-                "type": "integer"
-              },
-              {
+              }
+            },
+            {
+              "items": {
                 "type": "number"
-              },
-              {
+              }
+            },
+            {
+              "items": {
                 "type": "boolean"
               }
-            ]
-          }
+            }
+          ]
         },
         {
           "type": "object",


### PR DESCRIPTION
Follows up on @fatima-anes's review of #6433: rather than patching one rule of a stale copy, this refreshes the whole vendored schema from upstream.

## Why

`.github/actions/upload-omni-github-test-results/result-json.schema.json` is a pinned copy of the schema in [`NVIDIA-Omniverse/omni-github`](https://github.com/NVIDIA-Omniverse/omni-github) at `docs/test-results/clients/artifact-upload/schemas/result-json.schema.json`. Pinning is deliberate — `action.yml` notes the omni-github team recommends validating against a local copy — but ours was taken once in #6234 on 2026-06-26 and never refreshed.

That matters because the upload action treats this file as a hard gate and **silently drops** any result that fails validation:

```
Skipping omni-github upload because converted results failed schema validation
```

A stale copy therefore rejects payloads the service itself would accept, and says nothing about it.

## What changed

The file is now byte-identical to upstream. The drift is entirely additive — upstream gained `$defs.profileDetailString` and seven optional `testRow` fields:

`error`, `failure_component`, `failure_layer`, `reliability_class`, `retry_kind`, `retry_reason`, `test_category`

Nothing this repository relies on was removed upstream, and no producer here emits the new fields yet, so this is a no-op for current uploads and unblocks the new ones.

## Relationship to #6433

Upstream already uses `anyOf` for `customValue`, so #6433 was correcting our copy toward upstream rather than diverging from it. This branch is based on #6433 and subsumes it.

Either order works. If #6433 merges first this reduces to the remaining drift; if it doesn't, #6433 can be closed as superseded. #6433 is the smaller, already-approved change, so merging it first is the lower-risk path — it is what unblocks the perf-smoke gate's dashboard rows.

## Verification

- The vendored file is byte-identical to upstream (`cmp`).
- `test_junit_to_omni_github_results.py` passes (4 tests).
- The converter's real output validates against the resynced schema.
- The perf-smoke gate's result JSON validates against it too, unrelaxed — worth stating because that gate emits integral custom values (`num_envs: 4096`, `fps_mean`), which is precisely what #6433 addresses.

## Follow-up, not in this PR

The perf-smoke gate carries a `_relax_custom_value_oneof` test helper that rewrites `oneOf` to `anyOf` in memory before validating, added while #6433 was pending. It should be deleted once this or #6433 lands, but it lives in `tools/perf_smoke_test/`, which is not on `develop` yet, so it belongs with #6864.

Also worth considering separately: `failure_layer` (`code | infrastructure | environment | upstream | downstream`) and `retry_kind` map closely onto distinctions the perf gate already makes — a stale CI image is an `environment` failure, not a `code` one. Today that only exists as prose in the PR comment.