### PR TITLE
Fix bin-packing demo crash for small --num_envs

### DIFF
--- a/scripts/demos/bin_packing.py
+++ b/scripts/demos/bin_packing.py
@@ -12,11 +12,12 @@ declared layouts. Instead of listing those assets by hand, this script defines
 its own combination set, ``RandomSubsetSet``, which draws a random subset of
 the grocery slots: the cloner only reads ``assets`` and ``weight`` off a
 combination, so any subclass of :class:`~isaaclab.cloner.InclusionSet` that
-fills them in is a valid combination. The slots cycle through eight YCB grocery
-models, spawned by a custom spawner that authors the rigid bodies and colliders
-the visual models ship without. The simulation periodically re-drops every
-spawned grocery into its bin with pose, velocity, and mass noise, teleporting
-out-of-bounds objects back in.
+fills them in is a valid combination. The first layout fills the bin, which
+keeps every declared slot spawned no matter how many environments run. The
+slots cycle through eight YCB grocery models, spawned by a custom spawner that
+authors the rigid bodies and colliders the visual models ship without. The
+simulation periodically re-drops every spawned grocery into its bin with pose,
+velocity, and mass noise, teleporting out-of-bounds objects back in.
 
 .. note::
     Heterogeneous per-environment object counts require the PhysX backend, so
@@ -222,8 +223,8 @@ class BinPackingSceneCfg(InteractiveSceneCfg):
 
     Besides the world-shared ground plane and light and the storage bin, the
     scene declares one grocery slot per object that may end up in the bin, and
-    one :class:`RandomSubsetSet` clone combination per layout to pick which of
-    those slots are active.
+    one clone combination per layout to pick which of those slots are active:
+    a full bin first, then a :class:`RandomSubsetSet` draw per remaining layout.
     """
 
     # ground plane
@@ -273,10 +274,17 @@ class BinPackingSceneCfg(InteractiveSceneCfg):
     grocery_22: RigidObjectCfg = grocery_cfg(22)
     grocery_23: RigidObjectCfg = grocery_cfg(23)
 
+    # A slot claimed by some layout but active in none of the layouts the environments
+    # actually receive is never spawned, which the scene rejects. Environments cycle
+    # through the layouts in order, so a full first layout keeps every slot active for
+    # any ``--num_envs``, and the random draws below stay unconstrained.
     clone_cfg: CloneCfg = CloneCfg(
         clone_combinations=[
-            RandomSubsetSet(pool=GROCERY_NAMES, num_active=(MIN_OBJECTS_PER_BIN, MAX_OBJECTS_PER_BIN))
-            for _ in range(NUM_LAYOUTS)
+            InclusionSet(assets=GROCERY_NAMES),
+            *(
+                RandomSubsetSet(pool=GROCERY_NAMES, num_active=(MIN_OBJECTS_PER_BIN, MAX_OBJECTS_PER_BIN))
+                for _ in range(NUM_LAYOUTS - 1)
+            ),
         ],
         clone_strategy=sequential,
     )


### PR DESCRIPTION
## Description

Follow-up to #6562, which merged with a red `standalone demos (headless, Kit)` check. The bin-packing demo crashes when it runs with fewer environments than it declares layouts:

```
RuntimeError: Clone planning did not assign spawn_path for '/World/envs/env_.*/Groceries/Grocery_02'.
[ERROR] Command failed with code 1: "... scripts/demos/bin_packing.py --num_envs 2 --physics isaacsim_physx --visualizer none"
```

Environments cycle through the declared layouts in order (`sequential` gives env *i* layout `i % NUM_LAYOUTS`), so a run with two environments only ever activates layouts 0 and 1. The remaining grocery slots are claimed by some layout but active in none of the used ones, so clone planning leaves their `spawn_path` unset and `InteractiveScene._add_entities_from_cfg` rejects them. The bin itself is unaffected because an asset named by no combination at all stays active in every row — only *claimed* assets can end up orphaned.

This is user-facing, not just a CI artifact. Driving the layout construction through `make_valid_clone_combinations` and `sequential` over 200 random draws per environment count, the merged code leaves slots unspawned in:

| `--num_envs` | runs with an unspawned slot |
|---|---|
| 1 | 194/200 |
| 2 | 177/200 |
| 4 | 96/200 |
| 8 | 17/200 |
| 16 (default) | 0/200 |
| 64 | 0/200 |

The default of 16 passed only because sixteen random subsets happen to cover all 24 slots; nothing guarantees it.

Declaring the first layout as the full set of slots keeps every slot active in env 0 for any environment count, and leaves the remaining random draws unconstrained. Because `sequential` always hands layout 0 to env 0, this holds even at `--num_envs 1`. Env 0 now always shows a full bin; envs 1..N-1 keep their random subsets.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

None; the demo renders as before apart from env 0 always being full.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Notes on the checklist

- **Tests:** no new test is added. The existing `test_standalone_scripts.py` launch matrix already covers this — `demos-bin_packing-isaacsim_physx-default-none` is the check that failed on #6562. I verified it fails without this change (reproducing the identical `RuntimeError` locally) and passes with it. The three runnable visualizer cases (`none`, `kit`, `newton`) pass locally; `rerun` and `viser` skip, as they do in CI.
- **Changelog:** no fragment is required. This touches only `scripts/demos/`, so no package under `source/` is affected and the changelog gate passes.