### PR TITLE
Update Isaac RTX cloth motion-vector golden

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-update-motion-vector-cloth-golden.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-update-motion-vector-cloth-golden.skip
@@ -1,0 +1,1 @@
+Test-only: updated the Franka cloth motion-vector golden to use the third camera frame.

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-isaacsim_rtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-isaacsim_rtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5008db66000143efad3c7c7d1122767fc3e4164afb48e5bfb016531956cf649c
-size 87396
+oid sha256:3780437c12421e63dc32f4b62fee35a3733009f6c6afcc5ba475463ad4bfd737
+size 30011

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1810,12 +1810,12 @@ def rendering_test_franka_cloth(
 
         maybe_save_stage(test_name, physics_backend, renderer, data_type)
 
-        # Step once for other AOVs and twice for motion vectors so the cloth falls uniformly without hitting the cube.
+        # Step twice only for Isaac RTX motion vectors so the cloth falls uniformly without hitting the cube.
         # This is to limit the inconsistent nodal poses and pixels from run to run due to solver scheduling and
         # numerical precision.
         zero_actions = torch.zeros(env.num_envs, env.action_manager.total_action_dim, device=env.device)
         env.step(zero_actions)
-        if data_type == "motion_vectors":
+        if renderer == "isaacsim_rtx_renderer" and data_type == "motion_vectors":
             env.step(zero_actions)
 
         validate_camera_outputs(

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -1810,11 +1810,13 @@ def rendering_test_franka_cloth(
 
         maybe_save_stage(test_name, physics_backend, renderer, data_type)
 
-        # We step only once to let the cloth fall uniformly on the gravity but not collide with the cube on the table.
+        # Step once for other AOVs and twice for motion vectors so the cloth falls uniformly without hitting the cube.
         # This is to limit the inconsistent nodal poses and pixels from run to run due to solver scheduling and
         # numerical precision.
         zero_actions = torch.zeros(env.num_envs, env.action_manager.total_action_dim, device=env.device)
         env.step(zero_actions)
+        if data_type == "motion_vectors":
+            env.step(zero_actions)
 
         validate_camera_outputs(
             test_name,


### PR DESCRIPTION
# Description
- Capture Franka cloth motion vectors from frame index 2—the third camera frame—for Isaac RTX, then refresh its golden image.
- This replaces an older golden captured before the temporal motion-vector output was fully populated. The change is scoped to Isaac RTX motion vectors.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there