### PR TITLE
ci: Pin Isaac Sim image to the last known-good build

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -9,6 +9,7 @@
 # (frozen at 6.1.0-alpha.2). Both images use Isaac Sim's NGC org, which is current and
 # which the CI credential can reach.
 isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
-isaacsim_image_tag: latest-develop
+# Pinned to the last known-good build; newer ones fail the rendering tests.
+isaacsim_image_tag: latest-develop@sha256:71019ff76289be944cc4356323e32d17568ee082228e3bf1ef047b741f4fe380
 isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -175,8 +175,9 @@ jobs:
       run: |
         set -euo pipefail
         config=.github/workflows/config.yaml
-        base_image="$(awk -F ':[[:space:]]*' '$1 == "isaacsim_image_name" { print $2; exit }' "$config")"
-        base_tag="$(awk -F ':[[:space:]]*' '$1 == "isaacsim_image_tag" { print $2; exit }' "$config")"
+        # The tag may carry a digest, so strip the key rather than splitting on every colon.
+        base_image="$(awk '$1 == "isaacsim_image_name:" { sub(/^[^:]+:[[:space:]]*/, ""); print; exit }' "$config")"
+        base_tag="$(awk '$1 == "isaacsim_image_tag:" { sub(/^[^:]+:[[:space:]]*/, ""); print; exit }' "$config")"
         if [[ -z "$base_image" || -z "$base_tag" ]]; then
           echo "::error::Missing Isaac Sim image configuration in $config"
           exit 1


### PR DESCRIPTION
# Description

The `latest-develop` Isaac Sim image changed on 2026-08-04, and `rendering-correctness` has been red on `develop` and on every open PR since. This pins the base image to the last digest that passed so CI is usable again.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there