### PR TITLE
Normalize self-referencing root joints for OvPhysX

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-root-joint-stopgap.rst
+++ b/source/isaaclab_ovphysx/changelog.d/antoiner-ovphysx-root-joint-stopgap.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed OvPhysX failing to build any articulation for assets whose root joint targets its own
+  ``UsdPhysics.ArticulationRootAPI`` prim as ``body0`` instead of leaving ``body0`` empty, which
+  previously surfaced as ``could not create any articulation bindings``. Such joints are now
+  normalized to the empty-``body0`` world-attachment spelling before the stage is handed to the
+  OvPhysX parser.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -405,6 +405,71 @@ class OvPhysxManager(PhysicsManager):
         return root
 
     @classmethod
+    def _normalize_self_referencing_root_joints(cls, stage: Any) -> None:
+        """Clear ``body0`` on root joints that target their own articulation-root prim.
+
+        Some converted assets (e.g. the MuJoCo Menagerie Franka) anchor a fixed-base
+        articulation with a joint whose ``body0`` targets the ``UsdPhysics.ArticulationRootAPI``
+        prim itself -- a plain Xform that is not a rigid body -- rather than leaving ``body0``
+        empty, which is the conventional spelling for "attached to the world". The OVPhysX
+        parser does not recognize that form and builds no articulation anywhere on the stage,
+        so every ``ARTICULATION_*`` tensor binding comes back with ``count == 0``.
+
+        This rewrites the joint to the empty-``body0`` spelling in place, before the stage is
+        serialized for the wheel. It is deliberately narrow: the predicate it matches is
+        exactly the topology that currently fails to parse at all, so no stage that OVPhysX
+        can already ingest is affected.
+
+        .. warning::
+            Temporary workaround. It only fires when the joint's ``body0`` frame is the
+            identity, because clearing ``body0`` reinterprets ``localPos0``/``localRot0`` as
+            world-relative; joints with an authored ``body0`` frame are left alone so the
+            anchor pose can never be silently moved.
+
+        Args:
+            stage: The USD stage to normalize, mutated in place.
+        """
+        # TODO(ovphysx): remove this workaround, and its call site in ``_warmup_and_load``,
+        # once the OVPhysX USD parser accepts a root joint whose ``body0`` targets the
+        # articulation-root prim itself.
+        for prim in stage.Traverse():
+            joint = UsdPhysics.Joint(prim)
+            if not joint:
+                continue
+            body0_targets = joint.GetBody0Rel().GetTargets()
+            body1_targets = joint.GetBody1Rel().GetTargets()
+            if len(body0_targets) != 1 or len(body1_targets) != 1:
+                continue
+            # ``body0`` must be the articulation root itself: an ancestor of the jointed link
+            # that carries the root API but is not a rigid body.
+            if not body1_targets[0].HasPrefix(body0_targets[0]):
+                continue
+            body0_prim = stage.GetPrimAtPath(body0_targets[0])
+            if not body0_prim.IsValid():
+                continue
+            if not body0_prim.HasAPI(UsdPhysics.ArticulationRootAPI):
+                continue
+            if body0_prim.HasAPI(UsdPhysics.RigidBodyAPI):
+                continue
+            # Only rewrite when ``body0``'s joint frame is the identity, so dropping the
+            # relationship cannot move the anchor.
+            local_pos0 = joint.GetLocalPos0Attr().Get()
+            local_rot0 = joint.GetLocalRot0Attr().Get()
+            if local_pos0 is not None and tuple(local_pos0) != (0.0, 0.0, 0.0):
+                continue
+            if local_rot0 is not None and (
+                local_rot0.GetReal() != 1.0 or tuple(local_rot0.GetImaginary()) != (0.0, 0.0, 0.0)
+            ):
+                continue
+            joint.GetBody0Rel().SetTargets([])
+            logger.info(
+                "Cleared body0 on joint '%s': it targeted its own articulation root '%s', which the OVPhysX"
+                " parser does not recognize as a world attachment.",
+                prim.GetPath().pathString,
+                body0_targets[0],
+            )
+
+    @classmethod
     def register_clone(
         cls, source: str, targets: list[str], parent_positions: list[tuple[float, float, float]] | None = None
     ) -> None:
@@ -869,6 +934,7 @@ class OvPhysxManager(PhysicsManager):
         # binding fast path expects). Features that need distinct authored
         # physics in every environment request the full stage; missing
         # heterogeneous clone targets are materialized in its flattened layer.
+        cls._normalize_self_referencing_root_joints(sim.stage)
         cls._rearm_pending_clones()
         stage_usda = cls._serialize_selected_stage(sim.stage)
         cls._stage_usda = stage_usda


### PR DESCRIPTION
# Description

Assets converted from MuJoCo Menagerie — including `FRANKA_PANDA_MENAGERIE_CFG`, which `Isaac-Reach-Franka` ships — anchor a fixed-base articulation with a joint whose `body0` targets the `UsdPhysics.ArticulationRootAPI` prim *itself*, a plain Xform that is not a rigid body, instead of leaving `body0` empty (the conventional spelling for "attached to the world"):

```
/World/Robot                                  Xform, ArticulationRootAPI, NO RigidBodyAPI
/World/Robot/PhysicsFixedJoint                FixedJoint
                                                body0 = </World/Robot>              <-- self-referencing
                                                body1 = </World/Robot/Geometry/panda_link0>
```

The OvPhysX parser does not recognize that form. It builds **no** articulation anywhere on the stage — `create_tensor_binding(ARTICULATION_*, pattern='*')` returns `count == 0`, and the runtime logs `Failed to find articulation at '/World/Robot'` — so `Articulation` initialization fails:

```
RuntimeError: OVPhysX could not create any articulation bindings for pattern '/World/Robot'.
Check that prim_path='/World/Robot' matches at least one UsdPhysics.ArticulationRootAPI prim.
```

The suggestion in that message is a red herring: the prim does match, and it does carry the root API.

This PR rewrites such joints to the empty-`body0` spelling on the live stage, just before it is serialized for the wheel in `_warmup_and_load`.

## Why this is safe

The predicate is deliberately narrow. It fires only when **all** of the following hold:

1. the prim is a `UsdPhysics.Joint` with exactly one `body0` and one `body1` target
2. `body0` is an ancestor of `body1`
3. `body0` carries `ArticulationRootAPI` and **not** `RigidBodyAPI`
4. `localPos0` / `localRot0` are the identity

Conditions 1–3 describe exactly the topology that currently fails to parse at all, so no stage OvPhysX can already ingest is affected — the rewrite is unreachable from any currently-working configuration. Condition 4 exists because clearing `body0` reinterprets `localPos0`/`localRot0` as world-relative; joints with an authored `body0` frame are left alone rather than risking a silently moved anchor.

The change is scoped entirely to `isaaclab_ovphysx`, so PhysX and Newton are untouched.

## Stop-gap

This is a workaround for a parser gap, not a fix for it. The helper and its call site carry a `TODO(ovphysx)` to be removed once the OvPhysX parser accepts the self-referencing form. A minimal standalone `.usda` reproducing the failure (two cubes, one revolute joint, no Franka geometry) has been shared with the OvPhysX team.

## Related bug, deliberately not fixed here

`find_global_fixed_joint_prim` (`source/isaaclab/isaaclab/sim/utils/queries.py`) defines "connects to world" as *`body0` or `body1` is empty*. The joints described above have both populated, so they are not recognized as world joints on **any** backend. Reading the two call sites, that implies `fix_root_link=False` silently no-ops on these assets and `fix_root_link=True` raises `NotImplementedError: Cannot fix non-rigid articulation root`.

That is a real cross-backend gap, but fixing it changes which joints `fix_root_link` enables/disables everywhere, which would forfeit this PR's by-construction safety argument. Left for a separate PR.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

No test is added: reproducing this requires a full OvPhysX simulation, and the natural fixture would be a `.usda` file, which `.gitignore` excludes via `**/*.usda`. Verified manually instead.

Original repro, before → after:

```
RuntimeError: OVPhysX could not create any articulation bindings   →   num_joints=9
```

Multi-environment cloning (`Isaac-Reach-Franka`, `presets=ovphysx`, 4 envs), stepped 10 times — this was the main risk, since clearing `body0` could have collapsed every cloned robot onto the origin:

```
num_joints=9 num_bodies=11 num_instances=4
env_origins       = [[ 1.25 -1.25 0.] [ 1.25 1.25 0.] [-1.25 -1.25 0.] [-1.25 1.25 0.]]
root_pos_w        = [[ 1.25 -1.25 0.] [ 1.25 1.25 0.] [-1.25 -1.25 0.] [-1.25 1.25 0.]]
root_pos_w - env_origins = all zeros
```

Each robot sits exactly at its env origin, zero spread. A separate single-robot run spawned at `(1, 2, 3)` also held that pose across 10 steps.

`uv run isaaclab -f` passes on all files.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)