### PR TITLE
Set PXR_WORK_THREAD_LIMIT=1 in CI Docker env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,7 @@ recordings/
 **/__pycache__/
 **/*.egg-info/
 # ignore isaac sim symlink
-_isaac_sim?
+_isaac_sim
 # Docker history
 docker/.isaac-lab-docker-history
 # ignore uv environment

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -72,6 +72,10 @@ runs:
             -e PYTHONUNBUFFERED=1 \
             -e PYTHONIOENCODING=utf-8 \
             -e TEST_RESULT_FILE=$result_file"
+          # TODO: Remove once usd-core>=26.5 is the minimum - that release fixes the race condition.
+          # PXR_WORK_THREAD_LIMIT must be set before the process starts; setting it from Python after
+          # the pxr library loads has no effect because OpenUSD reads it at C++ init time.
+          docker_env_vars="$docker_env_vars -e PXR_WORK_THREAD_LIMIT=1"
 
           if [ -n "$filter_pattern" ]; then
             if [[ "$filter_pattern" == not* ]]; then

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# CI Workflows
+
+`schedule:` and `workflow_dispatch:` triggers fire **only from the default
+branch (`main`)**. A workflow YAML must live on `main` for its cron to
+register — the same file on other branches has no effect. `pull_request:`
+and `push:` triggers fire from the event branch's file and work normally
+on `develop`.

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -75,6 +75,8 @@ jobs:
           --exclude 'user@'
           --exclude 'helm\.ngc\.nvidia\.com'
           --exclude 'slurm\.schedmd\.com'
+          --exclude '^https://unitree\.com/h1$'
+          --exclude '^https://bostondynamics\.com/reinforcement-learning-researcher-kit/?$'
           --max-retries 3
           --retry-wait-time 5
           --timeout 30

--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Shared image config for CI workflows. Loaded by the `config` job in each
+# workflow via yq and exposed as job outputs (see e.g. .github/workflows/build.yaml).
+isaacsim_image_name: nvcr.io/nvidian/isaac-sim
+isaacsim_image_tag: latest-develop
+isaaclab_image_name: nvcr.io/nvidian/isaac-lab

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,15 +3,18 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-name: Build & deploy docs
+name: Docs
 
 on:
   push:
     branches:
       - main
-      - devel
+      - develop
       - 'release/**'
+      - 'feature/isaacsim-6-0'
   pull_request:
+    # we're skipping the branches and paths filter to allow docs to be built on any PR because heredoc is used
+    # additionally, we have a check that determines what version of docs will be built
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -19,50 +22,91 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-secrets:
-    name: Check secrets
+  doc-build-type:
+    name: Detect Doc Build Type
     runs-on: ubuntu-latest
     outputs:
       trigger-deploy: ${{ steps.trigger-deploy.outputs.defined }}
     steps:
+    - id: info
+      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}"
     - id: trigger-deploy
       env:
         REPO_NAME: ${{ secrets.REPO_NAME }}
-      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/devel' || startsWith(github.ref, 'refs/heads/release/')) }}"
-      run: echo "defined=true" >> "$GITHUB_OUTPUT"
+      # develop, main, release/ trigger multi-version build, then deployment to gh-pages
+      # all others - just the current docs without deployment
+      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')) }}"
+      run: echo "defined=true" >> "$GITHUB_OUTPUT"; echo "Docs will be built multi-version and deployed"
 
-  build-docs:
-    name: Build Docs
+  build-latest-docs:
+    name: Build Latest Docs
     runs-on: ubuntu-latest
-    needs: [check-secrets]
+    needs: [doc-build-type]
+    # run on non-deploy branches to build current version docs only
+    if: needs.doc-build-type.outputs.trigger-deploy != 'true'
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         architecture: x64
 
     - name: Install dev requirements
       working-directory: ./docs
       run: pip install -r requirements.txt
 
-    - name: Check branch docs building
+    - name: Build current version docs
       working-directory: ./docs
-      if: needs.check-secrets.outputs.trigger-deploy != 'true'
       run: make current-docs
+
+    - name: Upload docs artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: docs-html
+        path: ./docs/_build
+
+  build-multi-docs:
+    name: Build Multi-Version Docs
+    runs-on: ubuntu-latest
+    needs: [doc-build-type]
+    # run on deploy branches to create multi-version docs
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        architecture: x64
+
+    - name: Install dev requirements
+      working-directory: ./docs
+      run: pip install -r requirements.txt
 
     - name: Generate multi-version docs
       working-directory: ./docs
+      env:
+        # "deploy" branches build the full set of versions so every page
+        # has a complete version dropdown: main, develop, tags >= v2.0.0
+        # (including pre-release suffixes like -beta or -rc1). v1.x tags and
+        # release/ branches are excluded.
+        SMV_BRANCH_WHITELIST: '^(main|develop)$'
+        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
       run: |
         git fetch --prune --unshallow --tags
+        git checkout --detach HEAD
+        git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
     - name: Upload docs artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs-html
         path: ./docs/_build
@@ -70,18 +114,21 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     runs-on: ubuntu-latest
-    needs: [check-secrets, build-docs]
-    if: needs.check-secrets.outputs.trigger-deploy == 'true'
+    needs: [doc-build-type, build-multi-docs]
+    # deploy only on "deploy" branches
+    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
 
     steps:
     - name: Download docs artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: docs-html
         path: ./docs/_build
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
+        keep_files: false
+        force_orphan: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -140,4 +140,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
         keep_files: false
-        force_orphan: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,11 @@ on:
     # we're skipping the branches and paths filter to allow docs to be built on any PR because heredoc is used
     # additionally, we have a check that determines what version of docs will be built
     types: [opened, synchronize, reopened]
+  # Nightly multi-version rebuild + deploy from develop tip. Picks up every
+  # develop commit accumulated since the previous nightly in a single run.
+  schedule:
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,13 +34,13 @@ jobs:
       trigger-deploy: ${{ steps.trigger-deploy.outputs.defined }}
     steps:
     - id: info
-      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}"
+      run: echo "repo=github.repository=${{ github.repository }}, ref=github.ref=${{ github.ref }}, event=github.event_name=${{ github.event_name }}"
     - id: trigger-deploy
       env:
         REPO_NAME: ${{ secrets.REPO_NAME }}
-      # develop, main, release/ trigger multi-version build, then deployment to gh-pages
-      # all others - just the current docs without deployment
-      if: "${{ github.repository == env.REPO_NAME && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release/')) }}"
+      # Nightly schedule and workflow_dispatch trigger multi-version deploy.
+      # All branch pushes (including main) build current-docs only; deploy waits for the cron above.
+      if: "${{ github.repository == env.REPO_NAME && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}"
       run: echo "defined=true" >> "$GITHUB_OUTPUT"; echo "Docs will be built multi-version and deployed"
 
   build-latest-docs:
@@ -79,6 +84,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+      with:
+        # On schedule, always rebuild from the develop tip regardless of
+        # which ref the cron run defaults to. Other events use github.ref.
+        ref: ${{ github.event_name == 'schedule' && 'develop' || '' }}
 
     - name: Setup python
       uses: actions/setup-python@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -103,11 +103,11 @@ jobs:
       working-directory: ./docs
       env:
         # "deploy" branches build the full set of versions so every page
-        # has a complete version dropdown: main, develop, tags >= v2.0.0
-        # (including pre-release suffixes like -beta or -rc1). v1.x tags and
-        # release/ branches are excluded.
-        SMV_BRANCH_WHITELIST: '^(main|develop)$'
-        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
+        # has a complete version dropdown: main, develop, release/3.0.0-beta2,
+        # and stable tags >= v2.0.0. Other release branches and prerelease tags
+        # are excluded.
+        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0-beta2)$'
+        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
       run: |
         git fetch --prune --unshallow --tags
         git checkout --detach HEAD

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -114,10 +114,9 @@ jobs:
         git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
-    - name: Upload docs artifact
-      uses: actions/upload-artifact@v7
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        name: docs-html
         path: ./docs/_build
 
   deploy-docs:
@@ -127,16 +126,15 @@ jobs:
     # deploy only on "deploy" branches
     if: needs.doc-build-type.outputs.trigger-deploy == 'true'
 
-    steps:
-    - name: Download docs artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: docs-html
-        path: ./docs/_build
+    permissions:
+      pages: write
+      id-token: write
 
-    - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build
-        keep_files: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -1,0 +1,123 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Nightly auto-compile: rolls accumulated fragments under
+# ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
+# bumps each ``extension.toml``, deletes consumed fragments, and pushes the
+# result back to ``develop``. Keeps the develop branch's changelog current
+# without requiring a maintainer to run ``compile`` by hand.
+#
+# Scheduled workflow — must live on the default branch (``main``) for the
+# cron to register. See ``.github/workflows/README.md``.
+#
+# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
+# GitHub App token with ``contents:write`` on this repo) when it's
+# available so downstream CI runs on the auto-commit. Falls back to
+# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
+# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
+# commit, which is by design (avoids infinite loops) but means the
+# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+
+name: Nightly Changelog Compilation
+
+on:
+  schedule:
+    # Run nightly at 5 AM UTC (one hour after daily-compatibility, so we
+    # don't compete for runner capacity).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only — do not commit / push'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Only one nightly compile may be in flight at a time. ``cancel-in-progress``
+  # is intentionally false: if a previous run is still finishing its push, we
+  # queue rather than abort it mid-commit.
+  group: nightly-changelog
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  compile-changelog:
+    name: Compile changelog fragments
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          # Operate on develop, not the repo's default branch. Scheduled
+          # workflows fire from the default branch's workflow file by
+          # default, but we want the *checkout* to be develop so the
+          # compile sees develop's accumulated fragments and the push
+          # writes back to develop.
+          ref: develop
+          # Use a PAT so the auto-commit triggers downstream CI; falls back
+          # to GITHUB_TOKEN which is sufficient for the push itself.
+          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # Full history so the compiler can resolve each fragment's merge
+          # time via ``git log --diff-filter=A --first-parent``.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile fragments
+        run: |
+          ARGS="--all"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          echo "Running: python3 tools/changelog/cli.py compile $ARGS"
+          python3 tools/changelog/cli.py compile $ARGS
+
+      - name: Commit and push if fragments were compiled
+        if: inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add source/*/changelog.d/ \
+                  source/*/docs/CHANGELOG.rst \
+                  source/*/config/extension.toml
+          if git diff --staged --quiet; then
+            echo "No changelog fragments found — nothing to commit."
+          else
+            # Convention for CI-driven auto-commits on this repo:
+            #   [CI][<Specific Action>] <one-line summary>
+            # The leading ``[CI]`` tag groups every machine-driven commit
+            # (so future automations — auto image rebuilds, auto publish,
+            # etc. — all share the prefix and are easy to find/filter in
+            # ``git log --grep``). The second tag names the specific
+            # action. The trigger event suffix (``schedule`` vs
+            # ``workflow_dispatch``) is preserved for traceability.
+            #
+            # The body lists every package that bumped, derived from the
+            # staged ``extension.toml`` diff so the entries are accurate
+            # regardless of which packages happen to have pending
+            # fragments this run.
+            MSG_FILE=$(mktemp)
+            {
+              echo "[CI][Auto Version Bump] Compile changelog fragments (${{ github.event_name }})"
+              echo
+              echo "Bumped packages:"
+              for tom in $(git diff --staged --name-only -- 'source/*/config/extension.toml'); do
+                pkg=$(echo "$tom" | sed -E 's|source/([^/]+)/config/extension.toml|\1|')
+                old=$(git diff --staged "$tom" | awk -F'"' '/^-version/{print $2; exit}')
+                new=$(git diff --staged "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
+                echo "- $pkg: $old → $new"
+              done
+            } > "$MSG_FILE"
+            git commit -F "$MSG_FILE"
+            # Push explicitly to develop so we don't accidentally write
+            # to the source ref of a workflow_dispatch run.
+            git push origin HEAD:develop
+          fi

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -6,16 +6,22 @@
 # Nightly auto-compile: rolls accumulated fragments under
 # ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
 # bumps each ``extension.toml``, deletes consumed fragments, and pushes the
-# result back to ``develop``. Keeps the develop branch's changelog current
-# without requiring a maintainer to run ``compile`` by hand.
+# result back to each branch in the configured list. Keeps every tracked
+# branch's changelog current without requiring a maintainer to run
+# ``compile`` by hand.
 #
 # Scheduled workflow — must live on the default branch (``main``) for the
 # cron to register. See ``.github/workflows/README.md``.
 #
+# Adding a branch to the nightly set is a one-line edit to ``env.CRON_BRANCHES``
+# below. Each target branch uses its own ``tools/changelog/cli.py`` (the
+# same copy the PR gate already runs), so the nightly compile honours the
+# same rules that validated the fragments.
+#
 # The push uses a short-lived GitHub App installation token minted from
 # ``CHANGELOG_APP_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets). The
 # App must be installed on this repository with ``contents: write`` and
-# added to the bypass-actor list of ``develop``'s branch ruleset so the
+# added to the bypass-actor list of each target branch's ruleset so the
 # auto-commit can push directly without satisfying required-checks /
 # required-approval gates.
 # Commits signed by an App token (unlike ``GITHUB_TOKEN``) are treated as
@@ -24,6 +30,14 @@
 
 name: Nightly Changelog Compilation
 
+# Branches the nightly cron compiles. Single source of truth — append a
+# ref here to extend the nightly set (the active release branch belongs
+# here). Each branch must carry ``tools/changelog/cli.py`` and the
+# isaaclab-bot App must be in its branch-ruleset bypass list.
+# Surrounding whitespace per entry is stripped by the resolver below.
+env:
+  CRON_BRANCHES: develop,release/3.0.0-beta2
+
 on:
   schedule:
     # Run nightly at 5 AM UTC (one hour after daily-compatibility, so we
@@ -31,18 +45,20 @@ on:
     - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
+      branch:
+        # Manual trigger is always a single branch. Free-text on purpose
+        # — scales to any branch (e.g. a new ``release/*`` cut from
+        # develop) without needing to update the workflow. A branch
+        # that lacks ``tools/changelog/cli.py`` fails the verify step
+        # below with a clear error, which is the desired failure mode.
+        description: 'Branch to compile (e.g. develop, release/3.0.0-beta2). Must carry tools/changelog/cli.py.'
+        required: true
+        type: string
       dry_run:
         description: 'Preview only — do not commit / push'
         required: false
         type: boolean
         default: false
-
-concurrency:
-  # Only one nightly compile may be in flight at a time. ``cancel-in-progress``
-  # is intentionally false: if a previous run is still finishing its push, we
-  # queue rather than abort it mid-commit.
-  group: nightly-changelog
-  cancel-in-progress: false
 
 permissions:
   # Reduced: the App installation token below carries its own write scope.
@@ -50,16 +66,66 @@ permissions:
   contents: read
 
 jobs:
+  resolve-branches:
+    # CSV → JSON array bridge. ``workflow_dispatch`` inputs can only be
+    # string / bool / choice, so the branch list arrives as a comma-
+    # separated string; the matrix below needs a JSON list to fan out.
+    # Mirrors the ``setup-versions`` job in ``daily-compatibility.yml``.
+    name: Resolve branch list
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      branches: ${{ steps.b.outputs.branches }}
+    steps:
+      - id: b
+        env:
+          # Schedule → the CRON_BRANCHES list. Manual → the single branch
+          # the maintainer entered. The two paths are intentionally
+          # asymmetric: cron is the configured set, manual is exactly one
+          # branch (required input).
+          BRANCHES: ${{ github.event_name == 'schedule' && env.CRON_BRANCHES || inputs.branch }}
+          # ``EVENT_NAME`` mirrors ``github.event_name`` so the guard below
+          # branches on it without re-interpolating into the shell.
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # CSV → JSON array, trimming surrounding whitespace per entry.
+          # Manual produces a 1-element array; cron produces N elements.
+          arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
+          # Manual trigger contract: exactly one branch. A maintainer who
+          # pastes a comma-separated list into the dispatch form should
+          # see a clear error, not a silent multi-branch fan-out.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$(echo "$arr" | jq 'length')" -ne 1 ]; then
+            echo "::error::Manual trigger accepts exactly one branch; got $arr. Fire the workflow separately per branch."
+            exit 1
+          fi
+          echo "branches=$arr" >> "$GITHUB_OUTPUT"
+          echo "Resolved branches: $arr"
+
   compile-changelog:
-    name: Compile changelog fragments
+    name: Compile changelog fragments (${{ matrix.branch }})
+    needs: resolve-branches
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      # Independent branches: one failing shouldn't cancel the others.
+      # Each matrix entry shows up as a separate job tile in the Actions
+      # UI, so ``release/3.0.0-beta2`` failing doesn't hide ``develop``'s
+      # success (and ``gh run rerun --failed`` re-runs only the failed
+      # entry). Mirrors ``daily-compatibility.yml``'s matrix style.
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}
+    concurrency:
+      # Per-branch group: two runs against the same ref queue, but
+      # different refs (develop and a release branch) compile in parallel.
+      group: nightly-changelog-${{ matrix.branch }}
+      cancel-in-progress: false
 
     steps:
       # Mint a short-lived (1 h) installation access token for the
-      # ``isaaclab-bot`` GitHub App. The App is on develop's branch-ruleset
-      # bypass list, so its push lands without needing the standard
-      # required-checks / required-approval pipeline.
+      # ``isaaclab-bot`` GitHub App. The App is on each target branch's
+      # ruleset bypass list, so its push lands without needing the
+      # standard required-checks / required-approval pipeline.
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         id: app-token
         with:
@@ -74,12 +140,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # Operate on develop, not the repo's default branch. Scheduled
-          # workflows fire from the default branch's workflow file by
-          # default, but we want the *checkout* to be develop so the
-          # compile sees develop's accumulated fragments and the push
-          # writes back to develop.
-          ref: develop
+          # Operate on the target branch, not the repo's default branch.
+          # Scheduled workflows fire from the default branch's workflow
+          # file, but the *checkout* is the branch we're compiling so the
+          # compile sees that branch's accumulated fragments and the push
+          # writes back to it.
+          ref: ${{ matrix.branch }}
           # App token (vs. GITHUB_TOKEN) means the push is signed by
           # ``isaaclab-bot`` — the bypass identity — and downstream CI
           # workflows DO trigger on the resulting commit.
@@ -87,6 +153,20 @@ jobs:
           # Full history so the compiler can resolve each fragment's merge
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
+
+      - name: Verify changelog tooling exists on target branch
+        env:
+          TARGET_BRANCH: ${{ matrix.branch }}
+        run: |
+          # Loud-fail this matrix entry (not the whole run — ``fail-fast:
+          # false`` keeps siblings going) when the target branch lacks
+          # ``tools/changelog/cli.py``. A red tile is the desired signal:
+          # a branch in the nightly set without the compile tooling is a
+          # configuration error, not a "no-op" condition.
+          if [ ! -f tools/changelog/cli.py ]; then
+            echo "::error::Branch '$TARGET_BRANCH' is missing tools/changelog/cli.py — drop it from env.CRON_BRANCHES (or the dispatch input) or restore the tooling on that branch."
+            exit 1
+          fi
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -103,6 +183,14 @@ jobs:
 
       - name: Commit and push if fragments were compiled
         if: ${{ !inputs.dry_run }}
+        env:
+          # Pass the matrix branch through an env var rather than
+          # interpolating ``${{ matrix.branch }}`` directly into ``run:``.
+          # The interpolation happens *before* shell quoting, so an
+          # adversarial input could escape the surrounding quotes; the
+          # env passthrough keeps the value inside the shell's variable
+          # space where standard quoting protects it.
+          TARGET_BRANCH: ${{ matrix.branch }}
         run: |
           # Author commits as the App's bot user so the GitHub UI attributes
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
@@ -140,12 +228,14 @@ jobs:
               done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
-            # Rebase onto develop's current tip in case a human commit
-            # landed during this run (~2 min window between checkout and
-            # push). Without this the push fails non-fast-forward and the
-            # batch waits for the next run.
-            git pull --rebase origin develop
-            # Push explicitly to develop so we don't accidentally write
-            # to the source ref of a workflow_dispatch run.
-            git push origin HEAD:develop
+            # Rebase onto the target branch's current tip in case a human
+            # commit landed during this run (~2 min window between
+            # checkout and push). Without this the push fails non-fast-
+            # forward and the batch waits for the next run. ``refs/heads/``
+            # is explicit so a same-named tag (if one ever exists) can't
+            # disambiguate the wrong way.
+            git pull --rebase origin "refs/heads/$TARGET_BRANCH"
+            # Push explicitly to the target branch so we don't accidentally
+            # write to the source ref of a workflow_dispatch run.
+            git push origin "HEAD:refs/heads/$TARGET_BRANCH"
           fi

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -63,7 +63,9 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          # ``client-id`` (the App's OAuth client ID, ``Iv23...``) supersedes
+          # the deprecated ``app-id`` integer input as of v3.x.
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
           # Declare the scope the App must have so token mint fails loudly
           # if the App is misconfigured, instead of failing silently at the
@@ -86,7 +88,7 @@ jobs:
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -12,13 +12,15 @@
 # Scheduled workflow — must live on the default branch (``main``) for the
 # cron to register. See ``.github/workflows/README.md``.
 #
-# The push uses ``CHANGELOG_PAT`` (a personal access token / fine-grained
-# GitHub App token with ``contents:write`` on this repo) when it's
-# available so downstream CI runs on the auto-commit. Falls back to
-# ``GITHUB_TOKEN`` — sufficient for the push itself, but pushes signed
-# with ``GITHUB_TOKEN`` do not trigger workflow runs on the resulting
-# commit, which is by design (avoids infinite loops) but means the
-# Docker / docs rebuild won't re-trigger off the nightly's auto-commit.
+# The push uses a short-lived GitHub App installation token minted from
+# ``CHANGELOG_APP_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets). The
+# App must be installed on this repository with ``contents: write`` and
+# added to the bypass-actor list of ``develop``'s branch ruleset so the
+# auto-commit can push directly without satisfying required-checks /
+# required-approval gates.
+# Commits signed by an App token (unlike ``GITHUB_TOKEN``) are treated as
+# external pushes, so they DO trigger downstream workflow runs (Docker
+# rebuild, docs, etc.) without needing a separate PAT.
 
 name: Nightly Changelog Compilation
 
@@ -43,7 +45,9 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  # Reduced: the App installation token below carries its own write scope.
+  # GITHUB_TOKEN only needs read access for the standard checkout machinery.
+  contents: read
 
 jobs:
   compile-changelog:
@@ -52,6 +56,20 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Mint a short-lived (1 h) installation access token for the
+      # ``isaaclab-bot`` GitHub App. The App is on develop's branch-ruleset
+      # bypass list, so its push lands without needing the standard
+      # required-checks / required-approval pipeline.
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.CHANGELOG_APP_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          # Declare the scope the App must have so token mint fails loudly
+          # if the App is misconfigured, instead of failing silently at the
+          # push step.
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           # Operate on develop, not the repo's default branch. Scheduled
@@ -60,9 +78,10 @@ jobs:
           # compile sees develop's accumulated fragments and the push
           # writes back to develop.
           ref: develop
-          # Use a PAT so the auto-commit triggers downstream CI; falls back
-          # to GITHUB_TOKEN which is sufficient for the push itself.
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
+          # App token (vs. GITHUB_TOKEN) means the push is signed by
+          # ``isaaclab-bot`` — the bypass identity — and downstream CI
+          # workflows DO trigger on the resulting commit.
+          token: ${{ steps.app-token.outputs.token }}
           # Full history so the compiler can resolve each fragment's merge
           # time via ``git log --diff-filter=A --first-parent``.
           fetch-depth: 0
@@ -81,10 +100,12 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: inputs.dry_run != 'true'
+        if: ${{ !inputs.dry_run }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Author commits as the App's bot user so the GitHub UI attributes
+          # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
+          git config user.name "isaaclab-bot[bot]"
+          git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
                   source/*/config/extension.toml
@@ -117,6 +138,11 @@ jobs:
               done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
+            # Rebase onto develop's current tip in case a human commit
+            # landed during this run (~2 min window between checkout and
+            # push). Without this the push fails non-fast-forward and the
+            # batch waits for the next run.
+            git pull --rebase origin develop
             # Push explicitly to develop so we don't accidentally write
             # to the source ref of a workflow_dispatch run.
             git push origin HEAD:develop

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -173,6 +173,13 @@ jobs:
           python-version: "3.12"
 
       - name: Compile fragments
+        # Capture the compile exit code so the next step can commit/push
+        # whatever compiled successfully, then re-propagate the failure at
+        # the end. Without ``continue-on-error: true`` the workflow would
+        # short-circuit and discard the successful packages' on-disk state,
+        # which is exactly the wedge mode that motivated this design.
+        id: compile
+        continue-on-error: true
         run: |
           ARGS="--all"
           if [ "${{ inputs.dry_run }}" = "true" ]; then
@@ -182,7 +189,14 @@ jobs:
           python3 tools/changelog/cli.py compile $ARGS
 
       - name: Commit and push if fragments were compiled
-        if: ${{ !inputs.dry_run }}
+        # Fires when compile succeeded cleanly OR raised on at least one
+        # package (``continue-on-error: true`` above turned that conclusion
+        # to success while preserving the outcome — the surviving packages
+        # still ship). Explicitly NOT ``always()``: cancellation (timeout /
+        # maintainer cancel) leaves a partial on-disk state and the
+        # re-propagate step below wouldn't fire on ``outcome == 'cancelled'``,
+        # so this guard skips the commit/push entirely on cancel.
+        if: ${{ (success() || steps.compile.outcome == 'failure') && !inputs.dry_run }}
         env:
           # Pass the matrix branch through an env var rather than
           # interpolating ``${{ matrix.branch }}`` directly into ``run:``.
@@ -196,9 +210,15 @@ jobs:
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
           git config user.name "isaaclab-bot[bot]"
           git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
+          # ``pyproject.toml`` is staged alongside ``extension.toml`` because
+          # ``Package.write_version`` bumps both when a ``[project]`` block
+          # exists. Missing it leaves the pyproject write unstaged, which
+          # makes the subsequent ``git pull --rebase`` refuse with
+          # ``cannot pull with rebase: You have unstaged changes``.
           git add source/*/changelog.d/ \
                   source/*/docs/CHANGELOG.rst \
-                  source/*/config/extension.toml
+                  source/*/config/extension.toml \
+                  source/*/pyproject.toml
           if git diff --staged --quiet; then
             echo "No changelog fragments found — nothing to commit."
           else
@@ -239,3 +259,13 @@ jobs:
             # write to the source ref of a workflow_dispatch run.
             git push origin "HEAD:refs/heads/$TARGET_BRANCH"
           fi
+
+      - name: Re-propagate compile failure
+        # ``continue-on-error: true`` above lets the commit/push step run on
+        # partial success, but the job tile must still stay red so the
+        # maintainer notices the failed package. This step re-asserts the
+        # original exit code AFTER successful packages have shipped.
+        if: ${{ steps.compile.outcome == 'failure' }}
+        run: |
+          echo "::error::One or more packages failed to compile (see the Compile fragments step above)."
+          exit 1

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -5,9 +5,9 @@
 
 # Nightly auto-compile: rolls accumulated fragments under
 # ``source/<pkg>/changelog.d/`` into per-package ``CHANGELOG.rst`` entries,
-# bumps each ``extension.toml``, deletes consumed fragments, and pushes the
-# result back to each branch in the configured list. Keeps every tracked
-# branch's changelog current without requiring a maintainer to run
+# bumps each package's version metadata, deletes consumed fragments, and
+# pushes the result back to each branch in the configured list. Keeps every
+# tracked branch's changelog current without requiring a maintainer to run
 # ``compile`` by hand.
 #
 # Scheduled workflow — must live on the default branch (``main``) for the
@@ -210,15 +210,11 @@ jobs:
           # them correctly. ID 282401363 is isaaclab-bot[bot]'s user ID.
           git config user.name "isaaclab-bot[bot]"
           git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
-          # ``pyproject.toml`` is staged alongside ``extension.toml`` because
-          # ``Package.write_version`` bumps both when a ``[project]`` block
-          # exists. Missing it leaves the pyproject write unstaged, which
-          # makes the subsequent ``git pull --rebase`` refuse with
-          # ``cannot pull with rebase: You have unstaged changes``.
-          git add source/*/changelog.d/ \
-                  source/*/docs/CHANGELOG.rst \
-                  source/*/config/extension.toml \
-                  source/*/pyproject.toml
+          # Stage every tracked compiler output under ``source/``. Active
+          # branches store package versions in ``pyproject.toml``, while
+          # release branches still use ``config/extension.toml``; naming both
+          # path globs makes ``git add`` fail when either layout is absent.
+          git add --update -- source/
           if git diff --staged --quiet; then
             echo "No changelog fragments found — nothing to commit."
           else
@@ -231,21 +227,29 @@ jobs:
             # action. The trigger event suffix (``schedule`` vs
             # ``workflow_dispatch``) is preserved for traceability.
             #
-            # The body lists every package that bumped, derived from the
-            # staged ``extension.toml`` diff so the entries are accurate
-            # regardless of which packages happen to have pending
-            # fragments this run.
+            # The body lists every package that bumped, derived from whichever
+            # supported version metadata file changed on the target branch.
             MSG_FILE=$(mktemp)
             {
               echo "[CI][Auto Version Bump] Compile changelog fragments (${{ github.event_name }})"
               echo
               echo "Bumped packages:"
-              for tom in $(git diff --staged --name-only -- 'source/*/config/extension.toml'); do
-                pkg=$(echo "$tom" | sed -E 's|source/([^/]+)/config/extension.toml|\1|')
-                old=$(git diff --staged "$tom" | awk -F'"' '/^-version/{print $2; exit}')
-                new=$(git diff --staged "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
-                echo "- $pkg: $old → $new"
-              done
+              git diff --staged --name-only -- \
+                'source/*/config/extension.toml' \
+                'source/*/pyproject.toml' \
+                | sed -E 's|source/([^/]+)/.*|\1|' \
+                | sort -u \
+                | while IFS= read -r pkg; do
+                    pyproject="source/$pkg/pyproject.toml"
+                    if git diff --staged --quiet -- "$pyproject"; then
+                      tom="source/$pkg/config/extension.toml"
+                    else
+                      tom="$pyproject"
+                    fi
+                    old=$(git diff --staged -- "$tom" | awk -F'"' '/^-version/{print $2; exit}')
+                    new=$(git diff --staged -- "$tom" | awk -F'"' '/^\+version/{print $2; exit}')
+                    echo "- $pkg: $old → $new"
+                  done
             } > "$MSG_FILE"
             git commit -F "$MSG_FILE"
             # Rebase onto the target branch's current tip in case a human

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,256 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Publish Docker Images
+
+on:
+  # Nightly build + publish from develop and the active release branches listed
+  # in CRON_BRANCHES below. No push triggers — workflow_dispatch also accepts any
+  # publishable branch. main is intentionally excluded: main images are built
+  # by postmerge-ci.yml on push instead.
+  schedule:
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build and publish (e.g. develop, release/3.0.0-beta2)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Branches the nightly cron publishes. Single source of truth — append a ref
+# here when a new release/* is cut and drop it once that release is retired, so
+# stale branches aren't rebuilt nightly. Mirrors CRON_BRANCHES in
+# nightly-changelog.yml. Whitespace per entry is stripped. main is excluded on
+# purpose (it builds on the public isaac-sim base via postmerge-ci.yml).
+env:
+  NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+  CRON_BRANCHES: develop,release/3.0.0-beta2
+
+jobs:
+  resolve-branches:
+    name: Resolve publish branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      branches: ${{ steps.b.outputs.branches }}
+    steps:
+    - id: b
+      env:
+        # Schedule → the CRON_BRANCHES list. Manual → the single branch the
+        # maintainer entered (required input). Same pattern as nightly-changelog.yml.
+        BRANCHES: ${{ github.event_name == 'schedule' && env.CRON_BRANCHES || inputs.branch }}
+      run: |
+        # CSV → newline, trimming surrounding whitespace per entry, then to a
+        # compact JSON array. Manual produces a 1-element array; cron N elements.
+        arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
+        if [ "$(echo "$arr" | jq 'length')" -eq 0 ]; then
+          echo "::error::No branches resolved for publishing"
+          exit 1
+        fi
+        echo "branches=$arr" >> "$GITHUB_OUTPUT"
+        echo "Resolved branches: $arr"
+
+  config:
+    name: Load Config
+    runs-on: ubuntu-latest
+    outputs:
+      isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
+      isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
+      isaaclab_image_name: ${{ steps.load.outputs.isaaclab_image_name }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        sparse-checkout: .github/workflows/config.yaml
+        sparse-checkout-cone-mode: false
+    - id: load
+      run: |
+        set -euo pipefail
+        f=.github/workflows/config.yaml
+        echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
+        echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
+        echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
+
+  build-and-push-images:
+    name: Build and Push (${{ matrix.branch }})
+    needs: [config, resolve-branches]
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}
+    concurrency:
+      group: publish-images-${{ matrix.branch }}
+      cancel-in-progress: true
+    environment:
+      name: postmerge-production
+      url: https://github.com/${{ github.repository }}
+    env:
+        DOCKER_HOST: unix:///var/run/docker.sock
+        DOCKER_TLS_CERTDIR: ""
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        lfs: true
+        ref: ${{ matrix.branch }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+        driver-opts: |
+          image=moby/buildkit:buildx-stable-1
+
+    - name: Login to NGC
+      run: |
+        # Only attempt NGC login if API key is available
+        if [ -n "$NGC_API_KEY" ]; then
+          echo "🔵 Logging into NGC registry..."
+          if ! echo "$NGC_API_KEY" | docker login -u '$oauthtoken' --password-stdin nvcr.io; then
+            echo "🔴 Failed to log into NGC registry"
+            exit 1
+          fi
+          echo "🟢 Successfully logged into NGC registry"
+        else
+          echo "🟠 NGC_API_KEY not set - skipping NGC login (normal when secrets are not configured)"
+        fi
+
+    - name: Build and Push Docker Images
+      run: |
+        BRANCH_NAME="${{ matrix.branch }}"
+        IMAGE_BASE_VERSION="${{ needs.config.outputs.isaacsim_image_tag }}"
+        IMAGE="${{ needs.config.outputs.isaaclab_image_name }}"
+
+        # Use the SHA actually checked out for this branch (the matrix ref), not
+        # github.sha — on a scheduled run github.sha is the default branch (main)
+        # HEAD, which would mis-tag every nightly image.
+        FULL_SHA="$(git rev-parse HEAD)"
+
+        echo "Branch: $BRANCH_NAME"
+        echo "Commit: $FULL_SHA"
+        echo "IsaacSim base image: ${{ needs.config.outputs.isaacsim_image_name }}:$IMAGE_BASE_VERSION"
+        echo "Target Isaac Lab image: $IMAGE"
+
+        # Build the tag list for the branch (main is published separately via
+        # postmerge-ci.yml, so it is not handled here).
+        #
+        # Tagging scheme:
+        #   - develop:    $IMAGE:latest-develop               (moves to newest develop build)
+        #                 $IMAGE:latest-develop-<full-sha>    (immutable per-commit)
+        #   - release/X:  $IMAGE:latest-release-X             (moves to newest build on that release branch)
+        #                 $IMAGE:latest-release-X-<full-sha>  (immutable per-commit)
+        #
+        # The immutable per-commit tag doubles as the "already published" marker:
+        # if it exists in the registry the branch has not advanced since the last
+        # publish, so the nightly build is skipped (see the guard below).
+        MOVING_TAG=""
+        IMMUTABLE_TAG=""
+
+        case "$BRANCH_NAME" in
+          develop)
+            MOVING_TAG="$IMAGE:latest-develop"
+            IMMUTABLE_TAG="$IMAGE:latest-develop-$FULL_SHA"
+            ;;
+          release/*)
+            # Sanitize the part after release/ for use as a Docker tag suffix.
+            RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            MOVING_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX"
+            IMMUTABLE_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX-$FULL_SHA"
+            ;;
+          main)
+            # main is intentionally not published here; see postmerge-ci.yml for main.
+            echo "Branch 'main' is not published by this workflow; skipping. See postmerge-ci.yml for main."
+            exit 0
+            ;;
+          *)
+            echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."
+            exit 0
+            ;;
+        esac
+
+        # Skip the (expensive) build when this exact commit was already published.
+        # The immutable per-commit tag is the source of truth for "git advanced":
+        # if it already exists in the registry, nothing new to build for this branch.
+        if docker manifest inspect "$IMMUTABLE_TAG" >/dev/null 2>&1; then
+          echo "🟢 $IMMUTABLE_TAG already exists — $BRANCH_NAME has not advanced since the last publish. Skipping."
+          exit 0
+        fi
+
+        TAGS=("$MOVING_TAG" "$IMMUTABLE_TAG")
+
+        # Determine if multiarch is supported by inspecting the base image manifest
+        echo "🔵 Checking if base image supports multiarch..."
+        BASE_IMAGE_FULL="${{ needs.config.outputs.isaacsim_image_name }}:${IMAGE_BASE_VERSION}"
+        ARCHITECTURES=$(docker manifest inspect "$BASE_IMAGE_FULL" 2>/dev/null | grep -o '"architecture": "[^"]*"' | cut -d'"' -f4 | sort -u)
+
+        if [ -z "$ARCHITECTURES" ]; then
+          echo "🟠 Could not inspect base image manifest: $BASE_IMAGE_FULL - defaulting to linux/amd64 only"
+          BUILD_PLATFORMS="linux/amd64"
+        else
+          echo "Base image architectures found:"
+          echo "$ARCHITECTURES" | sed 's/^/  - /'
+
+          HAS_AMD64=$(echo "$ARCHITECTURES" | grep -c "amd64" || true)
+          HAS_ARM64=$(echo "$ARCHITECTURES" | grep -c "arm64" || true)
+
+          if [ "$HAS_AMD64" -gt 0 ] && [ "$HAS_ARM64" -gt 0 ]; then
+            echo "🟢 Base image supports multiarch (amd64 + arm64)"
+            BUILD_PLATFORMS="linux/amd64,linux/arm64"
+          elif [ "$HAS_AMD64" -gt 0 ]; then
+            echo "Base image only supports amd64"
+            BUILD_PLATFORMS="linux/amd64"
+          elif [ "$HAS_ARM64" -gt 0 ]; then
+            echo "Base image only supports arm64"
+            BUILD_PLATFORMS="linux/arm64"
+          else
+            echo "🟠 Unknown architecture support for $BASE_IMAGE_FULL - defaulting to linux/amd64"
+            BUILD_PLATFORMS="linux/amd64"
+          fi
+        fi
+
+        echo "Target platforms: $BUILD_PLATFORMS"
+        echo "Tags to publish:"
+        printf '  - %s\n' "${TAGS[@]}"
+
+        # Compose -t flags for buildx
+        TAG_ARGS=()
+        for t in "${TAGS[@]}"; do
+          TAG_ARGS+=("-t" "$t")
+        done
+
+        echo "🔵 Building and pushing image with tags listed above..."
+        if ! docker buildx build \
+          --platform "$BUILD_PLATFORMS" \
+          --progress=plain \
+          "${TAG_ARGS[@]}" \
+          --build-arg ISAACSIM_BASE_IMAGE_ARG=${{ needs.config.outputs.isaacsim_image_name }} \
+          --build-arg ISAACSIM_VERSION_ARG="$IMAGE_BASE_VERSION" \
+          --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim \
+          --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab \
+          --build-arg DOCKER_USER_HOME_ARG=/root \
+          --cache-from type=gha \
+          --cache-to type=gha,mode=max \
+          -f docker/Dockerfile.base \
+          --push .; then
+          echo "🔴 docker buildx build/push failed for tags:"
+          printf '  - %s\n' "${TAGS[@]}"
+          exit 1
+        fi
+
+        for t in "${TAGS[@]}"; do
+          echo "🟢 Successfully built and pushed: $t (platforms: $BUILD_PLATFORMS)"
+        done

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,8 +54,9 @@ Guidelines for modifications:
 * Brayden Zhang
 * Brian Bingham
 * Brian McCann
-* Cameron Upright
+* Caelan Garrett
 * Calvin Yu
+* Cameron Upright
 * Cathy Y. Li
 * Cheng-Rong Lai
 * Chenyu Yang

--- a/docs/_extensions/isaaclab_docs.py
+++ b/docs/_extensions/isaaclab_docs.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sphinx helpers for Isaac Lab documentation."""
+
+from __future__ import annotations
+
+from docutils import nodes
+from docutils.statemachine import StringList
+from sphinx.util.docutils import SphinxDirective
+
+
+def _branch(config) -> str:
+    """Return the branch or tag pinned in installation docs."""
+    current_version = getattr(config, "smv_current_version", "")
+    if current_version:
+        return current_version
+    return getattr(config, "isaaclab_latest_branch", "main")
+
+
+def _parse_rst(directive: SphinxDirective, content: str) -> list[nodes.Node]:
+    """Parse nested reST and return the generated document nodes."""
+    source = directive.env.doc2path(directive.env.docname, base=False)
+    lines = StringList(content.splitlines(), source=source)
+    container = nodes.container()
+    directive.state.nested_parse(lines, 0, container)
+    return container.children
+
+
+class IsaacLabCloneCommands(SphinxDirective):
+    """Render SSH/HTTPS clone tabs using copy-friendly ``code-block`` directives."""
+
+    has_content = False
+
+    def run(self) -> list[nodes.Node]:
+        branch = _branch(self.config)
+        content = f"""\
+.. tab-set::
+
+   .. tab-item:: SSH
+
+      .. code-block:: bash
+
+         git clone git@github.com:isaac-sim/IsaacLab.git --branch {branch}
+         cd IsaacLab
+
+   .. tab-item:: HTTPS
+
+      .. code-block:: bash
+
+         git clone https://github.com/isaac-sim/IsaacLab.git --branch {branch}
+         cd IsaacLab
+"""
+        return _parse_rst(self, content)
+
+
+def setup(app):
+    """Register Isaac Lab documentation directives."""
+    app.add_config_value("isaaclab_latest_branch", "main", "env")
+    app.add_directive("isaaclab-clone-commands", IsaacLabCloneCommands)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ templates_path = []
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "_redirect", "_templates", "Thumbs.db", ".DS_Store", "README.md", "licenses/*"]
+exclude_patterns = ["_build", "_redirect", "_templates", "Thumbs.db", ".DS_Store", "README.md", "licenses/*", "plans"]
 
 # Mock out modules that are not available on RTD
 autodoc_mock_imports = [
@@ -176,6 +176,7 @@ autodoc_mock_imports = [
     "omni.timeline",
     "omni.ui",
     "gym",
+    "gymnasium",
     "skrl",
     "stable_baselines3",
     "rsl_rl",
@@ -287,9 +288,11 @@ templates_path = [
 # Whitelist pattern for remotes
 smv_remote_whitelist = r"^.*$"
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|devel|release/.*)$")
-# Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+$")
+smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|develop|release/.*)$")
+# Whitelist pattern for tags (set to None to ignore all tags).
+# Matches vMAJOR.MINOR.PATCH with an optional pre-release suffix like -beta or -rc1,
+# so tags like v3.0.0-beta show up in the version selector.
+smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$")
 html_sidebars = {
     "**": ["navbar-logo.html", "versioning.html", "icon-links.html", "search-field.html", "sbt-sidebar-nav.html"]
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,8 @@ intersphinx_mapping = {
     "torch": ("https://docs.pytorch.org/docs/stable/", None),
     "isaacsim": ("https://docs.isaacsim.omniverse.nvidia.com/5.1.0/py/", None),
     "gymnasium": ("https://gymnasium.farama.org/", None),
-    "warp": ("https://nvidia.github.io/warp/", None),
+    # NOTE: pinned to /stable/ because /objects.inv at the root currently 404s
+    "warp": ("https://nvidia.github.io/warp/stable/", None),
     "omniverse": ("https://docs.omniverse.nvidia.com/dev-guide/latest", None),
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("_extensions"))
 sys.path.insert(0, os.path.abspath("../source/isaaclab"))
 sys.path.insert(0, os.path.abspath("../source/isaaclab/isaaclab"))
 sys.path.insert(0, os.path.abspath("../source/isaaclab_assets"))
@@ -42,6 +43,13 @@ with open(os.path.join(os.path.dirname(__file__), "..", "VERSION")) as f:
     full_version = f.read().strip()
     version = ".".join(full_version.split(".")[:3])
 
+# Latest branch referenced by installation documentation.
+isaaclab_latest_branch = os.getenv("ISAACLAB_LATEST_BRANCH", "main")
+
+rst_prolog = f"""
+.. |isaaclab_latest_branch| replace:: {isaaclab_latest_branch}
+"""
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -65,6 +73,7 @@ extensions = [
     "sphinx_design",
     "sphinx_tabs.tabs",  # backwards compatibility for building docs on v1.0.0
     "sphinx_multiversion",
+    "isaaclab_docs",
 ]
 
 # mathjax hacks

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,6 @@ sphinx-multiversion==0.2.4
 numpy
 matplotlib
 warp-lang
+lazy_loader>=0.4
 # learning
 gymnasium

--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -111,5 +111,5 @@ Simulation App Launcher
    :members:
 
 
-.. _livestream: https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/manual_livestream_clients.html
+.. _livestream: https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html
 .. _`WebRTC Livestream`: https://docs.isaacsim.omniverse.nvidia.com/latest/installation/manual_livestream_clients.html#isaac-sim-short-webrtc-streaming-client

--- a/docs/source/deployment/index.rst
+++ b/docs/source/deployment/index.rst
@@ -18,19 +18,7 @@ Cloning the Repository
 
 Before building the container, clone the Isaac Lab repository (if not already done):
 
-.. tab-set::
-
-   .. tab-item:: SSH
-
-      .. code:: bash
-
-         git clone git@github.com:isaac-sim/IsaacLab.git
-
-   .. tab-item:: HTTPS
-
-      .. code:: bash
-
-         git clone https://github.com/isaac-sim/IsaacLab.git
+.. isaaclab-clone-commands::
 
 Next Steps
 ----------

--- a/docs/source/experimental-features/newton-physics-integration/index.rst
+++ b/docs/source/experimental-features/newton-physics-integration/index.rst
@@ -1,34 +1,31 @@
 Newton Physics Integration
 ===========================
 
-`Newton <https://newton-physics.github.io/newton/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
+`Newton <https://newton-physics.github.io/newton/latest/guide/overview.html>`_ is a GPU-accelerated, extensible, and differentiable physics simulation engine designed for robotics, research,
 and advanced simulation workflows. Built on top of `NVIDIA Warp <https://nvidia.github.io/warp/>`_ and integrating MuJoCo Warp, Newton provides high-performance
 simulation, modern Python APIs, and a flexible architecture for both users and developers.
 
 Newton is an Open Source community-driven project with contributions from NVIDIA, Google Deep Mind, and Disney Research,
 managed through the Linux Foundation.
 
-This `experimental feature branch <https://github.com/isaac-sim/IsaacLab/tree/feature/newton>`_ of Isaac Lab provides an initial integration with the Newton Physics Engine, and is
+This integration is available on the `develop branch <https://github.com/isaac-sim/IsaacLab/tree/develop>`_ of Isaac Lab as part of Isaac Lab 3.0 Beta, and is
 under active development. Many features are not yet supported, and only a limited set of classic RL and flat terrain locomotion
 reinforcement learning examples are included at the moment.
 
-Both this Isaac Lab integration branch and Newton itself are under heavy development. We intend to support additional
+Both this Isaac Lab integration and Newton itself are under heavy development. We intend to support additional
 features for other reinforcement learning and imitation learning workflows in the future, but the above tasks should be
 a good lens through which to understand how Newton integration works in Isaac Lab.
 
 We have validated Newton simulation against PhysX by transferring learned policies from Newton to PhysX and vice versa
 Furthermore, we have also successfully deployed a Newton-trained locomotion policy to a G1 robot. Please see :ref:`here <sim2real>` for more information.
 
-Newton can support `multiple solvers <https://newton-physics.github.io/newton/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
+Newton can support `multiple solvers <https://newton-physics.github.io/newton/latest/api/newton_solvers.html>`_ for handling different types of physics simulation, but for the moment, the Isaac
 Lab integration focuses primarily on the MuJoCo-Warp solver.
 
-Future updates of this branch and Newton should include both ongoing improvements in performance as well as integration
+Future updates of Isaac Lab and Newton should include both ongoing improvements in performance as well as integration
 with additional solvers.
 
-Note that this branch does not include support for the PhysX physics engine - only Newton is supported. We are considering
-several possible paths to continue to support PhysX within Lab, and feedback from users about their needs around that would be appreciated.
-
-During the early development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
+During the development phase of both Newton and this Isaac Lab integration, you are likely to encounter breaking
 changes as well as limited documentation. We do not expect to be able to provide official support or debugging assistance
 until the framework has reached an official release. We appreciate your understanding and patience as we work to deliver a robust and polished framework!
 

--- a/docs/source/experimental-features/newton-physics-integration/installation.rst
+++ b/docs/source/experimental-features/newton-physics-integration/installation.rst
@@ -1,62 +1,68 @@
 Installation
 ============
 
-Installing the Newton physics integration branch requires three things:
+Installing the Newton physics integration requires three things:
 
-1) The ``feature/newton`` branch of Isaac Lab
-2) Ubuntu 22.04 or 24.04 (Windows will be supported soon)
-3) [Optional] Isaac sim 5.1 (Isaac Sim is not required if the Omniverse visualizer is not used)
+1) The ``develop`` branch of Isaac Lab
+2) Ubuntu 22.04 or 24.04
+3) [Optional] Isaac Sim 6.0 (Isaac Sim is not required if the Omniverse visualizer is not used)
 
-To begin, verify the version of Isaac Sim by checking the title of the window created when launching the simulation app.  Alternatively, you can
-find more explicit version information under the ``Help -> About`` menu within the app.
-If your version is less than 5.1, you must first `update or reinstall Isaac Sim <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/quick-install.html>`_ before
-you can proceed further.
+To begin, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
 
-Next, navigate to the root directory of your local copy of the Isaac Lab repository and open a terminal.
-
-Make sure we are on the ``feature/newton`` branch by running the following command:
+Make sure we are on the ``develop`` branch by running the following command:
 
 .. code-block:: bash
 
-    git checkout feature/newton
-
-Below, we provide instructions for installing Isaac Sim through pip.
+    git checkout develop
 
 
-Pip Installation
-----------------
+Installation
+------------
 
-We recommend using conda for managing your python environments. Conda can be downloaded and installed from `here <https://docs.conda.io/en/latest/miniconda.html>`_.
+We recommend using **uv** as the package manager — it is significantly faster than pip and conda.
+To install ``uv``, please follow the instructions `here <https://docs.astral.sh/uv/getting-started/installation/>`__.
 
 If you previously already have a virtual environment for Isaac Lab, please ensure to start from a fresh environment to avoid any dependency conflicts.
 If you have installed earlier versions of mujoco, mujoco-warp, or newton packages through pip, we recommend first
 cleaning your pip cache with ``pip cache purge`` to remove any cache of earlier versions that may be conflicting with the latest.
 
-Create a new conda environment:
+Create a new virtual environment with Python 3.12:
 
 .. code-block:: bash
 
-    conda create -n env_isaaclab python=3.11
+    uv venv --python 3.12 --seed env_isaaclab
 
 Activate the environment:
 
 .. code-block:: bash
 
-    conda activate env_isaaclab
+    source env_isaaclab/bin/activate
+
+.. note::
+
+   If you are using ``pip`` directly instead of ``uv pip``, replace ``uv pip`` with ``pip`` in the commands below.
+
+
+Ensure pip is up to date:
+
+.. code-block:: bash
+
+    uv pip install --upgrade pip
+
+[Optional] Install Isaac Sim 6.0:
+
+.. code-block:: bash
+
+    uv pip install "isaacsim[all,extscache]==6.0.0" --extra-index-url https://pypi.nvidia.com
+
 
 Install the correct version of torch and torchvision:
 
 .. code-block:: bash
 
-    pip install -U torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+    uv pip install -U torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cu128
 
-[Optional] Install Isaac Sim 5.1:
-
-.. code-block:: bash
-
-    pip install "isaacsim[all,extscache]==5.1.0" --extra-index-url https://pypi.nvidia.com
-
-Install Isaac Lab extensions and dependencies:
+Install Isaac Lab extensions and dependencies (this includes Newton 1.0):
 
 .. code-block:: bash
 
@@ -71,8 +77,3 @@ To verify that the installation was successful, run the following command from t
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct-v0 --num_envs 128
-
-
-Note that since Newton requires a more recent version of Warp than Isaac Sim 5.1, there may be some incompatibility issues
-that could result in errors such as ``ModuleNotFoundError: No module named 'warp.sim'``. These are ok to ignore and should not
-impact usability.

--- a/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
+++ b/docs/source/experimental-features/newton-physics-integration/isaaclab_newton-beta-2.rst
@@ -1,11 +1,11 @@
-Isaac Lab - Newton Beta 2
-=========================
+Isaac Lab 3.0 Beta
+==================
 
-Isaac Lab - Newton Beta 2 (feature/newton branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
+Isaac Lab 3.0 Beta (develop branch) provides Newton physics engine integration for Isaac Lab. We refactored our code so that we can not only support PhysX and Newton, but
 any other physics engine, enabling users to bring their own physics engine to Isaac Lab if they desire. To enable this, we introduce base implementations of
 our ``simulation interfaces``, :class:`~isaaclab.assets.articulation.Articulation` or :class:`~isaaclab.sensors.ContactSensor` for instance. These provide a
 set of abstract methods that all physics engines must implement. In turn this allows all of the default Isaac Lab environments to work with any physics engine.
-This also allows us to ensure that Isaac Lab - Newton Beta 2 is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
+This also allows us to ensure that Isaac Lab 3.0 Beta is backwards compatible with Isaac Lab 2.X. For engine specific calls, users could get the underlying view of
 the physics engine and call the engine specific APIs directly.
 
 However, as we are refactoring the code, we are also looking at ways to limit the overhead of Isaac Lab's. In an effort to minimize the overhead, we are moving
@@ -13,7 +13,7 @@ all our low level code away from torch, and instead will rely heavily on warp. T
 to take advantage of the cuda-graphing. However, this means that the ``data classes`` such as :class:`~isaaclab.assets.articulation.ArticulationData` or
 :class:`~isaaclab.sensors.ContactSensorData` will only return warp arrays. Users will hence have to call ``wp.to_torch`` to convert them to torch tensors if they desire.
 Our setters/writers will support both warp arrays and torch tensors, and will use the most optimal strategy to update the warp arrays under the hood. This minimizes the
-amount of changes required for users to migrate to Isaac Lab - Newton Beta 2.
+amount of changes required for users to migrate to Isaac Lab 3.0 Beta.
 
 Another new feature of the writers and setters is the ability to provide them with masks and complete data (as opposed to indices and partial data in Isaac Lab 2.X).
 Note that this feature will be available along with the ability to provide indices and partial data, and that the default behavior will still be to provide indices and partial data.
@@ -41,12 +41,3 @@ we are introducing cuda-graphing support for direct rl tasks. This drastically r
 .. code-block:: bash
 
     ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Humanoid-Direct-Warp-v0 --num_envs 4096 --headless
-
-
-What's Next?
-============
-
-Isaac Lab 3.0 is the upcoming release of Isaac Lab, which will be compatible with Isaac Sim 6.0, and at the same time will support the new Newton physics engine.
-This will allow users to train policies on the Newton physics engine, or PhysX. To accommodate this major code refactoring are required. In this section, we
-will go over some of the changes, how that will affect Isaac Lab 2.X users, and how to migrate to Isaac Lab 3.0. The current branch of ``feature/newton`` gives
-a glance of what is to come. While the changes to the internal code structure are significant, the changes to the user API are minimal.

--- a/docs/source/experimental-features/newton-physics-integration/training-environments.rst
+++ b/docs/source/experimental-features/newton-physics-integration/training-environments.rst
@@ -7,16 +7,15 @@ The currently supported tasks are as follows:
 
 * Isaac-Cartpole-Direct-v0
 * Isaac-Cartpole-v0
-* Isaac-Cartpole-RGB-Camera-Direct-v0
-* Isaac-Cartpole-Depth-Camera-Direct-v0
+* Isaac-Cartpole-Camera-Presets-Direct-v0
 * Isaac-Ant-Direct-v0
 * Isaac-Ant-v0
+* Isaac-Dexsuite-Kuka-Allegro-Lift-v0
 * Isaac-Humanoid-Direct-v0
 * Isaac-Humanoid-v0
 * Isaac-Velocity-Flat-Anymal-B-v0
 * Isaac-Velocity-Flat-Anymal-C-v0
 * Isaac-Velocity-Flat-Anymal-D-v0
-* Isaac-Velocity-Flat-Cassie-v0
 * Isaac-Velocity-Flat-G1-v0
 * Isaac-Velocity-Flat-G1-v1 (Sim-to-Real tested)
 * Isaac-Velocity-Flat-H1-v0

--- a/docs/source/experimental-features/newton-physics-integration/visualization.rst
+++ b/docs/source/experimental-features/newton-physics-integration/visualization.rst
@@ -59,8 +59,8 @@ Launch visualizers from the command line with ``--visualizer``:
 
 .. code-block:: bash
 
-    # Launch all visualizers
-    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer omniverse newton rerun
+    # Launch all visualizers (comma-delimited list, no spaces)
+    python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer kit,newton,rerun
 
     # Launch just newton visualizer
     python scripts/reinforcement_learning/rsl_rl/train.py --task Isaac-Cartpole-v0 --visualizer newton
@@ -77,18 +77,20 @@ If ``--headless`` is given, no visualizers will be launched.
 Configuration
 ~~~~~~~~~~~~~
 
-Launching visualizers with the command line will use default visualizer configurations. Default configs can be found and edited in ``source/isaaclab/isaaclab/visualizers``.
+Launching visualizers with the command line will use default visualizer configurations. Visualizer backends live in the ``isaaclab_visualizers`` package (e.g. ``source/isaaclab_visualizers/isaaclab_visualizers/kit``, ``newton``, ``rerun``).
 
-You can also configure custom visualizers in the code by defining new ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
+You can also configure custom visualizers in the code by defining ``VisualizerCfg`` instances for the ``SimulationCfg``, for example:
 
 .. code-block:: python
 
     from isaaclab.sim import SimulationCfg
-    from isaaclab.visualizers import NewtonVisualizerCfg, OVVisualizerCfg, RerunVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     sim_cfg = SimulationCfg(
         visualizer_cfgs=[
-            OVVisualizerCfg(
+            KitVisualizerCfg(
                 viewport_name="Visualizer Viewport",
                 create_viewport=True,
                 dock_position="SAME",
@@ -128,9 +130,9 @@ Omniverse Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import OVVisualizerCfg
+    from isaaclab_visualizers.kit import KitVisualizerCfg
 
-    visualizer_cfg = OVVisualizerCfg(
+    visualizer_cfg = KitVisualizerCfg(
         # Viewport settings
         viewport_name="Visualizer Viewport",      # Viewport window name
         create_viewport=True,                     # Create new viewport vs. use existing
@@ -176,8 +178,6 @@ Newton Visualizer
      - Look around
    * - **Mouse Scroll**
      - Zoom in/out
-   * - **Space**
-     - Pause/resume rendering (physics continues)
    * - **H**
      - Toggle UI sidebar
    * - **ESC**
@@ -187,7 +187,7 @@ Newton Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import NewtonVisualizerCfg
+    from isaaclab_visualizers.newton import NewtonVisualizerCfg
 
     visualizer_cfg = NewtonVisualizerCfg(
         # Window settings
@@ -233,12 +233,14 @@ Rerun Visualizer
 
 .. code-block:: python
 
-    from isaaclab.visualizers import RerunVisualizerCfg
+    from isaaclab_visualizers.rerun import RerunVisualizerCfg
 
     visualizer_cfg = RerunVisualizerCfg(
         # Server settings
         app_id="isaaclab-simulation",             # Application identifier for viewer
+        grpc_port=9876,                           # gRPC endpoint for logging SDK connection
         web_port=9090,                            # Port for local web viewer (launched in browser)
+        bind_address="0.0.0.0",                  # Endpoint host formatting/reuse checks
 
         # Camera settings
         camera_position=(8.0, 8.0, 3.0),         # Initial camera position (x, y, z)
@@ -251,6 +253,10 @@ Rerun Visualizer
         # Recording
         record_to_rrd="recording.rrd",            # Path to save .rrd file (None = no recording)
     )
+
+Rerun startup uses the Python SDK through ``newton.viewer.ViewerRerun`` (no external ``rerun`` CLI process
+management). If ``grpc_port`` is already active, Isaac Lab reuses that server. If ``web_port`` is occupied while
+starting a new server, initialization fails with a clear port-conflict error.
 
 
 Performance Note

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -124,6 +124,36 @@ To train with multiple GPUs, use the following command, where ``--nproc_per_node
 
                     python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/skrl/train.py --task=Isaac-Cartpole-v0 --headless --distributed --ml_framework jax
 
+.. _multi-gpu-nccl-troubleshooting:
+
+Troubleshooting NCCL Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``
+during or shortly after communicator initialization.
+
+If this occurs, try disabling the NCCL shared-memory transport before launching training:
+
+.. code-block:: shell
+
+    export NCCL_SHM_DISABLE=1
+
+If the issue persists, additional NCCL fallbacks that may help are:
+
+.. code-block:: shell
+
+    export NCCL_IB_DISABLE=1
+    export NCCL_ALGO=Ring
+
+Then relaunch the distributed training command as usual.
+
+.. note::
+
+    These variables are NCCL-level workarounds intended for affected systems. They are not
+    required on all machines, and may change communication behavior or performance depending
+    on the hardware topology.
+
 Multi-Node Training
 -------------------
 

--- a/docs/source/how-to/optimize_stage_creation.rst
+++ b/docs/source/how-to/optimize_stage_creation.rst
@@ -9,7 +9,7 @@ What These Features Do
 
 **Fabric Cloning**
 
-- Clones environments using Fabric library (see `USD Fabric USDRT Documentation <https://docs.omniverse.nvidia.com/kit/docs/usdrt/latest/docs/usd_fabric_usdrt.html>`_)
+- Clones environments using Fabric library (see `USD Fabric USDRT Documentation <https://docs.omniverse.nvidia.com/kit/docs/usdrt.scenegraph/latest/usd_fabric_usdrt.html>`_)
 - Partially supported and enabled by default on some environments (see `Limitations`_ section for a list)
 
 **Stage in Memory**
@@ -47,8 +47,8 @@ Stage in memory can be toggled by setting the :attr:`isaaclab.sim.SimulationCfg.
     # create env with stage in memory
     env = ManagerBasedRLEnv(cfg=cfg)
 
-Note, if stage in memory is enabled without using an existing RL environment class, a few more steps are need.
-The stage creation steps should be wrapped in a :py:keyword:`with` statement to set the stage context.
+Note, if stage in memory is enabled without using an existing RL environment class, a few more steps are needed.
+The stage creation steps should be wrapped in a ``with`` statement to set the stage context.
 If the stage needs to be attached, the :meth:`~isaaclab.sim.utils.attach_stage_to_usd_context` function should
 be called after the stage is created.
 

--- a/docs/source/how-to/record_animation.rst
+++ b/docs/source/how-to/record_animation.rst
@@ -122,6 +122,6 @@ After the stop time is reached, a file will be saved to:
 
 
 .. _Stage Recorder: https://docs.omniverse.nvidia.com/extensions/latest/ext_animation_stage-recorder.html
-.. _Fabric: https://docs.omniverse.nvidia.com/kit/docs/usdrt/latest/docs/usd_fabric_usdrt.html
+.. _Fabric: https://docs.omniverse.nvidia.com/kit/docs/usdrt.scenegraph/latest/usd_fabric_usdrt.html
 .. _Omniverse Launcher: https://docs.omniverse.nvidia.com/launcher/latest/index.html
 .. _tutorial on layering in Omniverse: https://www.youtube.com/watch?v=LTwmNkSDh-c&ab_channel=NVIDIAOmniverse

--- a/docs/source/overview/developer-guide/development.rst
+++ b/docs/source/overview/developer-guide/development.rst
@@ -68,12 +68,12 @@ python package to build the python module provided by the extensions. This is do
 .. note::
 
    The ``setup.py`` file is not required for extensions that are only loaded into Omniverse
-   using the `Extension Manager <https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_extension-manager.html>`__.
+   using the `Extension Manager <https://docs.omniverse.nvidia.com/extensions/latest/ext_extension-manager.html>`__.
 
 Lastly, the ``tests`` directory contains the unit tests for the extension. These are written
 using the `unittest <https://docs.python.org/3/library/unittest.html>`__ framework. It is
 important to note that Omniverse also provides a similar
-`testing framework <https://docs.omniverse.nvidia.com/kit/docs/kit-manual/104.0/guide/testing_exts_python.html>`__.
+`testing framework <https://docs.omniverse.nvidia.com/kit/docs/kit-manual/latest/guide/testing_exts_python.html>`__.
 However, it requires going through the build process and does not support testing of the python module in
 standalone applications.
 

--- a/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
+++ b/docs/source/policy_deployment/02_gear_assembly/gear_assembly_policy.rst
@@ -33,7 +33,7 @@ This environment has been successfully deployed on real UR10e robots without an 
 
 **Scope of This Tutorial:**
 
-This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_manipulator_ur_dnn_policy/index.html>`_.
+This tutorial focuses exclusively on the **training part** of the sim-to-real transfer workflow in Isaac Lab. For the complete deployment workflow on the real robot, including the exact steps to set up the vision pipeline, robot interface and the ROS inference node to run your trained policy on real hardware, please refer to the `Isaac ROS Documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_.
 
 Overview
 --------
@@ -493,7 +493,7 @@ Replace ``<log_dir>`` with the path to your training logs (e.g., ``logs/rsl_rl/g
 Step 3: Deploy on Real Robot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_manipulator_ur_dnn_policy/index.html>`_ to deploy your policy.
+Once training is complete, follow the `Isaac ROS inference documentation <https://nvidia-isaac-ros.github.io/reference_workflows/isaac_for_manipulation/packages/isaac_ros_manipulation_ur_dnn_policy/index.html>`_ to deploy your policy.
 
 The Isaac ROS deployment pipeline directly uses the trained model checkpoint (``.pt`` file) along with the ``agent.yaml`` and ``env.yaml`` configuration files generated during training. No additional export step is required.
 

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -74,7 +74,7 @@ If you use an instanceable assets for markers, the marker class removes all the 
 This is then replicated across other references of the same asset since physics properties of instanceable assets
 are stored in the instanceable asset's USD file and not in its stage reference's USD file.
 
-.. _instanceable assets: https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/tutorial_gym_instanceable_assets.html
+.. _instanceable assets: https://docs.isaacsim.omniverse.nvidia.com/latest/isaac_lab_tutorials/tutorial_instanceable_assets.html
 .. _Omniverse Isaac Sim documentation: https://docs.isaacsim.omniverse.nvidia.com/latest/overview/known_issues.html#
 
 

--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -9,6 +9,14 @@ Tricks and Troubleshooting
     assistance.
 
 
+Troubleshooting distributed training NCCL errors
+------------------------------------------------
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``.
+For documented NCCL workarounds, see :ref:`multi-gpu-nccl-troubleshooting`.
+
+
 Debugging physics simulation stability issues
 ---------------------------------------------
 

--- a/docs/source/setup/ecosystem.rst
+++ b/docs/source/setup/ecosystem.rst
@@ -147,7 +147,7 @@ to Isaac Lab, please reach out to us.
 .. _AirSim: https://microsoft.github.io/AirSim/
 .. _DoorGym: https://github.com/PSVL/DoorGym/
 .. _ManiSkill: https://github.com/haosulab/ManiSkill
-.. _ThreeDWorld: https://www.threedworld.org/
+.. _ThreeDWorld: https://github.com/threedworld-mit/tdw
 .. _RoboSuite: https://robosuite.ai/
 .. _MuJoCo: https://mujoco.org/
 .. _MuJoCo Playground: https://playground.mujoco.org/

--- a/docs/source/setup/installation/include/src_clone_isaaclab.rst
+++ b/docs/source/setup/installation/include/src_clone_isaaclab.rst
@@ -10,20 +10,7 @@ Cloning Isaac Lab
 
 Clone the Isaac Lab repository into your project's workspace:
 
-.. tab-set::
-
-   .. tab-item:: SSH
-
-      .. code:: bash
-
-         git clone git@github.com:isaac-sim/IsaacLab.git
-
-   .. tab-item:: HTTPS
-
-      .. code:: bash
-
-         git clone https://github.com/isaac-sim/IsaacLab.git
-
+.. isaaclab-clone-commands::
 
 We provide a helper executable `isaaclab.sh <https://github.com/isaac-sim/IsaacLab/blob/main/isaaclab.sh>`_
 and `isaaclab.bat <https://github.com/isaac-sim/IsaacLab/blob/main/isaaclab.bat>`_ for Linux and Windows

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -100,19 +100,7 @@ and now we can install the Isaac Sim packages.
 
 Finally, we can install Isaac Lab.  To start, clone the repository using the following
 
-.. tab-set::
-
-   .. tab-item:: SSH
-
-      .. code:: bash
-
-         git clone git@github.com:isaac-sim/IsaacLab.git
-
-   .. tab-item:: HTTPS
-
-      .. code:: bash
-
-         git clone https://github.com/isaac-sim/IsaacLab.git
+.. isaaclab-clone-commands::
 
 Installation is now as easy as navigating to the repo and then calling the root script with the ``--install`` flag!
 

--- a/docs/source/tutorials/00_sim/create_empty.rst
+++ b/docs/source/tutorials/00_sim/create_empty.rst
@@ -69,7 +69,7 @@ Configuring the simulation context
 
 When launching the simulator from a standalone script, the user has complete control over playing,
 pausing and stepping the simulator. All these operations are handled through the **simulation
-context**. It takes care of various timeline events and also configures the `physics scene`_ for
+context**. It takes care of various timeline events and also configures the physics scene for
 simulation.
 
 In Isaac Lab, the :class:`sim.SimulationContext` class inherits from Isaac Sim's
@@ -164,4 +164,3 @@ following tutorial where we will learn how to add assets to the stage.
 
 .. _`Isaac Sim Workflows`: https://docs.isaacsim.omniverse.nvidia.com/latest/introduction/workflows.html
 .. _carb: https://docs.omniverse.nvidia.com/kit/docs/carbonite/latest/index.html
-.. _`physics scene`: https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_physics.html#physics-scene

--- a/docs/source/tutorials/00_sim/spawn_prims.rst
+++ b/docs/source/tutorials/00_sim/spawn_prims.rst
@@ -188,5 +188,5 @@ demonstrates the basic concepts of scene designing in Isaac Lab and how to use t
 we will now look at how to interact with the scene and the simulation.
 
 
-.. _`USD documentation`: https://graphics.pixar.com/usd/docs/index.html
+.. _`USD documentation`: https://openusd.org/release/index.html
 .. _`different light prims`: https://youtu.be/c7qyI8pZvF4?feature=shared

--- a/scripts/demos/h1_locomotion.py
+++ b/scripts/demos/h1_locomotion.py
@@ -18,6 +18,7 @@ This script demonstrates an interactive demo with the H1 rough terrain environme
 import argparse
 import os
 import sys
+from importlib import metadata
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
 import scripts.reinforcement_learning.rsl_rl.cli_args as cli_args  # isort: skip
@@ -55,7 +56,12 @@ from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils.math import quat_apply
 
-from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
+from isaaclab_rl.rsl_rl import (
+    RslRlOnPolicyRunnerCfg,
+    RslRlVecEnvWrapper,
+    handle_deprecated_rsl_rl_cfg,
+    handle_deprecated_rsl_rl_checkpoint,
+)
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
 from isaaclab_tasks.manager_based.locomotion.velocity.config.h1.rough_env_cfg import H1RoughEnvCfg_PLAY
@@ -83,8 +89,11 @@ class H1RoughDemo:
         """Initializes environment config designed for the interactive model and sets up the environment,
         loads pre-trained checkpoints, and registers keyboard events."""
         agent_cfg: RslRlOnPolicyRunnerCfg = cli_args.parse_rsl_rl_cfg(TASK, args_cli)
+        agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, metadata.version("rsl-rl-lib"))
         # load the trained jit policy
         checkpoint = get_published_pretrained_checkpoint(RL_LIBRARY, TASK)
+        # convert pre-5.0 published checkpoints to the layout expected by rsl-rl >= 5.0
+        checkpoint = handle_deprecated_rsl_rl_checkpoint(checkpoint, metadata.version("rsl-rl-lib"))
         # create envionrment
         env_cfg = H1RoughEnvCfg_PLAY()
         env_cfg.scene.num_envs = 25

--- a/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/scripts/reinforcement_learning/rsl_rl/play.py
@@ -84,6 +84,7 @@ from isaaclab_rl.rsl_rl import (
     export_policy_as_jit,
     export_policy_as_onnx,
     handle_deprecated_rsl_rl_cfg,
+    handle_deprecated_rsl_rl_checkpoint,
 )
 from isaaclab_rl.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
 
@@ -162,6 +163,8 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
         runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
     else:
         raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+    # convert pre-5.0 published checkpoints to the layout expected by rsl-rl >= 5.0 (no-op otherwise)
+    resume_path = handle_deprecated_rsl_rl_checkpoint(resume_path, installed_version)
     runner.load(resume_path)
 
     # obtain the trained policy for inference

--- a/scripts/reinforcement_learning/skrl/play.py
+++ b/scripts/reinforcement_learning/skrl/play.py
@@ -46,15 +46,17 @@ parser.add_argument(
     "--ml_framework",
     type=str,
     default="torch",
-    choices=["torch", "jax", "jax-numpy"],
+    choices=["torch", "jax"],
     help="The ML framework used for training the skrl agent.",
 )
 parser.add_argument(
     "--algorithm",
     type=str,
     default="PPO",
-    choices=["AMP", "PPO", "IPPO", "MAPPO"],
-    help="The RL algorithm used for training the skrl agent.",
+    help=(
+        "Name of the RL algorithm to use (e.g. AMP, DDPG, IPPO, MAPPO, PPO, SAC, TD3, etc.) "
+        "when several algorithms exist for the same task. For a more specific selection, use the argument --agent."
+    ),
 )
 parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
 
@@ -84,7 +86,7 @@ import torch
 from packaging import version
 
 # check for minimum supported skrl version
-SKRL_VERSION = "1.4.3"
+SKRL_VERSION = "2.0.0"
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):
     skrl.logger.error(
         f"Unsupported skrl version: {skrl.__version__}. "
@@ -207,10 +209,11 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
     print(f"[INFO] Loading model checkpoint from: {resume_path}")
     runner.agent.load(resume_path)
     # set agent to evaluation mode
-    runner.agent.set_running_mode("eval")
+    runner.agent.enable_training_mode(False, apply_to_models=True)
 
     # reset environment
     obs, _ = env.reset()
+    states = env.state()
     timestep = 0
     # simulate environment
     while simulation_app.is_running():
@@ -219,7 +222,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
         # run everything in inference mode
         with torch.inference_mode():
             # agent stepping
-            outputs = runner.agent.act(obs, timestep=0, timesteps=0)
+            outputs = runner.agent.act(obs, states, timestep=0, timesteps=0)
             # - multi-agent (deterministic) actions
             if hasattr(env, "possible_agents"):
                 actions = {a: outputs[-1][a].get("mean_actions", outputs[0][a]) for a in env.possible_agents}
@@ -228,6 +231,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, expe
                 actions = outputs[-1].get("mean_actions", outputs[0])
             # env stepping
             obs, _, _, _, _ = env.step(actions)
+            states = env.state()
         if args_cli.video:
             timestep += 1
             # exit the play loop after recording one video

--- a/scripts/reinforcement_learning/skrl/train.py
+++ b/scripts/reinforcement_learning/skrl/train.py
@@ -44,15 +44,17 @@ parser.add_argument(
     "--ml_framework",
     type=str,
     default="torch",
-    choices=["torch", "jax", "jax-numpy"],
+    choices=["torch", "jax"],
     help="The ML framework used for training the skrl agent.",
 )
 parser.add_argument(
     "--algorithm",
     type=str,
     default="PPO",
-    choices=["AMP", "PPO", "IPPO", "MAPPO"],
-    help="The RL algorithm used for training the skrl agent.",
+    help=(
+        "Name of the RL algorithm to use (e.g. AMP, DDPG, IPPO, MAPPO, PPO, SAC, TD3, etc.) "
+        "when several algorithms exist for the same task. For a more specific selection, use the argument --agent."
+    ),
 )
 parser.add_argument(
     "--ray-proc-id", "-rid", type=int, default=None, help="Automatically configured by Ray integration, otherwise None."
@@ -85,7 +87,7 @@ import skrl
 from packaging import version
 
 # check for minimum supported skrl version
-SKRL_VERSION = "1.4.3"
+SKRL_VERSION = "2.0.0"
 if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):
     skrl.logger.error(
         f"Unsupported skrl version: {skrl.__version__}. "

--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.3"
+version = "0.54.4"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+0.54.4 (2026-06-01)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the Pink IK controller (:class:`~isaaclab.controllers.pink_ik.PinkIKController`)
+  producing a fixed ~26 mm end-effector offset that broke
+  ``test/controllers/test_pink_ik.py`` in CI. ``qpsolvers`` 4.12.0 enabled DAQP warm
+  starts, which require the ``primal_start`` argument that ``daqp`` only exposes from
+  0.8.0 onward; the pinned ``daqp==0.7.2`` lacked it. Bumped the pin to ``daqp==0.8.5``.
+
+
 0.54.3 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -183,11 +183,11 @@ def resolve_matching_names(
     When a list of query regular expressions is provided, the function checks each target string against each
     query regular expression and returns the indices of the matched strings and the matched strings.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
     of the provided list of strings. This means that the ordering is dictated by the order of the target strings
     and not the order of the query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
     of the provided list of query regular expressions.
 
     For example, consider the list of strings is ['a', 'b', 'c', 'd', 'e'] and the regular expressions are ['a|c', 'b'].
@@ -280,11 +280,11 @@ def resolve_matching_names_values(
     """Match a list of regular expressions in a dictionary against a list of strings and return
     the matched indices, names, and values.
 
-    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
     of the provided list of strings. This means that the ordering is dictated by the order of the target strings
     and not the order of the query regular expressions.
 
-    If the :attr:`preserve_order` is False, the ordering of the matched indices and names is the same as the order
+    If the :attr:`preserve_order` is True, the ordering of the matched indices and names is the same as the order
     of the provided list of query regular expressions.
 
     For example, consider the dictionary is {"a|d|e": 1, "b|c": 2}, the list of strings is ['a', 'b', 'c', 'd', 'e'].

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -42,7 +42,7 @@ INSTALL_REQUIRES = [
     "pytest",
     "pytest-mock",
     "junitparser",
-    "flatdict==4.0.0",
+    "flatdict>=4.1.0",
     "flaky",
     "packaging",
 ]

--- a/source/isaaclab/setup.py
+++ b/source/isaaclab/setup.py
@@ -52,8 +52,11 @@ SUPPORTED_ARCHS_ARM = "platform_machine in 'x86_64,AMD64,aarch64,arm64'"
 SUPPORTED_ARCHS = "platform_machine in 'x86_64,AMD64'"
 INSTALL_REQUIRES += [
     # required by isaaclab.isaaclab.controllers.pink_ik
+    # daqp>=0.8.0 is required: qpsolvers 4.12.0 enables DAQP warm starts, which need
+    # the ``primal_start`` argument that daqp only exposes from 0.8.0 onward. Pinned to
+    # 0.8.5 to match develop and avoid runtime-behavior changes in later releases.
     f"pin-pink==3.1.0 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
-    f"daqp==0.7.2 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
+    f"daqp==0.8.5 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS_ARM})",
     # required by isaaclab.devices.openxr.retargeters.humanoid.fourier.gr1_t2_dex_retargeting_utils
     f"dex-retargeting==0.4.6 ; platform_system == 'Linux' and ({SUPPORTED_ARCHS})",
 ]

--- a/source/isaaclab_rl/config/extension.toml
+++ b/source/isaaclab_rl/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.1"
+version = "0.5.2"
 
 # Description
 title = "Isaac Lab RL"

--- a/source/isaaclab_rl/config/extension.toml
+++ b/source/isaaclab_rl/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.5.0"
+version = "0.5.1"
 
 # Description
 title = "Isaac Lab RL"

--- a/source/isaaclab_rl/docs/CHANGELOG.rst
+++ b/source/isaaclab_rl/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.5.1 (2026-04-21)
+~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Updated skrl wrapper to support the new version of skrl 2.0.
+
 0.5.0 (2026-3-04)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_rl/docs/CHANGELOG.rst
+++ b/source/isaaclab_rl/docs/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+0.5.2 (2026-06-01)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added :func:`~isaaclab_rl.rsl_rl.handle_deprecated_rsl_rl_checkpoint` to convert pre-5.0 rsl-rl
+  checkpoints (single combined ``model_state_dict``) into the ``actor``/``critic`` layout expected by
+  rsl-rl >= 5.0. This lets older published pretrained checkpoints load without
+  ``KeyError: 'actor_state_dict'``.
+
+
 0.5.1 (2026-04-21)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/__init__.py
@@ -21,4 +21,4 @@ from .rl_cfg import *
 from .rnd_cfg import RslRlRndCfg
 from .symmetry_cfg import RslRlSymmetryCfg
 from .vecenv_wrapper import RslRlVecEnvWrapper
-from .utils import handle_deprecated_rsl_rl_cfg
+from .utils import handle_deprecated_rsl_rl_cfg, handle_deprecated_rsl_rl_checkpoint

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/distillation_cfg.py
@@ -22,7 +22,7 @@ class RslRlDistillationAlgorithmCfg:
     """Configuration for the distillation algorithm."""
 
     class_name: str = "Distillation"
-    """The algorithm class name. Default is Distillation."""
+    """The algorithm class name. Defaults to Distillation."""
 
     num_learning_epochs: int = MISSING
     """The number of updates performed with each sample."""
@@ -34,13 +34,13 @@ class RslRlDistillationAlgorithmCfg:
     """The number of environment steps the gradient flows back."""
 
     max_grad_norm: None | float = None
-    """The maximum norm the gradient is clipped to."""
+    """The maximum norm the gradient is clipped to. Defaults to None."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use for the student policy."""
+    """The optimizer to use for the student policy. Defaults to adam."""
 
     loss_type: Literal["mse", "huber"] = "mse"
-    """The loss type to use for the student policy."""
+    """The loss type to use for the student policy. Defaults to mse."""
 
 
 #########################
@@ -53,7 +53,7 @@ class RslRlDistillationRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for distillation algorithms."""
 
     class_name: str = "DistillationRunner"
-    """The runner class name. Default is DistillationRunner."""
+    """The runner class name. Defaults to DistillationRunner."""
 
     student: RslRlMLPModelCfg = MISSING
     """The student configuration."""
@@ -85,13 +85,13 @@ class RslRlDistillationStudentTeacherCfg:
     """
 
     class_name: str = "StudentTeacher"
-    """The policy class name. Default is StudentTeacher."""
+    """The policy class name. Defaults to StudentTeacher."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the student policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     student_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the student network."""
@@ -117,7 +117,7 @@ class RslRlDistillationStudentTeacherRecurrentCfg(RslRlDistillationStudentTeache
     """
 
     class_name: str = "StudentTeacherRecurrent"
-    """The policy class name. Default is StudentTeacherRecurrent."""
+    """The policy class name. Defaults to StudentTeacherRecurrent."""
 
     rnn_type: str = MISSING
     """The type of the RNN network. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rl_cfg.py
@@ -23,7 +23,7 @@ class RslRlMLPModelCfg:
     """Configuration for the MLP model."""
 
     class_name: str = "MLPModel"
-    """The model class name. Default is MLPModel."""
+    """The model class name. Defaults to MLPModel."""
 
     hidden_dims: list[int] = MISSING
     """The hidden dimensions of the MLP network."""
@@ -32,10 +32,10 @@ class RslRlMLPModelCfg:
     """The activation function for the MLP network."""
 
     obs_normalization: bool = False
-    """Whether to normalize the observation for the model. Default is False."""
+    """Whether to normalize the observation for the model. Defaults to False."""
 
     distribution_cfg: DistributionCfg | None = None
-    """The configuration for the output distribution. Default is None, in which case no distribution is used."""
+    """The configuration for the output distribution. Defaults to None, in which case no distribution is used."""
 
     @configclass
     class DistributionCfg:
@@ -79,14 +79,14 @@ class RslRlMLPModelCfg:
     """
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the model. Default is scalar.
+    """The type of noise standard deviation for the model. Defaults to scalar.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use the
     `std_type` field of the distribution configuration to specify the type of noise standard deviation.
     """
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False.
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False.
 
     For rsl-rl >= 5.0.0, this configuration is is deprecated. Please use `distribution_cfg` instead and use
     the `HeteroscedasticGaussianDistributionCfg` if state-dependent standard deviation is desired.
@@ -98,7 +98,7 @@ class RslRlRNNModelCfg(RslRlMLPModelCfg):
     """Configuration for RNN model."""
 
     class_name: str = "RNNModel"
-    """The model class name. Default is RNNModel."""
+    """The model class name. Defaults to RNNModel."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""
@@ -115,7 +115,7 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
     """Configuration for CNN model."""
 
     class_name: str = "CNNModel"
-    """The model class name. Default is CNNModel."""
+    """The model class name. Defaults to CNNModel."""
 
     @configclass
     class CNNCfg:
@@ -126,28 +126,28 @@ class RslRlCNNModelCfg(RslRlMLPModelCfg):
         """The kernel size for the CNN."""
 
         stride: int | tuple[int] | list[int] = 1
-        """The stride for the CNN."""
+        """The stride for the CNN. Defaults to 1."""
 
         dilation: int | tuple[int] | list[int] = 1
-        """The dilation for the CNN."""
+        """The dilation for the CNN. Defaults to 1."""
 
         padding: Literal["none", "zeros", "reflect", "replicate", "circular"] = "none"
-        """The padding for the CNN."""
+        """The padding for the CNN. Defaults to none."""
 
         norm: Literal["none", "batch", "layer"] | tuple[str] | list[str] = "none"
-        """The normalization for the CNN."""
+        """The normalization for the CNN. Defaults to none."""
 
         activation: str = MISSING
         """The activation function for the CNN."""
 
         max_pool: bool | tuple[bool] | list[bool] = False
-        """Whether to use max pooling for the CNN."""
+        """Whether to use max pooling for the CNN. Defaults to False."""
 
         global_pool: Literal["none", "max", "avg"] = "none"
-        """The global pooling for the CNN."""
+        """The global pooling for the CNN. Defaults to none."""
 
         flatten: bool = True
-        """Whether to flatten the output of the CNN."""
+        """Whether to flatten the output of the CNN. Defaults to True."""
 
     cnn_cfg: CNNCfg = MISSING
     """The configuration for the CNN(s)."""
@@ -163,7 +163,7 @@ class RslRlPpoAlgorithmCfg:
     """Configuration for the PPO algorithm."""
 
     class_name: str = "PPO"
-    """The algorithm class name. Default is PPO."""
+    """The algorithm class name. Defaults to PPO."""
 
     num_learning_epochs: int = MISSING
     """The number of learning epochs per update."""
@@ -193,7 +193,7 @@ class RslRlPpoAlgorithmCfg:
     """The maximum gradient norm."""
 
     optimizer: Literal["adam", "adamw", "sgd", "rmsprop"] = "adam"
-    """The optimizer to use."""
+    """The optimizer to use. Defaults to adam."""
 
     value_loss_coef: float = MISSING
     """The coefficient for the value loss."""
@@ -205,7 +205,7 @@ class RslRlPpoAlgorithmCfg:
     """The clipping parameter for the policy."""
 
     normalize_advantage_per_mini_batch: bool = False
-    """Whether to normalize the advantage per mini-batch. Default is False.
+    """Whether to normalize the advantage per mini-batch. Defaults to False.
 
     If True, the advantage is normalized over the mini-batches only.
     Otherwise, the advantage is normalized over the entire collected trajectories.
@@ -215,10 +215,10 @@ class RslRlPpoAlgorithmCfg:
     """Whether to share the CNN networks between actor and critic, in case CNNModels are used. Defaults to False."""
 
     rnd_cfg: RslRlRndCfg | None = None
-    """The RND configuration. Default is None, in which case RND is not used."""
+    """The RND configuration. Defaults to None, in which case RND is not used."""
 
     symmetry_cfg: RslRlSymmetryCfg | None = None
-    """The symmetry configuration. Default is None, in which case symmetry is not used."""
+    """The symmetry configuration. Defaults to None, in which case symmetry is not used."""
 
 
 #########################
@@ -231,10 +231,10 @@ class RslRlBaseRunnerCfg:
     """Base configuration of the runner."""
 
     seed: int = 42
-    """The seed for the experiment. Default is 42."""
+    """The seed for the experiment. Defaults to 42."""
 
     device: str = "cuda:0"
-    """The device for the rl-agent. Default is cuda:0."""
+    """The device for the rl-agent. Defaults to cuda:0."""
 
     num_steps_per_env: int = MISSING
     """The number of steps per environment per update."""
@@ -288,7 +288,7 @@ class RslRlBaseRunnerCfg:
     """The experiment name."""
 
     run_name: str = ""
-    """The run name. Default is empty string.
+    """The run name. Defaults to empty string.
 
     The name of the run directory is typically the time-stamp at execution. If the run name is not empty,
     then it is appended to the run directory's name, i.e. the logging directory's name will become
@@ -296,28 +296,28 @@ class RslRlBaseRunnerCfg:
     """
 
     logger: Literal["tensorboard", "neptune", "wandb"] = "tensorboard"
-    """The logger to use. Default is tensorboard."""
+    """The logger to use. Defaults to tensorboard."""
 
     neptune_project: str = "isaaclab"
-    """The neptune project name. Default is "isaaclab"."""
+    """The neptune project name. Defaults to "isaaclab"."""
 
     wandb_project: str = "isaaclab"
-    """The wandb project name. Default is "isaaclab"."""
+    """The wandb project name. Defaults to "isaaclab"."""
 
     resume: bool = False
-    """Whether to resume a previous training. Default is False.
+    """Whether to resume a previous training. Defaults to False.
 
     This flag will be ignored for distillation.
     """
 
     load_run: str = ".*"
-    """The run directory to load. Default is ".*" (all).
+    """The run directory to load. Defaults to ".*" (all).
 
     If regex expression, the latest (alphabetical order) matching run will be loaded.
     """
 
     load_checkpoint: str = "model_.*.pt"
-    """The checkpoint file to load. Default is ``"model_.*.pt"`` (all).
+    """The checkpoint file to load. Defaults to ``"model_.*.pt"`` (all).
 
     If regex expression, the latest (alphabetical order) matching file will be loaded.
     """
@@ -328,7 +328,7 @@ class RslRlOnPolicyRunnerCfg(RslRlBaseRunnerCfg):
     """Configuration of the runner for on-policy algorithms."""
 
     class_name: str = "OnPolicyRunner"
-    """The runner class name. Default is OnPolicyRunner."""
+    """The runner class name. Defaults to OnPolicyRunner."""
 
     actor: RslRlMLPModelCfg = MISSING
     """The actor configuration."""
@@ -360,16 +360,16 @@ class RslRlPpoActorCriticCfg:
     """
 
     class_name: str = "ActorCritic"
-    """The policy class name. Default is ActorCritic."""
+    """The policy class name. Defaults to ActorCritic."""
 
     init_noise_std: float = MISSING
     """The initial noise standard deviation for the policy."""
 
     noise_std_type: Literal["scalar", "log"] = "scalar"
-    """The type of noise standard deviation for the policy. Default is scalar."""
+    """The type of noise standard deviation for the policy. Defaults to scalar."""
 
     state_dependent_std: bool = False
-    """Whether to use state-dependent standard deviation for the policy. Default is False."""
+    """Whether to use state-dependent standard deviation for the policy. Defaults to False."""
 
     actor_obs_normalization: bool = MISSING
     """Whether to normalize the observation for the actor network."""
@@ -395,7 +395,7 @@ class RslRlPpoActorCriticRecurrentCfg(RslRlPpoActorCriticCfg):
     """
 
     class_name: str = "ActorCriticRecurrent"
-    """The policy class name. Default is ActorCriticRecurrent."""
+    """The policy class name. Defaults to ActorCriticRecurrent."""
 
     rnn_type: str = MISSING
     """The type of RNN to use. Either "lstm" or "gru"."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/rnd_cfg.py
@@ -20,7 +20,7 @@ class RslRlRndCfg:
         """Configuration for the weight schedule."""
 
         mode: str = "constant"
-        """The type of weight schedule. Default is "constant"."""
+        """The type of weight schedule. Defaults to "constant"."""
 
     @configclass
     class LinearWeightScheduleCfg(WeightScheduleCfg):
@@ -31,6 +31,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "linear"
+        """The type of weight schedule. Defaults to "linear"."""
 
         final_value: float = MISSING
         """The final value of the weight parameter."""
@@ -55,6 +56,7 @@ class RslRlRndCfg:
         """
 
         mode: str = "step"
+        """The type of weight schedule. Defaults to "step"."""
 
         final_step: int = MISSING
         """The final step of the weight schedule.
@@ -66,34 +68,34 @@ class RslRlRndCfg:
         """The final value of the weight parameter."""
 
     weight: float = 0.0
-    """The weight for the RND reward (also known as intrinsic reward). Default is 0.0.
+    """The weight for the RND reward (also known as intrinsic reward). Defaults to 0.0.
 
     Similar to other reward terms, the RND reward is scaled by this weight.
     """
 
     weight_schedule: WeightScheduleCfg | None = None
-    """The weight schedule for the RND reward. Default is None, which means the weight is constant."""
+    """The weight schedule for the RND reward. Defaults to None, which means the weight is constant."""
 
     reward_normalization: bool = False
-    """Whether to normalize the RND reward. Default is False."""
+    """Whether to normalize the RND reward. Defaults to False."""
 
     state_normalization: bool = False
-    """Whether to normalize the RND state. Default is False."""
+    """Whether to normalize the RND state. Defaults to False."""
 
     learning_rate: float = 1e-3
-    """The learning rate for the RND module. Default is 1e-3."""
+    """The learning rate for the RND module. Defaults to 1e-3."""
 
     num_outputs: int = 1
-    """The number of outputs for the RND module. Default is 1."""
+    """The number of outputs for the RND module. Defaults to 1."""
 
     predictor_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND predictor network. Default is [-1].
+    """The hidden dimensions for the RND predictor network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """
 
     target_hidden_dims: list[int] = [-1]
-    """The hidden dimensions for the RND target network. Default is [-1].
+    """The hidden dimensions for the RND target network. Defaults to [-1].
 
     If the list contains -1, then the hidden dimensions are the same as the input dimensions.
     """

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/symmetry_cfg.py
@@ -26,10 +26,10 @@ class RslRlSymmetryCfg:
     """
 
     use_data_augmentation: bool = False
-    """Whether to use symmetry-based data augmentation. Default is False."""
+    """Whether to use symmetry-based data augmentation. Defaults to False."""
 
     use_mirror_loss: bool = False
-    """Whether to use the symmetry-augmentation loss. Default is False."""
+    """Whether to use the symmetry-augmentation loss. Defaults to False."""
 
     data_augmentation_func: callable = MISSING
     """The symmetry data augmentation function.
@@ -48,4 +48,4 @@ class RslRlSymmetryCfg:
     """
 
     mirror_loss_coeff: float = 0.0
-    """The weight for the symmetry-mirror loss. Default is 0.0."""
+    """The weight for the symmetry-mirror loss. Defaults to 0.0."""

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/utils.py
@@ -200,6 +200,69 @@ def handle_deprecated_rsl_rl_cfg(agent_cfg: RslRlBaseRunnerCfg, installed_versio
     return agent_cfg
 
 
+def handle_deprecated_rsl_rl_checkpoint(checkpoint_path: str, installed_version) -> str:
+    """Convert a pre-5.0 rsl-rl checkpoint to the layout expected by rsl-rl >= 5.0.
+
+    Older rsl-rl versions saved a single combined ``model_state_dict`` (with ``actor.*``, ``critic.*``
+    and a top-level ``std`` parameter). rsl-rl >= 5.0 instead expects separate ``actor_state_dict`` and
+    ``critic_state_dict`` entries, so the published pretrained checkpoints shipped with older asset
+    releases fail to load with ``KeyError: 'actor_state_dict'``. This converts such a checkpoint into a
+    sibling file and returns its path. New-layout checkpoints, unrecognized payloads, and installations
+    of rsl-rl < 5.0 are returned unchanged.
+
+    Args:
+        checkpoint_path: Path to the checkpoint to (possibly) convert.
+        installed_version: Installed ``rsl-rl-lib`` version string.
+
+    Returns:
+        Path to a checkpoint compatible with the installed rsl-rl version.
+
+    Raises:
+        ValueError: If the checkpoint uses the deprecated combined layout but contains a key that does
+            not map to the ``actor``/``critic``/``std`` structure expected from older rsl-rl versions.
+    """
+    import os
+
+    import torch
+
+    if version.parse(str(installed_version)) < _V5_0_0:
+        return checkpoint_path
+
+    loaded = torch.load(checkpoint_path, weights_only=False, map_location="cpu")
+    # Only the deprecated combined layout needs conversion; leave new-layout/unknown payloads untouched.
+    if not isinstance(loaded, dict) or "actor_state_dict" in loaded or "model_state_dict" not in loaded:
+        return checkpoint_path
+
+    actor_state_dict: dict = {}
+    critic_state_dict: dict = {}
+    for key, value in loaded["model_state_dict"].items():
+        if key == "std":
+            actor_state_dict["distribution.std_param"] = value
+        elif key.startswith("actor."):
+            actor_state_dict["mlp." + key[len("actor.") :]] = value
+        elif key.startswith("critic."):
+            critic_state_dict["mlp." + key[len("critic.") :]] = value
+        else:
+            raise ValueError(
+                f"Unrecognized key '{key}' while converting deprecated rsl-rl checkpoint '{checkpoint_path}'."
+                " Only MLP actor-critic checkpoints from rsl-rl < 5.0 are supported for automatic conversion."
+            )
+
+    converted = {
+        "actor_state_dict": actor_state_dict,
+        "critic_state_dict": critic_state_dict,
+        # Carry the remaining payload so the runner's loader behaves as it does for native checkpoints.
+        "optimizer_state_dict": loaded.get("optimizer_state_dict"),
+        "iter": loaded.get("iter", 0),
+        "infos": loaded.get("infos"),
+    }
+    root, ext = os.path.splitext(checkpoint_path)
+    converted_path = f"{root}_rslrl5{ext}"
+    torch.save(converted, converted_path)
+    print(f"[INFO]: Converted deprecated rsl-rl checkpoint to '{converted_path}'.")
+    return converted_path
+
+
 def _is_missing(value) -> bool:
     return isinstance(value, type(MISSING))
 

--- a/source/isaaclab_rl/isaaclab_rl/skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/skrl.py
@@ -38,7 +38,7 @@ Vectorized environment wrapper.
 
 def SkrlVecEnvWrapper(
     env: ManagerBasedRLEnv | DirectRLEnv | DirectMARLEnv,
-    ml_framework: Literal["torch", "jax", "jax-numpy"] = "torch",
+    ml_framework: Literal["torch", "jax", "warp"] = "torch",
     wrapper: Literal["auto", "isaaclab", "isaaclab-single-agent", "isaaclab-multi-agent"] = "isaaclab",
 ):
     """Wraps around Isaac Lab environment for skrl.
@@ -77,9 +77,11 @@ def SkrlVecEnvWrapper(
         from skrl.envs.wrappers.torch import wrap_env
     elif ml_framework.startswith("jax"):
         from skrl.envs.wrappers.jax import wrap_env
+    elif ml_framework.startswith("warp"):
+        from skrl.envs.wrappers.warp import wrap_env
     else:
-        ValueError(
-            f"Invalid ML framework for skrl: {ml_framework}. Available options are: 'torch', 'jax' or 'jax-numpy'"
+        raise ValueError(
+            f"Invalid ML framework for skrl: {ml_framework}. Available options are: 'torch', 'jax', 'warp'"
         )
 
     # wrap and return the environment

--- a/source/isaaclab_rl/setup.py
+++ b/source/isaaclab_rl/setup.py
@@ -41,7 +41,7 @@ PYTORCH_INDEX_URL = ["https://download.pytorch.org/whl/cu128"]
 # Extra dependencies for RL agents
 EXTRAS_REQUIRE = {
     "sb3": ["stable-baselines3>=2.6", "tqdm", "rich"],  # tqdm/rich for progress bar
-    "skrl": ["skrl>=1.4.3"],
+    "skrl": ["skrl>=2.0.0"],
     "rl-games": [
         "rl-games @ git+https://github.com/isaac-sim/rl_games.git@python3.11",
         "gym",

--- a/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_cfg_deprecation.py
@@ -17,6 +17,7 @@ simulation_app = app_launcher.app
 from dataclasses import MISSING
 
 import pytest
+import torch
 
 from isaaclab_rl.rsl_rl import (
     RslRlDistillationAlgorithmCfg,
@@ -30,7 +31,7 @@ from isaaclab_rl.rsl_rl import (
     RslRlPpoAlgorithmCfg,
     RslRlRNNModelCfg,
 )
-from isaaclab_rl.rsl_rl.utils import _is_missing, handle_deprecated_rsl_rl_cfg
+from isaaclab_rl.rsl_rl.utils import _is_missing, handle_deprecated_rsl_rl_cfg, handle_deprecated_rsl_rl_checkpoint
 
 
 def _ppo_algo():
@@ -531,3 +532,54 @@ class TestV5:
     def test_returns_same_object(self):
         cfg = _on_policy_runner(policy=_ppo_mlp_policy(), algorithm=_ppo_algo())
         assert handle_deprecated_rsl_rl_cfg(cfg, "5.0.0") is cfg
+
+
+def _deprecated_checkpoint() -> dict:
+    """A pre-5.0 rsl-rl checkpoint: single combined ``model_state_dict`` with ``actor.*``/``critic.*``/``std``."""
+    return {
+        "model_state_dict": {
+            "std": torch.ones(3),
+            "actor.0.weight": torch.zeros(4, 5),
+            "actor.0.bias": torch.zeros(4),
+            "critic.0.weight": torch.zeros(1, 5),
+            "critic.0.bias": torch.zeros(1),
+        },
+        "optimizer_state_dict": {"state": {}, "param_groups": []},
+        "iter": 42,
+        "infos": None,
+    }
+
+
+class TestHandleDeprecatedRslRlCheckpoint:
+    def test_converts_combined_state_dict(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save(_deprecated_checkpoint(), path)
+
+        out = handle_deprecated_rsl_rl_checkpoint(path, "5.0.1")
+
+        assert out != path
+        converted = torch.load(out, weights_only=False)
+        assert set(converted["actor_state_dict"]) == {"distribution.std_param", "mlp.0.weight", "mlp.0.bias"}
+        assert set(converted["critic_state_dict"]) == {"mlp.0.weight", "mlp.0.bias"}
+        assert converted["iter"] == 42
+        # values are preserved through the remap
+        torch.testing.assert_close(converted["actor_state_dict"]["distribution.std_param"], torch.ones(3))
+
+    def test_new_layout_passthrough(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save({"actor_state_dict": {}, "critic_state_dict": {}, "iter": 0, "infos": None}, path)
+        assert handle_deprecated_rsl_rl_checkpoint(path, "5.0.1") == path
+
+    def test_old_rsl_rl_passthrough(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        torch.save(_deprecated_checkpoint(), path)
+        # rsl-rl < 5.0 reads the combined layout natively, so no conversion should happen
+        assert handle_deprecated_rsl_rl_checkpoint(path, "4.1.0") == path
+
+    def test_unrecognized_key_raises(self, tmp_path):
+        path = str(tmp_path / "checkpoint.pt")
+        ckpt = _deprecated_checkpoint()
+        ckpt["model_state_dict"]["unexpected.0.weight"] = torch.zeros(2)
+        torch.save(ckpt, path)
+        with pytest.raises(ValueError):
+            handle_deprecated_rsl_rl_checkpoint(path, "5.0.1")

--- a/source/isaaclab_tasks/config/extension.toml
+++ b/source/isaaclab_tasks/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.11.14"
+version = "0.11.16"
 
 # Description
 title = "Isaac Lab Environments"

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.11.15 (2026-03-07)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0``, ``Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0``,
+  ``Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0``, and ``Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0`` environments.
+
+
 0.11.14 (2026-02-27)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/docs/CHANGELOG.rst
+++ b/source/isaaclab_tasks/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.11.16 (2026-04-21)
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+* Updated some agents' configuration files for the skrl library to support the new version of skrl 2.0.
+
 0.11.15 (2026-03-07)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_ippo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_ippo_cfg.yaml
@@ -54,7 +54,9 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_mappo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/cart_double_pendulum/agents/skrl_mappo_cfg.yaml
@@ -28,7 +28,7 @@ models:
     clip_actions: False
     network:
       - name: net
-        input: OBSERVATIONS
+        input: STATES
         layers: [32, 32]
         activations: elu
     output: ONE
@@ -54,10 +54,10 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
   state_preprocessor: RunningStandardScaler
   state_preprocessor_kwargs: null
-  shared_state_preprocessor: RunningStandardScaler
-  shared_state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
   random_timesteps: 0

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_dance_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_dance_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_run_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_run_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_walk_amp_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/humanoid_amp/agents/skrl_walk_amp_cfg.yaml
@@ -75,12 +75,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -91,10 +93,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_ippo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_ippo_cfg.yaml
@@ -54,7 +54,9 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.016
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null

--- a/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_mappo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/direct/shadow_hand_over/agents/skrl_mappo_cfg.yaml
@@ -28,7 +28,7 @@ models:
     clip_actions: False
     network:
       - name: net
-        input: OBSERVATIONS
+        input: STATES
         layers: [512, 512, 256, 128]
         activations: elu
     output: ONE
@@ -54,10 +54,10 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.016
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
   state_preprocessor: RunningStandardScaler
   state_preprocessor_kwargs: null
-  shared_state_preprocessor: RunningStandardScaler
-  shared_state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
   random_timesteps: 0

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/__init__.py
@@ -72,6 +72,47 @@ gym.register(
 )
 
 gym.register(
+    id="Isaac-Stack-Cube-RedGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-RedGreenBlue-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackRedGreenBlueEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreen-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
+    id="Isaac-Stack-Cube-BlueGreenRed-Franka-IK-Rel-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.stack_ik_rel_env_cfg:FrankaCubeStackBlueGreenRedEnvCfg",
+        "robomimic_bc_cfg_entry_point": f"{agents.__name__}:robomimic/bc_rnn_low_dim.json",
+    },
+    disable_env_checker=True,
+)
+
+gym.register(
     id="Isaac-Stack-Cube-Franka-IK-Abs-v0",
     entry_point="isaaclab.envs:ManagerBasedRLEnv",
     kwargs={

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/config/franka/stack_ik_rel_env_cfg.py
@@ -10,7 +10,11 @@ from isaaclab.devices.openxr.openxr_device import OpenXRDeviceCfg
 from isaaclab.devices.openxr.retargeters.manipulator.gripper_retargeter import GripperRetargeterCfg
 from isaaclab.devices.openxr.retargeters.manipulator.se3_rel_retargeter import Se3RelRetargeterCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.utils import configclass
+
+from isaaclab_tasks.manager_based.manipulation.stack.stack_env_cfg import mdp
 
 from . import stack_joint_pos_env_cfg
 
@@ -66,4 +70,60 @@ class FrankaCubeStackEnvCfg(stack_joint_pos_env_cfg.FrankaCubeStackEnvCfg):
                     sim_device=self.sim.device,
                 ),
             }
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_2"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackRedGreenBlueEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_2"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_1"),
+            },
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"cube_1_cfg": SceneEntityCfg("cube_1"), "cube_2_cfg": SceneEntityCfg("cube_3"), "cube_3_cfg": None},
+        )
+
+
+@configclass
+class FrankaCubeStackBlueGreenRedEnvCfg(FrankaCubeStackEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={
+                "cube_1_cfg": SceneEntityCfg("cube_1"),
+                "cube_2_cfg": SceneEntityCfg("cube_3"),
+                "cube_3_cfg": SceneEntityCfg("cube_2"),
+            },
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/stack/mdp/terminations.py
@@ -27,35 +27,44 @@ def cubes_stacked(
     robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     cube_1_cfg: SceneEntityCfg = SceneEntityCfg("cube_1"),
     cube_2_cfg: SceneEntityCfg = SceneEntityCfg("cube_2"),
-    cube_3_cfg: SceneEntityCfg = SceneEntityCfg("cube_3"),
+    cube_3_cfg: SceneEntityCfg | None = SceneEntityCfg("cube_3"),
     xy_threshold: float = 0.04,
     height_threshold: float = 0.005,
     height_diff: float = 0.0468,
-    atol=0.0001,
-    rtol=0.0001,
-):
+    atol: float = 0.0001,
+    rtol: float = 0.0001,
+) -> torch.Tensor:
     robot: Articulation = env.scene[robot_cfg.name]
     cube_1: RigidObject = env.scene[cube_1_cfg.name]
     cube_2: RigidObject = env.scene[cube_2_cfg.name]
-    cube_3: RigidObject = env.scene[cube_3_cfg.name]
 
     pos_diff_c12 = cube_1.data.root_pos_w - cube_2.data.root_pos_w
-    pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
 
     # Compute cube position difference in x-y plane
     xy_dist_c12 = torch.norm(pos_diff_c12[:, :2], dim=1)
-    xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
 
     # Compute cube height difference
     h_dist_c12 = torch.norm(pos_diff_c12[:, 2:], dim=1)
-    h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
 
     # Check cube positions
-    stacked = torch.logical_and(xy_dist_c12 < xy_threshold, xy_dist_c23 < xy_threshold)
+    stacked = xy_dist_c12 < xy_threshold
     stacked = torch.logical_and(h_dist_c12 - height_diff < height_threshold, stacked)
     stacked = torch.logical_and(pos_diff_c12[:, 2] < 0.0, stacked)
-    stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
-    stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
+
+    if cube_3_cfg is not None:
+        cube_3: RigidObject = env.scene[cube_3_cfg.name]
+        pos_diff_c23 = cube_2.data.root_pos_w - cube_3.data.root_pos_w
+
+        # Compute cube position difference in x-y plane
+        xy_dist_c23 = torch.norm(pos_diff_c23[:, :2], dim=1)
+
+        # Compute cube height difference
+        h_dist_c23 = torch.norm(pos_diff_c23[:, 2:], dim=1)
+
+        # Check cube positions
+        stacked = torch.logical_and(xy_dist_c23 < xy_threshold, stacked)
+        stacked = torch.logical_and(h_dist_c23 - height_diff < height_threshold, stacked)
+        stacked = torch.logical_and(pos_diff_c23[:, 2] < 0.0, stacked)
 
     # Check gripper positions
     if hasattr(env.scene, "surface_grippers") and len(env.scene.surface_grippers) > 0:

--- a/tools/template/templates/agents/skrl_amp_cfg
+++ b/tools/template/templates/agents/skrl_amp_cfg
@@ -70,12 +70,14 @@ agent:
   learning_rate: 5.0e-05
   learning_rate_scheduler: null
   learning_rate_scheduler_kwargs: null
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
-  amp_state_preprocessor: RunningStandardScaler
-  amp_state_preprocessor_kwargs: null
+  amp_observation_preprocessor: RunningStandardScaler
+  amp_observation_preprocessor_kwargs: null
   random_timesteps: 0
   learning_starts: 0
   grad_norm_clip: 0.0
@@ -86,10 +88,9 @@ agent:
   value_loss_scale: 2.5
   discriminator_loss_scale: 5.0
   amp_batch_size: 512
-  task_reward_weight: 0.0
-  style_reward_weight: 1.0
+  task_reward_scale: 0.0
+  style_reward_scale: 2.0
   discriminator_batch_size: 4096
-  discriminator_reward_scale: 2.0
   discriminator_logit_regularization_scale: 0.05
   discriminator_gradient_penalty_scale: 5.0
   discriminator_weight_decay_scale: 1.0e-04

--- a/tools/template/templates/agents/skrl_ippo_cfg
+++ b/tools/template/templates/agents/skrl_ippo_cfg
@@ -49,7 +49,9 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
-  state_preprocessor: RunningStandardScaler
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
+  state_preprocessor: null
   state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null

--- a/tools/template/templates/agents/skrl_mappo_cfg
+++ b/tools/template/templates/agents/skrl_mappo_cfg
@@ -23,7 +23,7 @@ models:
     clip_actions: False
     network:
       - name: net
-        input: OBSERVATIONS
+        input: STATES
         layers: [32, 32]
         activations: elu
     output: ONE
@@ -49,10 +49,10 @@ agent:
   learning_rate_scheduler: KLAdaptiveLR
   learning_rate_scheduler_kwargs:
     kl_threshold: 0.008
+  observation_preprocessor: RunningStandardScaler
+  observation_preprocessor_kwargs: null
   state_preprocessor: RunningStandardScaler
   state_preprocessor_kwargs: null
-  shared_state_preprocessor: RunningStandardScaler
-  shared_state_preprocessor_kwargs: null
   value_preprocessor: RunningStandardScaler
   value_preprocessor_kwargs: null
   random_timesteps: 0


### PR DESCRIPTION
## Summary

- `PXR_WORK_THREAD_LIMIT` must be present before the process starts — OpenUSD's work-thread pool is sized at C++ library init time, so setting it from Python (`os.environ` or `monkeypatch.setenv`) after the `pxr` library loads has no effect.
- Adds `-e PXR_WORK_THREAD_LIMIT=1` to the Docker container environment in `action.yml`, alongside the other static env vars, so it is guaranteed to be visible before any test subprocess imports `pxr`.
- Includes a `TODO` comment to remove this once `usd-core>=26.5` is the minimum (that release fixes the underlying race condition).

## Test plan

- [ ] Confirm kitless rendering CI tests no longer hit the OpenUSD work-thread race condition
- [ ] Confirm no regression in non-rendering test jobs (env var is harmless when USD is not used)