### PR TITLE
Fix unrotated body-frame external wrench on Newton

### DIFF
--- a/source/isaaclab/changelog.d/fix-newton-body-frame-external-wrench.minor.rst
+++ b/source/isaaclab/changelog.d/fix-newton-body-frame-external-wrench.minor.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.compose_to_world_frame` together with
+  the :attr:`~isaaclab.utils.wrench_composer.WrenchComposer.out_force_w` and
+  :attr:`~isaaclab.utils.wrench_composer.WrenchComposer.out_torque_w` outputs, which express the
+  composed external wrench in the world frame at the body's center of mass. This complements the
+  existing body-frame composition for solvers that expect world-frame external wrenches.

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -657,6 +657,43 @@ def compose_wrench_to_body_frame(
 
 
 @wp.kernel
+def compose_wrench_to_world_frame(
+    global_force_w: wp.array2d(dtype=wp.vec3f),
+    global_torque_w: wp.array2d(dtype=wp.vec3f),
+    global_force_at_com_w: wp.array2d(dtype=wp.vec3f),
+    local_force_b: wp.array2d(dtype=wp.vec3f),
+    local_torque_b: wp.array2d(dtype=wp.vec3f),
+    com_pos_w: wp.array2d(dtype=wp.vec3f),
+    link_quat_w: wp.array2d(dtype=wp.quatf),
+    out_force_w: wp.array2d(dtype=wp.vec3f),
+    out_torque_w: wp.array2d(dtype=wp.vec3f),
+):
+    """Compose global and local wrench buffers into a single world-frame output.
+
+    World-frame counterpart of :func:`compose_wrench_to_body_frame`. Global buffers are already
+    world frame and are kept as-is; global torques store the moment of positional forces about the
+    world origin (``cross(P, F)``), corrected to be about the body's CoM via
+    ``cross(P, F) - cross(com_pos_w, F) = cross(P - com_pos_w, F)``. Local body-frame forces and
+    torques are rotated into the world frame using ``quat_rotate(link_quat_w, ...)`` and added. The
+    resulting wrench is expressed in world frame about the body's CoM, matching the reference frame
+    that solvers such as Newton use for their external-wrench (``body_f``) buffer.
+
+    Dispatched with ``dim=(num_envs, num_bodies)``.
+    """
+    tid_env, tid_body = wp.tid()
+    total_force_w = global_force_w[tid_env, tid_body] + global_force_at_com_w[tid_env, tid_body]
+    corrected_torque_w = global_torque_w[tid_env, tid_body] - wp.cross(
+        com_pos_w[tid_env, tid_body], global_force_w[tid_env, tid_body]
+    )
+    out_force_w[tid_env, tid_body] = total_force_w + wp.quat_rotate(
+        link_quat_w[tid_env, tid_body], local_force_b[tid_env, tid_body]
+    )
+    out_torque_w[tid_env, tid_body] = corrected_torque_w + wp.quat_rotate(
+        link_quat_w[tid_env, tid_body], local_torque_b[tid_env, tid_body]
+    )
+
+
+@wp.kernel
 def reset_wrench_composer_index(
     env_ids: wp.array(dtype=Any),
     global_force_w: wp.array2d(dtype=wp.vec3f),

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -19,6 +19,7 @@ from isaaclab.utils.warp.kernels import (
     add_forces_to_dual_buffers_mask,
     add_raw_wrench_buffers,
     compose_wrench_to_body_frame,
+    compose_wrench_to_world_frame,
     reset_wrench_composer_index_kernel,
     reset_wrench_composer_mask,
     set_forces_to_dual_buffers_index_kernel,
@@ -48,10 +49,13 @@ class WrenchComposer:
         - ``local_force_b``: Local forces [N] (body frame).
         - ``local_torque_b``: Local torques [N·m] (body frame).
 
-        And two output buffers:
+        And output buffers for each supported frame:
 
-        - ``out_force_b``: Composed force [N] in body frame.
-        - ``out_torque_b``: Composed torque [N·m] in body frame.
+        - ``out_force_b`` / ``out_torque_b``: Composed force [N] / torque [N·m] in body frame
+          (populated by :meth:`compose_to_body_frame`; consumed by body-frame solvers such as PhysX).
+        - ``out_force_w`` / ``out_torque_w``: Composed force [N] / torque [N·m] in world frame at the
+          body's CoM (populated by :meth:`compose_to_world_frame`; consumed by world-frame solvers
+          such as Newton).
 
         Args:
             asset: Asset to use.
@@ -66,6 +70,9 @@ class WrenchComposer:
         self._asset = asset
         self._active = False
         self._dirty = False
+        # Which frame the output buffers currently hold ("body", "world", or None if uncomposed).
+        # Reading an output property for a different frame than last composed triggers a recompose.
+        self._composed_frame: str | None = None
         if hasattr(self._asset.data, "body_com_pos_w"):
             self._get_com_pos_fn = lambda a=self._asset: a.data.body_com_pos_w.warp
         else:
@@ -82,13 +89,17 @@ class WrenchComposer:
         self._local_force_b = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
         self._local_torque_b = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
 
-        # -- Output buffers (2 total) --
+        # -- Output buffers (2 per frame) --
         self._out_force_b = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
         self._out_torque_b = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
+        self._out_force_w = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
+        self._out_torque_w = wp.zeros((self.num_envs, self.num_bodies), dtype=wp.vec3f, device=self.device)
 
         # ProxyArray caches for the output buffers, exposed via the public properties.
         self._out_force_b_ta = ProxyArray(self._out_force_b)
         self._out_torque_b_ta = ProxyArray(self._out_torque_b)
+        self._out_force_w_ta = ProxyArray(self._out_force_w)
+        self._out_torque_w_ta = ProxyArray(self._out_torque_w)
 
         # -- Index / mask helper arrays --
         self._ALL_ENV_INDICES = wp.array(np.arange(self.num_envs, dtype=np.int32), dtype=wp.int32, device=self.device)
@@ -178,7 +189,7 @@ class WrenchComposer:
 
         Triggers composition from input buffers if dirty.
         """
-        self._ensure_composed()
+        self._ensure_composed("body")
         return self._out_force_b_ta
 
     @property
@@ -191,8 +202,36 @@ class WrenchComposer:
 
         Triggers composition from input buffers if dirty.
         """
-        self._ensure_composed()
+        self._ensure_composed("body")
         return self._out_torque_b_ta
+
+    @property
+    def out_force_w(self) -> ProxyArray:
+        """Composed output force [N] in the world frame, at the body's center of mass.
+
+        Shape is ``(num_envs, num_bodies)``, dtype = ``wp.vec3f``. In torch this resolves to
+        ``(num_envs, num_bodies, 3)``. Use ``.warp`` for the underlying :class:`wp.array` or
+        ``.torch`` for a cached zero-copy :class:`torch.Tensor` view.
+
+        Triggers composition from input buffers if dirty. This is the frame expected by world-frame
+        external-wrench buffers such as Newton's ``body_f``.
+        """
+        self._ensure_composed("world")
+        return self._out_force_w_ta
+
+    @property
+    def out_torque_w(self) -> ProxyArray:
+        """Composed output torque [N·m] in the world frame, about the body's center of mass.
+
+        Shape is ``(num_envs, num_bodies)``, dtype = ``wp.vec3f``. In torch this resolves to
+        ``(num_envs, num_bodies, 3)``. Use ``.warp`` for the underlying :class:`wp.array` or
+        ``.torch`` for a cached zero-copy :class:`torch.Tensor` view.
+
+        Triggers composition from input buffers if dirty. This is the frame expected by world-frame
+        external-wrench buffers such as Newton's ``body_f``.
+        """
+        self._ensure_composed("world")
+        return self._out_torque_w_ta
 
     @property
     def composed_force(self) -> ProxyArray:
@@ -541,6 +580,41 @@ class WrenchComposer:
             device=self.device,
         )
         self._dirty = False
+        self._composed_frame = "body"
+
+    def compose_to_world_frame(self):
+        """Compose the five input buffers into the world-frame output buffers.
+
+        World-frame counterpart of :meth:`compose_to_body_frame`. Global (world-frame) contributions
+        are kept as-is with their torques corrected for the body's CoM position, while local
+        (body-frame) contributions are rotated into the world frame. After this call,
+        ``out_force_w`` and ``out_torque_w`` contain the final composed wrench expressed in the world
+        frame at the body's center of mass -- the reference frame expected by world-frame
+        external-wrench buffers such as Newton's ``body_f``.
+
+        The dirty flag is cleared after composition.
+        """
+        com_pos_w = self._get_com_pos_fn()
+        link_quat_w = self._get_link_quat_fn()
+
+        wp.launch(
+            compose_wrench_to_world_frame,
+            dim=(self.num_envs, self.num_bodies),
+            inputs=[
+                self._global_force_w,
+                self._global_torque_w,
+                self._global_force_at_com_w,
+                self._local_force_b,
+                self._local_torque_b,
+                com_pos_w,
+                link_quat_w,
+                self._out_force_w,
+                self._out_torque_w,
+            ],
+            device=self.device,
+        )
+        self._dirty = False
+        self._composed_frame = "world"
 
     def reset(
         self,
@@ -568,8 +642,11 @@ class WrenchComposer:
             self._local_torque_b.zero_()
             self._out_force_b.zero_()
             self._out_torque_b.zero_()
+            self._out_force_w.zero_()
+            self._out_torque_w.zero_()
             self._active = False
             self._dirty = False
+            self._composed_frame = None
         elif env_mask is not None:
             wp.launch(
                 reset_wrench_composer_mask,
@@ -718,7 +795,17 @@ class WrenchComposer:
             f"body_ids must be None, slice(None), a sequence, torch.Tensor, or wp.array, got {type(body_ids).__name__}"
         )
 
-    def _ensure_composed(self):
-        """Compose input buffers into output buffers if dirty."""
-        if self._dirty:
-            self.compose_to_body_frame()
+    def _ensure_composed(self, frame: str = "body"):
+        """Compose input buffers into the requested frame's output buffers if needed.
+
+        Recomposes when the input buffers are dirty or when the last composition targeted a
+        different frame than the one being requested.
+
+        Args:
+            frame: Target frame, ``"body"`` or ``"world"``.
+        """
+        if self._dirty or self._composed_frame != frame:
+            if frame == "world":
+                self.compose_to_world_frame()
+            else:
+                self.compose_to_body_frame()

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -83,6 +83,22 @@ def quat_rotate_inv_np(quat_xyzw: np.ndarray, vec: np.ndarray) -> np.ndarray:
     return vec + w * t + np.cross(-xyz, t, axis=-1)
 
 
+def quat_rotate_np(quat_xyzw: np.ndarray, vec: np.ndarray) -> np.ndarray:
+    """Rotate a vector by a quaternion (numpy).
+
+    Args:
+        quat_xyzw: Quaternion in (x, y, z, w) format. Shape: (..., 4)
+        vec: Vector to rotate. Shape: (..., 3)
+
+    Returns:
+        Rotated vector. Shape: (..., 3)
+    """
+    xyz = quat_xyzw[..., 0:3]
+    w = quat_xyzw[..., 3:4]
+    t = 2.0 * np.cross(xyz, vec, axis=-1)
+    return vec + w * t + np.cross(xyz, t, axis=-1)
+
+
 def random_unit_quaternion_np(rng: np.random.Generator, shape: tuple) -> np.ndarray:
     """Generate random unit quaternions in (x, y, z, w) format.
 
@@ -434,6 +450,72 @@ def test_global_forces_with_rotation(device: str, num_envs: int, num_bodies: int
         composed_force_np = wrench_composer.out_force_b.warp.numpy()
         assert np.allclose(composed_force_np, expected_forces_local, atol=1e-4, rtol=1e-5), (
             f"Global force rotation failed.\nExpected:\n{expected_forces_local}\nGot:\n{composed_force_np}"
+        )
+
+
+@pytest.mark.parametrize("device", test_devices())
+@pytest.mark.parametrize("num_envs", [1, 10, 100])
+@pytest.mark.parametrize("num_bodies", [1, 3, 5])
+def test_local_forces_composed_to_world(device: str, num_envs: int, num_bodies: int):
+    """Test that body-frame forces are rotated into the world frame by compose_to_world_frame.
+
+    Regression test for the Newton body-frame external-wrench bug: a body-frame force must be
+    rotated by the body's orientation when composed into the world frame (Newton's ``body_f``
+    reference frame), not written out unrotated.
+    """
+    rng = np.random.default_rng(seed=20)
+
+    for _ in range(5):
+        # Create random link quaternions (world <- body rotation).
+        link_quat_np = random_unit_quaternion_np(rng, (num_envs, num_bodies))
+        link_quat_torch = torch.from_numpy(link_quat_np)
+
+        mock_asset = create_mock_asset(num_envs, num_bodies, device, link_quat=link_quat_torch)
+        wrench_composer = WrenchComposer(mock_asset)
+
+        # Apply local (body-frame) forces.
+        forces_local_np = rng.uniform(-100.0, 100.0, (num_envs, num_bodies, 3)).astype(np.float32)
+        forces_local = wp.from_numpy(forces_local_np, dtype=wp.vec3f, device=device)
+        wrench_composer.add_forces_and_torques_index(forces=forces_local, is_global=False)
+
+        # Body-frame output must leave local forces unrotated (PhysX contract).
+        wrench_composer.compose_to_body_frame()
+        composed_force_b = wrench_composer.out_force_b.warp.numpy()
+        assert np.allclose(composed_force_b, forces_local_np, atol=1e-4, rtol=1e-5), (
+            f"Body-frame output should be unrotated.\nExpected:\n{forces_local_np}\nGot:\n{composed_force_b}"
+        )
+
+        # World-frame output must rotate local forces by the body orientation.
+        expected_force_w = quat_rotate_np(link_quat_np, forces_local_np)
+        wrench_composer.compose_to_world_frame()
+        composed_force_w = wrench_composer.out_force_w.warp.numpy()
+        assert np.allclose(composed_force_w, expected_force_w, atol=1e-4, rtol=1e-5), (
+            f"Local force world-frame rotation failed.\nExpected:\n{expected_force_w}\nGot:\n{composed_force_w}"
+        )
+
+
+@pytest.mark.parametrize("device", test_devices())
+@pytest.mark.parametrize("num_envs", [1, 10, 100])
+@pytest.mark.parametrize("num_bodies", [1, 3, 5])
+def test_global_forces_composed_to_world_unchanged(device: str, num_envs: int, num_bodies: int):
+    """Test that global (world-frame) forces at the CoM pass through compose_to_world_frame unchanged."""
+    rng = np.random.default_rng(seed=21)
+
+    for _ in range(5):
+        link_quat_np = random_unit_quaternion_np(rng, (num_envs, num_bodies))
+        link_quat_torch = torch.from_numpy(link_quat_np)
+
+        mock_asset = create_mock_asset(num_envs, num_bodies, device, link_quat=link_quat_torch)
+        wrench_composer = WrenchComposer(mock_asset)
+
+        forces_global_np = rng.uniform(-100.0, 100.0, (num_envs, num_bodies, 3)).astype(np.float32)
+        forces_global = wp.from_numpy(forces_global_np, dtype=wp.vec3f, device=device)
+        wrench_composer.add_forces_and_torques_index(forces=forces_global, is_global=True)
+
+        wrench_composer.compose_to_world_frame()
+        composed_force_w = wrench_composer.out_force_w.warp.numpy()
+        assert np.allclose(composed_force_w, forces_global_np, atol=1e-4, rtol=1e-5), (
+            f"World-frame global force should be unchanged.\nExpected:\n{forces_global_np}\nGot:\n{composed_force_w}"
         )
 
 

--- a/source/isaaclab_newton/changelog.d/fix-newton-body-frame-external-wrench.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-body-frame-external-wrench.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed body-frame external wrenches (``set_external_force_and_torque(..., is_global=False)``) being
+  applied unrotated on the Newton backend. The composed wrench was written directly into Newton's
+  world-frame ``body_f`` buffer without a body-to-world rotation, so forces and torques requested in
+  a body frame acted in the wrong direction for any non-axis-aligned body. The wrench is now composed
+  into the world frame before being written. Affects :class:`~isaaclab.assets.Articulation`,
+  :class:`~isaaclab.assets.RigidObject`, and :class:`~isaaclab.assets.RigidObjectCollection` on the
+  Newton backend.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -402,7 +402,10 @@ class Articulation(BaseArticulation):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            # Newton's ``body_f`` external-wrench buffer is expressed in the world frame at the
+            # body's CoM, so compose into world frame (rotating body-frame contributions out) rather
+            # than the body frame used by PhysX's ``apply_forces_and_torques_at_position``.
+            composer.compose_to_world_frame()
             # Kept separate from the joint-target gather below: this scatter runs
             # over bodies while the target gather runs over joints (mismatched
             # item axes), and it must precede ``_apply_actuator_model``, which
@@ -419,8 +422,8 @@ class Articulation(BaseArticulation):
                     dim=(self.num_instances, self.num_bodies),
                     device=self.device,
                     inputs=[
-                        composer.out_force_b.warp,
-                        composer.out_torque_b.warp,
+                        composer.out_force_w.warp,
+                        composer.out_torque_w.warp,
                         self._body_user_to_backend_map(),
                         self._data._sim_bind_body_external_wrench,
                         self._ALL_ENV_MASK,
@@ -433,8 +436,8 @@ class Articulation(BaseArticulation):
                     dim=(self.num_instances, self.num_bodies),
                     device=self.device,
                     inputs=[
-                        composer.out_force_b,
-                        composer.out_torque_b,
+                        composer.out_force_w,
+                        composer.out_torque_w,
                         self._data._sim_bind_body_external_wrench,
                         self._ALL_ENV_MASK,
                         self._ALL_BODY_MASK,

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/kernels.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/kernels.py
@@ -63,10 +63,10 @@ def update_wrench_array_with_force_and_torque_ordered(
     when no body ordering is active, so this kernel always applies the body map.
 
     Args:
-        forces: Body-frame forces [N], shaped [num_envs, num_bodies], in public
-            body order.
-        torques: Body-frame torques [N*m], shaped [num_envs, num_bodies], in
-            public body order.
+        forces: World-frame forces [N] at the body's CoM, shaped
+            [num_envs, num_bodies], in public body order.
+        torques: World-frame torques [N*m] about the body's CoM, shaped
+            [num_envs, num_bodies], in public body order.
         user_to_backend: Read-only map shaped [num_bodies] from each public body
             index to its backend body index.
         wrench: Backend-order wrench destination [N, N*m], shaped

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -148,14 +148,17 @@ class RigidObject(BaseRigidObject):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            # Newton's ``body_f`` external-wrench buffer is expressed in the world frame at the
+            # body's CoM, so compose into world frame (rotating body-frame contributions out)
+            # rather than the body frame used by PhysX.
+            composer.compose_to_world_frame()
             wp.launch(
                 shared_kernels.update_wrench_array_with_force_and_torque,
                 dim=(self.num_instances, self.num_bodies),
                 device=self.device,
                 inputs=[
-                    composer.out_force_b,
-                    composer.out_torque_b,
+                    composer.out_force_w,
+                    composer.out_torque_w,
                     self._data._sim_bind_body_external_wrench,
                     self._ALL_ENV_MASK,
                     self._ALL_BODY_MASK,

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -197,14 +197,17 @@ class RigidObjectCollection(BaseRigidObjectCollection):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            # Newton's ``body_f`` external-wrench buffer is expressed in the world frame at the
+            # body's CoM, so compose into world frame (rotating body-frame contributions out)
+            # rather than the body frame used by PhysX.
+            composer.compose_to_world_frame()
             wp.launch(
                 shared_kernels.update_wrench_array_with_force_and_torque,
                 dim=(self.num_instances, self.num_bodies),
                 device=self.device,
                 inputs=[
-                    composer.out_force_b,
-                    composer.out_torque_b,
+                    composer.out_force_w,
+                    composer.out_torque_w,
                     self._wrench_buffer,
                     self._ALL_ENV_MASK,
                     self._ALL_BODY_MASK,


### PR DESCRIPTION
Body-frame external wrenches applied via
set_external_force_and_torque(..., is_global=False) were written into Newton's body_f buffer without a body-to-world rotation. Newton's body_f is a world-frame wrench referenced to the body's center of mass, so a body-frame vector landed there verbatim and was applied unrotated. For any non-axis-aligned body this produced silently incorrect forces and torques; it only looked correct when a body happened to be axis-aligned. The PhysX backend was unaffected because it hands the same composed body-frame wrench to apply_forces_and_torques_at_position with is_global=False, letting the engine rotate it.

Add a symmetric WrenchComposer.compose_to_world_frame() (with out_force_w and out_torque_w outputs) that keeps world-frame contributions as-is and rotates body-frame contributions into the world frame. The Newton articulation, rigid object, and rigid object collection now compose to the world frame before writing body_f, matching its documented contract.

# Description

> [!IMPORTANT]
> Confirm the pull request base before submitting. Target `develop` for all
> contributions. The `release/3.0.0-beta2` branch is a frozen stable landing
> snapshot and is not used for ongoing maintenance.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
