### PR TITLE
Optimize Newton replicated camera startup

### DIFF
--- a/source/isaaclab/changelog.d/optimize-newton-startup.rst
+++ b/source/isaaclab/changelog.d/optimize-newton-startup.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed asset cloning and camera startup work scaling with the number of
+  environments when a headless Newton run can consume clone prototypes directly.

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -45,15 +45,44 @@ def queue_replication(cfg: Any) -> None:
     REPLICATION_QUEUE.append(cfg)
 
 
+def _automatic_usd_replication_required(queued: list[Any], backend_physics_ctx: type | None) -> bool:
+    """Return whether an automatic USD clone consumer is active.
+
+    A pure headless Newton run with only Newton Warp camera rendering consumes the
+    replicated Newton model and clone plan directly. Composing thousands of USD
+    destinations in that case is redundant. GUI/offscreen output, visualizers,
+    non-Newton camera renderers, and every non-Newton physics backend still require
+    concrete USD destinations.
+    """
+    if backend_physics_ctx is None or not backend_physics_ctx.__module__.startswith("isaaclab_newton"):
+        return True
+
+    from isaaclab.sim import SimulationContext  # noqa: PLC0415
+
+    sim = SimulationContext.instance()
+    if sim is None:
+        return True
+    if sim.has_gui or sim.has_offscreen_render or sim.resolve_visualizer_types():
+        return True
+    renderer_types = {
+        renderer_type
+        for cfg in queued
+        if (renderer_cfg := getattr(cfg, "renderer_cfg", None)) is not None
+        and (renderer_type := getattr(renderer_cfg, "renderer_type", None)) is not None
+    }
+    return bool(renderer_types - {"newton_warp"})
+
+
 def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = True) -> None:
     """Drain :data:`REPLICATION_QUEUE` against ``plan``, dispatch each backend, publish the plan.
 
     Physics contexts come from :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` when
     set, otherwise from the backend's ``PHYSICS_CONTEXT`` class.
     :class:`~isaaclab.cloner.UsdReplicateContext` is added automatically when the cfg has a
-    spawner and Kit is available, and is dropped entirely without Kit (nothing composes or
-    renders the replicated prims there). With ``replicate_physics=False`` physics contexts
-    are dropped; USD replication still fires when the spawner+Kit condition is met.
+    spawner and an active consumer needs concrete USD destinations. Pure headless Newton
+    runs can consume the replicated model and clone plan directly; GUI/offscreen rendering,
+    visualizers, and non-Newton renderers retain USD replication. With
+    ``replicate_physics=False`` physics contexts are dropped and USD replication is retained.
 
     Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
@@ -73,6 +102,9 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
     backend_physics_ctx = getattr(
         importlib.import_module(f"isaaclab_{FactoryBase._get_backend()}.cloner"), "PHYSICS_CONTEXT", None
     )
+    automatic_usd_replication = not replicate_physics or _automatic_usd_replication_required(
+        queued, backend_physics_ctx
+    )
 
     # Group queued cfgs by backend, taking the union of row indices each backend owns.
     # In the homogeneous plan every cfg maps to row 0, so multiple queue_replication
@@ -88,10 +120,13 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
             contexts = [backend_physics_ctx] if backend_physics_ctx else []
         else:
             contexts = [string_to_callable(c) if isinstance(c, str) else c for c in cfg.cloning_contexts]
+        renderer_type = getattr(getattr(cfg, "renderer_cfg", None), "renderer_type", None)
+        if replicate_physics and not automatic_usd_replication and renderer_type == "newton_warp":
+            contexts = [context for context in contexts if context is not UsdReplicateContext]
         if not replicate_physics:
             contexts = [c for c in contexts if c is UsdReplicateContext]
         ctx_set = dict.fromkeys(contexts)
-        if getattr(cfg, "spawn", None) is not None and kit_available:
+        if getattr(cfg, "spawn", None) is not None and kit_available and automatic_usd_replication:
             ctx_set.setdefault(UsdReplicateContext, None)
         for BackendCtxCls in ctx_set:
             backend_rows.setdefault(BackendCtxCls, set()).update(rows)

--- a/source/isaaclab/isaaclab/cloner/usd.py
+++ b/source/isaaclab/isaaclab/cloner/usd.py
@@ -26,17 +26,25 @@ def _select_env_ids(env_ids: torch.Tensor, mask: torch.Tensor | None, row: int) 
 
 
 class UsdReplicateContext:
-    """Queue and apply USD replication work for one stage."""
+    """Queue and apply compact USD prototype references for one stage.
+
+    Backend replication composes destinations through internal references instead
+    of copying every authored property into the root layer. The standalone
+    :func:`usd_replicate` helper retains copy-spec behavior for independent copies.
+    """
 
     replicate_priority = 100
 
-    def __init__(self, stage: Usd.Stage):
+    def __init__(self, stage: Usd.Stage, *, use_references: bool = True):
         """Initialize the context.
 
         Args:
             stage: USD stage to author replicated prim specs into.
+            use_references: Whether destinations use internal prototype references.
+                If False, source specs are copied into every destination.
         """
         self.stage = stage
+        self.use_references = use_references
         self._queue: list[tuple[str, str, torch.Tensor, torch.Tensor | None, torch.Tensor | None]] = []
 
     def queue(
@@ -125,6 +133,7 @@ class UsdReplicateContext:
                         wid = int(wid)
                         dp = tmpl.format(wid)
                         Sdf.CreatePrimInLayer(rl, dp)
+                        ps = rl.GetPrimAtPath(dp)
                         # ``CreatePrimInLayer`` authors missing intermediate ancestors (e.g. the
                         # ``Groceries`` scope in ``env_{}/Groceries/Object``) as ``over`` specs. A
                         # ``def`` copied below an ``over`` ancestor never composes as defined, so
@@ -138,11 +147,16 @@ class UsdReplicateContext:
                             ancestor_spec.specifier = Sdf.SpecifierDef
                             ancestor = ancestor.GetParentPath()
                         if src != dp:
-                            Sdf.CopySpec(rl, Sdf.Path(src), rl, Sdf.Path(dp))
+                            if self.use_references:
+                                reference = Sdf.Reference(primPath=src)
+                                references = list(ps.referenceList.prependedItems)
+                                if reference not in references:
+                                    ps.referenceList.prependedItems = [reference, *references]
+                            else:
+                                Sdf.CopySpec(rl, Sdf.Path(src), rl, Sdf.Path(dp))
 
                         # Author positions/quaternions for instance roots only.
                         if is_instance_root and (positions is not None or quaternions is not None):
-                            ps = rl.GetPrimAtPath(dp)
                             op_names = []
                             if positions is not None:
                                 p = positions[wid]
@@ -191,6 +205,6 @@ def usd_replicate(
         quaternions: Optional orientations in xyzw order, shape ``[E, 4]``. Authored as
             ``xformOp:orient`` only for env-instance root destinations (``.../env_{}``).
     """
-    ctx = UsdReplicateContext(stage)
+    ctx = UsdReplicateContext(stage, use_references=False)
     ctx.queue_mapping(sources, destinations, env_ids, mask, positions=positions, quaternions=quaternions)
     ctx.replicate()

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -13,11 +13,12 @@ import numpy as np
 import torch
 import warp as wp
 
-from pxr import Usd, UsdGeom, UsdPhysics
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.sensors as sensor_utils
 from isaaclab.app.logging_utils import force_log_level
+from isaaclab.cloner import query as clone_query
 from isaaclab.cloner import queue_replication
 from isaaclab.renderers import BaseRenderer, CameraRenderSpec
 from isaaclab.sim.views import FrameView
@@ -159,18 +160,31 @@ class Camera(SensorBase):
         # Resolve the camera prim path and spawn it, redirecting to a child if prim_path is a physics body.
         spawn = self.cfg.spawn
         if spawn is not None:
-            probe_path = (spawn.spawn_path or self.cfg.prim_path) if spawn is not None else self.cfg.prim_path
-            probe_matches = sim_utils.resolve_matching_prims_from_source(probe_path, raise_if_no_matches=False)
-            source_prim, _source_destination_expr = probe_matches[0] if probe_matches else (None, None)
+            probe_path = spawn.spawn_path or self.cfg.prim_path
+            if Sdf.Path.IsValidPathString(probe_path):
+                source_prim = self.stage.GetPrimAtPath(probe_path)
+            else:
+                probe_matches = sim_utils.resolve_matching_prims_from_source(probe_path, raise_if_no_matches=False)
+                source_prim = probe_matches[0][0] if probe_matches else None
             if source_prim is not None and source_prim.IsValid():
                 if source_prim.HasAPI(UsdPhysics.ArticulationRootAPI) or source_prim.HasAPI(UsdPhysics.RigidBodyAPI):
                     logger.info(f" Spawning camera at '{self.cfg.prim_path}/camera'.")
-                    self.cfg.prim_path = spawn.spawn_path = f"{self.cfg.prim_path}/camera"
+                    self.cfg.prim_path = f"{self.cfg.prim_path}/camera"
+                    if spawn.spawn_path is not None:
+                        spawn.spawn_path = f"{spawn.spawn_path}/camera"
 
             spawn_target = spawn.spawn_path or self.cfg.prim_path
-            if sim_utils.find_first_matching_prim(spawn_target) is None:
+            if Sdf.Path.IsValidPathString(spawn_target):
+                spawn_exists = self.stage.GetPrimAtPath(spawn_target).IsValid()
+            else:
+                spawn_exists = sim_utils.find_first_matching_prim(spawn_target) is not None
+            if not spawn_exists:
                 spawn.func(spawn_target, spawn, translation=self.cfg.offset.pos, orientation=rot_offset)
-            if not sim_utils.find_matching_prims(spawn_target):
+            if Sdf.Path.IsValidPathString(spawn_target):
+                spawn_exists = self.stage.GetPrimAtPath(spawn_target).IsValid()
+            else:
+                spawn_exists = bool(sim_utils.find_matching_prims(spawn_target))
+            if not spawn_exists:
                 raise RuntimeError(f"Could not find prim with path {spawn_target!r}.")
         queue_replication(self._source_cfg)
 
@@ -519,7 +533,8 @@ class Camera(SensorBase):
         # Build the render spec early — both the wrapper ISP (which delegates
         # any renderer-side per-camera setup) and ``create_render_data`` consume
         # it, and the prims are already authored at this point.
-        cam_paths = tuple(str(p.GetPath()) for p in sim_utils.find_matching_prims(self.cfg.prim_path, self.stage))
+        prototype_paths_only = getattr(self.cfg.renderer_cfg, "renderer_type", None) == "newton_warp"
+        cam_paths = self._resolve_camera_prim_paths(prototype_paths_only)
         env_0_prefix = "/World/envs/env_0/"
         rel_under_env0 = (
             cam_paths[0].removeprefix(env_0_prefix) if cam_paths and cam_paths[0].startswith(env_0_prefix) else ""
@@ -544,7 +559,10 @@ class Camera(SensorBase):
         # references to prims located in the stage.
         sim_ctx.render_context.ensure_prepare_stage(self.stage, self._num_envs)
 
-        self._view = FrameView(self.cfg.prim_path, device=self._device, stage=self.stage)
+        frame_view_kwargs = {}
+        if "newton" in sim_ctx.physics_manager.__name__.lower():
+            frame_view_kwargs["validate_physics_prims"] = False
+        self._view = FrameView(self.cfg.prim_path, device=self._device, stage=self.stage, **frame_view_kwargs)
         # Check that sizes are correct
         if self._view.count != self._num_envs:
             raise RuntimeError(
@@ -561,7 +579,19 @@ class Camera(SensorBase):
         self._sensor_prims.clear()
         view_prims = list(self._view.prims)
         if not view_prims and cam_paths:
-            view_prims = [self.stage.GetPrimAtPath(cam_paths[0])] * self._view.count
+            source_cameras: dict[str, UsdGeom.Camera] = {}
+            for camera_path in cam_paths:
+                if camera_path not in source_cameras:
+                    camera_prim = self.stage.GetPrimAtPath(camera_path)
+                    if not camera_prim.IsA(UsdGeom.Camera):
+                        raise RuntimeError(f"Prim at path '{camera_path}' is not a Camera.")
+                    source_cameras[camera_path] = UsdGeom.Camera(camera_prim)
+                self._sensor_prims.append(source_cameras[camera_path])
+            if len(self._sensor_prims) != self._view.count:
+                raise RuntimeError(
+                    f"Number of source camera paths ({len(self._sensor_prims)}) does not match"
+                    f" the number of environments ({self._view.count})."
+                )
         for cam_prim in view_prims:
             # Obtain the prim path
             cam_prim_path = cam_prim.GetPath().pathString
@@ -602,6 +632,37 @@ class Camera(SensorBase):
     """
     Private Helpers
     """
+
+    def _resolve_camera_prim_paths(self, prototype_paths_only: bool) -> tuple[str, ...]:
+        """Resolve camera paths from clone prototypes without traversing every environment.
+
+        Args:
+            prototype_paths_only: Whether the renderer consumes only prototype USD
+                cameras while using the clone plan for its per-environment view.
+
+        Returns:
+            Concrete camera prim paths in environment order.
+        """
+        sim_ctx = sim_utils.SimulationContext.instance()
+        plan = sim_ctx.get_clone_plan() if sim_ctx is not None else None
+        if plan is not None:
+            resolved: list[tuple[int, str]] = []
+            for source_root, destination, source_expr, env_ids in clone_query.iter_sources(plan, self.cfg.prim_path):
+                if Sdf.Path.IsValidPathString(source_expr):
+                    source_prim = self.stage.GetPrimAtPath(source_expr)
+                    source_prims = [source_prim] if source_prim.IsValid() else []
+                else:
+                    source_prims = sim_utils.find_matching_prims(source_expr, self.stage)
+                for source_prim in source_prims:
+                    source_path = source_prim.GetPath().pathString
+                    if prototype_paths_only:
+                        resolved.extend((env_id, source_path) for env_id in env_ids)
+                        continue
+                    shape_suffix = source_path[len(source_root) :]
+                    resolved.extend((env_id, destination.format(env_id) + shape_suffix) for env_id in env_ids)
+            if resolved:
+                return tuple(path for _, path in sorted(set(resolved)))
+        return tuple(str(prim.GetPath()) for prim in sim_utils.find_matching_prims(self.cfg.prim_path, self.stage))
 
     def _check_supported_data_types(self, cfg: CameraCfg):
         """Checks if the data types are supported by the ray-caster camera."""
@@ -734,25 +795,31 @@ class Camera(SensorBase):
         intrinsic_matrices = np.zeros((len(env_ids_np), 3, 3), dtype=np.float32)
         # viewport parameters are shared by every camera prim of this sensor
         height, width = self.image_shape
-        # iterate over all cameras
+        # Source-only Newton scenes reuse one USD camera prototype across many
+        # environments. Cache USD attribute reads by schema-object identity while
+        # still preserving distinct intrinsics for heterogeneous prototypes.
+        intrinsics_by_prim: dict[int, tuple[float, float, float, float]] = {}
         for matrix_id, i in enumerate(env_ids_np):
             # Get corresponding sensor prim
             sensor_prim = self._sensor_prims[int(i)]
-            # Prefer an authored OpenCV lens-distortion model when present: it carries the authoritative
-            # fx/fy/cx/cy that the RTX/OVRTX renderer projects through, which may be non-square or off-center.
-            authored = self._read_authored_opencv_intrinsics(sensor_prim.GetPrim(), width, height, int(i))
-            if authored is not None:
-                f_x, f_y, c_x, c_y = authored
-            else:
-                # get camera parameters
-                # currently rendering does not use aperture offsets or vertical aperture
-                focal_length = sensor_prim.GetFocalLengthAttr().Get()
-                horiz_aperture = sensor_prim.GetHorizontalApertureAttr().Get()
-                # extract intrinsic parameters (square pixels, centered principal point)
-                f_x = (width * focal_length) / horiz_aperture
-                f_y = f_x
-                c_x = width * 0.5
-                c_y = height * 0.5
+            prim_key = id(sensor_prim)
+            intrinsics = intrinsics_by_prim.get(prim_key)
+            if intrinsics is None:
+                # Prefer an authored OpenCV lens-distortion model when present: it carries the authoritative
+                # fx/fy/cx/cy that the RTX/OVRTX renderer projects through, which may be non-square or off-center.
+                authored = self._read_authored_opencv_intrinsics(sensor_prim.GetPrim(), width, height, int(i))
+                if authored is not None:
+                    intrinsics = authored
+                else:
+                    # get camera parameters
+                    # currently rendering does not use aperture offsets or vertical aperture
+                    focal_length = sensor_prim.GetFocalLengthAttr().Get()
+                    horiz_aperture = sensor_prim.GetHorizontalApertureAttr().Get()
+                    # extract intrinsic parameters (square pixels, centered principal point)
+                    f_x = (width * focal_length) / horiz_aperture
+                    intrinsics = (f_x, f_x, width * 0.5, height * 0.5)
+                intrinsics_by_prim[prim_key] = intrinsics
+            f_x, f_y, c_x, c_y = intrinsics
             # create intrinsic matrix for depth linear
             intrinsic_matrices[matrix_id, 0, 0] = f_x
             intrinsic_matrices[matrix_id, 0, 2] = c_x

--- a/source/isaaclab/test/cloner/test_replication_policy.py
+++ b/source/isaaclab/test/cloner/test_replication_policy.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for automatic USD replication policy."""
+
+from types import SimpleNamespace
+
+from isaaclab.cloner.replicate_session import _automatic_usd_replication_required
+from isaaclab.sim import SimulationContext
+
+
+def _sim(**overrides):
+    values = {
+        "has_gui": False,
+        "has_offscreen_render": False,
+        "resolve_visualizer_types": lambda: [],
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_pure_headless_newton_renderer_skips_automatic_usd_replication(monkeypatch):
+    """Newton physics plus Newton rendering consumes the clone plan without USD clones."""
+    monkeypatch.setattr(SimulationContext, "instance", classmethod(lambda cls: _sim()))
+    context = type("NewtonContext", (), {"__module__": "isaaclab_newton.cloner"})
+    camera_cfg = SimpleNamespace(renderer_cfg=SimpleNamespace(renderer_type="newton_warp"))
+
+    assert not _automatic_usd_replication_required([camera_cfg], context)
+
+
+def test_non_newton_renderer_keeps_automatic_usd_replication(monkeypatch):
+    """RTX still receives concrete USD destinations when Newton provides physics."""
+    monkeypatch.setattr(SimulationContext, "instance", classmethod(lambda cls: _sim()))
+    context = type("NewtonContext", (), {"__module__": "isaaclab_newton.cloner"})
+    camera_cfg = SimpleNamespace(renderer_cfg=SimpleNamespace(renderer_type="isaac_rtx"))
+
+    assert _automatic_usd_replication_required([camera_cfg], context)
+
+
+def test_visualizer_keeps_automatic_usd_replication(monkeypatch):
+    """A visualizer remains a USD clone consumer even with Newton Warp cameras."""
+    sim = _sim(resolve_visualizer_types=lambda: ["kit"])
+    monkeypatch.setattr(SimulationContext, "instance", classmethod(lambda cls: sim))
+    context = type("NewtonContext", (), {"__module__": "isaaclab_newton.cloner"})
+    camera_cfg = SimpleNamespace(renderer_cfg=SimpleNamespace(renderer_type="newton_warp"))
+
+    assert _automatic_usd_replication_required([camera_cfg], context)

--- a/source/isaaclab/test/cloner/test_usd_replicate_ancestors.py
+++ b/source/isaaclab/test/cloner/test_usd_replicate_ancestors.py
@@ -10,6 +10,7 @@ import torch
 from pxr import Sdf, Usd
 
 from isaaclab.cloner import usd_replicate
+from isaaclab.cloner.usd import UsdReplicateContext
 
 
 def _make_stage_with_source(source_path: str) -> Usd.Stage:
@@ -54,3 +55,22 @@ def test_usd_replicate_keeps_existing_ancestor_specs():
     assert scope.IsDefined()
     assert scope.GetTypeName() == "Xform"
     assert stage.GetPrimAtPath("/World/envs/env_1/Groceries/Object").IsDefined()
+
+
+def test_usd_replicate_context_composes_internal_prototype_references():
+    """Backend USD replication composes destinations from compact prototype references."""
+    stage = _make_stage_with_source("/World/envs/env_0/Robot")
+    stage.DefinePrim("/World/envs/env_0/Robot/Link", "Xform")
+    stage.DefinePrim("/World/envs/env_1", "Xform")
+    context = UsdReplicateContext(stage)
+    context.queue_mapping(
+        sources=["/World/envs/env_0/Robot"],
+        destinations=["/World/envs/env_{}/Robot"],
+        env_ids=torch.tensor([0, 1]),
+    )
+
+    context.replicate()
+
+    destination_spec = stage.GetRootLayer().GetPrimAtPath("/World/envs/env_1/Robot")
+    assert Sdf.Reference(primPath="/World/envs/env_0/Robot") in destination_spec.referenceList.prependedItems
+    assert stage.GetPrimAtPath("/World/envs/env_1/Robot/Link").IsDefined()

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from pxr import Usd, UsdGeom
+from pxr import Sdf, Usd, UsdGeom
 
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
@@ -98,7 +98,7 @@ def test_usd_replicate_with_positions_and_mask(sim):
 
 
 def test_usd_replicate_context_queue_and_replicate(sim):
-    """UsdReplicateContext queues copy specs and applies them on replicate."""
+    """UsdReplicateContext queues compact prototype references and applies them."""
     sim_utils.create_prim("/World/template", "Xform")
     sim_utils.create_prim("/World/template/A", "Xform")
     sim_utils.create_prim("/World/envs", "Xform")
@@ -117,6 +117,8 @@ def test_usd_replicate_context_queue_and_replicate(sim):
 
     assert stage.GetPrimAtPath("/World/envs/env_0/A").IsValid()
     assert stage.GetPrimAtPath("/World/envs/env_1/A").IsValid()
+    env_1_spec = stage.GetRootLayer().GetPrimAtPath("/World/envs/env_1/A")
+    assert Sdf.Reference(primPath="/World/template/A") in env_1_spec.referenceList.prependedItems
 
 
 def test_usd_replicate_nested_asset_preserves_local_offset_with_positions(sim):

--- a/source/isaaclab_newton/changelog.d/optimize-newton-startup.rst
+++ b/source/isaaclab_newton/changelog.d/optimize-newton-startup.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Newton scene import, collision processing, sensor initialization, and
+  segmentation mapping repeatedly scanning replicated environments.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -97,6 +97,7 @@ def _configure_builder_joint_target_modes(builder, cfg: ArticulationCfg) -> None
     articulation_ids, _ = resolve_matching_names(
         root_prim_path_regex, builder.articulation_label, raise_when_no_match=False
     )
+    resolved_modes: dict[tuple, tuple[tuple[int, int], ...]] = {}
     for articulation_id in articulation_ids:
         joint_start = builder.articulation_start[articulation_id]
         joint_end = builder.articulation_end[articulation_id]
@@ -116,29 +117,43 @@ def _configure_builder_joint_target_modes(builder, cfg: ArticulationCfg) -> None
                 dof_ids.append(dof_id)
                 dof_names.append(joint_name if dof_end - dof_start == 1 else f"{joint_name}:{axis_index}")
 
-        for actuator_cfg in cfg.actuators.values():
-            matched_indices, matched_names = resolve_matching_names(
-                actuator_cfg.joint_names_expr, dof_names, raise_when_no_match=False
-            )
-            if not matched_indices:
-                continue
-            selected_dof_ids = [dof_ids[index] for index in matched_indices]
-            stiffness_values = _resolve_actuator_gain_values(
-                actuator_cfg.stiffness,
-                matched_names,
-                [builder.joint_target_ke[dof_id] for dof_id in selected_dof_ids],
-            )
-            damping_values = _resolve_actuator_gain_values(
-                actuator_cfg.damping,
-                matched_names,
-                [builder.joint_target_kd[dof_id] for dof_id in selected_dof_ids],
-            )
-            for dof_id, stiffness, damping in zip(selected_dof_ids, stiffness_values, damping_values, strict=True):
-                builder.joint_target_mode[dof_id] = int(
-                    _target_mode_from_gains(stiffness, damping)
-                    if _is_implicit_actuator_cfg(actuator_cfg)
-                    else JointTargetMode.EFFORT
+        signature = (
+            tuple(dof_names),
+            tuple(builder.joint_target_ke[dof_id] for dof_id in dof_ids),
+            tuple(builder.joint_target_kd[dof_id] for dof_id in dof_ids),
+        )
+        modes = resolved_modes.get(signature)
+        if modes is None:
+            mode_by_local_dof: dict[int, int] = {}
+            for actuator_cfg in cfg.actuators.values():
+                matched_indices, matched_names = resolve_matching_names(
+                    actuator_cfg.joint_names_expr, dof_names, raise_when_no_match=False
                 )
+                if not matched_indices:
+                    continue
+                selected_dof_ids = [dof_ids[index] for index in matched_indices]
+                stiffness_values = _resolve_actuator_gain_values(
+                    actuator_cfg.stiffness,
+                    matched_names,
+                    [builder.joint_target_ke[dof_id] for dof_id in selected_dof_ids],
+                )
+                damping_values = _resolve_actuator_gain_values(
+                    actuator_cfg.damping,
+                    matched_names,
+                    [builder.joint_target_kd[dof_id] for dof_id in selected_dof_ids],
+                )
+                for local_dof, stiffness, damping in zip(
+                    matched_indices, stiffness_values, damping_values, strict=True
+                ):
+                    mode_by_local_dof[local_dof] = int(
+                        _target_mode_from_gains(stiffness, damping)
+                        if _is_implicit_actuator_cfg(actuator_cfg)
+                        else JointTargetMode.EFFORT
+                    )
+            modes = tuple(mode_by_local_dof.items())
+            resolved_modes[signature] = modes
+        for local_dof, mode in modes:
+            builder.joint_target_mode[dof_ids[local_dof]] = mode
 
 
 class Articulation(BaseArticulation):

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 import torch
 import warp as wp
-from newton import GeoType, ModelBuilder, ShapeFlags, solvers
+from newton import GeoType, ModelBuilder, ShapeFlags
 
 from pxr import Usd, UsdGeom, UsdPhysics
 
@@ -29,17 +29,24 @@ _APPROXIMATION_TO_REMESHING_METHOD = {
 }
 
 
-def _authored_collision_approximations(stage: Usd.Stage) -> dict[str, str]:
+def _authored_collision_approximations(stage: Usd.Stage, path_shape_map: dict[str, int]) -> dict[str, str]:
     """Prim path -> authored ``physics:approximation`` token (lower case).
 
     SDF collision prims are excluded: the attribute has no meaning on a shape with
     ``NewtonSDFCollisionAPI`` applied (matching Newton's importer semantics).
+
+    Only paths already imported into the source builder are inspected. This avoids a
+    full-stage traversal after USD replication, where nearly every visited prim belongs
+    to a clone and cannot affect the prototype builder.
     """
     authored: dict[str, str] = {}
-    for prim in stage.Traverse():
+    for path in path_shape_map:
+        prim = stage.GetPrimAtPath(path)
+        if not prim.IsValid() or prim.IsInstanceProxy():
+            continue
         attr = UsdPhysics.MeshCollisionAPI(prim).GetApproximationAttr()
         if attr and attr.HasAuthoredValue() and "NewtonSDFCollisionAPI" not in prim.GetAppliedSchemas():
-            authored[prim.GetPath().pathString] = str(attr.Get()).lower()
+            authored[path] = str(attr.Get()).lower()
     return authored
 
 
@@ -167,15 +174,16 @@ def build_source_builders(
             USD parse time and memory that only pays off when the shapes are rendered
             or ray cast.
     """
-    authored = _authored_collision_approximations(stage)
-    builders = {
+    build_results = {
         source: _build_source_builder(
-            stage, source, create_builder, schema_resolvers, ignore_paths, simplify_meshes, authored, load_visual_shapes
+            stage, source, create_builder, schema_resolvers, ignore_paths, simplify_meshes, load_visual_shapes
         )
         for source in sources
     }
+    builders = {source: result[0] for source, result in build_results.items()}
+    has_authored_approximations = any(result[1] for result in build_results.values())
 
-    if authored and len(builders) > 1:
+    if has_authored_approximations and len(builders) > 1:
         shape_sequences = {tuple(int(t) for t in b.shape_type) for b in builders.values()}
         if len(shape_sequences) > 1:
             warnings.warn(
@@ -193,9 +201,9 @@ def build_source_builders(
                     schema_resolvers,
                     ignore_paths,
                     simplify_meshes,
-                    {},
                     load_visual_shapes,
-                )
+                    honor_authored_approximations=False,
+                )[0]
                 for source in sources
             }
     return builders
@@ -208,13 +216,12 @@ def _build_source_builder(
     schema_resolvers: Sequence[Any],
     ignore_paths: Sequence[str] | None,
     simplify_meshes: bool,
-    authored: dict[str, str],
     load_visual_shapes: bool = True,
-) -> ModelBuilder:
-    """Build one source builder; an empty ``authored`` map restores hull-everything."""
+    *,
+    honor_authored_approximations: bool = True,
+) -> tuple[ModelBuilder, bool]:
+    """Build one source builder and report whether it had authored approximations."""
     builder = create_builder()
-    solvers.SolverMuJoCo.register_custom_attributes(builder)
-    solvers.SolverKamino.register_custom_attributes(builder)
     import_result = builder.add_usd(
         stage,
         root_path=source,
@@ -227,6 +234,11 @@ def _build_source_builder(
     _restore_visible_colliders_without_visual_shapes(
         builder, stage, import_result["path_shape_map"], load_visual_shapes
     )
+    authored = (
+        _authored_collision_approximations(stage, import_result["path_shape_map"])
+        if honor_authored_approximations
+        else {}
+    )
     if authored:
         authored_shape_indices = _apply_authored_approximations(builder, import_result["path_shape_map"], authored)
         if simplify_meshes:
@@ -238,7 +250,7 @@ def _build_source_builder(
     elif simplify_meshes:
         builder.approximate_meshes("convex_hull", keep_visual_shapes=True)
     replace_newton_builder_shape_colors(builder, stage)
-    return builder
+    return builder, bool(authored)
 
 
 def _quat_multiply(a: np.ndarray, b: np.ndarray) -> np.ndarray:

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -65,6 +65,45 @@ def newton_builder_world_hook(
             hooks.remove(hook)
 
 
+def _global_import_roots(stage: Usd.Stage, sources: Sequence[str]) -> list[str]:
+    """Return clone-external stage roots that Newton must import once.
+
+    Newton's importer still traverses descendants of ignored prims. Passing the
+    pseudo-root with ``/World/envs`` in ``ignore_paths`` therefore scales with the
+    fully replicated USD stage. Importing each clone-external top-level subtree by
+    ``root_path`` makes the work proportional to global scene content instead.
+    """
+    source_roots = tuple(source.rstrip("/") or "/" for source in sources)
+
+    def contains_source(path: str) -> bool:
+        path_prefix = path.rstrip("/") + "/"
+        return any(source == path or source.startswith(path_prefix) for source in source_roots)
+
+    roots: list[str] = []
+    for prim in stage.GetPseudoRoot().GetChildren():
+        path = prim.GetPath().pathString
+        if not contains_source(path):
+            roots.append(path)
+            continue
+        for child in prim.GetChildren():
+            child_path = child.GetPath().pathString
+            if not contains_source(child_path):
+                roots.append(child_path)
+    return roots
+
+
+def _merge_import_result(target: dict | None, incoming: dict) -> dict:
+    """Merge Newton USD-import metadata from independently scoped roots."""
+    if target is None:
+        return incoming
+    for key, value in incoming.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            target[key].update(value)
+        elif target.get(key) is None and value is not None:
+            target[key] = value
+    return target
+
+
 def _build_newton_builder_from_mapping(
     stage: Usd.Stage,
     sources: Sequence[str],
@@ -93,15 +132,22 @@ def _build_newton_builder_from_mapping(
     manager_cls = PhysicsManager._sim.physics_manager
 
     builder = manager_cls.create_builder(up_axis=up_axis)
+    global_roots = _global_import_roots(stage, sources)
     # Swap height-field-tagged terrain colliders for Newton heightfields before the
     # mesh import, and skip those prims in add_usd so the terrain is not imported twice.
-    hf_ignore_paths = manager_cls._inject_terrain_heightfields(stage, builder)
-    stage_info = builder.add_usd(
-        stage,
-        ignore_paths=["/World/envs", *sources, *hf_ignore_paths],
-        schema_resolvers=schema_resolvers,
-        load_visual_shapes=load_visual_shapes,
-    )
+    hf_ignore_paths = manager_cls._inject_terrain_heightfields(stage, builder, root_paths=global_roots)
+    stage_info = None
+    for root_path in global_roots:
+        import_result = builder.add_usd(
+            stage,
+            root_path=root_path,
+            ignore_paths=hf_ignore_paths,
+            schema_resolvers=schema_resolvers,
+            load_visual_shapes=load_visual_shapes,
+        )
+        stage_info = _merge_import_result(stage_info, import_result)
+    if stage_info is None:
+        stage_info = {"path_shape_map": {}}
     _restore_visible_colliders_without_visual_shapes(builder, stage, stage_info["path_shape_map"], load_visual_shapes)
     replace_newton_builder_shape_colors(builder, stage)
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, eval_fk
+from newton import Model, ModelBuilder, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -56,6 +56,11 @@ class NewtonKaminoManager(NewtonManager):
 
     # Annotate the concrete solver type.
     _solver: SolverKamino
+
+    @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register only the custom attributes consumed by Kamino."""
+        SolverKamino.register_custom_attributes(builder)
 
     @classmethod
     def _get_kamino_solver_cfg(cls) -> KaminoSolverCfg:

--- a/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy as np
 import warp as wp
-from newton import Contacts, Model
+from newton import Contacts, Model, ModelBuilder
 from newton.solvers import SolverMuJoCo
 
 from isaaclab.physics import PhysicsManager
@@ -30,6 +30,11 @@ class NewtonMJWarpManager(NewtonManager):
     convergence logging emitted from :meth:`_log_solver_debug` when
     :attr:`NewtonCfg.debug_mode` is enabled.
     """
+
+    @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register only the custom attributes consumed by MuJoCo Warp."""
+        SolverMuJoCo.register_custom_attributes(builder)
 
     @classmethod
     def _create_solver(cls, model: Model, solver_cfg: MJWarpSolverCfg) -> SolverMuJoCo:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1684,11 +1684,14 @@ class NewtonManager(PhysicsManager):
             fabric_hierarchy.update_world_xforms()
 
     @classmethod
-    def _inject_terrain_heightfields(cls, stage: Usd.Stage, builder: ModelBuilder) -> list[str]:
+    def _inject_terrain_heightfields(
+        cls, stage: Usd.Stage, builder: ModelBuilder, root_paths: Iterable[str] | None = None
+    ) -> list[str]:
         """Replace height-field-tagged terrain colliders with Newton heightfields.
 
-        Scans the stage for prims carrying the ``newton:heightfield:resolution``
-        attribute authored by :class:`~isaaclab.terrains.TerrainImporter`. For each,
+        Scans the requested clone-external roots for prims carrying the
+        ``newton:heightfield:resolution`` attribute authored by
+        :class:`~isaaclab.terrains.TerrainImporter`. For each,
         the collision mesh is rasterized into a :class:`newton.Heightfield` through
         :meth:`newton.Heightfield.create_from_mesh` and added to *builder* as a
         static heightfield shape. The tagged prim paths are returned so the caller
@@ -1702,13 +1705,24 @@ class NewtonManager(PhysicsManager):
         Args:
             stage: The USD stage being imported.
             builder: The Newton model builder receiving the heightfield shapes.
+            root_paths: Clone-external roots to inspect. If ``None``, inspect the
+                entire stage for compatibility with direct callers.
 
         Returns:
             Prim paths of terrain colliders that were converted to heightfields.
         """
         ignore_paths: list[str] = []
         xform_cache = UsdGeom.XformCache()
-        for prim in stage.Traverse():
+        if root_paths is None:
+            prims = stage.Traverse()
+        else:
+            prims = (
+                prim
+                for root_path in root_paths
+                for prim in Usd.PrimRange(stage.GetPrimAtPath(root_path))
+                if prim.IsValid()
+            )
+        for prim in prims:
             attr = prim.GetAttribute("newton:heightfield:resolution")
             if not attr or not attr.HasAuthoredValue():
                 continue

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -513,7 +513,8 @@ class NewtonWarpRenderer(BaseRenderer):
             or RenderBufferKind.INSTANCE_SEGMENTATION in spec.cfg.data_types
         ):
             if self._seg_mapper is None:
-                self._seg_mapper = NewtonSegmentationMapper(self._newton_model, self._stage, self.cfg)
+                clone_plan = SimulationContext.instance().get_clone_plan()
+                self._seg_mapper = NewtonSegmentationMapper(self._newton_model, self._stage, self.cfg, clone_plan)
         if RenderBufferKind.SEMANTIC_SEGMENTATION in spec.cfg.data_types:
             self._seg_mapper.build_mapping(
                 RenderBufferKind.SEMANTIC_SEGMENTATION, bool(self.cfg.colorize_semantic_segmentation)

--- a/source/isaaclab_newton/isaaclab_newton/renderers/segmentation.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/segmentation.py
@@ -20,6 +20,7 @@ are visually consistent across renderers.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
@@ -35,6 +36,8 @@ if TYPE_CHECKING:
     import newton
 
     from pxr import Usd
+
+    from isaaclab.cloner import ClonePlan
 
 _UNLABELLED_COLOR: int = 0xFF000000
 """Packed RGBA color for UNLABELLED pixels: ``(0, 0, 0, 255)`` opaque black."""
@@ -251,10 +254,19 @@ class NewtonSegmentationMapping:
             )
 
 
+@dataclass(frozen=True)
+class _CloneRoute:
+    """Compiled destination template and prototype selected for each environment."""
+
+    pattern: re.Pattern[str]
+    source_by_env: dict[int, str]
+    specificity: int
+
+
 class NewtonSegmentationMapper:
     """Builds per-shape segmentation lookup tables from a Newton model and its USD stage."""
 
-    def __init__(self, model: newton.Model, stage: Usd.Stage | None, cfg) -> None:
+    def __init__(self, model: newton.Model, stage: Usd.Stage | None, cfg, clone_plan: ClonePlan | None = None) -> None:
         """Initialize the mapper from the Newton model, USD stage, and renderer config.
 
         Construction is cheap — it only captures references and snapshots ``model.shape_label``.
@@ -265,6 +277,8 @@ class NewtonSegmentationMapper:
             stage: The live USD stage used to read :class:`UsdSemantics.LabelsAPI` labels. May be
                 ``None`` in stageless setups, in which case every shape is treated as unlabelled.
             cfg: Renderer config exposing ``semantic_filter`` and ``semantic_segmentation_mapping``.
+            clone_plan: Optional prototype-to-environment mapping. When present, semantics
+                are read once per prototype shape instead of once per replicated shape.
         """
         self._model = model
         self._stage = stage
@@ -273,9 +287,66 @@ class NewtonSegmentationMapper:
         self._shape_count = len(self._shape_labels)
         self._device = str(model.device)
         self._filter_clauses = _parse_semantic_filter(cfg.semantic_filter)
+        self._clone_routes = self._build_clone_routes(clone_plan)
         # Cache of prim path -> (matched_labels or None); labels resolved with ancestor inheritance.
         self._matched_cache: dict[str, tuple[dict[SemanticType, SemanticLabels], SemanticPrimPath] | None] = {}
         self._mappings: dict[tuple[str, bool], NewtonSegmentationMapping] = {}
+
+    @staticmethod
+    def _build_clone_routes(clone_plan: ClonePlan | None) -> list[_CloneRoute]:
+        """Compile clone-plan destinations into fast concrete-path resolvers."""
+        if clone_plan is None:
+            return []
+        clone_mask = clone_plan.clone_mask.detach().cpu()
+        env_ids = (
+            list(range(clone_mask.shape[1]))
+            if clone_plan.env_ids is None
+            else clone_plan.env_ids.detach().cpu().tolist()
+        )
+        rows_by_template: dict[str, list[int]] = {}
+        for row, template in enumerate(clone_plan.destinations):
+            if "{}" in template:
+                rows_by_template.setdefault(template, []).append(row)
+
+        routes: list[_CloneRoute] = []
+        for template, rows in rows_by_template.items():
+            prefix, suffix = template.split("{}", maxsplit=1)
+            pattern = re.compile(rf"^{re.escape(prefix)}(?P<env_id>\d+){re.escape(suffix)}(?P<shape_suffix>/.*)?$")
+            source_by_env: dict[int, str] = {}
+            for row in rows:
+                for column in clone_mask[row].nonzero(as_tuple=False).flatten().tolist():
+                    source_by_env[int(env_ids[column])] = clone_plan.sources[row]
+            routes.append(_CloneRoute(pattern, source_by_env, len(prefix) + len(suffix)))
+        routes.sort(key=lambda route: route.specificity, reverse=True)
+        return routes
+
+    def _prototype_path(self, prim_path: str) -> tuple[str, str | None, str | None]:
+        """Return prototype path plus the source/clone roots used to derive it."""
+        for route in self._clone_routes:
+            match = route.pattern.match(prim_path)
+            if match is None:
+                continue
+            source_root = route.source_by_env.get(int(match.group("env_id")))
+            if source_root is None:
+                continue
+            shape_suffix = match.group("shape_suffix") or ""
+            clone_root = prim_path[: len(prim_path) - len(shape_suffix)] if shape_suffix else prim_path
+            return source_root.rstrip("/") + shape_suffix, source_root.rstrip("/"), clone_root.rstrip("/")
+        return prim_path, None, None
+
+    @staticmethod
+    def _clone_ancestor_path(ancestor_path: str, source_root: str | None, clone_root: str | None) -> str:
+        """Rebase a prototype ancestor to its concrete clone for instance grouping."""
+        if source_root is None or clone_root is None:
+            return ancestor_path
+        if ancestor_path == source_root or ancestor_path.startswith(source_root + "/"):
+            return clone_root + ancestor_path[len(source_root) :]
+        if source_root.startswith(ancestor_path.rstrip("/") + "/"):
+            ancestor_depth = len(ancestor_path.strip("/").split("/"))
+            clone_parts = clone_root.strip("/").split("/")
+            if ancestor_depth <= len(clone_parts):
+                return "/" + "/".join(clone_parts[:ancestor_depth])
+        return ancestor_path
 
     def build_mapping(self, kind: _SegKind, colorize: bool) -> None:
         """Build and cache the :class:`NewtonSegmentationMapping` for ``kind`` at the requested colorization."""
@@ -407,15 +478,17 @@ class NewtonSegmentationMapper:
         next_id = _FIRST_ID
 
         for shape_index, prim_path in enumerate(self._shape_labels):
-            match = self._resolve_semantic_match(prim_path)
+            prototype_path, source_root, clone_root = self._prototype_path(prim_path)
+            match = self._resolve_semantic_match(prototype_path)
             if match is None:
                 shape_to_id[shape_index] = UNLABELLED_ID
                 continue
             matched, ancestor_path = match
             if kind == "instance_segmentation":
                 # All shapes under the same labelled ancestor prim form one instance group.
-                group_key = ancestor_path
-                label_value = ancestor_path
+                clone_ancestor_path = self._clone_ancestor_path(ancestor_path, source_root, clone_root)
+                group_key = clone_ancestor_path
+                label_value = clone_ancestor_path
                 semantics_value = self._semantics_payload(matched)
             else:  # semantic_segmentation
                 payload = self._semantics_payload(matched)

--- a/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING
 
 import warp as wp
@@ -133,12 +134,28 @@ class JointWrenchSensor(BaseJointWrenchSensor):
 
         resolve_kwargs = {"predicate": has_articulation_root_api, "expected_num_matches": 1}
         _, root_prim_path_expr = resolve_matching_prims_from_source(self.cfg.prim_path, **resolve_kwargs)[0]
-        self._root_view = ArticulationView(
-            model,
-            root_prim_path_expr.replace(".*", "*"),
-            verbose=False,
-            exclude_joint_types=[JointType.FREE, JointType.FIXED],
+        root_pattern = root_prim_path_expr.replace(".*", "*").rstrip("/")
+        self._root_view = next(
+            (
+                view
+                for view in NewtonManager.get_physics_sim_view()
+                if isinstance(view, ArticulationView)
+                and view.model is model
+                and view.link_labels
+                and (
+                    fnmatchcase(view.link_labels[0], root_pattern)
+                    or fnmatchcase(view.link_labels[0], root_pattern + "/*")
+                )
+            ),
+            None,
         )
+        if self._root_view is None:
+            self._root_view = ArticulationView(
+                model,
+                root_pattern,
+                verbose=False,
+                exclude_joint_types=[JointType.FREE, JointType.FIXED],
+            )
         self._num_joints = self._root_view.joint_count
         if self._num_joints == 0:
             raise RuntimeError(

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -189,6 +189,7 @@ class NewtonSiteFrameView(BaseFrameView):
         prim_path: str | list[str],
         device: str = "cpu",
         validate_xform_ops: bool = True,
+        validate_physics_prims: bool = True,
         stage: object | None = None,
         **kwargs,
     ):
@@ -198,6 +199,9 @@ class NewtonSiteFrameView(BaseFrameView):
             prim_path: User-facing frame path pattern, or list of patterns.
             device: Warp device for GPU arrays.
             validate_xform_ops: Whether to validate source USD xform ops.
+            validate_physics_prims: Whether to reject paths that already belong to
+                Newton body or shape arrays. Callers that have validated a concrete
+                non-physics USD type may disable this model-wide label scan.
             stage: USD stage that contains the source prims.
             **kwargs: Unused.
         """
@@ -209,7 +213,7 @@ class NewtonSiteFrameView(BaseFrameView):
         self._prims = []
 
         stage = sim_utils.get_current_stage() if stage is None else stage
-        self._site_specs = self._resolve_site_specs(stage, validate_xform_ops)
+        self._site_specs = self._resolve_site_specs(stage, validate_xform_ops, validate_physics_prims)
         self._site_labels: list[str] = []
         self._site_label_scales: list[tuple[float, float, float]] = []
         self._site_body: wp.array | None = None
@@ -245,25 +249,25 @@ class NewtonSiteFrameView(BaseFrameView):
             )
 
     def _resolve_site_specs(
-        self, stage, validate_xform_ops: bool
+        self, stage, validate_xform_ops: bool, validate_physics_prims: bool
     ) -> list[tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]]:
         """Resolve source prims into Newton site registration specs."""
         plan = sim_utils.SimulationContext.instance().get_clone_plan()
         model = NewtonManager.get_model()
-        body_labels = list(model.body_label) if model is not None else ()
-        shape_labels = list(model.shape_label) if model is not None else ()
+        body_labels = list(model.body_label) if model is not None and validate_physics_prims else ()
+        shape_labels = list(model.shape_label) if model is not None and validate_physics_prims else ()
         use_clone_body_pattern = model is None
         specs: list[
             tuple[tuple[str, ...] | None, wp.transform, tuple[float, float, float], bool, tuple[int, ...] | None]
         ] = []
 
         for path_expr in self._prim_paths:
-            if resolve_matching_names(path_expr, body_labels, raise_when_no_match=False)[1]:
+            if validate_physics_prims and resolve_matching_names(path_expr, body_labels, raise_when_no_match=False)[1]:
                 raise ValueError(
                     f"FrameView prim '{path_expr}' is a Newton physics body. "
                     "FrameView should only be used for non-physics frames."
                 )
-            if resolve_matching_names(path_expr, shape_labels, raise_when_no_match=False)[1]:
+            if validate_physics_prims and resolve_matching_names(path_expr, shape_labels, raise_when_no_match=False)[1]:
                 raise ValueError(
                     f"FrameView prim '{path_expr}' is a Newton collision shape. "
                     "FrameView should only be used for non-physics frames."

--- a/source/isaaclab_newton/test/assets/test_articulation_target_modes_unit.py
+++ b/source/isaaclab_newton/test/assets/test_articulation_target_modes_unit.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Kit-less unit tests for replicated articulation target-mode configuration."""
+
+from types import SimpleNamespace
+
+from isaaclab_newton.assets.articulation import articulation as articulation_module
+from newton import JointTargetMode, JointType
+
+from isaaclab.actuators import ImplicitActuatorCfg
+
+
+def test_identical_replicated_articulations_reuse_resolution_and_update_every_dof(monkeypatch):
+    """Cached mode resolution is applied to every replicated articulation."""
+    resolve_call_count = 0
+    original_resolve_matching_names = articulation_module.resolve_matching_names
+
+    def counted_resolve_matching_names(*args, **kwargs):
+        nonlocal resolve_call_count
+        resolve_call_count += 1
+        return original_resolve_matching_names(*args, **kwargs)
+
+    monkeypatch.setattr(
+        articulation_module,
+        "_resolve_articulation_root_prim_path_expr",
+        lambda cfg: "/World/envs/env_.*/Robot",
+    )
+    monkeypatch.setattr(articulation_module, "resolve_matching_names", counted_resolve_matching_names)
+    builder = SimpleNamespace(
+        articulation_label=["/World/envs/env_0/Robot", "/World/envs/env_1/Robot"],
+        articulation_start=[0, 2],
+        articulation_end=[2, 4],
+        joint_type=[JointType.REVOLUTE] * 4,
+        joint_qd_start=[0, 1, 2, 3],
+        joint_label=[
+            "/World/envs/env_0/Robot/left",
+            "/World/envs/env_0/Robot/right",
+            "/World/envs/env_1/Robot/left",
+            "/World/envs/env_1/Robot/right",
+        ],
+        joint_target_mode=[int(JointTargetMode.NONE)] * 4,
+        joint_target_ke=[0.0] * 4,
+        joint_target_kd=[0.0] * 4,
+    )
+    cfg = SimpleNamespace(
+        actuators={
+            "left": ImplicitActuatorCfg(joint_names_expr=["left"], stiffness=10.0, damping=0.0),
+            "right": ImplicitActuatorCfg(joint_names_expr=["right"], stiffness=0.0, damping=2.0),
+        }
+    )
+
+    articulation_module._configure_builder_joint_target_modes(builder, cfg)
+
+    assert builder.joint_target_mode == [
+        int(JointTargetMode.POSITION),
+        int(JointTargetMode.VELOCITY),
+        int(JointTargetMode.POSITION),
+        int(JointTargetMode.VELOCITY),
+    ]
+    assert resolve_call_count == 3

--- a/source/isaaclab_newton/test/cloner/test_collision_approximation.py
+++ b/source/isaaclab_newton/test/cloner/test_collision_approximation.py
@@ -7,10 +7,10 @@
 
 import newton
 import pytest
-from isaaclab_newton.cloner.newton_clone_utils import build_source_builders
+from isaaclab_newton.cloner.newton_clone_utils import _authored_collision_approximations, build_source_builders
 from newton import GeoType, ShapeFlags
 
-from pxr import Usd, UsdGeom, UsdPhysics
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
 _SOURCE = "/World/Asset"
 
@@ -184,6 +184,18 @@ class TestClonerCollisionApproximation:
 
         for source in sources:
             assert list(_collision_shapes(builders[source]).values()) == [GeoType.SPHERE]
+
+    def test_authored_approximation_scan_skips_instance_proxies(self):
+        """Scoped lookup preserves the prior full-traversal treatment of instance proxies."""
+        stage = Usd.Stage.CreateInMemory()
+        _add_l_prism(stage, "/Prototype/geom", "boundingSphere")
+        instance = stage.DefinePrim("/World/Instance", "Xform")
+        instance.GetReferences().AddInternalReference(Sdf.Path("/Prototype"))
+        instance.SetInstanceable(True)
+        proxy_path = "/World/Instance/geom"
+
+        assert stage.GetPrimAtPath(proxy_path).IsInstanceProxy()
+        assert _authored_collision_approximations(stage, {proxy_path: 0}) == {}
 
     def test_primitive_collider_remains_visible_in_mixed_visual_model(self):
         """Colliders remain visible only when their body or static parent has no visual shape."""

--- a/source/isaaclab_newton/test/cloner/test_global_import_roots.py
+++ b/source/isaaclab_newton/test/cloner/test_global_import_roots.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for clone-external Newton USD import scoping."""
+
+from isaaclab_newton.cloner.replicate import _global_import_roots
+
+from pxr import Usd
+
+
+def test_global_import_roots_excludes_replicated_environment_tree():
+    """Global import roots contain clone-external branches without entering ``/World/envs``."""
+    stage = Usd.Stage.CreateInMemory()
+    for path in (
+        "/physicsScene",
+        "/World/envs/env_0/Robot",
+        "/World/envs/env_1/Robot",
+        "/World/ground",
+        "/GlobalAsset",
+    ):
+        stage.DefinePrim(path, "Xform")
+
+    roots = _global_import_roots(stage, ["/World/envs/env_0"])
+
+    assert set(roots) == {"/physicsScene", "/World/ground", "/GlobalAsset"}
+    assert all(not path.startswith("/World/envs") for path in roots)
+
+
+def test_global_import_roots_preserves_heterogeneous_prototype_exclusion():
+    """Asset-level heterogeneous sources still exclude their shared environment branch."""
+    stage = Usd.Stage.CreateInMemory()
+    for path in (
+        "/physicsScene",
+        "/World/envs/env_0/Object",
+        "/World/envs/env_1/Object",
+        "/World/ground",
+    ):
+        stage.DefinePrim(path, "Xform")
+
+    roots = _global_import_roots(stage, ["/World/envs/env_0/Object", "/World/envs/env_1/Object"])
+
+    assert set(roots) == {"/physicsScene", "/World/ground"}

--- a/source/isaaclab_newton/test/renderers/test_segmentation.py
+++ b/source/isaaclab_newton/test/renderers/test_segmentation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 pytest.importorskip("numpy")
 pytest.importorskip("warp")
@@ -18,6 +19,8 @@ pytest.importorskip("pxr")
 from isaaclab_newton.renderers.segmentation import NewtonSegmentationMapper
 
 from pxr import Usd
+
+from isaaclab.cloner import ClonePlan
 
 # The color palette / reserved ids live in core and are unit-tested there
 # (``isaaclab/test/renderers/test_segmentation_colors.py``); here they are only an oracle for the
@@ -189,3 +192,67 @@ def test_semantic_segmentation_mapping_overrides_color():
     assert mapping.info["idToLabels"][override] == {"class": "cartpole"}
     packed = pack_rgba(override)
     assert packed in mapping.shape_to_color.numpy().tolist()
+
+
+def test_clone_plan_resolves_semantics_once_per_prototype():
+    """Replicated shape paths read semantics from their prototype while preserving instances."""
+    stage, shape_paths = _scene()
+    shape_paths.insert(3, "/World/envs/env_2/Robot/cart/geom")
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        env_ids=torch.arange(3),
+    )
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg(), plan)
+    mapper.build_mapping("instance_segmentation", colorize=False)
+    mapping = mapper.get_mapping("instance_segmentation", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    assert ids[1] != ids[2]
+    assert ids[2] != ids[3]
+    assert mapping.info["idToLabels"][ids[3]] == "/World/envs/env_2/Robot"
+    assert set(mapper._matched_cache).isdisjoint({"/World/envs/env_1/Robot/pole/geom", shape_paths[3]})
+
+
+def test_heterogeneous_clone_plan_selects_semantics_from_each_variant():
+    """Each heterogeneous environment resolves the prototype selected by its clone row."""
+    stage = Usd.Stage.CreateInMemory()
+    for env_id, label in ((0, "red"), (1, "blue")):
+        root = f"/World/envs/env_{env_id}/Object"
+        stage.DefinePrim(f"{root}/geom", "Mesh")
+        add_labels(stage.GetPrimAtPath(root), labels=[label], instance_name="class")
+    shape_paths = [f"/World/envs/env_{env_id}/Object/geom" for env_id in range(4)]
+    plan = ClonePlan(
+        sources=("/World/envs/env_0/Object", "/World/envs/env_1/Object"),
+        destinations=("/World/envs/env_{}/Object", "/World/envs/env_{}/Object"),
+        clone_mask=torch.tensor([[True, False, True, False], [False, True, False, True]]),
+        env_ids=torch.arange(4),
+    )
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg(), plan)
+    mapper.build_mapping("semantic_segmentation", colorize=False)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    assert ids[0] == ids[2]
+    assert ids[1] == ids[3]
+    assert ids[0] != ids[1]
+    assert mapping.info["idToLabels"][ids[0]] == {"class": "red"}
+    assert mapping.info["idToLabels"][ids[1]] == {"class": "blue"}
+
+
+def test_clone_plan_with_implicit_env_ids_resolves_prototype_semantics():
+    """Clone plans with implicit sequential environment ids use prototype semantics."""
+    stage, shape_paths = _scene()
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+    )
+    mapper = NewtonSegmentationMapper(_model(shape_paths), stage, _cfg(), plan)
+    mapper.build_mapping("semantic_segmentation", colorize=False)
+    mapping = mapper.get_mapping("semantic_segmentation", colorize=False)
+
+    ids = mapping.shape_to_id.numpy().tolist()
+    assert ids[1] == ids[2]
+    assert "/World/envs/env_1/Robot/pole/geom" not in mapper._matched_cache

--- a/source/isaaclab_tasks/changelog.d/fix-reorient-replication.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-reorient-replication.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Shadow Hand reorientation scene setup authoring every environment before
+  backend replication.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_camera_env.py
@@ -49,14 +49,17 @@ class ShadowHandCameraEnv(ReorientDirectEnv):
 
     def _setup_scene(self):
         # add hand, in-hand object, and goal object
-        self.hand = Articulation(self.cfg.robot_cfg)
-        self.object: Articulation | RigidObject = self.cfg.object_cfg.class_type(self.cfg.object_cfg)
-        self._joint_wrench_sensor = self._create_joint_wrench_sensor()
-        self._tiled_camera = Camera(self.cfg.tiled_camera)
-        src, dest = "/World/envs/env_0", "/World/envs/env_{}"
-        pos = cloner.grid_transforms(self.scene.num_envs, self.scene.cfg.env_spacing, device=self.device)[0]
-        plan = cloner.clone_plan_from_env_0(src, dest, self.scene.num_envs, self.device, pos)
-        cloner.replicate(plan, stage=self.scene.stage)
+        with cloner.ReplicateSession(
+            [self.cfg.robot_cfg, self.cfg.object_cfg, self.cfg.tiled_camera],
+            num_clones=self.scene.num_envs,
+            env_spacing=self.scene.cfg.env_spacing,
+            device=self.device,
+            stage=self.scene.stage,
+        ):
+            self.hand = Articulation(self.cfg.robot_cfg)
+            self.object: Articulation | RigidObject = self.cfg.object_cfg.class_type(self.cfg.object_cfg)
+            self._joint_wrench_sensor = self._create_joint_wrench_sensor()
+            self._tiled_camera = Camera(self.cfg.tiled_camera)
         # PhysX replication requires explicit collision filtering between environments.
         if "physx" in self.scene.physics_backend:
             self.scene.filter_collisions(global_prim_paths=[])

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
@@ -95,17 +95,20 @@ class ReorientDirectEnv(DirectRLEnv):
 
     def _setup_scene(self):
         # add hand, in-hand object, and goal object
-        self.hand = Articulation(self.cfg.robot_cfg)
-        self.object: Articulation | RigidObject = self.cfg.object_cfg.class_type(self.cfg.object_cfg)
-        self._joint_wrench_sensor = None
-        if self.cfg.asymmetric_obs:
-            self._joint_wrench_sensor = self._create_joint_wrench_sensor()
         # add ground plane
         spawn_ground_plane(prim_path="/World/ground", cfg=GroundPlaneCfg())
-        src, dest = "/World/envs/env_0", "/World/envs/env_{}"
-        pos = cloner.grid_transforms(self.scene.num_envs, self.scene.cfg.env_spacing, device=self.device)[0]
-        plan = cloner.clone_plan_from_env_0(src, dest, self.scene.num_envs, self.device, pos)
-        cloner.replicate(plan, stage=self.scene.stage)
+        with cloner.ReplicateSession(
+            [self.cfg.robot_cfg, self.cfg.object_cfg],
+            num_clones=self.scene.num_envs,
+            env_spacing=self.scene.cfg.env_spacing,
+            device=self.device,
+            stage=self.scene.stage,
+        ):
+            self.hand = Articulation(self.cfg.robot_cfg)
+            self.object: Articulation | RigidObject = self.cfg.object_cfg.class_type(self.cfg.object_cfg)
+            self._joint_wrench_sensor = None
+            if self.cfg.asymmetric_obs:
+                self._joint_wrench_sensor = self._create_joint_wrench_sensor()
         # PhysX replication requires explicit collision filtering between environments.
         if "physx" in self.scene.physics_backend:
             self.scene.filter_collisions(global_prim_paths=["/World/ground"])


### PR DESCRIPTION
# Description

Optimize the full replicated-scene startup path used by the 4K Shadow Hand
camera task while preserving heterogeneous-environment support.

The change is intentionally kept in one draft PR so the cloning, camera,
Newton import, mesh/collision, articulation, sensor, and semantic-mapping
optimizations can be tested together.

## What changed

- Construct Shadow Hand reorientation assets and cameras inside
  `ReplicateSession`, so backend replication sees the complete asset queue.
- Avoid automatic concrete asset clones for pure headless Newton + Newton Warp
  runs; retain concrete USD for PhysX, RTX, GUI/offscreen output, visualizers,
  and explicit USD clone consumers.
- Use compact internal USD references when concrete destinations are required.
- Resolve camera prototypes through the clone plan, cache shared camera
  intrinsics, and skip Newton-irrelevant physics validation in `FrameView`.
- Import clone-external Newton USD roots directly instead of traversing the
  replicated environment tree from the pseudo-root.
- Scope heightfield and collision-approximation scans to imported roots/shapes,
  and register only the selected solver's builder attributes.
- Cache repeated articulation target-mode resolution and reuse joint-wrench and
  site-frame view work.
- Resolve segmentation labels through the clone plan, reading semantic labels
  once per prototype while preserving per-environment instance identities and
  heterogeneous source selection.

Dependencies: none.

## Performance

Measured against `upstream/develop` at `e3c7dd87b6` on an RTX PRO 6000
Blackwell with warm asset and kernel caches.

### Shadow Hand camera, 4096 environments

```bash
uv run --frozen isaaclab benchmark startup \
  --task Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct \
  --num_envs 4096 \
  physics=newton_mjwarp renderer=newton_renderer \
  --benchmark_formatter summary
```

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Scene creation | 19.34 s | 3.47 s | -15.87 s (-82.1%) |
| Builder finalization | 2.52 s | 2.46 s | -0.06 s (-2.4%) |
| Semantic mapping | 5.14 s | 0.62 s | -4.53 s (-88.0%) |
| Solver initialization | 1.70 s | 1.69 s | effectively unchanged |
| CUDA graph capture | 1.51 s | 1.52 s | effectively unchanged |
| Simulation start | 14.82 s | 8.46 s | -6.36 s (-42.9%) |
| Profiled environment creation | 35.83 s | 13.57 s | -22.26 s (-62.1%) |
| First step | 0.22 s | 0.23 s | effectively unchanged |
| Profiled launch through first step | 38.52 s | 16.15 s | -22.37 s (-58.1%) |

A second post-fix run measured 15.91 s through the first step, showing the
expected small run-to-run variance. This does **not** yet meet the 10 s
end-to-end goal. The largest remaining fixed costs include builder finalization
(~2.46 s), solver initialization plus graph capture (~3.22 s), and the remaining
model/callback/reset work around them.

### Kuka-Allegro lift camera, 4096 heterogeneous environments

```bash
uv run --frozen isaaclab benchmark startup \
  --task Isaac-Lift-KukaAllegro-Camera \
  --num_envs 4096 \
  physics=newton_mjwarp renderer=newton_renderer \
  presets=single_camera,rgb64 \
  --benchmark_formatter summary
```

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Scene creation | 13.13 s | 12.42 s | -0.71 s (-5.4%) |
| Simulation start | 8.73 s | 7.35 s | -1.38 s (-15.9%) |
| Profiled environment creation | 25.10 s | 22.67 s | -2.43 s (-9.7%) |
| First step | 0.53 s | 0.52 s | -0.01 s (-1.9%) |
| Profiled launch through first step | 29.39 s | 26.93 s | -2.46 s (-8.4%) |

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Performance improvement

## Validation

- 33 focused tests passed, covering replication policy, compact USD references,
  articulation caching, scoped global/collision imports, clone-plan semantic
  mapping, and Kuka heterogeneous rendering.
- Verified the new regression tests fail against unmodified `upstream/develop`.
- Kuka heterogeneous Newton-renderer golden tests passed for both RGB and
  semantic segmentation.
- `Isaac-Lift-KukaAllegro-Camera`: RSL-RL, 16 environments, Newton MJWarp +
  Newton renderer, two learning iterations completed.
- `Isaac-Reorient-Cube-Shadow-Camera-Direct`: RSL-RL, 16 environments, Newton
  MJWarp + Newton renderer, two learning iterations completed.
- Both 4096-environment benchmarks above completed through the first step.
- `uv run --frozen python tools/changelog/cli.py check develop`: passed.
- `uv run --frozen isaaclab -f`: passed.
- Local Isaac Sim PhysX + RTX benchmarking is unavailable in this kitless
  worktree because the full Isaac Sim/Kit runtime is not installed. This remains
  an explicit CI/reviewer validation request.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks
- [x] Documentation changes are not required for this internal startup path
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to `CONTRIBUTORS.md` or my name already exists there
