### PR TITLE
Document direct physics engine API access

### DIFF
--- a/docs/source/api/lab_ovphysx/isaaclab_ovphysx.physics.rst
+++ b/docs/source/api/lab_ovphysx/isaaclab_ovphysx.physics.rst
@@ -2,3 +2,28 @@
 =========================
 
 .. automodule:: isaaclab_ovphysx.physics
+
+  .. rubric:: Classes
+
+  .. autosummary::
+
+    OvPhysxManager
+    OvPhysxCfg
+
+.. currentmodule:: isaaclab_ovphysx.physics
+
+Physics Manager
+---------------
+
+.. autoclass:: OvPhysxManager
+  :members:
+  :inherited-members:
+  :show-inheritance:
+
+Physics Configuration
+---------------------
+
+.. autoclass:: OvPhysxCfg
+  :members:
+  :show-inheritance:
+  :exclude-members: __init__

--- a/docs/source/api/lab_ovphysx/isaaclab_ovphysx.sim.views.rst
+++ b/docs/source/api/lab_ovphysx/isaaclab_ovphysx.sim.views.rst
@@ -2,3 +2,18 @@ isaaclab\_ovphysx.sim.views
 ===========================
 
 .. automodule:: isaaclab_ovphysx.sim.views
+
+  .. rubric:: Classes
+
+  .. autosummary::
+
+    OvPhysxView
+
+.. currentmodule:: isaaclab_ovphysx.sim.views
+
+Tensor Binding View
+-------------------
+
+.. autoclass:: OvPhysxView
+  :members:
+  :show-inheritance:

--- a/docs/source/api/lab_physx/isaaclab_physx.physics.rst
+++ b/docs/source/api/lab_physx/isaaclab_physx.physics.rst
@@ -16,8 +16,7 @@ Physics Manager
 ---------------
 
 .. autoclass:: PhysxManager
-  :members:
-  :inherited-members:
+  :members: get_physics_sim_view
   :show-inheritance:
 
 Physics Configuration

--- a/docs/source/api/lab_physx/isaaclab_physx.physics.rst
+++ b/docs/source/api/lab_physx/isaaclab_physx.physics.rst
@@ -2,3 +2,28 @@
 =======================
 
 .. automodule:: isaaclab_physx.physics
+
+  .. rubric:: Classes
+
+  .. autosummary::
+
+    PhysxManager
+    PhysxCfg
+
+.. currentmodule:: isaaclab_physx.physics
+
+Physics Manager
+---------------
+
+.. autoclass:: PhysxManager
+  :members:
+  :inherited-members:
+  :show-inheritance:
+
+Physics Configuration
+---------------------
+
+.. autoclass:: PhysxCfg
+  :members:
+  :show-inheritance:
+  :exclude-members: __init__

--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -967,7 +967,7 @@ Here's a complete example showing how to update your code:
    from isaaclab_physx.assets import SurfaceGripper, SurfaceGripperCfg
    from isaaclab.assets import RigidObjectCollection  # unchanged
 
-   # Using new root_view property
+   # Using the new backend-specific root_view property (PhysX shown)
    robot = scene["robot"]
    masses = robot.root_view.get_masses()
 
@@ -975,6 +975,12 @@ Here's a complete example showing how to update your code:
    collection = scene["object_collection"]
    poses = collection.data.body_pose_w
    collection.write_body_state_to_sim(state, env_ids=env_ids, body_ids=object_ids)
+
+The concrete ``root_view`` type is backend-specific. The ``get_masses()`` call
+above is a PhysX Tensor API example; Newton selections and OvPhysX bindings use
+different access methods. See
+:doc:`/source/overview/core-concepts/physical-backends/direct-api-access/index`
+before using ``root_view`` in backend-portable code.
 
 
 Quaternion Format

--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -952,7 +952,7 @@ Here's a complete example showing how to update your code:
 
    # Using deprecated root_physx_view
    robot = scene["robot"]
-   masses = robot.root_physx_view.get_masses()
+   material_properties = robot.root_physx_view.get_material_properties()
 
    # Using deprecated object_* API
    collection = scene["object_collection"]
@@ -969,16 +969,17 @@ Here's a complete example showing how to update your code:
 
    # Using the new backend-specific root_view property (PhysX shown)
    robot = scene["robot"]
-   masses = robot.root_view.get_masses()
+   material_properties = robot.root_view.get_material_properties()
 
    # Using new body_* API
    collection = scene["object_collection"]
    poses = collection.data.body_pose_w
    collection.write_body_state_to_sim(state, env_ids=env_ids, body_ids=object_ids)
 
-The concrete ``root_view`` type is backend-specific. The ``get_masses()`` call
-above is a PhysX Tensor API example; Newton selections and OvPhysX bindings use
-different access methods. See
+The concrete ``root_view`` type is backend-specific. The
+``get_material_properties()`` call above reads each rigid shape's static friction,
+dynamic friction, and restitution through the PhysX Tensor API; Newton selections
+and OvPhysX bindings use different access methods. See
 :doc:`/source/overview/core-concepts/physical-backends/direct-api-access/index`
 before using ``root_view`` in backend-portable code.
 

--- a/docs/source/overview/core-concepts/multi_backend_architecture.rst
+++ b/docs/source/overview/core-concepts/multi_backend_architecture.rst
@@ -308,6 +308,12 @@ that all backends must provide. Current backend implementations use ``wp.array``
 Data classes follow the same pattern with their own factories (e.g.,
 ``ArticulationData(FactoryBase, BaseArticulationData)``).
 
+These base interfaces define the portable contract. Advanced code can also use
+each engine's native low-level data API, but those APIs deliberately retain
+different ownership and synchronization semantics. See
+:doc:`physical-backends/direct-api-access/index` for PhysX typed views, Newton
+live model/state arrays and generic selections, and OvPhysX tensor bindings.
+
 Adding a New Physics Backend
 ----------------------------
 

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
@@ -1,0 +1,92 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+Direct Physics Engine API Access
+================================
+
+.. warning::
+
+   Native physics APIs are backend-specific escape hatches. They can bypass
+   Isaac Lab's buffering, validation, ordering, and lifecycle management. Use
+   the unified asset and sensor APIs unless an engine-native capability or a
+   lower-overhead data path is required.
+
+When to use native access
+-------------------------
+
+Use native access when a task depends on an engine-specific capability or when
+the unified APIs add data movement that is material to the workload. Keep this
+access close to the component that owns the simulation state, and prefer the
+portable Isaac Lab APIs for task logic that does not need it.
+
+Why there is no unified low-level view
+--------------------------------------
+
+The backends expose fundamentally different access models. PhysX and OvPhysX
+use explicit pull/push operations. PhysX organizes access into typed views for
+physics-object families. OvPhysX organizes access into bindings selected by
+tensor type; ``OvPhysxView`` is an Isaac Lab convenience manager over those
+bindings.
+
+Newton instead exposes live arrays owned by ``Model``, ``State``, ``Control``,
+and ``Contacts``. Its selection describes subsets and batched layouts rather
+than owning copied data. A single facade would erase these ownership and
+synchronization differences and reduce the engines to a least-common-
+denominator API. Isaac Lab preserves native access so advanced users retain
+engine-specific performance and capabilities.
+
+How the access models differ
+----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 20 17 18 18 20 20
+
+   * - Backend
+     - Native entry point
+     - Selection model
+     - Data ownership
+     - Read/write model
+     - Synchronization
+     - Invalidation
+   * - PhysX
+     - ``PhysxManager.get_physics_sim_view()``
+     - Typed views selected by prim globs
+     - Engine/view-owned buffers
+     - Getter/setter pull/push
+     - Explicit setters and occasional kinematic refresh
+     - Reacquire after view invalidation, hard reset, or teardown
+   * - Newton
+     - ``NewtonManager.get_model()``, ``get_state_0()``, ``get_control()``,
+       and ``get_contacts()``
+     - Generic labels and ``ArticulationView``
+     - Live engine-owned Warp arrays
+     - Direct pointer or selection reads/writes
+     - Forward kinematics and model-change notification when applicable
+     - Reacquire current state across state-buffer swaps and all objects after
+       model rebuild
+   * - OvPhysX
+     - ``OvPhysxManager.get_physx_instance()`` or ``OvPhysxView``
+     - A tensor type plus pattern/prim list
+     - Caller-owned transfer buffers backed by engine bindings
+     - Explicit ``read()``/``write()`` or guarded convenience methods
+     - Caller respects access mode, device, dtype, and shape
+     - Reacquire after stage/runtime teardown
+
+Choosing an access level
+------------------------
+
+#. Prefer the unified Isaac Lab data and write APIs for portable task code.
+#. Reuse an Isaac Lab-owned native handle when its selection already matches.
+#. Construct raw engine access only for selections or capabilities not exposed
+   by the owning Isaac Lab object.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   physx
+   newton
+   ovphysx

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
@@ -27,8 +27,8 @@ Why there is no unified low-level view
 The backends expose fundamentally different access models. PhysX and OvPhysX
 use explicit pull/push operations. PhysX organizes access into typed views for
 physics-object families. OvPhysX organizes access into bindings selected by
-tensor type; ``OvPhysxView`` is an Isaac Lab convenience manager over those
-bindings.
+tensor type; :class:`~isaaclab_ovphysx.sim.views.OvPhysxView` is an Isaac Lab
+convenience manager over those bindings.
 
 Newton instead exposes live arrays owned by ``Model``, ``State``, ``Control``,
 and ``Contacts``. Its selection describes subsets and batched layouts rather
@@ -52,15 +52,17 @@ How the access models differ
      - Synchronization
      - Invalidation
    * - PhysX
-     - ``PhysxManager.get_physics_sim_view()``
+     - :meth:`~isaaclab_physx.physics.PhysxManager.get_physics_sim_view`
      - Typed views selected by prim globs
      - Engine/view-owned buffers
      - Getter/setter pull/push
      - Explicit setters and occasional kinematic refresh
      - Reacquire after view invalidation, hard reset, or teardown
    * - Newton
-     - ``NewtonManager.get_model()``, ``get_state_0()``, ``get_control()``,
-       and ``get_contacts()``
+     - :meth:`~isaaclab_newton.physics.NewtonManager.get_model`,
+       :meth:`~isaaclab_newton.physics.NewtonManager.get_state_0`,
+       :meth:`~isaaclab_newton.physics.NewtonManager.get_control`, and
+       :meth:`~isaaclab_newton.physics.NewtonManager.get_contacts`
      - Generic labels and ``ArticulationView``
      - Live engine-owned Warp arrays
      - Direct pointer or selection reads/writes
@@ -68,7 +70,8 @@ How the access models differ
      - Reacquire current state across state-buffer swaps and all objects after
        model rebuild
    * - OvPhysX
-     - ``OvPhysxManager.get_physx_instance()`` or ``OvPhysxView``
+     - :meth:`~isaaclab_ovphysx.physics.OvPhysxManager.get_physx_instance`
+       or :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`
      - A tensor type plus pattern/prim list
      - Caller-owned transfer buffers backed by engine bindings
      - Explicit ``read()``/``write()`` or guarded convenience methods

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/index.rst
@@ -1,7 +1,7 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+.. Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+.. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-3-Clause
 
 Direct Physics Engine API Access
 ================================
@@ -17,25 +17,28 @@ When to use native access
 -------------------------
 
 Use native access when a task depends on an engine-specific capability or when
-the unified APIs add data movement that is material to the workload. Keep this
-access close to the component that owns the simulation state, and prefer the
-portable Isaac Lab APIs for task logic that does not need it.
+the unified APIs do not do what you need. Keep this access close to the
+component that owns the simulation state, and prefer the portable Isaac Lab
+APIs for task logic that does not need it.
 
 Why there is no unified low-level view
 --------------------------------------
 
 The backends expose fundamentally different access models. PhysX and OvPhysX
-use explicit pull/push operations. PhysX organizes access into typed views for
-physics-object families. OvPhysX organizes access into bindings selected by
-tensor type; :class:`~isaaclab_ovphysx.sim.views.OvPhysxView` is an Isaac Lab
-convenience manager over those bindings.
+use explicit pull/push operations, so data is refreshed or published only when
+the corresponding method is called. Newton instead exposes live arrays owned
+by ``Model``, ``State``, ``Control``, and ``Contacts``. Changes to those arrays
+immediately affect the owning object, although derived state and solver caches
+can still require explicit synchronization.
 
-Newton instead exposes live arrays owned by ``Model``, ``State``, ``Control``,
-and ``Contacts``. Its selection describes subsets and batched layouts rather
-than owning copied data. A single facade would erase these ownership and
-synchronization differences and reduce the engines to a least-common-
-denominator API. Isaac Lab preserves native access so advanced users retain
-engine-specific performance and capabilities.
+PhysX organizes access into typed views for physics-object families. OvPhysX
+organizes access into bindings selected by tensor type;
+:class:`~isaaclab_ovphysx.sim.views.OvPhysxView` is an Isaac Lab convenience
+manager over those bindings. Newton selections describe subsets and batched
+layouts without imposing an asset type. A single facade would erase these
+ownership and synchronization differences and reduce the engines to a
+least-common-denominator API. Isaac Lab preserves native access so advanced
+users retain engine-specific performance and capabilities.
 
 How the access models differ
 ----------------------------

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
@@ -1,7 +1,7 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+.. Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+.. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-3-Clause
 
 Newton Native Data and Selection API
 ====================================
@@ -9,7 +9,10 @@ Newton Native Data and Selection API
 Mental model
 ------------
 
-The Newton backend exposes its engine-owned ``Model``, ``State``, ``Control``, and optional
+The Newton backend exposes its engine-owned `Model
+<https://newton-physics.github.io/newton/stable/api/_generated/newton.Model.html>`_, `State
+<https://newton-physics.github.io/newton/stable/api/_generated/newton.State.html>`_, `Control
+<https://newton-physics.github.io/newton/stable/api/_generated/newton.Control.html>`_, and optional
 ``Contacts`` objects through :class:`isaaclab_newton.physics.NewtonManager`. Their Warp arrays are
 the live engine data, rather than values pulled into a separate per-asset view buffer. The model
 owns structural and static arrays and labels; a state owns evolving simulation arrays; and a
@@ -112,40 +115,34 @@ of assuming a fixed set of arrays or methods:
 Read and write through a selection
 ----------------------------------
 
-Read from a ``Model`` or ``State`` source, then write values to a ``Model`` or ``State`` target.
-For the installed Newton version, ``ArticulationView.get_dof_positions()``
-accepts a source and ``ArticulationView.set_dof_positions()`` accepts a target,
-values, and an optional mask. Clone before modifying values so the intermediate changes are
-explicit:
+Selections provide typed convenience methods as well as generic string-keyed
+``get_attribute()`` and ``set_attribute()`` methods. The generic methods expose
+engine properties that do not have dedicated selection methods. Clone a
+selected value before modifying it when you want the write to remain explicit:
 
 .. code-block:: python
 
    import warp as wp
-   from isaaclab_newton.physics import NewtonManager
-
-   joint_positions = wp.clone(selection.get_dof_positions(state))
-   selection.set_dof_positions(state, joint_positions)
-   NewtonManager.invalidate_fk()
-   NewtonManager.forward()
-
-Callers can modify the cloned Warp array before writing it through the selection. Because this
-example writes manager-owned state, notify the manager with ``invalidate_fk()`` and then use its
-solver-aware ``forward()`` path to propagate generalized-coordinate edits to body transforms. Raw
-``newton.eval_fk`` remains appropriate for compatible standalone models and solvers outside the
-manager-owned lifecycle; the exact synchronization requirement depends on the edited arrays and
-active solver.
-
-For model-property changes, notify the manager with the flag appropriate to the property changed.
-For example, changing body inertial properties uses:
-
-.. code-block:: python
-
    from newton import ModelFlags
    from isaaclab_newton.physics import NewtonManager
 
-   NewtonManager.add_model_change(ModelFlags.BODY_INERTIAL_PROPERTIES)
+   rolling_friction = wp.clone(
+       selection.get_attribute("shape_material_mu_rolling", model)
+   )
+   # Modify rolling_friction with a Warp kernel before writing it back.
+   selection.set_attribute(
+       "shape_material_mu_rolling",
+       model,
+       rolling_friction,
+   )
+   NewtonManager.add_model_change(ModelFlags.SHAPE_PROPERTIES)
 
-This example does not imply that every model write uses the same flag.
+The string names a Newton model attribute rather than an Isaac Lab field. This
+example uses rolling friction because it has no dedicated selection method.
+Notify the manager with the flag appropriate to the property changed; other
+model writes can require a different flag. State writes that change generalized
+coordinates instead require forward-kinematics synchronization through
+``NewtonManager.invalidate_fk()`` and ``NewtonManager.forward()``.
 
 Ownership, synchronization, and invalidation
 ---------------------------------------------
@@ -160,6 +157,8 @@ maximal-coordinate conventions remain authoritative.
 Authoritative references
 ------------------------
 
-`Newton API reference <https://newton-physics.github.io/newton/stable/api/newton.html>`_
-
-`Newton articulation and selection guide <https://newton-physics.github.io/newton/stable/concepts/articulations.html>`_
+* `Model reference <https://newton-physics.github.io/newton/stable/api/_generated/newton.Model.html>`_
+* `State reference <https://newton-physics.github.io/newton/stable/api/_generated/newton.State.html>`_
+* `Control reference <https://newton-physics.github.io/newton/stable/api/_generated/newton.Control.html>`_
+* `ArticulationView selection reference <https://newton-physics.github.io/newton/stable/api/_generated/newton.selection.ArticulationView.html>`_
+* `Newton articulation guide <https://newton-physics.github.io/newton/stable/concepts/articulations.html>`_

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
@@ -1,0 +1,156 @@
+Newton Native Data and Selection API
+====================================
+
+Mental model
+------------
+
+The Newton backend exposes its engine-owned ``Model``, ``State``, ``Control``, and optional
+``Contacts`` objects through :class:`isaaclab_newton.physics.NewtonManager`. Their Warp arrays are
+the live engine data, rather than values pulled into a separate per-asset view buffer. The model
+owns structural and static arrays and labels; a state owns evolving simulation arrays; and a
+control owns actuation inputs. Contacts are optional and depend on the active solver and collision
+path.
+
+Lifecycle prerequisite
+----------------------
+
+Access Newton data after the simulation context has initialized the physics backend and built its
+model. Treat the objects as invalid after a model rebuild and reacquire them after Isaac Lab has
+reinitialized the simulation. This API is intended for code that can own the necessary lifecycle
+and synchronization responsibilities.
+
+Access live engine data
+-----------------------
+
+Use the manager accessors to obtain the current Newton objects:
+
+.. code-block:: python
+
+   from isaaclab_newton.physics import NewtonManager
+
+   model = NewtonManager.get_model()
+   state = NewtonManager.get_state_0()
+   control = NewtonManager.get_control()
+   contacts = NewtonManager.get_contacts()
+
+   body_poses = state.body_q
+   joint_forces = control.joint_f
+
+:meth:`isaaclab_newton.physics.NewtonManager.get_model` can construct a visualization shadow
+model when PhysX is active. The write semantics in this guide apply only when Newton is the active,
+authoritative physics backend.
+
+Reuse an Isaac Lab selection
+----------------------------
+
+Isaac Lab's Newton-backed assets expose the same generic
+:class:`newton.selection.ArticulationView` selection helper. For example, reuse an articulation's
+root selection instead of constructing the matching selection again:
+
+.. code-block:: python
+
+   robot = scene["robot"]
+   selection = robot.root_view
+   joint_positions = selection.get_dof_positions(state)
+
+Newton uses this generic, label-based selection concept for Isaac Lab articulations, rigid objects,
+rigid-object collections, and cables. It is a selection helper over model indices, not per-asset
+typed storage.
+
+Create a generic selection
+--------------------------
+
+Code that owns a matching model can construct its own selection from a model and a label pattern:
+
+.. code-block:: python
+
+   from newton.selection import ArticulationView
+
+   selection = ArticulationView(
+       model,
+       pattern="/World/envs/env_*/Robot",
+   )
+
+Discover data and labels
+------------------------
+
+Discover the available labels, counts, state fields, and selection operations at runtime instead
+of assuming a fixed set of arrays or methods:
+
+.. code-block:: python
+
+   print(model.articulation_label)
+   print(model.body_label)
+   print(model.joint_label)
+
+   model_counts = {
+       name: getattr(model, name)
+       for name in dir(model)
+       if name.endswith("_count") and isinstance(getattr(model, name), int)
+   }
+   selection_shape = {
+       "instances": selection.count,
+       "joint_dofs_per_instance": selection.joint_dof_count,
+       "links_per_instance": selection.link_count,
+   }
+   state_fields = sorted(name for name in dir(state) if not name.startswith("_"))
+   selection_methods = sorted(
+       name
+       for name in dir(selection)
+       if name.startswith(("get_", "set_"))
+   )
+   print(model_counts)
+   print(selection_shape)
+   print(state_fields)
+   print(selection_methods)
+
+Read and write through a selection
+----------------------------------
+
+Read from a ``Model`` or ``State`` source, then write values to a ``Model`` or ``State`` target.
+For the installed Newton version, :meth:`newton.selection.ArticulationView.get_dof_positions`
+accepts a source and :meth:`newton.selection.ArticulationView.set_dof_positions` accepts a target,
+values, and an optional mask. Clone before modifying values so the intermediate changes are
+explicit:
+
+.. code-block:: python
+
+   import newton
+   import warp as wp
+
+   joint_positions = wp.clone(selection.get_dof_positions(state))
+   selection.set_dof_positions(state, joint_positions)
+   newton.eval_fk(model, state.joint_q, state.joint_qd, state)
+
+Callers can modify the cloned Warp array before writing it through the selection. Use
+``newton.eval_fk`` when generalized-coordinate edits must be propagated to body transforms; the
+exact requirement depends on the edited arrays and active solver.
+
+For model-property changes, notify the manager with the flag appropriate to the property changed.
+For example, changing body inertial properties uses:
+
+.. code-block:: python
+
+   from newton import ModelFlags
+   from isaaclab_newton.physics import NewtonManager
+
+   NewtonManager.add_model_change(ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+This example does not imply that every model write uses the same flag.
+
+Ownership, synchronization, and invalidation
+---------------------------------------------
+
+Direct writes bypass Isaac Lab caches and shape/order validation. Some Newton solvers swap current
+and next state buffers, so reacquire
+:meth:`isaaclab_newton.physics.NewtonManager.get_state_0` when code needs the current authoritative
+state on a later step. A selection can survive state-buffer swaps because it describes model
+indices, but it must be recreated after a model rebuild. Solver-specific generalized- and
+maximal-coordinate conventions remain authoritative.
+
+Authoritative references
+------------------------
+
+`Newton API reference <https://newton-physics.github.io/newton/stable/api/newton.html>`_
+
+`Newton articulation and selection guide <https://newton-physics.github.io/newton/stable/concepts/articulations.html>`_

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
@@ -1,3 +1,8 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 Newton Native Data and Selection API
 ====================================
 
@@ -115,16 +120,20 @@ explicit:
 
 .. code-block:: python
 
-   import newton
    import warp as wp
+   from isaaclab_newton.physics import NewtonManager
 
    joint_positions = wp.clone(selection.get_dof_positions(state))
    selection.set_dof_positions(state, joint_positions)
-   newton.eval_fk(model, state.joint_q, state.joint_qd, state)
+   NewtonManager.invalidate_fk()
+   NewtonManager.forward()
 
-Callers can modify the cloned Warp array before writing it through the selection. Use
-``newton.eval_fk`` when generalized-coordinate edits must be propagated to body transforms; the
-exact requirement depends on the edited arrays and active solver.
+Callers can modify the cloned Warp array before writing it through the selection. Because this
+example writes manager-owned state, notify the manager with ``invalidate_fk()`` and then use its
+solver-aware ``forward()`` path to propagate generalized-coordinate edits to body transforms. Raw
+``newton.eval_fk`` remains appropriate for compatible standalone models and solvers outside the
+manager-owned lifecycle; the exact synchronization requirement depends on the edited arrays and
+active solver.
 
 For model-property changes, notify the manager with the flag appropriate to the property changed.
 For example, changing body inertial properties uses:

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/newton.rst
@@ -44,7 +44,7 @@ Reuse an Isaac Lab selection
 ----------------------------
 
 Isaac Lab's Newton-backed assets expose the same generic
-:class:`newton.selection.ArticulationView` selection helper. For example, reuse an articulation's
+``newton.selection.ArticulationView`` selection helper. For example, reuse an articulation's
 root selection instead of constructing the matching selection again:
 
 .. code-block:: python
@@ -108,8 +108,8 @@ Read and write through a selection
 ----------------------------------
 
 Read from a ``Model`` or ``State`` source, then write values to a ``Model`` or ``State`` target.
-For the installed Newton version, :meth:`newton.selection.ArticulationView.get_dof_positions`
-accepts a source and :meth:`newton.selection.ArticulationView.set_dof_positions` accepts a target,
+For the installed Newton version, ``ArticulationView.get_dof_positions()``
+accepts a source and ``ArticulationView.set_dof_positions()`` accepts a target,
 values, and an optional mask. Clone before modifying values so the intermediate changes are
 explicit:
 

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
@@ -1,7 +1,7 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+.. Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+.. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-3-Clause
 
 OvPhysX Tensor Bindings
 =======================
@@ -20,9 +20,9 @@ Lifecycle prerequisite
 ----------------------
 
 Create bindings only after the OvPhysX simulation has initialized and reset,
-when its native runtime is live. A stage reload, reset path that rebuilds the
-stage or runtime, and manager teardown invalidate existing bindings and views;
-reacquire the runtime handle and then recreate bindings and views afterwards.
+when its native runtime is live. A stage reload, a reset path that rebuilds the
+stage or runtime, and manager teardown invalidate all existing bindings and
+views. Reacquire them afterwards.
 
 Access the native runtime
 -------------------------
@@ -47,7 +47,8 @@ Create a raw tensor binding
 
 Create a raw binding when the desired selection is not already owned by an
 Isaac Lab asset. The following representative pose binding is float32 and
-device-resident; it is not a generic allocator for every tensor type:
+uses the simulation device; it is not a generic allocator for every tensor
+type:
 
 .. code-block:: python
 
@@ -67,11 +68,31 @@ device-resident; it is not a generic allocator for every tensor type:
    binding.read(poses)
    binding.write(poses)
 
-Before allocating a buffer, inspect ``binding.shape``, ``binding.dtype``, and
-the binding's count and path metadata. Match the binding shape and DLPack scalar
-metadata exactly, and respect the binding's native residency and access mode.
+Before allocating a buffer, inspect ``binding.shape``, ``binding.dtype``, the
+binding's count, and its path metadata. Match the binding shape and DLPack scalar
+metadata exactly, and respect the binding's native device and access mode.
 ``RIGID_BODY_POSE`` has the float32 layout used above, but another tensor type
 can have a different scalar dtype, shape, native device, or write permission.
+
+Discover installed tensor types
+---------------------------------
+
+Discover installed tensor types at runtime instead of maintaining an enum
+inventory:
+
+.. code-block:: python
+
+   from ovphysx.types import TensorType
+
+   tensor_types = [
+       tensor_type
+       for tensor_type in TensorType
+       if tensor_type.name != "INVALID"
+   ]
+   print(tensor_types)
+
+This lists the vocabulary provided by the installed OvPhysX version. A listed
+tensor type is not necessarily available for every prim selection.
 
 Reuse or create an ``OvPhysxView``
 ----------------------------------
@@ -98,35 +119,12 @@ with the native runtime and a Tensor API pattern:
        device=PhysicsManager.get_device(),
    )
 
-Discover tensor types and availability
---------------------------------------
-
-Discover installed tensor types at runtime instead of maintaining an enum
-inventory:
-
-.. code-block:: python
-
-   from ovphysx.types import TensorType
-
-   tensor_types = [
-       tensor_type
-       for tensor_type in TensorType
-       if tensor_type.name != "INVALID"
-   ]
-   print(tensor_types)
-
-The view separates its installed vocabulary from selection-specific
-availability:
-
-.. code-block:: python
-
-   print(view.attribute_names)
-
    if view.try_binding_for("rigid_body_pose") is not None:
        poses = view.get_attribute("rigid_body_pose")
-       view.read_into("rigid_body_pose", poses)
        view.set_attribute("rigid_body_pose", poses)
+       view.read_into("rigid_body_pose", poses)
 
+   print(view.attribute_names)
    print(view.available_attributes)
 
 ``attribute_names`` is the installed ``TensorType`` vocabulary, not selection
@@ -139,9 +137,9 @@ shape, and read-only guards.
 Read and write data
 -------------------
 
-``binding.read(buffer)`` explicitly pulls the selected values into the
-caller-owned buffer; editing that buffer has no engine effect until
-``binding.write(buffer)`` explicitly pushes it. The guarded
+Raw ``binding.read(buffer)`` calls pull values into caller-owned buffers, while
+``binding.write(buffer)`` calls push values to the simulation. Editing a local
+buffer alone does not change the simulation. The guarded
 :meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.get_attribute`,
 :meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.read_into`, and
 :meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.set_attribute` paths provide the
@@ -151,17 +149,15 @@ native device, and writable access.
 Ownership, synchronization, and invalidation
 --------------------------------------------
 
-State tensors normally live on the simulation device, while some property
-tensors are CPU-only. Allocate or supply a buffer on the binding's native
-device and match its DLPack ``code``, ``bits``, and ``lanes`` scalar metadata
-as well as its shape. :class:`~isaaclab_ovphysx.sim.views.OvPhysxView` can
-reinterpret supported flat scalar layouts as structured Warp values, but it
-does not perform implicit CPU/GPU staging.
+Allocate buffers on the binding's required device and match its shape and
+DLPack scalar metadata. State tensors normally use the simulation device, while
+some property tensors are CPU-only. :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`
+validates these requirements and can reinterpret supported flat scalar layouts
+as structured Warp values, but it does not move data between CPU and GPU.
 
-A valid ``TensorType`` need not apply to the selected prims. Use
-``try_binding_for`` for optional bindings, and do not treat a vocabulary entry
-as a promise of availability. Reacquire raw bindings and convenience views
-after reset paths that rebuild the stage or runtime, or after teardown.
+Use ``try_binding_for`` when a tensor type might not apply to the selected
+prims. Reacquire raw bindings and convenience views after reset paths that
+rebuild the stage or runtime, or after teardown.
 
 Authoritative references
 ------------------------

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
@@ -1,0 +1,168 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+OvPhysX Tensor Bindings
+=======================
+
+Mental model
+------------
+
+OvPhysX exposes generic ``TensorBinding`` objects. A binding combines a prim
+selection with one installed ``TensorType``; it is not an asset-specific native
+storage object. Callers explicitly pull values into their own buffer with
+``read()`` and push a buffer back with ``write()``. Isaac Lab optionally wraps
+these bindings in :class:`~isaaclab_ovphysx.sim.views.OvPhysxView` for a
+string-keyed, guarded convenience surface.
+
+Lifecycle prerequisite
+----------------------
+
+Create bindings only after the OvPhysX simulation has initialized and reset,
+when its native runtime is live. A stage reload, reset path that rebuilds the
+stage or runtime, and manager teardown invalidate existing bindings and views;
+reacquire them afterwards.
+
+Access the native runtime
+-------------------------
+
+Get the active OvPhysX handle from the manager:
+
+.. code-block:: python
+
+   from isaaclab_ovphysx.physics import OvPhysxManager
+
+   physx = OvPhysxManager.get_physx_instance()
+   if physx is None:
+       raise RuntimeError("OvPhysX is not ready; initialize and reset the simulation first.")
+
+Create a raw tensor binding
+---------------------------
+
+Create a raw binding when the desired selection is not already owned by an
+Isaac Lab asset. The following representative pose binding is float32 and
+device-resident; it is not a generic allocator for every tensor type:
+
+.. code-block:: python
+
+   import warp as wp
+   from isaaclab.physics import PhysicsManager
+   from ovphysx.types import TensorType
+
+   binding = physx.create_tensor_binding(
+       pattern="/World/envs/env_*/Object",
+       tensor_type=TensorType.RIGID_BODY_POSE,
+   )
+   poses = wp.empty(
+       tuple(binding.shape),
+       dtype=wp.float32,
+       device=PhysicsManager.get_device(),
+   )
+   binding.read(poses)
+   binding.write(poses)
+
+Before allocating a buffer, inspect ``binding.shape``, ``binding.dtype``, and
+the binding's count and path metadata. Match the binding shape and DLPack scalar
+metadata exactly, and respect the binding's native residency and access mode.
+``RIGID_BODY_POSE`` has the float32 layout used above, but another tensor type
+can have a different scalar dtype, shape, native device, or write permission.
+
+Reuse or create an ``OvPhysxView``
+----------------------------------
+
+Reuse the convenience view already owned by an Isaac Lab asset when its
+selection matches:
+
+.. code-block:: python
+
+   object_view = scene["object"].root_view
+   poses = object_view.get_attribute("rigid_body_pose")
+
+For a new selection, construct :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`
+with the native runtime and a Tensor API pattern:
+
+.. code-block:: python
+
+   from isaaclab.physics import PhysicsManager
+   from isaaclab_ovphysx.sim.views import OvPhysxView
+
+   view = OvPhysxView(
+       physx,
+       pattern="/World/envs/env_*/Object",
+       device=PhysicsManager.get_device(),
+   )
+
+Discover tensor types and availability
+--------------------------------------
+
+Discover installed tensor types at runtime instead of maintaining an enum
+inventory:
+
+.. code-block:: python
+
+   from ovphysx.types import TensorType
+
+   tensor_types = [
+       tensor_type
+       for tensor_type in TensorType
+       if tensor_type.name != "INVALID"
+   ]
+   print(tensor_types)
+
+The view separates its installed vocabulary from selection-specific
+availability:
+
+.. code-block:: python
+
+   print(view.attribute_names)
+
+   if view.try_binding_for("rigid_body_pose") is not None:
+       poses = view.get_attribute("rigid_body_pose")
+       view.read_into("rigid_body_pose", poses)
+       view.set_attribute("rigid_body_pose", poses)
+
+   print(view.available_attributes)
+
+``attribute_names`` is the installed ``TensorType`` vocabulary, not selection
+availability. ``try_binding_for`` attempts to create a binding for this
+selection and returns ``None`` when a valid type is unavailable. By contrast,
+``available_attributes`` lists bindings already instantiated for the view.
+``binding_for`` returns a raw binding and bypasses the view's device, dtype,
+shape, and read-only guards.
+
+Read and write data
+-------------------
+
+``binding.read(buffer)`` explicitly pulls the selected values into the
+caller-owned buffer; editing that buffer has no engine effect until
+``binding.write(buffer)`` explicitly pushes it. The guarded
+:meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.get_attribute`,
+:meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.read_into`, and
+:meth:`~isaaclab_ovphysx.sim.views.OvPhysxView.set_attribute` paths provide the
+same pull/push boundary while validating the binding's shape, scalar dtype,
+native device, and writable access.
+
+Ownership, synchronization, and invalidation
+--------------------------------------------
+
+State tensors normally live on the simulation device, while some property
+tensors are CPU-only. Allocate or supply a buffer on the binding's native
+device and match its DLPack ``code``, ``bits``, and ``lanes`` scalar metadata
+as well as its shape. :class:`~isaaclab_ovphysx.sim.views.OvPhysxView` can
+reinterpret supported flat scalar layouts as structured Warp values, but it
+does not perform implicit CPU/GPU staging.
+
+A valid ``TensorType`` need not apply to the selected prims. Use
+``try_binding_for`` for optional bindings, and do not treat a vocabulary entry
+as a promise of availability. Reacquire raw bindings and convenience views
+after reset paths that rebuild the stage or runtime, or after teardown.
+
+Authoritative references
+------------------------
+
+The generated Isaac Lab reference for
+:class:`~isaaclab_ovphysx.sim.views.OvPhysxView` documents the convenience
+manager. The repository metadata pins OvPhysX to a version but does not provide
+a versioned official OvPhysX documentation URL, so inspect the installed
+``TensorType`` and binding metadata at runtime.

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/ovphysx.rst
@@ -22,7 +22,7 @@ Lifecycle prerequisite
 Create bindings only after the OvPhysX simulation has initialized and reset,
 when its native runtime is live. A stage reload, reset path that rebuilds the
 stage or runtime, and manager teardown invalidate existing bindings and views;
-reacquire them afterwards.
+reacquire the runtime handle and then recreate bindings and views afterwards.
 
 Access the native runtime
 -------------------------
@@ -35,7 +35,12 @@ Get the active OvPhysX handle from the manager:
 
    physx = OvPhysxManager.get_physx_instance()
    if physx is None:
-       raise RuntimeError("OvPhysX is not ready; initialize and reset the simulation first.")
+       raise RuntimeError("OvPhysX has not been constructed; initialize and reset the simulation first.")
+
+A non-``None`` handle proves only that the manager constructed an OvPhysX instance; it is not a
+readiness predicate for the current simulation context. The manager can retain that cached handle
+after teardown. Initialize and reset the current context before access, and always reacquire the
+handle before creating new bindings or views.
 
 Create a raw tensor binding
 ---------------------------

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
@@ -1,0 +1,151 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+PhysX Tensor API
+================
+
+The PhysX Tensor API is an engine-native interface for data paths that need
+typed PhysX views or capabilities beyond the unified Isaac Lab APIs. It is
+backend-specific: use Isaac Lab asset and sensor APIs unless native access is
+needed for the workload.
+
+Mental model
+------------
+
+The API starts from a ``SimulationView`` and creates typed views over selected
+physics objects. A view owns an engine-backed selection; getters pull data from
+that selection and setters publish data back to it. A raw view selection uses
+the Tensor API's glob syntax, which is distinct from Isaac Lab's
+regular-expression syntax.
+
+Lifecycle prerequisite
+----------------------
+
+Isaac Lab creates its ``SimulationView`` with the Warp frontend. Low-level
+code must run only after physics initialization and simulation reset, when the
+PhysX Tensor API view has been created:
+
+.. code-block:: python
+
+   from isaaclab_physx.physics import PhysxManager
+
+   simulation_view = PhysxManager.get_physics_sim_view()
+   if simulation_view is None:
+       raise RuntimeError("PhysX Tensor API is not ready; initialize and reset the simulation first.")
+
+Reuse an Isaac Lab view
+-----------------------
+
+When an Isaac Lab asset already has the desired selection, reuse its
+``root_view`` rather than creating a second view:
+
+.. code-block:: python
+
+   robot = scene["robot"]
+   articulation_view = robot.root_view
+   joint_positions = articulation_view.get_dof_positions()
+
+``root_view`` is backend-specific and typed. An articulation, rigid object,
+rigid-object collection, or deformable can expose a different native PhysX
+view type, so choose methods that match the returned view rather than assuming
+one common interface.
+
+Create a raw typed view
+-----------------------
+
+Create a view directly only when no Isaac Lab-owned selection matches the
+needed objects or capability. The path below uses Tensor API wildcards, not an
+Isaac Lab regular expression:
+
+.. code-block:: python
+
+   rigid_body_view = simulation_view.create_rigid_body_view(
+       "/World/envs/env_*/Object"
+   )
+
+Discover available view factories
+---------------------------------
+
+The available factories are provided by the installed PhysX version. Discover
+them at runtime instead of maintaining a hand-written inventory:
+
+.. code-block:: python
+
+   view_factories = sorted(
+       name
+       for name in dir(simulation_view)
+       if name.startswith("create_") and name.endswith("_view")
+   )
+   print(view_factories)
+
+Read and write data
+-------------------
+
+Getters and setters make the transfer boundary explicit. Clone a returned
+Warp buffer before editing it locally, then use the setter to publish the
+result:
+
+.. code-block:: python
+
+   import warp as wp
+
+   poses = wp.clone(rigid_body_view.get_transforms())
+   rigid_body_view.set_transforms(poses)
+
+Cloning makes ownership explicit. Callers can modify the clone with Warp before
+the setter, but edits to a local buffer do not publish themselves; the setter
+performs the write. For active Tensor API contracts that require link transforms
+to be refreshed after joint-state writes, call
+``SimulationView.update_articulations_kinematic()``. Not every setter requires
+that refresh; follow the method-level behavior in the upstream reference.
+
+Sensor view families
+--------------------
+
+Isaac Lab sensors internally create the following native view families. These
+are implementation details for understanding data sources, not additional
+sensor APIs; prefer the sensor's public data interface when it provides the
+needed information. Consult the upstream reference for method-level behavior.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 34 42
+
+   * - Isaac Lab sensor
+     - Native PhysX view family
+     - Scope
+   * - Contact sensor
+     - ``RigidBodyView`` and ``RigidContactView``
+     - Tracked-body state and contact reporting.
+   * - Frame transformer
+     - ``RigidBodyView``
+     - Tracked-body transforms.
+   * - IMU
+     - ``RigidBodyView``
+     - Rigid-body motion state.
+   * - PVA sensor
+     - ``RigidBodyView``
+     - Rigid-parent motion state.
+   * - Joint-wrench sensor
+     - ``ArticulationView``
+     - Articulation joint-wrench state.
+   * - Ray caster
+     - ``RigidBodyView``
+     - Tracked-body transforms; ray intersection is not a PhysX Tensor API
+       view.
+
+Ownership, synchronization, and invalidation
+--------------------------------------------
+
+Preserve a view's expected selection ordering, device, dtype, and tensor shape
+when supplying values to a setter. Check and reacquire views after a hard
+reset, object removal, stage reload, or manager teardown. Prefer public Isaac
+Lab sensor data when direct native contact or motion data is not required.
+
+Authoritative reference
+-----------------------
+
+The upstream API documents view-specific factory, getter, setter, and
+synchronization behavior: `Omni Physics Python APIs <https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/dev_guide/pythonapi.html>`_.

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
@@ -14,7 +14,7 @@ needed for the workload.
 Mental model
 ------------
 
-The API starts from a :class:`~omni.physics.tensors.SimulationView` and creates
+The API starts from a ``SimulationView`` and creates
 typed views over selected physics objects. A view owns an engine-backed
 selection; getters pull data from that selection and setters publish data back
 to it. A raw view selection uses the Tensor API's glob syntax, which is distinct
@@ -24,7 +24,7 @@ Lifecycle prerequisite
 ----------------------
 
 :class:`~isaaclab_physx.physics.PhysxManager` creates its
-:class:`~omni.physics.tensors.SimulationView` with the Warp frontend. Low-level
+``SimulationView`` with the Warp frontend. Low-level
 code must run only after physics initialization and simulation reset, when the
 PhysX Tensor API view has been created:
 
@@ -100,7 +100,7 @@ Cloning makes ownership explicit. Callers can modify the clone with Warp before
 the setter, but edits to a local buffer do not publish themselves; the setter
 performs the write. For active Tensor API contracts that require link transforms
 to be refreshed after joint-state writes, call
-:meth:`~omni.physics.tensors.SimulationView.update_articulations_kinematic`.
+``update_articulations_kinematic()``.
 Not every setter requires that refresh; follow the method-level behavior in the
 upstream reference.
 

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
@@ -1,7 +1,7 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+.. Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+.. All rights reserved.
+..
+.. SPDX-License-Identifier: BSD-3-Clause
 
 PhysX Tensor API
 ================
@@ -9,16 +9,18 @@ PhysX Tensor API
 The PhysX Tensor API is an engine-native interface for data paths that need
 typed PhysX views or capabilities beyond the unified Isaac Lab APIs. It is
 backend-specific: use Isaac Lab asset and sensor APIs unless native access is
-needed for the workload.
+needed for the workload. The `Omni Physics Python API reference
+<https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/dev_guide/pythonapi.html>`_
+documents the Tensor API view families and their methods.
 
 Mental model
 ------------
 
-The API starts from a ``SimulationView`` and creates
-typed views over selected physics objects. A view owns an engine-backed
-selection; getters pull data from that selection and setters publish data back
-to it. A raw view selection uses the Tensor API's glob syntax, which is distinct
-from Isaac Lab's regular-expression syntax.
+The API starts from a ``SimulationView`` and creates typed views over selected
+physics objects. Access is entirely method-based: a getter pulls data from the
+view, and an independent setter publishes data back. Returned buffers are not
+live pointers, so editing a getter result does not update the simulation. Raw
+views select objects with PhysX Tensor API wildcard patterns.
 
 Lifecycle prerequisite
 ----------------------
@@ -58,8 +60,8 @@ Create a raw typed view
 -----------------------
 
 Create a view directly only when no Isaac Lab-owned selection matches the
-needed objects or capability. The path below uses Tensor API wildcards, not an
-Isaac Lab regular expression:
+needed objects or capability. In this Tensor API pattern, ``*`` selects the
+matching object below every cloned environment:
 
 .. code-block:: python
 
@@ -67,11 +69,12 @@ Isaac Lab regular expression:
        "/World/envs/env_*/Object"
    )
 
-Discover available view factories
----------------------------------
+Discover supported view types
+-----------------------------
 
-The available factories are provided by the installed PhysX version. Discover
-them at runtime instead of maintaining a hand-written inventory:
+The installed PhysX version determines which typed views are available. Inspect
+the ``SimulationView`` at runtime to list its view factories instead of relying
+on a hand-written inventory that can become stale:
 
 .. code-block:: python
 
@@ -85,9 +88,8 @@ them at runtime instead of maintaining a hand-written inventory:
 Read and write data
 -------------------
 
-Getters and setters make the transfer boundary explicit. Clone a returned
-Warp buffer before editing it locally, then use the setter to publish the
-result:
+Each getter and setter is a separate operation. Clone a returned Warp buffer
+before editing it locally, then call the matching setter to publish the result:
 
 .. code-block:: python
 
@@ -110,40 +112,22 @@ contracts that require link transforms to be refreshed after joint-state writes,
 Not every setter requires that refresh; follow the method-level behavior in the
 upstream reference.
 
-Sensor view families
---------------------
+Access the contact view
+-----------------------
 
-Isaac Lab sensors internally create the following native view families. These
-are implementation details for understanding data sources, not additional
-sensor APIs; prefer the sensor's public data interface when it provides the
-needed information. Consult the upstream reference for method-level behavior.
+The PhysX contact sensor exposes its native ``RigidContactView`` through
+:attr:`~isaaclab_physx.sensors.ContactSensor.contact_view`. Use it when the
+public sensor data does not expose the required contact details:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 24 34 42
+.. code-block:: python
 
-   * - Isaac Lab sensor
-     - Native PhysX view family
-     - Scope
-   * - Contact sensor
-     - ``RigidBodyView`` and ``RigidContactView``
-     - Tracked-body state and contact reporting.
-   * - Frame transformer
-     - ``RigidBodyView``
-     - Tracked-body transforms.
-   * - IMU
-     - ``RigidBodyView``
-     - Rigid-body motion state.
-   * - PVA sensor
-     - ``RigidBodyView``
-     - Rigid-parent motion state.
-   * - Joint-wrench sensor
-     - ``ArticulationView``
-     - Articulation joint-wrench state.
-   * - Ray caster
-     - ``RigidBodyView``
-     - Tracked-body transforms; ray intersection is not a PhysX Tensor API
-       view.
+   contact_sensor = scene["contact_sensor"]
+   friction_forces, _, buffer_counts, buffer_start_indices = (
+       contact_sensor.contact_view.get_friction_data(dt=sim.cfg.dt)
+   )
+
+Other Isaac Lab sensors may use ordinary rigid-body or articulation views
+internally, but those views are not sensor-specific low-level interfaces.
 
 Ownership, synchronization, and invalidation
 --------------------------------------------
@@ -153,8 +137,6 @@ when supplying values to a setter. Check and reacquire views after a hard
 reset, object removal, stage reload, or manager teardown. Prefer public Isaac
 Lab sensor data when direct native contact or motion data is not required.
 
-Authoritative reference
------------------------
-
-The upstream API documents view-specific factory, getter, setter, and
-synchronization behavior: `Omni Physics Python APIs <https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/dev_guide/pythonapi.html>`_.
+For method-specific shapes, synchronization requirements, and supported
+setters, follow the upstream Tensor API reference linked at the top of this
+page.

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
@@ -94,12 +94,18 @@ result:
    import warp as wp
 
    poses = wp.clone(rigid_body_view.get_transforms())
-   rigid_body_view.set_transforms(poses)
+   indices = wp.array(
+       range(poses.shape[0]),
+       dtype=wp.int32,
+       device=poses.device,
+   )
+   rigid_body_view.set_transforms(poses, indices)
 
 Cloning makes ownership explicit. Callers can modify the clone with Warp before
-the setter, but edits to a local buffer do not publish themselves; the setter
-performs the write. For active Tensor API contracts that require link transforms
-to be refreshed after joint-state writes, call
+the setter, but edits to a local buffer do not publish themselves. The
+``indices`` array selects the complete view and matches the setter's required
+``int32`` dtype and device; the setter performs the write. For active Tensor API
+contracts that require link transforms to be refreshed after joint-state writes, call
 ``update_articulations_kinematic()``.
 Not every setter requires that refresh; follow the method-level behavior in the
 upstream reference.

--- a/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
+++ b/docs/source/overview/core-concepts/physical-backends/direct-api-access/physx.rst
@@ -14,16 +14,17 @@ needed for the workload.
 Mental model
 ------------
 
-The API starts from a ``SimulationView`` and creates typed views over selected
-physics objects. A view owns an engine-backed selection; getters pull data from
-that selection and setters publish data back to it. A raw view selection uses
-the Tensor API's glob syntax, which is distinct from Isaac Lab's
-regular-expression syntax.
+The API starts from a :class:`~omni.physics.tensors.SimulationView` and creates
+typed views over selected physics objects. A view owns an engine-backed
+selection; getters pull data from that selection and setters publish data back
+to it. A raw view selection uses the Tensor API's glob syntax, which is distinct
+from Isaac Lab's regular-expression syntax.
 
 Lifecycle prerequisite
 ----------------------
 
-Isaac Lab creates its ``SimulationView`` with the Warp frontend. Low-level
+:class:`~isaaclab_physx.physics.PhysxManager` creates its
+:class:`~omni.physics.tensors.SimulationView` with the Warp frontend. Low-level
 code must run only after physics initialization and simulation reset, when the
 PhysX Tensor API view has been created:
 
@@ -39,7 +40,8 @@ Reuse an Isaac Lab view
 -----------------------
 
 When an Isaac Lab asset already has the desired selection, reuse its
-``root_view`` rather than creating a second view:
+:attr:`~isaaclab_physx.assets.Articulation.root_view` rather than creating a
+second view:
 
 .. code-block:: python
 
@@ -47,10 +49,10 @@ When an Isaac Lab asset already has the desired selection, reuse its
    articulation_view = robot.root_view
    joint_positions = articulation_view.get_dof_positions()
 
-``root_view`` is backend-specific and typed. An articulation, rigid object,
-rigid-object collection, or deformable can expose a different native PhysX
-view type, so choose methods that match the returned view rather than assuming
-one common interface.
+:attr:`~isaaclab_physx.assets.Articulation.root_view` is backend-specific and
+typed. An articulation, rigid object, rigid-object collection, or deformable
+can expose a different native PhysX view type, so choose methods that match the
+returned view rather than assuming one common interface.
 
 Create a raw typed view
 -----------------------
@@ -98,8 +100,9 @@ Cloning makes ownership explicit. Callers can modify the clone with Warp before
 the setter, but edits to a local buffer do not publish themselves; the setter
 performs the write. For active Tensor API contracts that require link transforms
 to be refreshed after joint-state writes, call
-``SimulationView.update_articulations_kinematic()``. Not every setter requires
-that refresh; follow the method-level behavior in the upstream reference.
+:meth:`~omni.physics.tensors.SimulationView.update_articulations_kinematic`.
+Not every setter requires that refresh; follow the method-level behavior in the
+upstream reference.
 
 Sensor view families
 --------------------

--- a/docs/source/overview/core-concepts/physical-backends/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/index.rst
@@ -17,9 +17,14 @@ backend-specific configuration, installation, and limitations.
     physx/index
     newton/index
     ovphysx/index
+    direct-api-access/index
     solver-comparison
     sim-to-sim-policy-transfer
 
+
+For backend-specific access to native engine data and views, see
+:doc:`direct-api-access/index`. That guide explains the different ownership and
+synchronization models rather than presenting a false common low-level API.
 
 Choosing a Backend
 ------------------

--- a/docs/source/overview/core-concepts/physical-backends/newton/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/index.rst
@@ -53,6 +53,9 @@ reaches an official release.
 For an overview of how the multi-backend architecture works, including how to add a
 new backend, see :doc:`../../multi_backend_architecture`.
 
+For direct ``Model``/``State`` access and generic selections, see
+:doc:`../direct-api-access/newton`.
+
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
@@ -187,3 +187,6 @@ conservative. Broader feature coverage and documentation parity are tracked in
 `issue #5634 <https://github.com/isaac-sim/IsaacLab/issues/5634>`_.
 
 For architectural context, see :doc:`../../multi_backend_architecture`.
+
+For raw ``TensorBinding`` access and :class:`~isaaclab_ovphysx.sim.views.OvPhysxView`,
+see :doc:`../direct-api-access/ovphysx`.

--- a/docs/source/overview/core-concepts/physical-backends/physx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/physx/index.rst
@@ -27,6 +27,8 @@ schema. See :doc:`configuration` for the most common knobs.
 For an overview of how the multi-backend architecture works, see
 :doc:`../../multi_backend_architecture`.
 
+For native Tensor API access, see :doc:`../direct-api-access/physx`.
+
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
# Description

Adds a Direct Physics Engine API Access guide with a high-level comparison and focused PhysX, Newton, and OvPhysX pages.

The guide explains why Isaac Lab preserves each native access model instead of presenting one low-level view abstraction:

- PhysX typed Tensor API views with explicit pull and push operations
- Newton live Model, State, Control, and Contacts arrays with generic selections
- OvPhysX raw tensor bindings with the optional OvPhysxView convenience layer

It covers both Isaac Lab-owned handles and caller-created raw access, uses runtime discovery instead of maintained API inventories, maps PhysX sensor concepts to native view families, and documents ownership, synchronization, lifecycle, and invalidation constraints.

The backend hub, architecture guide, migration guide, and generated API references now link to the new documentation. No runtime behavior or public API changes are included.

## Type of change

- [x] Documentation update

## Screenshots

Not applicable.

## Verification

- [x] OvPhysX focused tests: 72 passed, 2 skipped
- [x] Full 226-page documentation build completed with warnings treated as errors
- [x] All pre-commit hooks passed with ./isaaclab.sh -f
- [x] Final whole-branch review and scoped fix re-review completed

## Checklist

- [ ] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Existing focused tests cover the documented OvPhysxView behavior
- [x] Changelog fragment is not applicable because this PR touches only top-level documentation
- [x] My name already exists in CONTRIBUTORS.md