### PR TITLE
Restore the sensor USD replication default

### DIFF
--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -342,9 +342,7 @@ own clones). :func:`~isaaclab.cloner.replicate` adds
 :class:`~isaaclab.cloner.UsdReplicateContext` automatically whenever a cfg has a
 spawner and Kit is available, so USD clones accompany physics replication under
 Kit and are skipped by default in headless runs. An explicit cfg override may
-still request USD replication without Kit, which is what
-:attr:`~isaaclab.sensors.SensorBaseCfg.cloning_contexts` does by default so that
-sensor prims exist in every environment on kitless backends. With
+still request USD replication without Kit. With
 :attr:`~isaaclab.cloner.CloneCfg.replicate_physics` disabled, cloning is
 USD-only: every physics context is dropped and the physics engine parses the
 per-env USD prims directly.

--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -342,7 +342,9 @@ own clones). :func:`~isaaclab.cloner.replicate` adds
 :class:`~isaaclab.cloner.UsdReplicateContext` automatically whenever a cfg has a
 spawner and Kit is available, so USD clones accompany physics replication under
 Kit and are skipped by default in headless runs. An explicit cfg override may
-still request USD replication without Kit. With
+still request USD replication without Kit, which is what
+:attr:`~isaaclab.sensors.SensorBaseCfg.cloning_contexts` does by default so that
+sensor prims exist in every environment on kitless backends. With
 :attr:`~isaaclab.cloner.CloneCfg.replicate_physics` disabled, cloning is
 USD-only: every physics context is dropped and the physics engine parses the
 per-env USD prims directly.

--- a/source/isaaclab/changelog.d/esekkin-restore-kitless-sensor-usd-replication.rst
+++ b/source/isaaclab/changelog.d/esekkin-restore-kitless-sensor-usd-replication.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed kitless sensor cloning by restoring the default
+  :attr:`~isaaclab.sensors.SensorBaseCfg.cloning_contexts` request for
+  :class:`~isaaclab.cloner.UsdReplicateContext`. Without it a spawned sensor was authored only
+  under ``env_0``, so backends that resolve their sensor views from USD reported a
+  per-environment prim count mismatch when Kit was absent.

--- a/source/isaaclab/changelog.d/esekkin-restore-kitless-sensor-usd-replication.rst
+++ b/source/isaaclab/changelog.d/esekkin-restore-kitless-sensor-usd-replication.rst
@@ -1,8 +1,6 @@
 Fixed
 ^^^^^
 
-* Fixed kitless sensor cloning by restoring the default
-  :attr:`~isaaclab.sensors.SensorBaseCfg.cloning_contexts` request for
-  :class:`~isaaclab.cloner.UsdReplicateContext`. Without it a spawned sensor was authored only
-  under ``env_0``, so backends that resolve their sensor views from USD reported a
-  per-environment prim count mismatch when Kit was absent.
+* Fixed :attr:`~isaaclab.sensors.SensorBaseCfg.cloning_contexts` not requesting
+  :class:`~isaaclab.cloner.UsdReplicateContext`, which left sensor prims in ``env_0`` only on
+  kitless backends.

--- a/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
@@ -22,13 +22,13 @@ class SensorBaseCfg:
     The class should inherit from :class:`isaaclab.sensors.sensor_base.SensorBase`.
     """
 
-    cloning_contexts: tuple[str | type, ...] | None = ()
-    """Cloning contexts for this sensor. Defaults to no explicit cloning context.
+    cloning_contexts: tuple[str | type, ...] | None = ("isaaclab.cloner:UsdReplicateContext",)
+    """Cloning contexts for this sensor. Defaults to USD-only cloning.
 
-    Sensors carry no physics of their own. When the sensor has a spawner, USD replication is
-    added automatically under Kit. Listing :class:`~isaaclab.cloner.UsdReplicateContext`
-    explicitly forces USD replication without Kit; see
-    :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
+    Sensors carry no physics of their own, so they request USD replication explicitly instead of
+    relying on the context :func:`~isaaclab.cloner.replicate` adds only under Kit. Kitless
+    backends still resolve their sensor views from USD, so the per-environment prims have to
+    exist there too. See :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
     """
 
     prim_path: str = MISSING

--- a/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
@@ -25,10 +25,7 @@ class SensorBaseCfg:
     cloning_contexts: tuple[str | type, ...] | None = ("isaaclab.cloner:UsdReplicateContext",)
     """Cloning contexts for this sensor. Defaults to USD-only cloning.
 
-    Sensors carry no physics of their own, so they request USD replication explicitly instead of
-    relying on the context :func:`~isaaclab.cloner.replicate` adds only under Kit. Kitless
-    backends still resolve their sensor views from USD, so the per-environment prims have to
-    exist there too. See :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
+    Sensors carry no physics of their own; see :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
     """
 
     prim_path: str = MISSING

--- a/source/isaaclab/test/cloner/test_replicate_session.py
+++ b/source/isaaclab/test/cloner/test_replicate_session.py
@@ -16,10 +16,45 @@ from isaaclab.sensors import SensorBaseCfg
 from isaaclab.sim import SimulationContext
 
 
-def test_sensor_default_does_not_request_a_cloning_context():
-    """Sensors rely on automatic Kit replication unless a user explicitly overrides it."""
+def test_sensor_default_requests_usd_replication():
+    """Sensors ask for USD cloning outright rather than relying on the Kit-gated context."""
 
-    assert SensorBaseCfg().cloning_contexts == ()
+    assert SensorBaseCfg().cloning_contexts == ("isaaclab.cloner:UsdReplicateContext",)
+
+
+def test_replicate_clones_a_default_sensor_without_kit(monkeypatch):
+    """A stock sensor cfg must author its per-environment prims when Kit is absent.
+
+    Backends resolve sensor views by matching the cfg's path expression against the stage, so a
+    camera left only in ``env_0`` fails the per-environment count check at initialization.
+    """
+    from pxr import Usd
+
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim("/World/envs/env_0", "Xform")
+    stage.DefinePrim("/World/envs/env_1", "Xform")
+    stage.DefinePrim("/World/envs/env_0/Camera", "Camera")
+
+    published = SimpleNamespace(plan=None)
+    published.set_clone_plan = lambda plan: setattr(published, "plan", plan)
+    monkeypatch.setattr(replicate_session, "has_kit", lambda: False)
+    monkeypatch.setattr(replicate_session.FactoryBase, "_get_backend", lambda: "newton")
+    monkeypatch.setattr(SimulationContext, "instance", lambda: published)
+
+    cfg = SensorBaseCfg(prim_path="/World/envs/env_.*/Camera")
+    replicate_session.REPLICATION_QUEUE.append(cfg)
+    plan = ClonePlan(
+        sources=("/World/envs/env_0/Camera",),
+        destinations=("/World/envs/env_{}/Camera",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        env_ids=torch.arange(2, dtype=torch.long),
+        positions=torch.zeros((2, 3)),
+        cfg_rows={id(cfg): (0,)},
+    )
+
+    replicate_session.replicate(plan, stage=stage)
+
+    assert stage.GetPrimAtPath("/World/envs/env_1/Camera").IsValid()
 
 
 @pytest.mark.parametrize(

--- a/source/isaaclab/test/cloner/test_replicate_session.py
+++ b/source/isaaclab/test/cloner/test_replicate_session.py
@@ -17,44 +17,9 @@ from isaaclab.sim import SimulationContext
 
 
 def test_sensor_default_requests_usd_replication():
-    """Sensors ask for USD cloning outright rather than relying on the Kit-gated context."""
+    """Sensors request USD cloning explicitly so kitless runs author per-env prims."""
 
     assert SensorBaseCfg().cloning_contexts == ("isaaclab.cloner:UsdReplicateContext",)
-
-
-def test_replicate_clones_a_default_sensor_without_kit(monkeypatch):
-    """A stock sensor cfg must author its per-environment prims when Kit is absent.
-
-    Backends resolve sensor views by matching the cfg's path expression against the stage, so a
-    camera left only in ``env_0`` fails the per-environment count check at initialization.
-    """
-    from pxr import Usd
-
-    stage = Usd.Stage.CreateInMemory()
-    stage.DefinePrim("/World/envs/env_0", "Xform")
-    stage.DefinePrim("/World/envs/env_1", "Xform")
-    stage.DefinePrim("/World/envs/env_0/Camera", "Camera")
-
-    published = SimpleNamespace(plan=None)
-    published.set_clone_plan = lambda plan: setattr(published, "plan", plan)
-    monkeypatch.setattr(replicate_session, "has_kit", lambda: False)
-    monkeypatch.setattr(replicate_session.FactoryBase, "_get_backend", lambda: "newton")
-    monkeypatch.setattr(SimulationContext, "instance", lambda: published)
-
-    cfg = SensorBaseCfg(prim_path="/World/envs/env_.*/Camera")
-    replicate_session.REPLICATION_QUEUE.append(cfg)
-    plan = ClonePlan(
-        sources=("/World/envs/env_0/Camera",),
-        destinations=("/World/envs/env_{}/Camera",),
-        clone_mask=torch.ones((1, 2), dtype=torch.bool),
-        env_ids=torch.arange(2, dtype=torch.long),
-        positions=torch.zeros((2, 3)),
-        cfg_rows={id(cfg): (0,)},
-    )
-
-    replicate_session.replicate(plan, stage=stage)
-
-    assert stage.GetPrimAtPath("/World/envs/env_1/Camera").IsValid()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
`rendering-correctness-kitless (legacy)` is red on `develop`:

```
RuntimeError: Number of camera prims in the view (1) does not match the number of environments (4).
```

Reverting https://github.com/isaac-sim/IsaacLab/pull/6904 to get the pipeline back to green. Then we will follow up with a fix.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there