### PR TITLE
Enable synchronous texture streaming for OVRTX

### DIFF
--- a/source/isaaclab_ov/changelog.d/enable-synchronous-texture-streaming.rst
+++ b/source/isaaclab_ov/changelog.d/enable-synchronous-texture-streaming.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Enabled synchronous texture streaming on the internal OVRTX ``RendererConfig`` in
+  :class:`~isaaclab_ov.renderers.ovrtx_renderer.OVRTXRenderer` via
+  ``texture_streaming_mode=TextureStreamingMode.SYNCHRONOUS`` to improve cross-run
+  render determinism. Requires ``ovrtx>=0.4.1``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -63,6 +63,7 @@ try:
         Renderer,
         RendererConfig,
         Semantic,
+        TextureStreamingMode,
     )
 except ModuleNotFoundError as exc:
     if exc.name != "ovrtx":
@@ -71,7 +72,7 @@ except ModuleNotFoundError as exc:
         "The OVRTX renderer requires the optional 'ovrtx' runtime wheel, which is not installed. "
         "Run your command with: uv run --extra ovrtx <command> "
         "(or, manually: python -m pip install --extra-index-url https://pypi.nvidia.com "
-        "'ovrtx>=0.4.0,<0.5.0')."
+        "'ovrtx>=0.4.1,<0.5.0')."
     ) from exc
 
 from isaaclab.cloner.clone_plan import ClonePlan
@@ -399,6 +400,7 @@ class OVRTXRenderer(BaseRenderer):
             log_level=self.cfg.log_level,
             read_gpu_transforms=_read_gpu_transforms_enabled(),
             keep_system_alive=True,
+            texture_streaming_mode=TextureStreamingMode.SYNCHRONOUS,
         )
         self._renderer = Renderer(OVRTX_CONFIG)
         if not self._renderer:


### PR DESCRIPTION
# Description

Set texture_streaming_mode to SYNCHRONOUS on `ovrtx.RendererConfig` to improve cross-run render determinism. Requires ovrtx>=0.4.1.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
