### PR TITLE
Fix Newton contact visualization controls

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/ruziniuuuuu-fix-newton-contact-controls.rst
+++ b/source/isaaclab_visualizers/changelog.d/ruziniuuuuu-fix-newton-contact-controls.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the Newton GL sidebar to expose native contact normals, contact modes,
+  forces, and visualization scales in a debug section that opens by default.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -84,10 +84,49 @@ CONTACT_ARROW_COLOR = (0.0, 1.0, 0.0)
 CONTACT_ARROW_LENGTH = 0.1
 """Length of synthesized contact arrows in meters."""
 
+_VISUALIZATION_MARKERS_DEFAULT_OPEN = True
+"""Whether Newton debug overlays are expanded when the GL viewer opens."""
+
 if TYPE_CHECKING:
     from newton import State
 
     from isaaclab.scene_data import SceneDataProvider
+
+
+def _render_contact_controls(imgui, viewer, renderer) -> None:
+    """Render Newton's native contact visualization controls."""
+    _changed, viewer.show_contacts = imgui.checkbox("Show Contacts", viewer.show_contacts)
+    if not viewer.show_contacts or renderer is None:
+        return
+
+    imgui.indent()
+    _, viewer.show_contact_normals = imgui.checkbox("Normal", bool(viewer.show_contact_normals))
+    _, viewer.show_contact_disks = imgui.checkbox("Contact Mode", bool(viewer.show_contact_disks))
+    _, viewer.show_contact_forces = imgui.checkbox("Force", bool(viewer.show_contact_forces))
+    imgui.unindent()
+
+    log_flag = imgui.SliderFlags_.logarithmic.value
+    default_contact_scale = float(viewer._contact_viz_scale_default) or 1.0
+    _, viewer.contact_viz_scale = imgui.slider_float(
+        "Contact Scale",
+        float(viewer.contact_viz_scale),
+        default_contact_scale * 0.01,
+        default_contact_scale * 100.0,
+        "%.4g",
+        log_flag,
+    )
+    if viewer.show_contact_forces:
+        default_force_scale = float(viewer._contact_force_scale_default) or 0.5
+        _, viewer.contact_force_scale = imgui.slider_float(
+            "Force Relative Scale",
+            float(viewer.contact_force_scale),
+            default_force_scale * 0.01,
+            default_force_scale * 100.0,
+            "%.4g",
+            log_flag,
+        )
+    if hasattr(renderer, "arrow_scale") and (viewer.show_contact_normals or viewer.show_contact_forces):
+        _, renderer.arrow_scale = imgui.slider_float("Arrow Thickness", renderer.arrow_scale, 0.25, 5.0)
 
 
 def _eye_lookat_to_pitch_yaw(
@@ -303,23 +342,14 @@ class _NewtonViewerUIMixin:
 
             # --- Visualization Markers (GL only; RTX log_mesh crashes on empty USD path) --
             if viewer.model is not None and not isinstance(viewer, NewtonViewerRTX):
-                imgui.set_next_item_open(False, imgui.Cond_.appearing)
+                imgui.set_next_item_open(_VISUALIZATION_MARKERS_DEFAULT_OPEN, imgui.Cond_.appearing)
                 if imgui.collapsing_header("Visualization Markers"):
                     imgui.separator()
                     renderer = getattr(viewer, "renderer", None)
                     _c, viewer.show_joints = imgui.checkbox("Show Joints", viewer.show_joints)
                     if viewer.show_joints and renderer is not None and hasattr(renderer, "joint_scale"):
                         _, renderer.joint_scale = imgui.slider_float("Joint Scale", renderer.joint_scale, 0.25, 5.0)
-                    _c, viewer.show_contacts = imgui.checkbox("Show Contacts", viewer.show_contacts)
-                    if viewer.show_contacts and renderer is not None:
-                        if hasattr(renderer, "arrow_length_scale"):
-                            _, renderer.arrow_length_scale = imgui.slider_float(
-                                "Contact Length", renderer.arrow_length_scale, 0.25, 5.0
-                            )
-                        if hasattr(renderer, "arrow_scale"):
-                            _, renderer.arrow_scale = imgui.slider_float(
-                                "Contact Width", renderer.arrow_scale, 0.25, 5.0
-                            )
+                    _render_contact_controls(imgui, viewer, renderer)
                     _c, viewer.show_particles = imgui.checkbox("Show Particles", viewer.show_particles)
                     _c, viewer.show_springs = imgui.checkbox("Show Springs", viewer.show_springs)
                     _c, viewer.show_com = imgui.checkbox("Show Center of Mass", viewer.show_com)

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -174,6 +174,57 @@ def test_newton_visualizer_cfg_exposes_world_spacing():
     assert cfg.world_spacing == (2.0, 2.0, 0.0)
 
 
+def test_newton_contact_controls_expose_native_debug_overlays():
+    class _Imgui:
+        SliderFlags_ = SimpleNamespace(logarithmic=SimpleNamespace(value=1))
+
+        def __init__(self):
+            self.checkboxes = []
+            self.sliders = []
+            self.indent_depth = 0
+
+        def checkbox(self, label, value):
+            self.checkboxes.append(label)
+            return False, value
+
+        def indent(self):
+            self.indent_depth += 1
+
+        def unindent(self):
+            self.indent_depth -= 1
+
+        def slider_float(self, label, value, minimum, maximum, *args):
+            self.sliders.append((label, minimum, maximum))
+            return False, value
+
+    imgui = _Imgui()
+    viewer = SimpleNamespace(
+        show_contacts=True,
+        show_contact_normals=True,
+        show_contact_disks=True,
+        show_contact_forces=True,
+        contact_viz_scale=0.2,
+        contact_force_scale=0.5,
+        _contact_viz_scale_default=0.2,
+        _contact_force_scale_default=0.5,
+    )
+    renderer = SimpleNamespace(arrow_scale=1.0)
+
+    newton_visualizer_module._render_contact_controls(imgui, viewer, renderer)
+
+    assert imgui.checkboxes == ["Show Contacts", "Normal", "Contact Mode", "Force"]
+    assert [label for label, _, _ in imgui.sliders] == [
+        "Contact Scale",
+        "Force Relative Scale",
+        "Arrow Thickness",
+    ]
+    assert imgui.indent_depth == 0
+
+
+def test_newton_visualization_markers_open_by_default():
+    assert newton_visualizer_module._VISUALIZATION_MARKERS_DEFAULT_OPEN is True
+
+
 def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():
     visualizer = NewtonGLVisualizer(NewtonGLVisualizerCfg())
 


### PR DESCRIPTION
# Description

The Isaac Lab-oriented Newton panel replaced the upstream viewer's contact debug controls with only a master checkbox and legacy length/width sliders. This restores the current Newton controls for normals, contact modes, forces, visualization scale, force-relative scale, and arrow thickness. The Visualization Markers section now opens by default so the contact tools are discoverable while debugging.

No dependencies are added.

Fixes #6962

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not included; the change is covered by a unit-level ImGui control regression test.

## Validation

- `pytest source/isaaclab_visualizers/test/test_newton_adapter.py`: 47 passed
- `python tools/changelog/cli.py check develop`: passed
- all repository pre-commit hooks: passed
- regression test verified failing before the implementation and passing afterward

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation (package changelog fragment)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_visualizers/changelog.d/`
- [ ] I have added my name to `CONTRIBUTORS.md` or my name already exists there
