### PR TITLE
Fix Kamino camera crash: disable internal collision detector for cartpole

### DIFF
--- a/source/isaaclab_newton/changelog.d/antoiner-kamino-collision-detector-max-contacts-per-world.rst
+++ b/source/isaaclab_newton/changelog.d/antoiner-kamino-collision-detector-max-contacts-per-world.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_newton.physics.KaminoSolverCfg.collision_detector_max_contacts_per_world`
+  to :class:`~isaaclab_newton.physics.KaminoSolverCfg`. When set, this overrides Newton's
+  geometry-based contact capacity estimation for Kamino's internal collision detector and guarantees
+  the collision pipeline is created regardless of whether the model has pre-computed explicit
+  broadphase pairs.

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager_cfg.py
@@ -165,6 +165,15 @@ class KaminoSolverCfg(NewtonSolverCfg):
     Only used when :attr:`use_collision_detector` is ``True``. If ``None``, Newton's default is used.
     """
 
+    collision_detector_max_contacts_per_world: int | None = None
+    """Maximum number of contacts to pre-allocate per simulation world for Kamino's internal detector.
+
+    Only used when :attr:`use_collision_detector` is ``True``. When set, this overrides the
+    geometry-based contact capacity estimation and guarantees the collision pipeline is created even
+    when the model has no pre-computed explicit broadphase pairs. If ``None``, Newton estimates
+    capacity from the model's collidable geometry.
+    """
+
     max_contacts_per_world: int | None = None
     """Cap the per-world contact pre-allocation handed to Kamino.
 
@@ -228,6 +237,8 @@ class KaminoSolverCfg(NewtonSolverCfg):
                 cd_kwargs["pipeline"] = self.collision_detector_pipeline
             if self.collision_detector_max_contacts_per_pair is not None:
                 cd_kwargs["max_contacts_per_pair"] = self.collision_detector_max_contacts_per_pair
+            if self.collision_detector_max_contacts_per_world is not None:
+                cd_kwargs["max_contacts_per_world"] = self.collision_detector_max_contacts_per_world
             collision_detector = CollisionDetectorConfig(**cd_kwargs)
 
         return SolverKamino.Config(

--- a/source/isaaclab_tasks/changelog.d/antoiner-cartpole-kamino-collision-detector-max-contacts-per-world.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-cartpole-kamino-collision-detector-max-contacts-per-world.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed the cartpole ``newton_kamino`` preset crashing with
+  ``RuntimeError: Cannot perform collision detection: a collision pipeline has not been created``
+  when running with a camera (RTX deferred CUDA-graph capture path). Set
+  ``use_collision_detector=False`` in the preset since cartpole bodies never contact each other or
+  the ground, so Kamino's internal collision detector is unnecessary. This causes Kamino to receive
+  pre-computed (empty) contacts from Newton's collision pipeline and skip internal collision
+  detection entirely.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -45,7 +45,7 @@ class CartpolePhysicsCfg(PresetCfg):
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(
             integrator="moreau",
-            use_collision_detector=True,
+            use_collision_detector=False,
             sparse_jacobian=True,
             constraints_alpha=0.1,
             padmm_max_iterations=100,
@@ -58,8 +58,6 @@ class CartpolePhysicsCfg(PresetCfg):
             padmm_warmstart_mode="containers",
             padmm_contact_warmstart_method="geom_pair_net_force",
             padmm_use_graph_conditionals=False,
-            collision_detector_pipeline="unified",
-            collision_detector_max_contacts_per_pair=8,
         ),
         debug_mode=False,
         use_cuda_graph=True,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -55,7 +55,7 @@ class CartpolePhysicsCfg(PresetCfg):
     newton_kamino: NewtonCfg = NewtonCfg(
         solver_cfg=KaminoSolverCfg(
             integrator="moreau",
-            use_collision_detector=True,
+            use_collision_detector=False,
             sparse_jacobian=True,
             constraints_alpha=0.1,
             padmm_max_iterations=100,
@@ -68,8 +68,6 @@ class CartpolePhysicsCfg(PresetCfg):
             padmm_warmstart_mode="containers",
             padmm_contact_warmstart_method="geom_pair_net_force",
             padmm_use_graph_conditionals=False,
-            collision_detector_pipeline="unified",
-            collision_detector_max_contacts_per_pair=8,
         ),
         debug_mode=False,
         use_cuda_graph=True,


### PR DESCRIPTION
## Summary

- Fixes `RuntimeError: Cannot perform collision detection: a collision pipeline has not been created` when running `Isaac-Cartpole-Camera` with `physics=newton_kamino`
- Sets `use_collision_detector=False` in the cartpole `newton_kamino` preset — cartpole bodies never contact each other or the ground, so Kamino's internal collision detector serves no purpose
- Adds `collision_detector_max_contacts_per_world` field to `KaminoSolverCfg` for tasks that do need the internal detector on models without pre-computed explicit broadphase pairs

## Root cause

The updated Newton library only creates the internal Kamino collision pipeline when `model_minimum_contacts > 0` (pre-computed explicit broadphase pairs). The cartpole has none, so the pipeline stays `None`. However, `ContactsKamino` silently substitutes zero capacities with a default of 128 per world, leaving `model_max_contacts_host > 0`. When `detector.collide()` runs, it bypasses the early-return guard but finds no pipeline → crash.

This only manifested with cameras because `cameras_enabled=True` sets `_clone_physics_only=False` → `_usdrt_stage` is set → CUDA graph capture is deferred to the first `step()`, where the warmup executes `_simulate_physics_only()` eagerly and hits the broken state. Without cameras the standard `wp.ScopedCapture` path is used instead.

## Test plan

- [x] `uv run --extra isaacsim isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Camera physics=newton_kamino` — confirmed no longer crashes
- [x] `uv run isaaclab -f` — all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)