### PR TITLE
Restore AppLauncher.has_window dropped by #6658

### DIFF
--- a/source/isaaclab/changelog.d/rwiltz-fix-has-window-teleop.rst
+++ b/source/isaaclab/changelog.d/rwiltz-fix-has-window-teleop.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab.app.AppLauncher.has_window` being accidentally removed in
+  `#6658 <https://github.com/isaac-sim/IsaacLab/pull/6658>`_, which caused an
+  ``AttributeError`` in ``teleop_se3_agent.py`` and ``record_demos.py`` on every
+  IsaacTeleop run.
+* Fixed XR sessions without an explicit windowed visualizer no longer forcing headless
+  mode, caused by the same PR renaming ``_xr_implies_headless`` to ``_xr_auto_start``
+  without updating the enforcement block in ``_resolve_headless_settings``.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -407,6 +407,19 @@ class AppLauncher:
         """
         return bool(get_settings_manager().get("/isaaclab/has_gui"))
 
+    @property
+    def has_window(self) -> bool:
+        """Whether a local window exists that can render UI and receive input.
+
+        ``True`` when a windowed visualizer was requested, or when livestreaming, which
+        renders a window and forwards input from the remote client. Use this rather than
+        :meth:`has_gui` to decide whether local UI-driven features such as keyboard
+        bindings are available: livestreaming runs the host headless yet still presents
+        an interactive window, while XR without an explicit windowed visualizer does not
+        open a local window.
+        """
+        return not self._headless or self._livestream >= 1
+
     @staticmethod
     def _fuse_kit_args(argv: list[str]) -> list[str]:
         """Fuse ``["--kit_args", "<option-like value>"]`` pairs into single ``--kit_args=<value>`` tokens.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -670,6 +670,10 @@ class AppLauncher:
     Internal functions.
     """
 
+    # Set by :meth:`_resolve_xr_settings`. Defaulted here so :meth:`_resolve_headless_settings`
+    # stays independent of resolver call order and of whether XR was resolved at all.
+    _xr_auto_start: bool = False
+
     _APPLAUNCHER_CFG_INFO: dict[str, tuple[list[type], Any]] = {
         "headless": ([bool], False),
         "livestream": ([int], -1),
@@ -902,7 +906,15 @@ class AppLauncher:
 
         # Resolve headless from visualizer intent when livestream is disabled.
         if self._livestream == 0:
-            if self._cli_visualizer_explicit:
+            if self._xr_auto_start:
+                # XR without an explicit windowed visualizer: no viewport to start the session from.
+                if not self._headless:
+                    logger.info(
+                        "XR is enabled without an explicit windowed visualizer, so running headless. "
+                        "To also open a local viewport, pass '--viz <names>' (for example '--viz kit')."
+                    )
+                self._headless = True
+            elif self._cli_visualizer_explicit:
                 # Explicit CLI selection controls headless: only Kit implies non-headless.
                 requested_visualizers = set(self._cli_visualizer_types)
                 if self._cli_visualizer_disable_all or "kit" not in requested_visualizers:


### PR DESCRIPTION
  # Description:
  ## What broke
  
  PR #6658 introduced two regressions in `AppLauncher` by removing and
  renaming XR-related attributes without updating all callers.

  ### 1. AttributeError on every IsaacTeleop run
  
  `AppLauncher.has_window` was deleted without updating its two callers:
  
  - `scripts/environments/teleoperation/teleop_se3_agent.py:463`
  - `scripts/tools/record_demos.py:671`

  Both use `has_window` to decide whether to wire up local keyboard bindings
  (B/P/R) for the IsaacTeleop control path. `AppLauncher.has_gui` is not a
  substitute: it returns `True` for XR sessions even without a local window,
  which would incorrectly attempt to register keyboard bindings with no
  window to receive input.

  ### 2. XR sessions no longer forced headless without `--viz kit`

  `_xr_implies_headless` was renamed to `_xr_auto_start` in
  `_resolve_xr_settings`, but the enforcement block in
  `_resolve_headless_settings` that checked `if self._xr_implies_headless:`
  was deleted rather than updated. As a result, XR sessions without an
  explicit windowed visualizer no longer force headless, opening an unwanted
  local window.

  ## Fix
  
  - Restore `has_window` as an instance `@property` with a
    renderer-agnostic docstring.
  - Restore the XR headless enforcement block in `_resolve_headless_settings`,
    now keyed off `_xr_auto_start` (the same boolean, new name). Add a
    class-level default so resolver call order doesn't matter.
 
  ## Why CI passed

  Both `has_window` and its test (`test_xr_without_explicit_windowed_visualizer_forces_headless`,
  which asserts both `launcher._headless` and `launcher.has_window`) were added to `develop`
  on Aug 4, after PR #6658 had already branched. CI ran against the PR branch
  state and saw neither the property nor the test. The squash-merge was not
  re-tested against the post-merge `develop` tip.               


Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there