### PR TITLE
Add changelog fragment pre-commit check

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -22,3 +22,7 @@ jobs:
       with:
         python-version: "3.12"
     - uses: pre-commit/action@v3.0.0
+      # The local fragment hook needs a full base-branch history. The
+      # dedicated changelog-check workflow supplies that authoritative gate.
+      env:
+        SKIP: check-changelog-fragments

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,8 +79,8 @@ repos:
     hooks:
       - id: check-changelog-fragments
         name: check changelog fragments
-        entry: python3 tools/changelog/cli.py check --include-worktree
-        language: system
+        entry: python tools/changelog/cli.py check --include-worktree
+        language: python
         always_run: true
         pass_filenames: false
       - id: check-git-lfs-pointers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,12 @@ repos:
       - id: rst-inline-touching-normal
   - repo: local
     hooks:
+      - id: check-changelog-fragments
+        name: check changelog fragments
+        entry: python3 tools/changelog/cli.py check --include-worktree
+        language: system
+        always_run: true
+        pass_filenames: false
       - id: check-git-lfs-pointers
         name: check Git LFS pointers
         entry: tools/pre_commit/check_git_lfs_pointers.sh

--- a/tools/changelog/cli.py
+++ b/tools/changelog/cli.py
@@ -34,6 +34,12 @@ Usage:
     # CI invocation on every pull_request:
     cli.py check <base-branch>
 
+    # Local invocation used by pre-commit (defaults to develop):
+    cli.py check --include-worktree
+
+    # Override the local base for a release branch:
+    ISAACLAB_CHANGELOG_BASE_REF=release/6.0 cli.py check --include-worktree
+
     # ── compile ───────────────────────────────────────────────────
     # Normal release-time invocation — bump every managed package
     # from accumulated fragments, write entries, delete fragments:
@@ -59,6 +65,7 @@ incremental bumps, not for jumps.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -725,12 +732,31 @@ class PRDiff:
     added: set[str]
 
     @classmethod
-    def from_git(cls, base_ref: str) -> PRDiff:
-        """Run ``git diff`` against ``origin/<base_ref>...HEAD`` to populate the diff."""
+    def from_git(cls, base_ref: str, *, include_worktree: bool = False) -> PRDiff:
+        """Collect the branch diff against ``origin/<base_ref>``.
+
+        Args:
+            base_ref: Base branch name.
+            include_worktree: Whether to include staged and unstaged tracked
+                changes in addition to committed branch changes.
+        """
+
+        remote_base = f"origin/{base_ref}"
+        if include_worktree:
+            merge_base = subprocess.run(
+                ["git", "merge-base", remote_base, "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=REPO_ROOT,
+            ).stdout.strip()
+            diff_target = merge_base
+        else:
+            diff_target = f"{remote_base}...HEAD"
 
         def _diff(extra_args: list[str]) -> set[str]:
             result = subprocess.run(
-                ["git", "diff", "--name-only", *extra_args, f"origin/{base_ref}...HEAD"],
+                ["git", "diff", "--name-only", *extra_args, diff_target],
                 capture_output=True,
                 text=True,
                 check=True,
@@ -738,7 +764,9 @@ class PRDiff:
             )
             return {f for f in result.stdout.splitlines() if f}
 
-        return cls(changed=_diff([]), added=_diff(["--diff-filter=A"]))
+        changed = _diff([])
+        added = _diff(["--diff-filter=A"])
+        return cls(changed=changed, added=added)
 
     def evaluate(
         self,
@@ -933,7 +961,7 @@ def cmd_compile(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
 
 def cmd_check(args: argparse.Namespace, _parser: argparse.ArgumentParser) -> int:
     try:
-        diff = PRDiff.from_git(args.base_ref)
+        diff = PRDiff.from_git(args.base_ref, include_worktree=args.include_worktree)
     except subprocess.CalledProcessError as e:
         print(f"ERROR: git diff failed: {e.stderr}", file=sys.stderr)
         return 1
@@ -1092,10 +1120,17 @@ def _build_parser() -> argparse.ArgumentParser:
     p_check.set_defaults(func=cmd_check)
     p_check.add_argument(
         "base_ref",
+        nargs="?",
+        default=os.environ.get("ISAACLAB_CHANGELOG_BASE_REF", "develop"),
         help=(
             "Base branch to diff against (e.g. 'main' or 'develop'). "
-            "The diff is taken against ``origin/<base_ref>...HEAD``."
+            "Defaults to ISAACLAB_CHANGELOG_BASE_REF or 'develop'."
         ),
+    )
+    p_check.add_argument(
+        "--include-worktree",
+        action="store_true",
+        help=("Include staged and unstaged tracked changes in the branch diff. Used by the local pre-commit hook."),
     )
 
     return parser

--- a/tools/changelog/test/test_git_diff.py
+++ b/tools/changelog/test/test_git_diff.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Git-backed tests for changelog pull-request diff collection."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import cli
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run Git in a temporary repository and return standard output."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_from_git_include_worktree_collects_tracked_local_changes(tmp_path, monkeypatch):
+    """Local checks include tracked changes but ignore untracked files."""
+    _git(tmp_path, "init", "-b", "develop")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test User")
+
+    package_dir = tmp_path / "source" / "example"
+    package_dir.mkdir(parents=True)
+    (package_dir / "base.py").write_text("base\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/base.py")
+    _git(tmp_path, "commit", "-m", "Add base")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/develop", "HEAD")
+    _git(tmp_path, "switch", "-c", "feature")
+
+    (package_dir / "committed.py").write_text("committed\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/committed.py")
+    _git(tmp_path, "commit", "-m", "Add committed change")
+
+    (package_dir / "staged.py").write_text("staged\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/staged.py")
+    (package_dir / "base.py").write_text("unstaged\n", encoding="utf-8")
+    (package_dir / "untracked.py").write_text("untracked\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+
+    committed_diff = cli.PRDiff.from_git("develop")
+    assert committed_diff == cli.PRDiff(
+        changed={"source/example/committed.py"},
+        added={"source/example/committed.py"},
+    )
+
+    local_diff = cli.PRDiff.from_git("develop", include_worktree=True)
+    assert local_diff == cli.PRDiff(
+        changed={
+            "source/example/base.py",
+            "source/example/committed.py",
+            "source/example/staged.py",
+        },
+        added={
+            "source/example/committed.py",
+            "source/example/staged.py",
+        },
+    )
+
+
+def test_check_parser_defaults_to_develop_for_local_checks(monkeypatch):
+    """Local checks can omit the base branch and request worktree changes."""
+    monkeypatch.delenv("ISAACLAB_CHANGELOG_BASE_REF", raising=False)
+
+    args = cli._build_parser().parse_args(["check", "--include-worktree"])
+
+    assert args.base_ref == "develop"
+    assert args.include_worktree is True
+
+
+def test_check_parser_uses_environment_base_override(monkeypatch):
+    """Release-branch contributors can override the local default base."""
+    monkeypatch.setenv("ISAACLAB_CHANGELOG_BASE_REF", "release/6.0")
+
+    args = cli._build_parser().parse_args(["check", "--include-worktree"])
+
+    assert args.base_ref == "release/6.0"
+
+
+def test_cmd_check_include_worktree_rejects_untracked_fragment(tmp_path, monkeypatch):
+    """An untracked fragment cannot satisfy an uncommitted package change."""
+    _git(tmp_path, "init", "-b", "develop")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test User")
+
+    package_dir = tmp_path / "source" / "example"
+    (package_dir / "docs").mkdir(parents=True)
+    (package_dir / "changelog.d").mkdir()
+    (package_dir / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n', encoding="utf-8")
+    (package_dir / "docs" / "CHANGELOG.rst").write_text("Changelog\n---------\n\n", encoding="utf-8")
+    (package_dir / "base.py").write_text("base\n", encoding="utf-8")
+    (package_dir / "changelog.d" / ".gitkeep").touch()
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "Add base package")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/develop", "HEAD")
+    _git(tmp_path, "switch", "-c", "feature")
+
+    (package_dir / "uncommitted.py").write_text("change\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/uncommitted.py")
+    (package_dir / "changelog.d" / "local.skip").touch()
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli.Package, "discover", classmethod(lambda cls: [cls(package_dir)]))
+    parser = cli._build_parser()
+    args = parser.parse_args(["check", "--include-worktree"])
+
+    assert cli.cmd_check(args, parser) == 1

--- a/tools/changelog/test/test_git_diff.py
+++ b/tools/changelog/test/test_git_diff.py
@@ -13,16 +13,9 @@ from pathlib import Path
 import cli
 
 
-def _git(repo: Path, *args: str) -> str:
-    """Run Git in a temporary repository and return standard output."""
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip()
+def _git(repo: Path, *args: str) -> None:
+    """Run Git in a temporary repository."""
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
 def test_from_git_include_worktree_collects_tracked_local_changes(tmp_path, monkeypatch):
@@ -46,18 +39,11 @@ def test_from_git_include_worktree_collects_tracked_local_changes(tmp_path, monk
     (package_dir / "staged.py").write_text("staged\n", encoding="utf-8")
     _git(tmp_path, "add", "source/example/staged.py")
     (package_dir / "base.py").write_text("unstaged\n", encoding="utf-8")
-    (package_dir / "untracked.py").write_text("untracked\n", encoding="utf-8")
+    (package_dir / "changelog.d").mkdir()
+    (package_dir / "changelog.d" / "untracked.skip").touch()
 
     monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
-
-    committed_diff = cli.PRDiff.from_git("develop")
-    assert committed_diff == cli.PRDiff(
-        changed={"source/example/committed.py"},
-        added={"source/example/committed.py"},
-    )
-
-    local_diff = cli.PRDiff.from_git("develop", include_worktree=True)
-    assert local_diff == cli.PRDiff(
+    assert cli.PRDiff.from_git("develop", include_worktree=True) == cli.PRDiff(
         changed={
             "source/example/base.py",
             "source/example/committed.py",
@@ -68,52 +54,3 @@ def test_from_git_include_worktree_collects_tracked_local_changes(tmp_path, monk
             "source/example/staged.py",
         },
     )
-
-
-def test_check_parser_defaults_to_develop_for_local_checks(monkeypatch):
-    """Local checks can omit the base branch and request worktree changes."""
-    monkeypatch.delenv("ISAACLAB_CHANGELOG_BASE_REF", raising=False)
-
-    args = cli._build_parser().parse_args(["check", "--include-worktree"])
-
-    assert args.base_ref == "develop"
-    assert args.include_worktree is True
-
-
-def test_check_parser_uses_environment_base_override(monkeypatch):
-    """Release-branch contributors can override the local default base."""
-    monkeypatch.setenv("ISAACLAB_CHANGELOG_BASE_REF", "release/6.0")
-
-    args = cli._build_parser().parse_args(["check", "--include-worktree"])
-
-    assert args.base_ref == "release/6.0"
-
-
-def test_cmd_check_include_worktree_rejects_untracked_fragment(tmp_path, monkeypatch):
-    """An untracked fragment cannot satisfy an uncommitted package change."""
-    _git(tmp_path, "init", "-b", "develop")
-    _git(tmp_path, "config", "user.email", "test@example.com")
-    _git(tmp_path, "config", "user.name", "Test User")
-
-    package_dir = tmp_path / "source" / "example"
-    (package_dir / "docs").mkdir(parents=True)
-    (package_dir / "changelog.d").mkdir()
-    (package_dir / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n', encoding="utf-8")
-    (package_dir / "docs" / "CHANGELOG.rst").write_text("Changelog\n---------\n\n", encoding="utf-8")
-    (package_dir / "base.py").write_text("base\n", encoding="utf-8")
-    (package_dir / "changelog.d" / ".gitkeep").touch()
-    _git(tmp_path, "add", ".")
-    _git(tmp_path, "commit", "-m", "Add base package")
-    _git(tmp_path, "update-ref", "refs/remotes/origin/develop", "HEAD")
-    _git(tmp_path, "switch", "-c", "feature")
-
-    (package_dir / "uncommitted.py").write_text("change\n", encoding="utf-8")
-    _git(tmp_path, "add", "source/example/uncommitted.py")
-    (package_dir / "changelog.d" / "local.skip").touch()
-
-    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(cli.Package, "discover", classmethod(lambda cls: [cls(package_dir)]))
-    parser = cli._build_parser()
-    args = parser.parse_args(["check", "--include-worktree"])
-
-    assert cli.cmd_check(args, parser) == 1


### PR DESCRIPTION
# Description

Adds an early changelog-fragment check to the local pre-commit workflow so contributors receive actionable feedback before CI. The check reuses the existing fragment policy and evaluates committed plus staged or unstaged tracked changes from the base merge point.

The base defaults to develop and can be overridden with ISAACLAB_CHANGELOG_BASE_REF. Untracked fragments are intentionally excluded so a fragment cannot satisfy a commit before it is staged. The dedicated full-history changelog workflow remains the authoritative CI gate.

Dependencies: None.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing

- env VIRTUAL_ENV=/home/antoiner/Documents/IsaacLab/env_isaaclab ./isaaclab.sh -p -m pytest tools/changelog/ -q (91 passed)
- env VIRTUAL_ENV=/home/antoiner/Documents/IsaacLab/env_isaaclab ./isaaclab.sh -f (all hooks passed)
- Live hook probe rejected a package change without a fragment and accepted it with a skip fragment
- Independent review found no remaining issues

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with ./isaaclab.sh -f
- [x] I have updated the CLI usage documentation
- [x] My changes generate no new warnings
- [x] I have added one compact real-Git regression test for the new collector
- [x] No source package is touched, so no package changelog fragment is required
- [x] My name is already present in CONTRIBUTORS.md