### PR TITLE
Fix SO-101 leader-arm build commands in teleop docs

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -375,20 +375,18 @@ Prerequisites
      sudo apt-get update
      sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
 
-  Then clone, configure, build, and install. Each preset builds into its own directory, so the
-  install path must match the preset you configured with -- ``py3.11`` builds into
-  ``build/cmake-cpython-311``, ``py3.12`` into ``build/cmake-cpython-312``, ``py3.13`` into
-  ``build/cmake-cpython-313``:
+  Then clone, configure, build, and install. To target a specific Python version, pass
+  ``-DISAAC_TELEOP_PYTHON_VERSION=3.12`` (or ``3.11``, ``3.13``) on the configure line; each
+  version needs its own build directory if building multiple at once:
 
   .. code-block:: bash
 
      git clone https://github.com/NVIDIA/IsaacTeleop.git
      cd IsaacTeleop
 
-     # Pick the preset matching your Python, and keep it consistent across all three commands.
-     cmake --preset py3.12                       # configure
-     cmake --build --preset py3.12 --parallel    # build
-     cmake --install build/cmake-cpython-312     # install into ./install
+     cmake -B build                       # configure (default: Python 3.11)
+     cmake --build build --parallel       # build
+     cmake --install build                # install into ./install
 
   The plugin is installed to ``<IsaacTeleop>/install/plugins/so101_leader/so101_leader_plugin``.
   Every later command in this section runs from the Isaac Teleop checkout root; substitute your own
@@ -400,9 +398,9 @@ Prerequisites
      cd /path/to/IsaacTeleop
      ./install/plugins/so101_leader/so101_leader_plugin
 
-  See `Build from Source`_ for the full prerequisite list, the CMake presets, and all build
-  options, and the build-troubleshooting table in `Data Collection in Sim`_ for common failures
-  (including the ``clang-format not found but ENABLE_CLANG_FORMAT_CHECK is ON`` CMake error).
+  See `Build from Source`_ for the full prerequisite list and all build options, and the
+  build-troubleshooting table in `Data Collection in Sim`_ for common failures (including the
+  ``clang-format not found but ENABLE_CLANG_FORMAT_CHECK is ON`` CMake error).
 
 * **Calibration**: The SO-101 arm must be calibrated before use. The plugin talks to the FEETECH
   servos directly -- it has no ``lerobot`` or FEETECH SDK dependency -- so calibrate with its own


### PR DESCRIPTION
# Description
  * Replaces the broken `cmake --preset py3.12` / `--build --preset` / `--install build/cmake-cpython-312` block with the current `cmake -B build` / `cmake --build build --parallel` / `cmake --install
  build` invocation
  * Removes the stale "each preset builds into its own directory" explanation; adds a note on `-DISAAC_TELEOP_PYTHON_VERSION=<ver>` for targeting a specific Python
  * Removes the phrase "the CMake presets" from the cross-reference sentence (CMakePresets.json was dropped upstream in NVIDIA/IsaacTeleop@f8b5eaa) 


Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there