### PR TITLE
Add firewall setup to the Docker section of the CloudXR teleoperation…

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -733,19 +733,6 @@ Run the teleop script (e.g. ``record_demos.py`` to record demonstrations):
            --dataset_file ./datasets/dataset.hdf5 \
            --xr --visualizer kit
 
-.. tip::
-
-   Once the script is running and the WSS proxy has started, you can verify that port 48322
-   is reachable from another machine on the same network:
-
-   .. code-block:: bash
-
-      nc -vz <isaac-lab-host-ip> 48322
-
-   Expected output: ``Connection to <ip> port 48322 [tcp/*] succeeded!``
-   A ``Connection refused`` result after opening the firewall indicates the proxy has not
-   yet started — wait a few seconds and retry.
-
 Then in the Isaac Sim UI, set the XR panel to **System OpenXR Runtime** and click **Start XR**.
 
 For a fully headless experience, replace ``--visualizer kit`` with ``--visualizer none`` or

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -707,13 +707,7 @@ devices can reach Isaac Lab. Apply the same ``ufw`` rules from :ref:`install-isa
 
    If port 48322 is not open, the headset browser will show **"This site can't be reached"**
    when navigating to the certificate-acceptance page — the TCP connection fails before any
-   certificate exchange occurs. To verify connectivity from another machine on the same network:
-
-   .. code-block:: bash
-
-      nc -vz <isaac-lab-host-ip> 48322
-
-   Expected output: ``Connection to <ip> port 48322 [tcp/*] succeeded!``
+   certificate exchange occurs.
 
 Run the teleop script (e.g. ``record_demos.py`` to record demonstrations):
 
@@ -738,6 +732,19 @@ Run the teleop script (e.g. ``record_demos.py`` to record demonstrations):
            --num_demos 5 \
            --dataset_file ./datasets/dataset.hdf5 \
            --xr --visualizer kit
+
+.. tip::
+
+   Once the script is running and the WSS proxy has started, you can verify that port 48322
+   is reachable from another machine on the same network:
+
+   .. code-block:: bash
+
+      nc -vz <isaac-lab-host-ip> 48322
+
+   Expected output: ``Connection to <ip> port 48322 [tcp/*] succeeded!``
+   A ``Connection refused`` result after opening the firewall indicates the proxy has not
+   yet started — wait a few seconds and retry.
 
 Then in the Isaac Sim UI, set the XR panel to **System OpenXR Runtime** and click **Start XR**.
 

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -674,6 +674,47 @@ runtime command is needed.
      ``sudo chown -R 1000:1000`` them before launching, so the non-root user can write to
      them.
 
+Because the Isaac Lab container runs with ``network_mode: host``, the container's ports are
+exposed directly on the host network stack. The host firewall therefore governs whether XR
+devices can reach Isaac Lab. Apply the same ``ufw`` rules from :ref:`install-isaac-teleop`
+**on the host machine** before starting the container:
+
+.. tab-set::
+
+   .. tab-item:: Meta Quest 3 / Pico 4 Ultra (web client)
+
+      .. code-block:: bash
+
+         sudo ufw allow 49100/tcp   # Signaling (WebRTC)
+         sudo ufw allow 47998/udp   # Media stream
+         sudo ufw allow 48322/tcp   # WSS proxy — required for cert acceptance and streaming
+
+   .. tab-item:: Apple Vision Pro (native client)
+
+      .. code-block:: bash
+
+         sudo ufw allow 48010/tcp   # Standard mode signaling
+         sudo ufw allow 48322/tcp   # Secure mode signaling
+         sudo ufw allow 47998/udp
+         sudo ufw allow 48005/udp
+         sudo ufw allow 48008/udp
+         sudo ufw allow 48012/udp
+         sudo ufw allow 47999/udp
+         sudo ufw allow 48000/udp
+         sudo ufw allow 48002/udp
+
+.. note::
+
+   If port 48322 is not open, the headset browser will show **"This site can't be reached"**
+   when navigating to the certificate-acceptance page — the TCP connection fails before any
+   certificate exchange occurs. To verify connectivity from another machine on the same network:
+
+   .. code-block:: bash
+
+      nc -vz <isaac-lab-host-ip> 48322
+
+   Expected output: ``Connection to <ip> port 48322 [tcp/*] succeeded!``
+
 Run the teleop script (e.g. ``record_demos.py`` to record demonstrations):
 
 .. tab-set::


### PR DESCRIPTION
# Description

  - The "Run with Docker" section of the CloudXR teleoperation guide was missing the `ufw`
    firewall configuration step. The bare-metal "Install Isaac Teleop" section already
    documented the required ports; the Docker path now matches it.
  - Added a tab-set covering both client types (Quest/Pico web client and Apple Vision Pro)
    with `ufw` rules for ports 48322/tcp (WSS proxy), 49100/tcp (WebRTC signaling), and
    47998/udp (media stream).
  - Added a note explaining that a blocked port 48322 produces "This site can't be reached"
    — a TCP-level failure — rather than a certificate warning, and a `nc -vz` verification
    command to confirm connectivity before wearing the headset.

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there