### PR TITLE
DO NOT MERGE: diagnose fork-PR nvcr.io credential loss

### DIFF
--- a/.github/actions/_lib/setup-docker-config/action.yml
+++ b/.github/actions/_lib/setup-docker-config/action.yml
@@ -16,6 +16,28 @@ runs:
   steps:
     - shell: bash
       run: |
+        # TEMPORARY DIAGNOSTIC (remove before merge): prints only registry names
+        # and booleans, never credential values, to establish whether the runner's
+        # nvcr.io credential is plain-auths (survives the rewrite below) or
+        # helper-backed (destroyed by it). See the fork-PR cuRobo build failures.
+        dump_docker_cfg() {
+          echo "🔍 docker config: $1"
+          python3 -c '
+        import json, os, sys
+        path = sys.argv[1]
+        if not os.path.exists(path):
+            print("   <no config file>")
+            raise SystemExit
+        cfg = json.load(open(path))
+        auths = cfg.get("auths", {})
+        print("   registries      :", sorted(auths))
+        print("   has_credential  :", {k: bool(v) for k, v in sorted(auths.items())})
+        print("   credsStore_set  :", bool(cfg.get("credsStore")))
+        print("   credHelpers_for :", sorted(cfg.get("credHelpers", {})))
+        ' "$1"
+        }
+        dump_docker_cfg "${HOME}/.docker/config.json"
+
         # The runner's credential helper backend is broken ("not implemented")
         # and causes docker login calls to fail unless we point DOCKER_CONFIG at
         # a temp config with credsStore disabled. The value is written to
@@ -23,6 +45,7 @@ runs:
         # invocation sees it already set and short-circuits.
         if [ -n "${DOCKER_CONFIG:-}" ] && [ -f "${DOCKER_CONFIG}/config.json" ]; then
           echo "🟢 Docker config already set up at ${DOCKER_CONFIG}, skipping"
+          dump_docker_cfg "${DOCKER_CONFIG}/config.json"
           exit 0
         fi
 
@@ -34,6 +57,7 @@ runs:
         fi
         export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
         echo "DOCKER_CONFIG=${DOCKER_CONFIG_DIR}" >> "$GITHUB_ENV"
+        dump_docker_cfg "${DOCKER_CONFIG_DIR}/config.json"
 
         if [ -n "${NGC_API_KEY:-}" ]; then
           echo "🔵 Logging into nvcr.io..."

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+# CI diagnostic: bust the deps-cache so the image is really built (remove with the diagnostic).
 # Isaac Sim base container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-sim
 # Please check the NGC container page for license information.
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+# CI diagnostic: bust the deps-cache so the image is really built (remove with the diagnostic).
 # Isaac Sim base container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/isaac-sim
 # Please check the NGC container page for license information.
 


### PR DESCRIPTION
## 1. Purpose — diagnostic only, do not merge

Fork-PR ``Build cuRobo Docker Image`` fails pulling the private isaac-sim base
image:

    #3 [auth] 0947644777160149/internal/isaac-sim:pull token for nvcr.io
    #4 ERROR: failed to authorize: failed to fetch oauth token: denied: Access Denied

In the **same run**, with the **same empty** ``NGC_API_KEY``, ``Build Base Docker
Image`` pulled the **same image at the same digest** successfully. The two jobs
ran on different runners (``ip-10-0-2-183`` ✅ / ``ip-10-0-3-247`` ❌), so the
runner credential is what does the work and it differs per instance.

## 2. What this tests

``setup-docker-config`` repoints ``DOCKER_CONFIG`` at a rewritten copy with
``credsStore`` and ``credHelpers`` removed. If a runner's nvcr.io credential is
helper-backed, that rewrite destroys the only credential a fork PR has. If it is
a plain ``auths`` entry, it survives.

Printing the config shape before and after the rewrite distinguishes the two:

| output | meaning |
|---|---|
| ``has_credential {'nvcr.io': True}`` | plain auths — survives |
| ``has_credential {'nvcr.io': False}`` + ``credHelpers_for ['nvcr.io']`` | helper-backed — destroyed by the rewrite |
| ``nvcr.io`` absent | runner has no credential |

## 3. Safety

Only dict **keys** (registry hostnames) and booleans are printed, never values.
Verified locally against a config containing fake credentials: no value appears
in the output.

## 4. Type of change

- Diagnostic, to be reverted
