### PR TITLE
Stabilize standalone demo smoke tests

### DIFF
--- a/scripts/demos/sensors/cameras.py
+++ b/scripts/demos/sensors/cameras.py
@@ -26,7 +26,6 @@ from isaaclab.app import AppLauncher
 parser = argparse.ArgumentParser(description="Example on using the different camera sensor implementations.")
 parser.add_argument("--num_envs", type=int, default=4, help="Number of environments to spawn.")
 parser.add_argument("--disable_fabric", action="store_true", help="Disable Fabric API and use USD instead.")
-parser.add_argument("--disable_image_saving", action="store_true", help="Disable periodic camera image saving.")
 parser.add_argument(
     "--physics",
     default="isaacsim_physx",
@@ -50,6 +49,7 @@ simulation_app = app_launcher.app
 
 import os
 
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
@@ -144,9 +144,6 @@ def save_images_grid(
         title: Title of the grid. Defaults to None, in which case no title is shown.
         filename: Path to save the figure. Defaults to None, in which case the figure is not saved.
     """
-    # Matplotlib's first import may build its font cache, so defer it until an image is actually saved.
-    import matplotlib.pyplot as plt
-
     # show images in a grid
     n_images = len(images)
     ncol = int(np.ceil(n_images / nrow))
@@ -190,8 +187,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
     # Create output directory to save images
     output_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
-    if not args_cli.disable_image_saving:
-        os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
 
     # Simulate physics
     while simulation_app.is_running():
@@ -250,7 +246,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
         # save every 10th image (for visualization purposes only)
         # note: saving images will slow down the simulation
-        if not args_cli.disable_image_saving and count % 10 == 0:
+        if count % 10 == 0:
             # compare generated RGB images across different cameras
             rgb_images = [scene["camera"].data.output["rgb"][0, ..., :3], scene["tiled_camera"].data.output["rgb"][0]]
             save_images_grid(

--- a/scripts/demos/sensors/cameras.py
+++ b/scripts/demos/sensors/cameras.py
@@ -26,6 +26,7 @@ from isaaclab.app import AppLauncher
 parser = argparse.ArgumentParser(description="Example on using the different camera sensor implementations.")
 parser.add_argument("--num_envs", type=int, default=4, help="Number of environments to spawn.")
 parser.add_argument("--disable_fabric", action="store_true", help="Disable Fabric API and use USD instead.")
+parser.add_argument("--disable_image_saving", action="store_true", help="Disable periodic camera image saving.")
 parser.add_argument(
     "--physics",
     default="isaacsim_physx",
@@ -49,7 +50,6 @@ simulation_app = app_launcher.app
 
 import os
 
-import matplotlib.pyplot as plt
 import numpy as np
 import torch
 
@@ -144,6 +144,9 @@ def save_images_grid(
         title: Title of the grid. Defaults to None, in which case no title is shown.
         filename: Path to save the figure. Defaults to None, in which case the figure is not saved.
     """
+    # Matplotlib's first import may build its font cache, so defer it until an image is actually saved.
+    import matplotlib.pyplot as plt
+
     # show images in a grid
     n_images = len(images)
     ncol = int(np.ceil(n_images / nrow))
@@ -187,7 +190,8 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
     # Create output directory to save images
     output_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
-    os.makedirs(output_dir, exist_ok=True)
+    if not args_cli.disable_image_saving:
+        os.makedirs(output_dir, exist_ok=True)
 
     # Simulate physics
     while simulation_app.is_running():
@@ -246,7 +250,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
 
         # save every 10th image (for visualization purposes only)
         # note: saving images will slow down the simulation
-        if count % 10 == 0:
+        if not args_cli.disable_image_saving and count % 10 == 0:
             # compare generated RGB images across different cameras
             rgb_images = [scene["camera"].data.output["rgb"][0, ..., :3], scene["tiled_camera"].data.output["rgb"][0]]
             save_images_grid(

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -402,12 +402,14 @@ def run_until_ready(
     stopped_after_soak = False
     screenshot_captured = False
     fatal_patterns = set()
+    monitor_fatal_patterns = True
 
     def record_output(chunk: bytes) -> None:
         """Record bounded output while retaining fatal-pattern state."""
         output.extend(chunk)
         decoded_output = output.decode(errors="replace")
-        fatal_patterns.update(pattern for pattern in _FATAL_PATTERNS if pattern in decoded_output)
+        if monitor_fatal_patterns:
+            fatal_patterns.update(pattern for pattern in _FATAL_PATTERNS if pattern in decoded_output)
         if len(output) > MAX_OUTPUT_BYTES:
             del output[:-MAX_OUTPUT_BYTES]
 
@@ -435,6 +437,8 @@ def run_until_ready(
                 screenshot_captured = True
             if ready_at is not None and now - ready_at >= soak_time:
                 stopped_after_soak = True
+                # Preserve shutdown logs without treating errors caused by intentional teardown as runtime failures.
+                monitor_fatal_patterns = False
                 _terminate_process_group(process)
                 returncode = process.poll()
                 break

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -183,9 +183,7 @@ OVERRIDES = {
         fixed_physics_backend="newton_xpbd",
         visualizers=("newton_gl",),
     ),
-    "scripts/demos/sensors/cameras.py": ScriptOverride(
-        args=("--num_envs", "1", "--disable_image_saving"), startup_timeout=600.0
-    ),
+    "scripts/demos/sensors/cameras.py": ScriptOverride(args=("--num_envs", "1"), startup_timeout=900.0),
     "scripts/demos/sensors/multi_mesh_raycaster.py": ScriptOverride(
         args=("--flat_ground",),
         startup_timeout=600.0,

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -413,12 +413,19 @@ def run_until_ready(
         if len(output) > MAX_OUTPUT_BYTES:
             del output[:-MAX_OUTPUT_BYTES]
 
+    def read_available_output(timeout: float) -> bool:
+        """Read one available chunk per ready stream and report whether any bytes were read."""
+        read_output = False
+        for key, _ in selector.select(timeout=timeout):
+            chunk = os.read(key.fileobj.fileno(), 65536)
+            if chunk:
+                record_output(chunk)
+                read_output = True
+        return read_output
+
     try:
         while True:
-            for key, _ in selector.select(timeout=0.1):
-                chunk = os.read(key.fileobj.fileno(), 65536)
-                if chunk:
-                    record_output(chunk)
+            read_available_output(timeout=0.1)
             decoded = output.decode(errors="replace")
             if ready_at is None and re.search(readiness_pattern, decoded):
                 ready_at = time.monotonic()
@@ -437,6 +444,9 @@ def run_until_ready(
                 screenshot_captured = True
             if ready_at is not None and now - ready_at >= soak_time:
                 stopped_after_soak = True
+                # Classify every byte already waiting in the pipe before crossing the teardown boundary.
+                while read_available_output(timeout=0.0):
+                    pass
                 # Preserve shutdown logs without treating errors caused by intentional teardown as runtime failures.
                 monitor_fatal_patterns = False
                 _terminate_process_group(process)

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -183,7 +183,9 @@ OVERRIDES = {
         fixed_physics_backend="newton_xpbd",
         visualizers=("newton_gl",),
     ),
-    "scripts/demos/sensors/cameras.py": ScriptOverride(args=("--num_envs", "1"), startup_timeout=600.0),
+    "scripts/demos/sensors/cameras.py": ScriptOverride(
+        args=("--num_envs", "1", "--disable_image_saving"), startup_timeout=600.0
+    ),
     "scripts/demos/sensors/multi_mesh_raycaster.py": ScriptOverride(
         args=("--flat_ground",),
         startup_timeout=600.0,

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -334,6 +334,47 @@ def test_subprocess_supervisor_soaks_then_stops_process_group():
     assert result.elapsed < 2.0
 
 
+def test_subprocess_supervisor_ignores_fatal_output_after_intentional_teardown(monkeypatch):
+    """Fatal-looking output caused by intentional teardown must not fail a healthy launch."""
+
+    class FakeStdout:
+        def fileno(self):
+            return 1
+
+    class FakeProcess:
+        stdout = FakeStdout()
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def communicate(self, timeout):
+            return b"Traceback (most recent call last):\n", None
+
+    class FakeSelector:
+        def register(self, fileobj, events):
+            self.fileobj = fileobj
+
+        def select(self, timeout):
+            key = type("Key", (), {"fileobj": self.fileobj})()
+            return [(key, script_cases.selectors.EVENT_READ)]
+
+        def close(self):
+            pass
+
+    process = FakeProcess()
+    monkeypatch.setattr(script_cases.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(script_cases.selectors, "DefaultSelector", FakeSelector)
+    monkeypatch.setattr(script_cases.os, "read", lambda *args: b"READY\n")
+    monkeypatch.setattr(script_cases, "_terminate_process_group", lambda process: setattr(process, "returncode", -15))
+
+    result = run_until_ready(["demo.py"], r"READY", startup_timeout=2.0, soak_time=0.0)
+    assert result.ready
+    assert result.stopped_after_soak
+    assert "Traceback (most recent call last):" in result.output
+    assert not result.fatal_patterns
+
+
 def test_subprocess_supervisor_accepts_clean_exit_after_readiness():
     """A finite script may exit successfully immediately after becoming ready."""
     result = run_until_ready([sys.executable, "-u", "-c", "print('READY')"], r"READY", startup_timeout=2.0)

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -353,10 +353,15 @@ def test_subprocess_supervisor_ignores_fatal_output_after_intentional_teardown(m
             return b"Traceback (most recent call last):\n", None
 
     class FakeSelector:
+        selections = 0
+
         def register(self, fileobj, events):
             self.fileobj = fileobj
 
         def select(self, timeout):
+            self.selections += 1
+            if self.selections > 1:
+                return []
             key = type("Key", (), {"fileobj": self.fileobj})()
             return [(key, script_cases.selectors.EVENT_READ)]
 
@@ -374,6 +379,52 @@ def test_subprocess_supervisor_ignores_fatal_output_after_intentional_teardown(m
     assert result.stopped_after_soak
     assert "Traceback (most recent call last):" in result.output
     assert not result.fatal_patterns
+
+
+def test_subprocess_supervisor_classifies_buffered_fatal_output_before_intentional_teardown(monkeypatch):
+    """Fatal output already buffered at the soak deadline must remain test-failing."""
+
+    class FakeStdout:
+        def fileno(self):
+            return 1
+
+    class FakeProcess:
+        stdout = FakeStdout()
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def communicate(self, timeout):
+            return b"post-teardown output\n", None
+
+    class FakeSelector:
+        selections = 0
+
+        def register(self, fileobj, events):
+            self.fileobj = fileobj
+
+        def select(self, timeout):
+            self.selections += 1
+            if self.selections > 2:
+                return []
+            key = type("Key", (), {"fileobj": self.fileobj})()
+            return [(key, script_cases.selectors.EVENT_READ)]
+
+        def close(self):
+            pass
+
+    process = FakeProcess()
+    chunks = iter((b"READY\n", b"Traceback (most recent call last):\n"))
+    monkeypatch.setattr(script_cases.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(script_cases.selectors, "DefaultSelector", FakeSelector)
+    monkeypatch.setattr(script_cases.os, "read", lambda *args: next(chunks))
+    monkeypatch.setattr(script_cases, "_terminate_process_group", lambda process: setattr(process, "returncode", -15))
+
+    result = run_until_ready(["demo.py"], r"READY", startup_timeout=2.0, soak_time=0.0)
+    assert result.ready
+    assert result.stopped_after_soak
+    assert "Traceback (most recent call last):" in result.fatal_patterns
 
 
 def test_subprocess_supervisor_accepts_clean_exit_after_readiness():

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -234,6 +234,18 @@ def test_commands_respect_script_launcher_capabilities():
     assert "--enable_cameras" in ray_camera_case.command()
 
 
+def test_camera_smoke_defers_optional_image_plotting():
+    """The camera smoke must not pay Matplotlib's cold-start cost before readiness."""
+    path = script_cases.ROOT / "scripts/demos/sensors/cameras.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    top_level_imports = {alias.name for node in tree.body if isinstance(node, ast.Import) for alias in node.names}
+    assert "matplotlib.pyplot" not in top_level_imports
+
+    spec = next(spec for spec in SPECS if spec.relative_path == "scripts/demos/sensors/cameras.py")
+    assert "--disable_image_saving" in spec.options
+    assert spec.args == ("--num_envs", "1", "--disable_image_saving")
+
+
 @pytest.mark.parametrize(
     "relative_path",
     [

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -175,6 +175,7 @@ def test_commands_respect_script_launcher_capabilities():
     )
     assert camera_case.command()[3:5] == ["--num_envs", "1"]
     assert camera_case.command()[-2:] == ["--visualizer", "none"]
+    assert camera_case.spec.startup_timeout == 900.0
 
     kitless_case = next(
         case for case in build_cases(SPECS) if case.spec.relative_path == "scripts/demos/sensors/ppisp_camera_ovrtx.py"
@@ -232,18 +233,6 @@ def test_commands_respect_script_launcher_capabilities():
         and case.visualizer == "none"
     )
     assert "--enable_cameras" in ray_camera_case.command()
-
-
-def test_camera_smoke_defers_optional_image_plotting():
-    """The camera smoke must not pay Matplotlib's cold-start cost before readiness."""
-    path = script_cases.ROOT / "scripts/demos/sensors/cameras.py"
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    top_level_imports = {alias.name for node in tree.body if isinstance(node, ast.Import) for alias in node.names}
-    assert "matplotlib.pyplot" not in top_level_imports
-
-    spec = next(spec for spec in SPECS if spec.relative_path == "scripts/demos/sensors/cameras.py")
-    assert "--disable_image_saving" in spec.options
-    assert spec.args == ("--num_envs", "1", "--disable_image_saving")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Standalone demo smoke tests had two independent flaky failure modes:

1. The supervisor kept classifying fatal-looking output after it intentionally sent `SIGTERM`. Kit can emit Material Library, USD caching, and Replicator asyncio tracebacks during that forced teardown, after the demo reached readiness and completed its healthy soak.
2. The first camera-enabled Kit/RTX process consistently needs roughly 526?558 seconds to initialize on CI, but the camera case had a fixed 600-second startup budget. That left only 42?74 seconds for runner, cache, and service variation. In the timeout example, approximately 10 seconds of failed OmniHub launch retries contributed to the case crossing the limit at 605.8 seconds.

A CI experiment that disabled image saving and deferred the camera demo's Matplotlib import still took 526 seconds. That rules out optional plotting and confirms the long phase belongs to cold camera-enabled Kit/RTX initialization; the experimental demo change has been removed from the final diff.

This change fixes both test boundaries:

- Fatal-pattern detection stops immediately before intentional teardown, while shutdown output remains captured for diagnostics. Fatal output during startup or the soak still fails the test.
- The camera case receives a 900-second startup timeout, providing headroom for its known cold initialization while preserving the 300-second default hang detector for other demos.

Example failures:

- Intentional-teardown traceback: https://github.com/isaac-sim/IsaacLab/actions/runs/31243355943/job/93068486798?pr=6831
- Same teardown race on another unrelated PR: https://github.com/isaac-sim/IsaacLab/actions/runs/31230902685/job/93048260426
- Same teardown race on PR 6979: https://github.com/isaac-sim/IsaacLab/actions/runs/31247096260/job/93077436474?pr=6979
- Camera startup budget exhausted: https://github.com/isaac-sim/IsaacLab/actions/runs/31243047225/job/93069642023?pr=6979

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this changes headless smoke-test supervision and a case-specific timeout.

## Validation

- Teardown regression confirmed failing before the fix and passing after it:
  `uv run --frozen python -m pytest source/isaaclab/test/app/test_standalone_scripts.py::test_subprocess_supervisor_ignores_fatal_output_after_intentional_teardown -q`
- Camera timeout contract confirmed failing at the previous 600-second value and passing at 900 seconds:
  `uv run --frozen python -m pytest source/isaaclab/test/app/test_standalone_scripts.py::test_commands_respect_script_launcher_capabilities -q`
- Buffered pre-teardown output regression confirmed failing before the drain fix and passing after it:
  `uv run --frozen python -m pytest source/isaaclab/test/app/test_standalone_scripts.py::test_subprocess_supervisor_classifies_buffered_fatal_output_before_intentional_teardown -q`
- Platform-independent standalone harness subset: 35 passed, 298 simulator launches skipped, and 7 POSIX process-control tests deselected on Windows.
- Linux standalone Kit CI passed with the teardown boundary; the camera case took 526 seconds, providing the direct timing evidence used for the final timeout fix: https://github.com/isaac-sim/IsaacLab/actions/runs/31247940912/job/93079622769
- Changelog fragment gate against current upstream `develop`: passed.
- `uv run --frozen isaaclab -f`: passed after staging and again after commit.
## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] Documentation changes are not applicable to this test stabilization
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` ? CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
