### PR TITLE
Keep kitless runs from launching Omniverse Hub

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-kitless-disable-omni-hub.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-kitless-disable-omni-hub.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed kitless runs auto-launching a globally installed Omniverse Hub to read USD assets.
+  ``OMNICLIENT_HUB_MODE`` now defaults to ``disabled`` when Kit is not started, and setting the
+  variable explicitly still selects the shared or exclusive mode.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -527,6 +527,9 @@ def launch_simulation(
     # Kit-based backends apply the Python logging level inside AppLauncher; kitless backends
     # never construct it, so honor --verbose / --info here to keep behavior consistent.
     if not needs_kit:
+        # Avoid auto-launching a globally installed Omniverse Hub for kitless USD access.
+        # Explicit shared/exclusive modes remain available through the environment variable.
+        os.environ.setdefault("OMNICLIENT_HUB_MODE", "disabled")
         apply_python_logging_level(resolve_python_logging_level(launcher_args))
 
     if needs_kit and config_scan.has_kit_camera:


### PR DESCRIPTION
# Description

A kitless run still reads USD through the Omniverse client, which auto-launches a globally installed Omniverse Hub process when it finds one. For a backend that never starts Kit this is pure overhead: the Hub is slow to come up, retries on failure, and floods the log when it cannot write its config file — routine in containers and on cluster nodes, where it produces long runs of

```
Hub encountered error. Trying to reconnect to Hub. retry_reason="Hub failed to launch: Io(\"child exited with exit status: 1 without writing file ...\")"
```

before eventually giving up with `Not using Hub`.

This defaults `OMNICLIENT_HUB_MODE` to `disabled` on the kitless path only. `os.environ.setdefault` leaves an explicitly exported value untouched, so the `shared` and `exclusive` modes remain available to anyone who wants the Hub.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

None.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there