### PR TITLE
[Fix] Revert gc.collect(0)

### DIFF
--- a/source/isaaclab_newton/changelog.d/mh-restore-full-post-capture-collect.rst
+++ b/source/isaaclab_newton/changelog.d/mh-restore-full-post-capture-collect.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed intermittent segmentation faults after a CUDA graph capture by restoring the full
+  collection that runs when the capture window ends. Scoping it to generation 0 left cycles
+  that were promoted before the window but became unreachable during it -- a previous
+  ``wp.Graph``/``State`` released on a hard reset, for instance -- to the periodic collector,
+  which freed their Warp arrays long after the capture stream was destroyed.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -47,14 +47,6 @@ def _paused_gc():
     deterministic solver behavior and remain allowed; only the collector is
     deferred, and a collection runs immediately after the capture window,
     where freeing graph-scoped allocations is handled correctly.
-
-    Only generation 0 is collected afterwards: objects allocated inside the
-    window are still in gen 0, so this reclaims the graph-scoped garbage the
-    pause deferred, without the full-heap walk a ``gc.collect()`` would do
-    (hundreds of milliseconds once the replicated model exists). Cycles that
-    were already in an older generation before the window and became
-    unreachable during it -- a previous ``wp.Graph``/``State`` released on a
-    hard reset, for instance -- are left to the periodic collector.
     """
     was_enabled = gc.isenabled()
     gc.disable()
@@ -63,7 +55,7 @@ def _paused_gc():
     finally:
         if was_enabled:
             gc.enable()
-            gc.collect(0)
+            gc.collect()
 
 
 from newton import (


### PR DESCRIPTION
# Description

There is a small bug with garbage collection corrupting the environment such that the test scripts crash.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
