### PR TITLE
Add make_uninstanceable to UsdFileCfg

### DIFF
--- a/source/isaaclab/changelog.d/zhengyuz-usd-spawn-make-uninstanceable.rst
+++ b/source/isaaclab/changelog.d/zhengyuz-usd-spawn-make-uninstanceable.rst
@@ -1,0 +1,7 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.sim.spawners.from_files.from_files_cfg.UsdFileCfg.make_uninstanceable` to disable
+  USD instancing below a spawned prim before overrides are applied. Recursive overrides such as
+  :attr:`~isaaclab.sim.spawners.from_files.from_files_cfg.FileCfg.physics_material` can then author
+  properties on descendants of an instanceable asset, which are otherwise read-only instance proxies.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -26,6 +26,7 @@ from isaaclab.sim.utils import (
     get_current_stage,
     get_first_matching_child_prim,
     has_deformable_body_api,
+    make_uninstanceable,
     select_usd_variants,
     set_prim_visibility,
 )
@@ -343,6 +344,10 @@ def _spawn_from_usd_file(
     if hasattr(cfg, "variants") and cfg.variants is not None:
         select_usd_variants(prim_path, cfg.variants)
 
+    # make instance proxies editable before any override tries to author properties on them
+    if getattr(cfg, "make_uninstanceable", False):
+        make_uninstanceable(prim_path, stage=stage)
+
     # modify rigid body properties
     if cfg.rigid_props is not None:
         # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> modify_*
@@ -503,10 +508,11 @@ def _spawn_from_usd_file(
 
     # apply physics material
     if cfg.physics_material is not None:
-        if not cfg.physics_material_path.startswith("/"):
-            material_path = f"{prim_path}/{cfg.physics_material_path}"
-        else:
-            material_path = cfg.physics_material_path
+        material_path = (
+            cfg.physics_material_path
+            if cfg.physics_material_path.startswith("/")
+            else f"{prim_path}/{cfg.physics_material_path}"
+        )
         # create material (accepts a legacy material cfg or rigid-body fragment(s))
         spawn_physics_material(material_path, cfg.physics_material, stage=stage)
         # apply material

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -191,6 +191,17 @@ class UsdFileCfg(FileCfg):
     :meth:`~isaaclab.sim.utils.select_usd_variants` function for more information.
     """
 
+    make_uninstanceable: bool = False
+    """Whether to disable USD instancing below the spawned prim before applying overrides. Defaults to False.
+
+    Descendants of an instanceable prim are instance proxies, which cannot be edited. Enable this option
+    when a recursive override, such as :attr:`physics_material`, has to author properties on those
+    descendants. Disabling instancing makes them editable at the cost of stage memory, so leave this
+    option disabled unless an override requires it.
+
+    Please check the :meth:`~isaaclab.sim.utils.make_uninstanceable` function for more information.
+    """
+
 
 @configclass
 class UrdfFileCfg(FileCfg, converters.UrdfConverterCfg):

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -15,9 +15,11 @@ simulation_app = AppLauncher(headless=True).app
 import pytest
 
 import omni.kit.app
+from pxr import Usd, UsdGeom, UsdPhysics, UsdShade
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
+from isaaclab.sim.spawners.materials.physics_materials_cfg import UsdPhysicsRigidBodyMaterialCfg
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 pytestmark = pytest.mark.integration
@@ -52,6 +54,44 @@ def test_spawn_usd(sim):
     assert prim.IsValid()
     assert sim.stage.GetPrimAtPath("/World/Franka").IsValid()
     assert prim.GetPrimTypeInfo().GetTypeName() == "Xform"
+
+
+@pytest.mark.isaacsim_ci
+def test_spawn_usd_make_uninstanceable_applies_material_to_instance_colliders(sim, tmp_path):
+    """Test applying a physics material to colliders inside an instanceable USD asset."""
+    geometry_path = tmp_path / "geometry.usda"
+    geometry_stage = Usd.Stage.CreateNew(str(geometry_path))
+    geometry_root = UsdGeom.Xform.Define(geometry_stage, "/Geometry").GetPrim()
+    geometry_stage.SetDefaultPrim(geometry_root)
+    collider = UsdGeom.Cube.Define(geometry_stage, "/Geometry/Collider").GetPrim()
+    UsdPhysics.CollisionAPI.Apply(collider)
+    geometry_stage.GetRootLayer().Save()
+
+    asset_path = tmp_path / "asset.usda"
+    asset_stage = Usd.Stage.CreateNew(str(asset_path))
+    asset_root = UsdGeom.Xform.Define(asset_stage, "/Asset").GetPrim()
+    asset_stage.SetDefaultPrim(asset_root)
+    instance = UsdGeom.Xform.Define(asset_stage, "/Asset/collisions").GetPrim()
+    instance.GetReferences().AddReference(str(geometry_path), "/Geometry")
+    instance.SetInstanceable(True)
+    asset_stage.GetRootLayer().Save()
+
+    cfg = sim_utils.UsdFileCfg(
+        usd_path=str(asset_path),
+        make_uninstanceable=True,
+        physics_material=[UsdPhysicsRigidBodyMaterialCfg(static_friction=0.73)],
+    )
+    prim = cfg.func("/World/Asset", cfg)
+
+    assert prim.IsValid()
+    instance = sim.stage.GetPrimAtPath("/World/Asset/collisions")
+    collider = sim.stage.GetPrimAtPath("/World/Asset/collisions/Collider")
+    assert not instance.IsInstance()
+    assert not collider.IsInstanceProxy()
+    material = sim.stage.GetPrimAtPath("/World/Asset/material")
+    bound_material, _ = UsdShade.MaterialBindingAPI(collider).ComputeBoundMaterial(materialPurpose="physics")
+    assert bound_material.GetPath() == material.GetPath()
+    assert material.GetAttribute("physics:staticFriction").Get() == pytest.approx(0.73)
 
 
 @pytest.mark.isaacsim_ci


### PR DESCRIPTION
# Description

Descendants of an instanceable prim are instance proxies, which USD does not allow editing. A recursive override such as `physics_material` therefore cannot reach the colliders inside an instanceable asset: spawning the asset with a physics material appears to succeed, but the colliders stay bound to whatever the source layer specified. This is easy to hit with converted assets, where the collision geometry is commonly authored under an instanceable scope.

This adds an opt-in `make_uninstanceable` flag to `UsdFileCfg`. When enabled, instancing is disabled below the spawned prim immediately after variant selection and before any override runs, so the recursive overrides apply to the descendants as intended. It defaults to `False` because making descendants editable increases stage memory, so users only pay for it when an override needs it. The `make_uninstanceable` helper it calls already exists in `isaaclab.sim.utils`.

One incidental change: the new branch takes `_spawn_from_usd_file` one point over the repo `C901` complexity limit (31 > 30), so the adjacent material-path `if/else` is collapsed into an equivalent ternary to stay within budget. No behavior change there.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Screenshots

None.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there