### PR TITLE
Add lightweight performance smoke comparisons

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -914,16 +914,19 @@ jobs:
           -e ISAAC_SIM_HEADLESS=1 \
           -v "$PWD/benchmark-output:/benchmark-output" \
           --entrypoint bash "$CI_IMAGE_TAG" -lc \
-          "./isaaclab.sh benchmark runtime \
+          "set -euo pipefail
+          mkdir -p /tmp/benchmark-output
+          ./isaaclab.sh benchmark runtime \
             --task '$BENCHMARK_TASK' \
             --num_envs '$NUM_ENVS' \
             --num_steps 200 \
             --warmup_steps 100 \
             --seed 42 \
             --benchmark_formatter schema \
-            --output_path /benchmark-output \
+            --output_path /tmp/benchmark-output \
             --visualizer none \
-            $BENCHMARK_ARGS"
+            $BENCHMARK_ARGS
+          cp /tmp/benchmark-output/*.json /benchmark-output/"
     - name: Download authoritative baseline
       if: vars.PERF_BASELINE_S3_URI != ''
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -835,6 +835,141 @@ jobs:
         container-name: "isaac-lab-rendering-correctness-kitless-${{ matrix.variant }}-test"
         omni-github-test-type: "rendering-correctness-kitless-${{ matrix.variant }}"
 
+  performance-smoke:
+    name: "performance-smoke (${{ matrix.name }})"
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    needs: [build, config]
+    if: >-
+      github.event_name != 'push' &&
+      needs.build.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: cartpole-physx
+          task: Isaac-Cartpole-Direct
+          num_envs: 4096
+          timeout_minutes: 10
+          args: ""
+        - name: cartpole-newton
+          task: Isaac-Cartpole-Direct
+          num_envs: 4096
+          timeout_minutes: 10
+          args: physics=newton_mjwarp
+        - name: gear-mesh-physx
+          task: IsaacContrib-Factory-GearMesh-Direct
+          num_envs: 512
+          timeout_minutes: 15
+          args: ""
+        - name: shadow-camera-physx-rtx
+          task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
+          num_envs: 512
+          timeout_minutes: 20
+          args: renderer=isaacsim_rtx
+        - name: shadow-camera-physx-newton-renderer
+          task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
+          num_envs: 512
+          timeout_minutes: 20
+          args: renderer=newton_renderer
+        - name: shadow-camera-newton-rtx
+          task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
+          num_envs: 512
+          timeout_minutes: 20
+          args: physics=newton_mjwarp renderer=isaacsim_rtx
+        - name: shadow-camera-newton-renderer
+          task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
+          num_envs: 512
+          timeout_minutes: 20
+          args: physics=newton_mjwarp renderer=newton_renderer
+        - name: g1-physx
+          task: Isaac-Velocity-Flat-G1
+          num_envs: 512
+          timeout_minutes: 12
+          args: ""
+        - name: g1-newton
+          task: Isaac-Velocity-Flat-G1
+          num_envs: 512
+          timeout_minutes: 12
+          args: physics=newton_mjwarp
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+    - name: Pull pull-request image
+      uses: ./.github/actions/ecr-build-push-pull
+      with:
+        image-tag: ${{ needs.config.outputs.ci_image_tag }}
+        isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+        isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+        dockerfile-path: docker/Dockerfile.base
+        cache-tag: cache-base
+    - name: Run runtime benchmark
+      env:
+        BENCHMARK_ARGS: ${{ matrix.args }}
+        BENCHMARK_TASK: ${{ matrix.task }}
+        CI_IMAGE_TAG: ${{ needs.config.outputs.ci_image_tag }}
+        NUM_ENVS: ${{ matrix.num_envs }}
+      run: |
+        set -euo pipefail
+        install -d -m 0777 benchmark-output
+        docker run --rm --gpus all --network=host --ipc=host \
+          -e OMNI_KIT_ACCEPT_EULA=yes \
+          -e ACCEPT_EULA=Y \
+          -e ISAAC_SIM_HEADLESS=1 \
+          -v "$PWD/benchmark-output:/benchmark-output" \
+          --entrypoint bash "$CI_IMAGE_TAG" -lc \
+          "./isaaclab.sh benchmark runtime \
+            --task '$BENCHMARK_TASK' \
+            --num_envs '$NUM_ENVS' \
+            --num_steps 200 \
+            --warmup_steps 100 \
+            --seed 42 \
+            --benchmark_formatter schema \
+            --output_path /benchmark-output \
+            --visualizer none \
+            $BENCHMARK_ARGS"
+    - name: Download authoritative baseline
+      if: vars.PERF_BASELINE_S3_URI != ''
+      env:
+        PERF_BASELINE_S3_URI: ${{ vars.PERF_BASELINE_S3_URI }}
+      run: aws s3 cp "$PERF_BASELINE_S3_URI" "$RUNNER_TEMP/performance-baseline.json"
+    - name: Compare with baseline
+      env:
+        BASELINE_CONFIGURED: ${{ vars.PERF_BASELINE_S3_URI != '' }}
+      run: |
+        set -euo pipefail
+        mapfile -t results < <(find benchmark-output -maxdepth 1 -type f -name 'benchmark_runtime_*.json')
+        if [ "${#results[@]}" -ne 1 ]; then
+          echo "Expected one runtime benchmark JSON, found ${#results[@]}"
+          exit 1
+        fi
+
+        baseline_args=()
+        if [ "$BASELINE_CONFIGURED" = "true" ]; then
+          baseline_args=(--baseline "$RUNNER_TEMP/performance-baseline.json")
+        fi
+
+        set +e
+        python3 tools/performance_compare.py \
+          --benchmark_result "${results[0]}" \
+          "${baseline_args[@]}" \
+          --markdown benchmark-output/comparison.md \
+          --output_json benchmark-output/comparison.json \
+          --junit benchmark-output/comparison.xml
+        status=$?
+        set -e
+        cat benchmark-output/comparison.md >> "$GITHUB_STEP_SUMMARY"
+        exit "$status"
+    - name: Upload performance results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: performance-smoke-${{ matrix.name }}-${{ github.run_id }}
+        path: benchmark-output/
+        if-no-files-found: warn
+        retention-days: 7
+
   # Publishes the shared Warp kernel cache the test jobs restore. Needed as its
   # own job because a cache written from a PR is readable only by that PR, and
   # no solver-heavy test job runs on push. Does not restore before saving:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -949,17 +949,11 @@ jobs:
           baseline_args=(--baseline "$RUNNER_TEMP/performance-baseline.json")
         fi
 
-        set +e
         python3 tools/performance_compare.py \
           --benchmark_result "${results[0]}" \
           "${baseline_args[@]}" \
-          --markdown benchmark-output/comparison.md \
           --output_json benchmark-output/comparison.json \
-          --junit benchmark-output/comparison.xml
-        status=$?
-        set -e
-        cat benchmark-output/comparison.md >> "$GITHUB_STEP_SUMMARY"
-        exit "$status"
+          | tee -a "$GITHUB_STEP_SUMMARY"
     - name: Upload performance results
       if: always()
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -872,11 +872,6 @@ jobs:
           num_envs: 512
           timeout_minutes: 20
           args: renderer=newton_renderer
-        - name: shadow-camera-newton-rtx
-          task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
-          num_envs: 512
-          timeout_minutes: 20
-          args: physics=newton_mjwarp renderer=isaacsim_rtx
         - name: shadow-camera-newton-renderer
           task: Isaac-Reorient-Cube-Shadow-Camera-Benchmark-Direct
           num_envs: 512

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -908,11 +908,12 @@ jobs:
       run: |
         set -euo pipefail
         install -d -m 0777 benchmark-output
-        docker run --rm --gpus all --network=host --ipc=host \
+        container_name="performance-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.name }}"
+        trap 'docker rm -f "$container_name" >/dev/null 2>&1 || true' EXIT
+        docker run --name "$container_name" --gpus all --network=host --ipc=host \
           -e OMNI_KIT_ACCEPT_EULA=yes \
           -e ACCEPT_EULA=Y \
           -e ISAAC_SIM_HEADLESS=1 \
-          -v "$PWD/benchmark-output:/benchmark-output" \
           --entrypoint bash "$CI_IMAGE_TAG" -lc \
           "set -euo pipefail
           mkdir -p /tmp/benchmark-output
@@ -925,8 +926,8 @@ jobs:
             --benchmark_formatter schema \
             --output_path /tmp/benchmark-output \
             --visualizer none \
-            $BENCHMARK_ARGS
-          cp /tmp/benchmark-output/*.json /benchmark-output/"
+            $BENCHMARK_ARGS"
+        docker cp "$container_name:/tmp/benchmark-output/." benchmark-output/
     - name: Download authoritative baseline
       if: vars.PERF_BASELINE_S3_URI != ''
       env:

--- a/source/isaaclab/changelog.d/antoiner-perf-smoke-s3.rst
+++ b/source/isaaclab/changelog.d/antoiner-perf-smoke-s3.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added an opt-in aggregate-throughput mode to runtime benchmarks.

--- a/source/isaaclab/isaaclab/benchmark/api.py
+++ b/source/isaaclab/isaaclab/benchmark/api.py
@@ -92,6 +92,9 @@ class BenchmarkRuntimeRequest:
         hydra_args: Additional Hydra overrides.
         output: Output configuration.
         launcher: Simulation launcher configuration.
+        aggregate_throughput: Whether to report throughput as total completed steps
+            divided by total measured wall time instead of the arithmetic mean of
+            per-step throughput.
     """
 
     task: str
@@ -104,6 +107,7 @@ class BenchmarkRuntimeRequest:
     hydra_args: tuple[str, ...] = field(default_factory=tuple)
     output: BenchmarkOutputConfig = field(default_factory=BenchmarkOutputConfig)
     launcher: BenchmarkLauncherConfig = field(default_factory=BenchmarkLauncherConfig)
+    aggregate_throughput: bool = False
 
     @property
     def workflow(self) -> Literal["runtime"]:

--- a/source/isaaclab/isaaclab/benchmark/dispatch.py
+++ b/source/isaaclab/isaaclab/benchmark/dispatch.py
@@ -131,6 +131,8 @@ def _request_argv(request: BenchmarkRequest) -> list[str]:
     if request.workflow == "runtime":
         _append_value(argv, "--num_steps", request.num_steps)
         _append_value(argv, "--warmup_steps", request.warmup_steps)
+        if request.aggregate_throughput:
+            argv.append("--aggregate_throughput")
     elif request.workflow == "startup":
         _append_value(argv, "--top_n", request.top_n)
         _append_value(argv, "--whitelist_config", request.whitelist_config)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
@@ -62,6 +62,11 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         action="store_true",
         help="Measure a serialized synchronized simulation and outside-simulation step breakdown.",
     )
+    parser.add_argument(
+        "--aggregate_throughput",
+        action="store_true",
+        help="Report total steps divided by total measured time instead of mean per-step throughput.",
+    )
     parser.add_argument("--seed", type=int, default=None, help="Environment seed.")
     parser.add_argument("--output_path", type=str, default=".", help="Directory to write the output JSON.")
     parser.add_argument(
@@ -156,6 +161,10 @@ def run(argv: list[str]) -> BenchmarkResult:
                         "name": "environment_step_measurement_mode",
                         "data": ("serialized_synchronized" if args.measure_sync_step else "host_return"),
                     },
+                    {
+                        "name": "throughput_aggregation",
+                        "data": "aggregate" if args.aggregate_throughput else "per_step_mean",
+                    },
                     {"name": "presets", "data": ",".join(cfg.presets)},
                 ]
             },
@@ -195,7 +204,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 steps_per_iteration=num_envs,
                 frames_per_environment_step=env.unwrapped.num_envs,
                 environment_step_warmup_steps=args.warmup_steps,
-                aggregate_throughput=True,
+                aggregate_throughput=args.aggregate_throughput,
                 environment_step_times_s=environment_step_timer.step_times_s,
                 simulation_step_times_s=environment_step_timer.simulation_step_times_s,
                 simulation_step_calls=environment_step_timer.simulation_step_calls,

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -27,7 +27,7 @@ from isaaclab.benchmark import (
     TrainingBundle,
     dispatch,
 )
-from isaaclab.benchmark.entrypoints import startup
+from isaaclab.benchmark.entrypoints import runtime, startup
 from isaaclab.benchmark.entrypoints.backends.rl_games.registry import register_scoped_rl_games_environment
 
 
@@ -128,6 +128,20 @@ def test_runtime_request_uses_runtime_defaults() -> None:
         "--benchmark_formatter",
         "schema",
     ]
+
+
+def test_runtime_throughput_aggregation_is_opt_in(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["isaaclab", "benchmark", "runtime"])
+
+    default_args, _ = runtime._parse_args(["--task", "Isaac-Cartpole-Direct"])
+    aggregate_args, _ = runtime._parse_args(["--task", "Isaac-Cartpole-Direct", "--aggregate_throughput"])
+    request_args = dispatch._request_argv(
+        BenchmarkRuntimeRequest(task="Isaac-Cartpole-Direct", aggregate_throughput=True)
+    )
+
+    assert default_args.aggregate_throughput is False
+    assert aggregate_args.aggregate_throughput is True
+    assert "--aggregate_throughput" in request_args
 
 
 @pytest.mark.parametrize("backend", ["rsl_rl", "rl_games", "skrl", "sb3"])

--- a/tools/performance_compare.py
+++ b/tools/performance_compare.py
@@ -145,23 +145,20 @@ def _metric_value(data: dict[str, Any], name: str, paths: tuple[tuple[str, ...],
 
 def _fps_statistics(
     bundle: dict[str, Any], measured_fps: float, expected_steps_per_iteration: int
-) -> tuple[float, float, int, int]:
+) -> tuple[float, float, int]:
     if measured_fps <= 0:
         raise ComparisonError("Measured total_fps must be greater than zero")
     runtime = _mapping(bundle.get("runtime"), "runtime")
-    mean = _nested_number(bundle, ("runtime", "iteration_time_s", "mean"))
-    std = _nested_number(bundle, ("runtime", "iteration_time_s", "std"))
-    if mean is None or std is None:
-        raise ComparisonError("Benchmark result does not contain iteration-time statistics for total_fps")
-    if mean <= 0 or std < 0:
-        raise ComparisonError("Iteration-time mean must be positive and standard deviation non-negative")
+    std = _nested_number(bundle, ("runtime", "total_fps", "std"))
+    if std is None:
+        raise ComparisonError("Benchmark result does not contain throughput statistics for total_fps")
+    if std < 0:
+        raise ComparisonError("Throughput standard deviation must be non-negative")
     samples = _sample_count(runtime.get("iterations_completed"), "measured total_fps sample count")
     steps = _positive_int(runtime.get("steps_per_iteration"), "runtime.steps_per_iteration")
     if steps != expected_steps_per_iteration:
         raise ComparisonError("runtime.steps_per_iteration must match run.num_envs")
-    if not math.isclose(mean, steps / measured_fps, rel_tol=1e-6):
-        raise ComparisonError("total_fps.mean and iteration_time_s.mean describe different aggregates")
-    return mean, std, samples, steps
+    return measured_fps, std, samples
 
 
 def _normalize_gpu_model(value: str) -> str:
@@ -248,7 +245,6 @@ def _metric_result(
     require_significance: bool = False,
     significance_measured: float | None = None,
     significance_measured_std: float | None = None,
-    significance_scale: int | None = None,
 ) -> MetricResult:
     config = _mapping(config, f"metrics.{name}")
     if measured is None:
@@ -277,21 +273,17 @@ def _metric_result(
             raise ComparisonError(f"Benchmark result does not contain a measured sample count for {name}")
         measured_samples = _sample_count(measured_samples, f"measured {name} sample count")
         reference_samples = _sample_count(config.get("reference_samples"), f"metrics.{name}.reference_samples")
-        if significance_measured is None or significance_measured_std is None or significance_scale is None:
-            raise ComparisonError(f"Benchmark result does not contain iteration-time statistics for {name}")
-        significance_metric = "iteration_time_s"
-        significance_measured = _number(significance_measured, "runtime.iteration_time_s.mean")
-        significance_measured_std = _number(significance_measured_std, "runtime.iteration_time_s.std")
-        significance_reference = _number(
-            significance_scale / reference, f"derived metrics.{name}.reference_iteration_time_s"
-        )
-        significance_reference_std = _number(
-            config.get("reference_iteration_time_std_s"), f"metrics.{name}.reference_iteration_time_std_s"
-        )
+        if significance_measured is None or significance_measured_std is None:
+            raise ComparisonError(f"Benchmark result does not contain throughput statistics for {name}")
+        significance_metric = name
+        significance_measured = _number(significance_measured, "runtime.total_fps.mean")
+        significance_measured_std = _number(significance_measured_std, "runtime.total_fps.std")
+        significance_reference = reference
+        significance_reference_std = _number(config.get("reference_std"), f"metrics.{name}.reference_std")
         if significance_measured <= 0 or significance_reference <= 0:
-            raise ComparisonError("iteration-time means must be greater than zero")
+            raise ComparisonError("throughput means must be greater than zero")
         if significance_measured_std < 0 or significance_reference_std < 0:
-            raise ComparisonError("iteration-time standard deviations must be non-negative")
+            raise ComparisonError("throughput standard deviations must be non-negative")
         standard_error = _number(
             math.hypot(
                 significance_measured_std / math.sqrt(measured_samples),
@@ -353,9 +345,7 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
     if missing_metrics:
         raise ComparisonError(f"The matching baseline row is missing required metrics: {', '.join(missing_metrics)}")
     values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
-    iteration_time_mean, iteration_time_std, fps_samples, steps_per_iteration = _fps_statistics(
-        bundle, values["total_fps"], identity["num_envs"]
-    )
+    fps_mean, fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
 
     metrics = tuple(
         _metric_result(
@@ -365,9 +355,8 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
             higher_is_worse=higher_is_worse,
             measured_samples=fps_samples if name == "total_fps" else None,
             require_significance=name == "total_fps",
-            significance_measured=iteration_time_mean if name == "total_fps" else None,
-            significance_measured_std=iteration_time_std if name == "total_fps" else None,
-            significance_scale=steps_per_iteration if name == "total_fps" else None,
+            significance_measured=fps_mean if name == "total_fps" else None,
+            significance_measured_std=fps_std if name == "total_fps" else None,
         )
         for name, _, paths, higher_is_worse in _METRICS
     )
@@ -382,9 +371,7 @@ def skipped_report(runtime_bundle: dict[str, object], reason: str) -> Comparison
     bundle = _mapping(runtime_bundle, "benchmark result")
     identity = _identity(bundle)
     values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
-    iteration_time_mean, iteration_time_std, fps_samples, _ = _fps_statistics(
-        bundle, values["total_fps"], identity["num_envs"]
-    )
+    fps_mean, fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
     metrics = tuple(
         MetricResult(
             name,
@@ -396,9 +383,9 @@ def skipped_report(runtime_bundle: dict[str, object], reason: str) -> Comparison
             "SKIP",
             reason,
             measured_samples=fps_samples if name == "total_fps" else None,
-            significance_metric="iteration_time_s" if name == "total_fps" else None,
-            significance_measured=iteration_time_mean if name == "total_fps" else None,
-            significance_measured_std=iteration_time_std if name == "total_fps" else None,
+            significance_metric="total_fps" if name == "total_fps" else None,
+            significance_measured=fps_mean if name == "total_fps" else None,
+            significance_measured_std=fps_std if name == "total_fps" else None,
         )
         for name, _, paths, _ in _METRICS
     )
@@ -424,7 +411,7 @@ def write_outputs(
         "",
         report.message,
         "",
-        "| Metric | Measured | Reference | Regression | Measured timing std [s] | Reference timing std [s] | "
+        "| Metric | Measured | Reference | Regression | Measured FPS std | Reference FPS std | "
         "Significance | Warn | Fail | Verdict |",
         "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]

--- a/tools/performance_compare.py
+++ b/tools/performance_compare.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Compare an Isaac Lab runtime benchmark with an authoritative baseline row."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ComparisonError(ValueError):
+    """Raised when benchmark or baseline input cannot produce one comparison."""
+
+
+@dataclass(frozen=True)
+class MetricResult:
+    """Result for one compared performance metric."""
+
+    name: str
+    measured: float | None
+    reference: float | None
+    regression_pct: float | None
+    verdict: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ComparisonReport:
+    """Complete performance comparison report."""
+
+    identity: dict[str, object]
+    metrics: tuple[MetricResult, ...]
+    verdict: str
+    message: str
+
+
+_METRICS = (
+    ("total_fps", "Total FPS", ("runtime", "total_fps", "mean"), False),
+    ("gpu_mem_peak_gb", "Peak GPU memory [GB]", ("resources", "gpu_mem_gb", "peak"), True),
+    ("ram_peak_gb", "Peak process RSS [GB]", ("resources", "ram_gb", "peak"), True),
+)
+_LABELS = {name: label for name, label, _, _ in _METRICS}
+
+
+def _mapping(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ComparisonError(f"{name} must be an object")
+    return value
+
+
+def _number(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ComparisonError(f"{name} must be a number")
+    return float(value)
+
+
+def _nested_number(data: dict[str, Any], path: tuple[str, ...]) -> float | None:
+    value: Any = data
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    return _number(value, ".".join(path))
+
+
+def _normalize_gpu_model(value: str) -> str:
+    value = re.sub(r"^nvidia\s+", "", value.strip(), flags=re.IGNORECASE)
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _identity(bundle: dict[str, Any]) -> dict[str, object]:
+    run = _mapping(bundle.get("run"), "run")
+    config = _mapping(run.get("config"), "run.config")
+    versions = _mapping(bundle.get("versions"), "versions")
+    hardware = _mapping(bundle.get("hardware"), "hardware")
+    gpu_devices = hardware.get("gpu_devices")
+    if not isinstance(gpu_devices, list) or not gpu_devices:
+        raise ComparisonError("hardware.gpu_devices must contain at least one device")
+    gpu = _mapping(gpu_devices[0], "hardware.gpu_devices[0]")
+    gpu_name = gpu.get("name")
+    presets = config.get("presets", [])
+    if not isinstance(gpu_name, str) or not gpu_name.strip():
+        raise ComparisonError("hardware.gpu_devices[0].name must be a non-empty string")
+    if not isinstance(presets, list) or not all(isinstance(item, str) for item in presets):
+        raise ComparisonError("run.config.presets must be a list of strings")
+
+    identity = {
+        "task": run.get("task"),
+        "physics_backend": config.get("physics_backend"),
+        "rendering_backend": config.get("rendering_backend"),
+        "presets": sorted(presets),
+        "gpu_model": _normalize_gpu_model(gpu_name),
+        "isaacsim_version": versions.get("isaacsim"),
+        "num_envs": run.get("num_envs"),
+    }
+    for key in ("task", "physics_backend", "rendering_backend", "isaacsim_version"):
+        if not isinstance(identity[key], str) or not identity[key]:
+            raise ComparisonError(f"benchmark identity field {key!r} must be a non-empty string")
+    if isinstance(identity["num_envs"], bool) or not isinstance(identity["num_envs"], int):
+        raise ComparisonError("benchmark identity field 'num_envs' must be an integer")
+    return identity
+
+
+def _matching_row(table: dict[str, Any], identity: dict[str, object]) -> dict[str, Any]:
+    if table.get("schema_version") != 1:
+        raise ComparisonError("Baseline schema_version must be 1")
+    rows = table.get("baselines")
+    if not isinstance(rows, list):
+        raise ComparisonError("baselines must be a list")
+
+    matches: list[dict[str, Any]] = []
+    for index, value in enumerate(rows):
+        row = _mapping(value, f"baselines[{index}]")
+        row_presets = row.get("presets", [])
+        if not isinstance(row_presets, list) or not all(isinstance(item, str) for item in row_presets):
+            raise ComparisonError(f"baselines[{index}].presets must be a list of strings")
+        row_identity = {key: row.get(key) for key in identity}
+        row_identity["presets"] = sorted(row_presets)
+        if isinstance(row_identity.get("gpu_model"), str):
+            row_identity["gpu_model"] = _normalize_gpu_model(row_identity["gpu_model"])
+        if row_identity == identity:
+            matches.append(row)
+
+    if not matches:
+        raise ComparisonError(f"No baseline row matches {json.dumps(identity, sort_keys=True)}")
+    if len(matches) > 1:
+        raise ComparisonError(f"Multiple baseline rows match {json.dumps(identity, sort_keys=True)}")
+    return matches[0]
+
+
+def _metric_result(
+    name: str,
+    measured: float | None,
+    config: Any,
+    *,
+    higher_is_worse: bool,
+) -> MetricResult:
+    if config is None:
+        return MetricResult(name, measured, None, None, "SKIP", "Metric is not configured in the baseline")
+    config = _mapping(config, f"metrics.{name}")
+    if measured is None:
+        raise ComparisonError(f"Benchmark result does not contain a measured value for {name}")
+
+    reference = _number(config.get("reference"), f"metrics.{name}.reference")
+    warn = _number(config.get("warn_regression_pct"), f"metrics.{name}.warn_regression_pct")
+    fail = _number(config.get("fail_regression_pct"), f"metrics.{name}.fail_regression_pct")
+    if reference <= 0:
+        raise ComparisonError(f"metrics.{name}.reference must be greater than zero")
+    if warn < 0 or fail < 0:
+        raise ComparisonError(f"metrics.{name} thresholds must be non-negative")
+    if fail < warn:
+        raise ComparisonError(f"metrics.{name}.fail_regression_pct must be greater than or equal to warning")
+
+    change = (measured - reference) / reference * 100.0
+    regression = change if higher_is_worse else -change
+    if regression >= fail:
+        verdict = "FAIL"
+    elif regression >= warn:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+    message = f"Measured {measured:g} versus {reference:g} ({regression:+.2f}% regression)"
+    return MetricResult(name, measured, reference, regression, verdict, message)
+
+
+def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]) -> ComparisonReport:
+    """Compare one runtime benchmark bundle with its exact baseline row."""
+    bundle = _mapping(runtime_bundle, "benchmark result")
+    table = _mapping(baseline_table, "baseline table")
+    identity = _identity(bundle)
+    row = _matching_row(table, identity)
+    metric_configs = _mapping(row.get("metrics"), "baseline metrics")
+    if not any(name in metric_configs for name, _, _, _ in _METRICS):
+        raise ComparisonError("The matching baseline row configures no supported metrics")
+
+    metrics = tuple(
+        _metric_result(
+            name,
+            _nested_number(bundle, path),
+            metric_configs.get(name),
+            higher_is_worse=higher_is_worse,
+        )
+        for name, _, path, higher_is_worse in _METRICS
+    )
+    verdict = "FAIL" if any(item.verdict == "FAIL" for item in metrics) else "WARN"
+    if verdict == "WARN" and not any(item.verdict == "WARN" for item in metrics):
+        verdict = "PASS"
+    return ComparisonReport(identity, metrics, verdict, f"Performance comparison {verdict.lower()}")
+
+
+def skipped_report(runtime_bundle: dict[str, object], reason: str) -> ComparisonReport:
+    """Build a report that records unavailable baseline configuration."""
+    bundle = _mapping(runtime_bundle, "benchmark result")
+    metrics = tuple(
+        MetricResult(name, _nested_number(bundle, path), None, None, "SKIP", reason) for name, _, path, _ in _METRICS
+    )
+    return ComparisonReport(_identity(bundle), metrics, "SKIP", reason)
+
+
+def _format_value(value: float | None) -> str:
+    return "-" if value is None else f"{value:.6g}"
+
+
+def write_outputs(
+    report: ComparisonReport,
+    markdown_path: Path,
+    json_path: Path,
+    junit_path: Path,
+) -> None:
+    """Write Markdown, JSON, and JUnit representations of a comparison report."""
+    for path in (markdown_path, json_path, junit_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = [
+        f"## Performance comparison: {report.verdict}",
+        "",
+        report.message,
+        "",
+        "| Metric | Measured | Reference | Regression | Verdict |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for metric in report.metrics:
+        regression = "-" if metric.regression_pct is None else f"{metric.regression_pct:+.2f}%"
+        lines.append(
+            f"| {_LABELS.get(metric.name, metric.name)} | {_format_value(metric.measured)} | "
+            f"{_format_value(metric.reference)} | {regression} | {metric.verdict} |"
+        )
+    markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    json_path.write_text(json.dumps(asdict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    test_metrics = report.metrics or (MetricResult("comparison", None, None, None, report.verdict, report.message),)
+    failures = sum(metric.verdict in {"FAIL", "ERROR"} for metric in test_metrics)
+    skipped = sum(metric.verdict == "SKIP" for metric in test_metrics)
+    suite = ET.Element(
+        "testsuite",
+        name="performance-comparison",
+        tests=str(len(test_metrics)),
+        failures=str(failures),
+        skipped=str(skipped),
+    )
+    for metric in test_metrics:
+        case = ET.SubElement(suite, "testcase", name=metric.name, classname="performance-comparison")
+        if metric.verdict in {"FAIL", "ERROR"}:
+            ET.SubElement(case, "failure", message=metric.message).text = metric.message
+        elif metric.verdict == "SKIP":
+            ET.SubElement(case, "skipped", message=metric.message)
+        ET.SubElement(case, "system-out").text = metric.message
+    ET.ElementTree(suite).write(junit_path, encoding="unicode", xml_declaration=True)
+
+
+def _error_report(message: str) -> ComparisonReport:
+    metric = MetricResult("comparison", None, None, None, "ERROR", message)
+    return ComparisonReport({}, (metric,), "ERROR", message)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--benchmark_result", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--markdown", type=Path, required=True)
+    parser.add_argument("--output_json", type=Path, required=True)
+    parser.add_argument("--junit", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the performance comparison CLI."""
+    args = _parser().parse_args(argv)
+    try:
+        bundle = json.loads(args.benchmark_result.read_text(encoding="utf-8"))
+        if args.baseline is None:
+            report = skipped_report(bundle, "PERF_BASELINE_S3_URI is not configured")
+        else:
+            table = json.loads(args.baseline.read_text(encoding="utf-8"))
+            report = compare(bundle, table)
+    except (ComparisonError, json.JSONDecodeError, OSError, TypeError) as exc:
+        report = _error_report(str(exc))
+
+    write_outputs(report, args.markdown, args.output_json, args.junit)
+    print(args.markdown.read_text(encoding="utf-8"), end="")
+    return int(report.verdict in {"FAIL", "ERROR"})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/performance_compare.py
+++ b/tools/performance_compare.py
@@ -11,7 +11,6 @@ import argparse
 import json
 import math
 import re
-import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -32,14 +31,10 @@ class MetricResult:
     warn_regression_pct: float | None
     fail_regression_pct: float | None
     verdict: str
-    message: str
     measured_samples: int | None = None
     reference_samples: int | None = None
-    significance_metric: str | None = None
-    significance_measured: float | None = None
-    significance_reference: float | None = None
-    significance_measured_std: float | None = None
-    significance_reference_std: float | None = None
+    measured_std: float | None = None
+    reference_std: float | None = None
     significance_sigma: float | None = None
     statistically_significant: bool | None = None
 
@@ -55,21 +50,10 @@ class ComparisonReport:
 
 
 _METRICS = (
-    ("total_fps", "Total FPS", (("runtime", "total_fps", "mean"),), False),
-    (
-        "startup_time_s",
-        "Total startup time [s]",
-        (
-            ("runtime", "startup_time_s", "app_launch"),
-            ("runtime", "startup_time_s", "python_imports"),
-            ("runtime", "startup_time_s", "task_config"),
-            ("runtime", "startup_time_s", "env_creation"),
-            ("runtime", "startup_time_s", "first_step"),
-        ),
-        True,
-    ),
-    ("gpu_mem_peak_gb", "Peak GPU memory [GB]", (("resources", "gpu_mem_gb", "peak"),), True),
-    ("ram_peak_gb", "Peak process RSS [GB]", (("resources", "ram_gb", "peak"),), True),
+    ("total_fps", "Total FPS", ("runtime", "total_fps", "mean"), False),
+    ("startup_time_s", "Total startup time [s]", None, True),
+    ("gpu_mem_peak_gb", "Peak GPU memory [GB]", ("resources", "gpu_mem_gb", "peak"), True),
+    ("ram_peak_gb", "Peak process RSS [GB]", ("resources", "ram_gb", "peak"), True),
 )
 _LABELS = {name: label for name, label, _, _ in _METRICS}
 _MIN_SIGNIFICANCE_SIGMA = 2.0
@@ -131,11 +115,10 @@ def _startup_time(data: dict[str, Any]) -> float | None:
     return _number(sum(values), "total startup time")
 
 
-def _metric_value(data: dict[str, Any], name: str, paths: tuple[tuple[str, ...], ...]) -> float:
-    if name == "startup_time_s":
+def _metric_value(data: dict[str, Any], name: str, path: tuple[str, ...] | None) -> float:
+    if path is None:
         return _startup_time(data)
-    values = [_nested_number(data, path) for path in paths]
-    value = values[0] if len(values) == 1 else sum(item for item in values if item is not None)
+    value = _nested_number(data, path)
     if value is None:
         raise ComparisonError(f"Benchmark result does not contain a measured value for {name}")
     if value < 0:
@@ -145,7 +128,7 @@ def _metric_value(data: dict[str, Any], name: str, paths: tuple[tuple[str, ...],
 
 def _fps_statistics(
     bundle: dict[str, Any], measured_fps: float, expected_steps_per_iteration: int
-) -> tuple[float, float, int]:
+) -> tuple[float, int]:
     if measured_fps <= 0:
         raise ComparisonError("Measured total_fps must be greater than zero")
     runtime = _mapping(bundle.get("runtime"), "runtime")
@@ -158,7 +141,7 @@ def _fps_statistics(
     steps = _positive_int(runtime.get("steps_per_iteration"), "runtime.steps_per_iteration")
     if steps != expected_steps_per_iteration:
         raise ComparisonError("runtime.steps_per_iteration must match run.num_envs")
-    return measured_fps, std, samples
+    return std, samples
 
 
 def _normalize_gpu_model(value: str) -> str:
@@ -243,8 +226,7 @@ def _metric_result(
     higher_is_worse: bool,
     measured_samples: Any = None,
     require_significance: bool = False,
-    significance_measured: float | None = None,
-    significance_measured_std: float | None = None,
+    measured_std: float | None = None,
 ) -> MetricResult:
     config = _mapping(config, f"metrics.{name}")
     if measured is None:
@@ -263,9 +245,7 @@ def _metric_result(
     change = _number((measured - reference) / reference * 100.0, f"derived {name} percentage change")
     regression = change if higher_is_worse else -change
     reference_samples: int | None = None
-    significance_metric: str | None = None
-    significance_reference: float | None = None
-    significance_reference_std: float | None = None
+    reference_std: float | None = None
     significance_sigma: float | None = None
     statistically_significant: bool | None = None
     if require_significance:
@@ -273,27 +253,22 @@ def _metric_result(
             raise ComparisonError(f"Benchmark result does not contain a measured sample count for {name}")
         measured_samples = _sample_count(measured_samples, f"measured {name} sample count")
         reference_samples = _sample_count(config.get("reference_samples"), f"metrics.{name}.reference_samples")
-        if significance_measured is None or significance_measured_std is None:
+        if measured_std is None:
             raise ComparisonError(f"Benchmark result does not contain throughput statistics for {name}")
-        significance_metric = name
-        significance_measured = _number(significance_measured, "runtime.total_fps.mean")
-        significance_measured_std = _number(significance_measured_std, "runtime.total_fps.std")
-        significance_reference = reference
-        significance_reference_std = _number(config.get("reference_std"), f"metrics.{name}.reference_std")
-        if significance_measured <= 0 or significance_reference <= 0:
+        measured_std = _number(measured_std, "runtime.total_fps.std")
+        reference_std = _number(config.get("reference_std"), f"metrics.{name}.reference_std")
+        if measured <= 0:
             raise ComparisonError("throughput means must be greater than zero")
-        if significance_measured_std < 0 or significance_reference_std < 0:
+        if measured_std < 0 or reference_std < 0:
             raise ComparisonError("throughput standard deviations must be non-negative")
         standard_error = _number(
             math.hypot(
-                significance_measured_std / math.sqrt(measured_samples),
-                significance_reference_std / math.sqrt(reference_samples),
+                measured_std / math.sqrt(measured_samples),
+                reference_std / math.sqrt(reference_samples),
             ),
             f"derived metrics.{name} standard error",
         )
-        difference = _number(
-            abs(significance_measured - significance_reference), f"derived metrics.{name} timing difference"
-        )
+        difference = _number(abs(measured - reference), f"derived metrics.{name} throughput difference")
         if standard_error == 0.0:
             statistically_significant = difference > 0.0
         else:
@@ -309,10 +284,6 @@ def _metric_result(
         verdict = "WARN"
     else:
         verdict = "PASS"
-    message = f"Measured {measured:g} versus {reference:g} ({regression:+.2f}% regression)"
-    if statistically_significant is not None:
-        sigma = "infinite" if significance_sigma is None else f"{significance_sigma:.2f}"
-        message += f", {sigma} sigma ({'significant' if statistically_significant else 'not significant'})"
     return MetricResult(
         name,
         measured,
@@ -321,14 +292,10 @@ def _metric_result(
         warn,
         fail,
         verdict,
-        message,
         measured_samples=measured_samples,
         reference_samples=reference_samples,
-        significance_metric=significance_metric,
-        significance_measured=significance_measured,
-        significance_reference=significance_reference,
-        significance_measured_std=significance_measured_std,
-        significance_reference_std=significance_reference_std,
+        measured_std=measured_std,
+        reference_std=reference_std,
         significance_sigma=significance_sigma,
         statistically_significant=statistically_significant,
     )
@@ -344,8 +311,8 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
     missing_metrics = [name for name, _, _, _ in _METRICS if name not in metric_configs]
     if missing_metrics:
         raise ComparisonError(f"The matching baseline row is missing required metrics: {', '.join(missing_metrics)}")
-    values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
-    fps_mean, fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
+    values = {name: _metric_value(bundle, name, path) for name, _, path, _ in _METRICS}
+    fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
 
     metrics = tuple(
         _metric_result(
@@ -355,10 +322,9 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
             higher_is_worse=higher_is_worse,
             measured_samples=fps_samples if name == "total_fps" else None,
             require_significance=name == "total_fps",
-            significance_measured=fps_mean if name == "total_fps" else None,
-            significance_measured_std=fps_std if name == "total_fps" else None,
+            measured_std=fps_std if name == "total_fps" else None,
         )
-        for name, _, paths, higher_is_worse in _METRICS
+        for name, _, path, higher_is_worse in _METRICS
     )
     verdict = "FAIL" if any(item.verdict == "FAIL" for item in metrics) else "WARN"
     if verdict == "WARN" and not any(item.verdict == "WARN" for item in metrics):
@@ -370,8 +336,8 @@ def skipped_report(runtime_bundle: dict[str, object], reason: str) -> Comparison
     """Build a report that records unavailable baseline configuration."""
     bundle = _mapping(runtime_bundle, "benchmark result")
     identity = _identity(bundle)
-    values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
-    fps_mean, fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
+    values = {name: _metric_value(bundle, name, path) for name, _, path, _ in _METRICS}
+    fps_std, fps_samples = _fps_statistics(bundle, values["total_fps"], identity["num_envs"])
     metrics = tuple(
         MetricResult(
             name,
@@ -381,13 +347,10 @@ def skipped_report(runtime_bundle: dict[str, object], reason: str) -> Comparison
             None,
             None,
             "SKIP",
-            reason,
             measured_samples=fps_samples if name == "total_fps" else None,
-            significance_metric="total_fps" if name == "total_fps" else None,
-            significance_measured=fps_mean if name == "total_fps" else None,
-            significance_measured_std=fps_std if name == "total_fps" else None,
+            measured_std=fps_std if name == "total_fps" else None,
         )
-        for name, _, paths, _ in _METRICS
+        for name, _, path, _ in _METRICS
     )
     return ComparisonReport(identity, metrics, "SKIP", reason)
 
@@ -396,15 +359,9 @@ def _format_value(value: float | None) -> str:
     return "-" if value is None else f"{value:.6g}"
 
 
-def write_outputs(
-    report: ComparisonReport,
-    markdown_path: Path,
-    json_path: Path,
-    junit_path: Path,
-) -> None:
-    """Write Markdown, JSON, and JUnit representations of a comparison report."""
-    for path in (markdown_path, json_path, junit_path):
-        path.parent.mkdir(parents=True, exist_ok=True)
+def write_output(report: ComparisonReport, json_path: Path) -> str:
+    """Write the JSON report and return its Markdown representation."""
+    json_path.parent.mkdir(parents=True, exist_ok=True)
 
     lines = [
         f"## Performance comparison: {report.verdict}",
@@ -425,40 +382,19 @@ def write_outputs(
             significance = "infinite" if metric.statistically_significant else "0.00 sigma"
         else:
             significance = f"{metric.significance_sigma:.2f} sigma"
-        measured_timing_std = _format_value(metric.significance_measured_std)
-        reference_timing_std = _format_value(metric.significance_reference_std)
+        measured_std = _format_value(metric.measured_std)
+        reference_std = _format_value(metric.reference_std)
         lines.append(
             f"| {_LABELS.get(metric.name, metric.name)} | {_format_value(metric.measured)} | "
-            f"{_format_value(metric.reference)} | {regression} | {measured_timing_std} | "
-            f"{reference_timing_std} | {significance} | {warn} | {fail} | {metric.verdict} |"
+            f"{_format_value(metric.reference)} | {regression} | {measured_std} | "
+            f"{reference_std} | {significance} | {warn} | {fail} | {metric.verdict} |"
         )
-    markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     json_path.write_text(json.dumps(asdict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    test_metrics = report.metrics or (
-        MetricResult("comparison", None, None, None, None, None, report.verdict, report.message),
-    )
-    failures = sum(metric.verdict in {"FAIL", "ERROR"} for metric in test_metrics)
-    skipped = sum(metric.verdict == "SKIP" for metric in test_metrics)
-    suite = ET.Element(
-        "testsuite",
-        name="performance-comparison",
-        tests=str(len(test_metrics)),
-        failures=str(failures),
-        skipped=str(skipped),
-    )
-    for metric in test_metrics:
-        case = ET.SubElement(suite, "testcase", name=metric.name, classname="performance-comparison")
-        if metric.verdict in {"FAIL", "ERROR"}:
-            ET.SubElement(case, "failure", message=metric.message).text = metric.message
-        elif metric.verdict == "SKIP":
-            ET.SubElement(case, "skipped", message=metric.message)
-        ET.SubElement(case, "system-out").text = metric.message
-    ET.ElementTree(suite).write(junit_path, encoding="unicode", xml_declaration=True)
+    return "\n".join(lines) + "\n"
 
 
 def _error_report(message: str) -> ComparisonReport:
-    metric = MetricResult("comparison", None, None, None, None, None, "ERROR", message)
+    metric = MetricResult("comparison", None, None, None, None, None, "ERROR")
     return ComparisonReport({}, (metric,), "ERROR", message)
 
 
@@ -466,9 +402,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--benchmark_result", type=Path, required=True)
     parser.add_argument("--baseline", type=Path)
-    parser.add_argument("--markdown", type=Path, required=True)
     parser.add_argument("--output_json", type=Path, required=True)
-    parser.add_argument("--junit", type=Path, required=True)
     return parser
 
 
@@ -485,8 +419,7 @@ def main(argv: list[str] | None = None) -> int:
     except (ComparisonError, json.JSONDecodeError, OSError, TypeError) as exc:
         report = _error_report(str(exc))
 
-    write_outputs(report, args.markdown, args.output_json, args.junit)
-    print(args.markdown.read_text(encoding="utf-8"), end="")
+    print(write_output(report, args.output_json), end="")
     return int(report.verdict in {"FAIL", "ERROR"})
 
 

--- a/tools/performance_compare.py
+++ b/tools/performance_compare.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
@@ -28,6 +29,8 @@ class MetricResult:
     measured: float | None
     reference: float | None
     regression_pct: float | None
+    warn_regression_pct: float | None
+    fail_regression_pct: float | None
     verdict: str
     message: str
 
@@ -59,7 +62,13 @@ def _mapping(value: Any, name: str) -> dict[str, Any]:
 def _number(value: Any, name: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ComparisonError(f"{name} must be a number")
-    return float(value)
+    try:
+        number = float(value)
+    except OverflowError:
+        raise ComparisonError(f"{name} must be finite") from None
+    if not math.isfinite(number):
+        raise ComparisonError(f"{name} must be finite")
+    return number
 
 
 def _nested_number(data: dict[str, Any], path: tuple[str, ...]) -> float | None:
@@ -139,12 +148,10 @@ def _matching_row(table: dict[str, Any], identity: dict[str, object]) -> dict[st
 def _metric_result(
     name: str,
     measured: float | None,
-    config: Any,
+    config: dict[str, Any],
     *,
     higher_is_worse: bool,
 ) -> MetricResult:
-    if config is None:
-        return MetricResult(name, measured, None, None, "SKIP", "Metric is not configured in the baseline")
     config = _mapping(config, f"metrics.{name}")
     if measured is None:
         raise ComparisonError(f"Benchmark result does not contain a measured value for {name}")
@@ -168,7 +175,7 @@ def _metric_result(
     else:
         verdict = "PASS"
     message = f"Measured {measured:g} versus {reference:g} ({regression:+.2f}% regression)"
-    return MetricResult(name, measured, reference, regression, verdict, message)
+    return MetricResult(name, measured, reference, regression, warn, fail, verdict, message)
 
 
 def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]) -> ComparisonReport:
@@ -178,14 +185,15 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
     identity = _identity(bundle)
     row = _matching_row(table, identity)
     metric_configs = _mapping(row.get("metrics"), "baseline metrics")
-    if not any(name in metric_configs for name, _, _, _ in _METRICS):
-        raise ComparisonError("The matching baseline row configures no supported metrics")
+    missing_metrics = [name for name, _, _, _ in _METRICS if name not in metric_configs]
+    if missing_metrics:
+        raise ComparisonError(f"The matching baseline row is missing required metrics: {', '.join(missing_metrics)}")
 
     metrics = tuple(
         _metric_result(
             name,
             _nested_number(bundle, path),
-            metric_configs.get(name),
+            metric_configs[name],
             higher_is_worse=higher_is_worse,
         )
         for name, _, path, higher_is_worse in _METRICS
@@ -200,7 +208,8 @@ def skipped_report(runtime_bundle: dict[str, object], reason: str) -> Comparison
     """Build a report that records unavailable baseline configuration."""
     bundle = _mapping(runtime_bundle, "benchmark result")
     metrics = tuple(
-        MetricResult(name, _nested_number(bundle, path), None, None, "SKIP", reason) for name, _, path, _ in _METRICS
+        MetricResult(name, _nested_number(bundle, path), None, None, None, None, "SKIP", reason)
+        for name, _, path, _ in _METRICS
     )
     return ComparisonReport(_identity(bundle), metrics, "SKIP", reason)
 
@@ -224,19 +233,23 @@ def write_outputs(
         "",
         report.message,
         "",
-        "| Metric | Measured | Reference | Regression | Verdict |",
-        "| --- | ---: | ---: | ---: | --- |",
+        "| Metric | Measured | Reference | Regression | Warn | Fail | Verdict |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     for metric in report.metrics:
         regression = "-" if metric.regression_pct is None else f"{metric.regression_pct:+.2f}%"
+        warn = "-" if metric.warn_regression_pct is None else f"{metric.warn_regression_pct:.2f}%"
+        fail = "-" if metric.fail_regression_pct is None else f"{metric.fail_regression_pct:.2f}%"
         lines.append(
             f"| {_LABELS.get(metric.name, metric.name)} | {_format_value(metric.measured)} | "
-            f"{_format_value(metric.reference)} | {regression} | {metric.verdict} |"
+            f"{_format_value(metric.reference)} | {regression} | {warn} | {fail} | {metric.verdict} |"
         )
     markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     json_path.write_text(json.dumps(asdict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    test_metrics = report.metrics or (MetricResult("comparison", None, None, None, report.verdict, report.message),)
+    test_metrics = report.metrics or (
+        MetricResult("comparison", None, None, None, None, None, report.verdict, report.message),
+    )
     failures = sum(metric.verdict in {"FAIL", "ERROR"} for metric in test_metrics)
     skipped = sum(metric.verdict == "SKIP" for metric in test_metrics)
     suite = ET.Element(
@@ -257,7 +270,7 @@ def write_outputs(
 
 
 def _error_report(message: str) -> ComparisonReport:
-    metric = MetricResult("comparison", None, None, None, "ERROR", message)
+    metric = MetricResult("comparison", None, None, None, None, None, "ERROR", message)
     return ComparisonReport({}, (metric,), "ERROR", message)
 
 

--- a/tools/performance_compare.py
+++ b/tools/performance_compare.py
@@ -33,6 +33,15 @@ class MetricResult:
     fail_regression_pct: float | None
     verdict: str
     message: str
+    measured_samples: int | None = None
+    reference_samples: int | None = None
+    significance_metric: str | None = None
+    significance_measured: float | None = None
+    significance_reference: float | None = None
+    significance_measured_std: float | None = None
+    significance_reference_std: float | None = None
+    significance_sigma: float | None = None
+    statistically_significant: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -46,11 +55,24 @@ class ComparisonReport:
 
 
 _METRICS = (
-    ("total_fps", "Total FPS", ("runtime", "total_fps", "mean"), False),
-    ("gpu_mem_peak_gb", "Peak GPU memory [GB]", ("resources", "gpu_mem_gb", "peak"), True),
-    ("ram_peak_gb", "Peak process RSS [GB]", ("resources", "ram_gb", "peak"), True),
+    ("total_fps", "Total FPS", (("runtime", "total_fps", "mean"),), False),
+    (
+        "startup_time_s",
+        "Total startup time [s]",
+        (
+            ("runtime", "startup_time_s", "app_launch"),
+            ("runtime", "startup_time_s", "python_imports"),
+            ("runtime", "startup_time_s", "task_config"),
+            ("runtime", "startup_time_s", "env_creation"),
+            ("runtime", "startup_time_s", "first_step"),
+        ),
+        True,
+    ),
+    ("gpu_mem_peak_gb", "Peak GPU memory [GB]", (("resources", "gpu_mem_gb", "peak"),), True),
+    ("ram_peak_gb", "Peak process RSS [GB]", (("resources", "ram_gb", "peak"),), True),
 )
 _LABELS = {name: label for name, label, _, _ in _METRICS}
+_MIN_SIGNIFICANCE_SIGMA = 2.0
 
 
 def _mapping(value: Any, name: str) -> dict[str, Any]:
@@ -71,6 +93,20 @@ def _number(value: Any, name: str) -> float:
     return number
 
 
+def _sample_count(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 1:
+        raise ComparisonError(f"{name} must be an integer greater than one")
+    _number(value, name)
+    return value
+
+
+def _positive_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ComparisonError(f"{name} must be a positive integer")
+    _number(value, name)
+    return value
+
+
 def _nested_number(data: dict[str, Any], path: tuple[str, ...]) -> float | None:
     value: Any = data
     for key in path:
@@ -80,9 +116,68 @@ def _nested_number(data: dict[str, Any], path: tuple[str, ...]) -> float | None:
     return _number(value, ".".join(path))
 
 
+def _startup_time(data: dict[str, Any]) -> float | None:
+    runtime = _mapping(data.get("runtime"), "runtime")
+    startup = _mapping(runtime.get("startup_time_s"), "runtime.startup_time_s")
+    values: list[float] = []
+    for name in ("app_launch", "env_creation", "first_step"):
+        values.append(_number(startup.get(name), f"runtime.startup_time_s.{name}"))
+    for name in ("python_imports", "task_config"):
+        value = startup.get(name)
+        if value is not None:
+            values.append(_number(value, f"runtime.startup_time_s.{name}"))
+    if any(value < 0 for value in values):
+        raise ComparisonError("runtime startup phases must be non-negative")
+    return _number(sum(values), "total startup time")
+
+
+def _metric_value(data: dict[str, Any], name: str, paths: tuple[tuple[str, ...], ...]) -> float:
+    if name == "startup_time_s":
+        return _startup_time(data)
+    values = [_nested_number(data, path) for path in paths]
+    value = values[0] if len(values) == 1 else sum(item for item in values if item is not None)
+    if value is None:
+        raise ComparisonError(f"Benchmark result does not contain a measured value for {name}")
+    if value < 0:
+        raise ComparisonError(f"Measured {name} must be non-negative")
+    return value
+
+
+def _fps_statistics(
+    bundle: dict[str, Any], measured_fps: float, expected_steps_per_iteration: int
+) -> tuple[float, float, int, int]:
+    if measured_fps <= 0:
+        raise ComparisonError("Measured total_fps must be greater than zero")
+    runtime = _mapping(bundle.get("runtime"), "runtime")
+    mean = _nested_number(bundle, ("runtime", "iteration_time_s", "mean"))
+    std = _nested_number(bundle, ("runtime", "iteration_time_s", "std"))
+    if mean is None or std is None:
+        raise ComparisonError("Benchmark result does not contain iteration-time statistics for total_fps")
+    if mean <= 0 or std < 0:
+        raise ComparisonError("Iteration-time mean must be positive and standard deviation non-negative")
+    samples = _sample_count(runtime.get("iterations_completed"), "measured total_fps sample count")
+    steps = _positive_int(runtime.get("steps_per_iteration"), "runtime.steps_per_iteration")
+    if steps != expected_steps_per_iteration:
+        raise ComparisonError("runtime.steps_per_iteration must match run.num_envs")
+    if not math.isclose(mean, steps / measured_fps, rel_tol=1e-6):
+        raise ComparisonError("total_fps.mean and iteration_time_s.mean describe different aggregates")
+    return mean, std, samples, steps
+
+
 def _normalize_gpu_model(value: str) -> str:
     value = re.sub(r"^nvidia\s+", "", value.strip(), flags=re.IGNORECASE)
     return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _runtime_version(versions: dict[str, Any]) -> str:
+    for provider in ("isaacsim", "newton"):
+        value = versions.get(provider)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            raise ComparisonError(f"versions.{provider} must be a non-empty string when present")
+        return f"{provider}:{value.strip()}"
+    raise ComparisonError("versions must contain an Isaac Sim or Newton runtime version")
 
 
 def _identity(bundle: dict[str, Any]) -> dict[str, object]:
@@ -107,14 +202,12 @@ def _identity(bundle: dict[str, Any]) -> dict[str, object]:
         "rendering_backend": config.get("rendering_backend"),
         "presets": sorted(presets),
         "gpu_model": _normalize_gpu_model(gpu_name),
-        "isaacsim_version": versions.get("isaacsim"),
-        "num_envs": run.get("num_envs"),
+        "runtime_version": _runtime_version(versions),
+        "num_envs": _positive_int(run.get("num_envs"), "benchmark identity field 'num_envs'"),
     }
-    for key in ("task", "physics_backend", "rendering_backend", "isaacsim_version"):
+    for key in ("task", "physics_backend", "rendering_backend"):
         if not isinstance(identity[key], str) or not identity[key]:
             raise ComparisonError(f"benchmark identity field {key!r} must be a non-empty string")
-    if isinstance(identity["num_envs"], bool) or not isinstance(identity["num_envs"], int):
-        raise ComparisonError("benchmark identity field 'num_envs' must be an integer")
     return identity
 
 
@@ -151,6 +244,11 @@ def _metric_result(
     config: dict[str, Any],
     *,
     higher_is_worse: bool,
+    measured_samples: Any = None,
+    require_significance: bool = False,
+    significance_measured: float | None = None,
+    significance_measured_std: float | None = None,
+    significance_scale: int | None = None,
 ) -> MetricResult:
     config = _mapping(config, f"metrics.{name}")
     if measured is None:
@@ -166,16 +264,82 @@ def _metric_result(
     if fail < warn:
         raise ComparisonError(f"metrics.{name}.fail_regression_pct must be greater than or equal to warning")
 
-    change = (measured - reference) / reference * 100.0
+    change = _number((measured - reference) / reference * 100.0, f"derived {name} percentage change")
     regression = change if higher_is_worse else -change
-    if regression >= fail:
+    reference_samples: int | None = None
+    significance_metric: str | None = None
+    significance_reference: float | None = None
+    significance_reference_std: float | None = None
+    significance_sigma: float | None = None
+    statistically_significant: bool | None = None
+    if require_significance:
+        if measured_samples is None:
+            raise ComparisonError(f"Benchmark result does not contain a measured sample count for {name}")
+        measured_samples = _sample_count(measured_samples, f"measured {name} sample count")
+        reference_samples = _sample_count(config.get("reference_samples"), f"metrics.{name}.reference_samples")
+        if significance_measured is None or significance_measured_std is None or significance_scale is None:
+            raise ComparisonError(f"Benchmark result does not contain iteration-time statistics for {name}")
+        significance_metric = "iteration_time_s"
+        significance_measured = _number(significance_measured, "runtime.iteration_time_s.mean")
+        significance_measured_std = _number(significance_measured_std, "runtime.iteration_time_s.std")
+        significance_reference = _number(
+            significance_scale / reference, f"derived metrics.{name}.reference_iteration_time_s"
+        )
+        significance_reference_std = _number(
+            config.get("reference_iteration_time_std_s"), f"metrics.{name}.reference_iteration_time_std_s"
+        )
+        if significance_measured <= 0 or significance_reference <= 0:
+            raise ComparisonError("iteration-time means must be greater than zero")
+        if significance_measured_std < 0 or significance_reference_std < 0:
+            raise ComparisonError("iteration-time standard deviations must be non-negative")
+        standard_error = _number(
+            math.hypot(
+                significance_measured_std / math.sqrt(measured_samples),
+                significance_reference_std / math.sqrt(reference_samples),
+            ),
+            f"derived metrics.{name} standard error",
+        )
+        difference = _number(
+            abs(significance_measured - significance_reference), f"derived metrics.{name} timing difference"
+        )
+        if standard_error == 0.0:
+            statistically_significant = difference > 0.0
+        else:
+            significance_sigma = _number(difference / standard_error, f"derived metrics.{name} significance")
+            statistically_significant = significance_sigma >= _MIN_SIGNIFICANCE_SIGMA
+
+    crosses_fail = regression > 0 and regression >= fail
+    crosses_warn = regression > 0 and regression >= warn
+    threshold_is_significant = statistically_significant is not False
+    if crosses_fail and threshold_is_significant:
         verdict = "FAIL"
-    elif regression >= warn:
+    elif crosses_warn and threshold_is_significant:
         verdict = "WARN"
     else:
         verdict = "PASS"
     message = f"Measured {measured:g} versus {reference:g} ({regression:+.2f}% regression)"
-    return MetricResult(name, measured, reference, regression, warn, fail, verdict, message)
+    if statistically_significant is not None:
+        sigma = "infinite" if significance_sigma is None else f"{significance_sigma:.2f}"
+        message += f", {sigma} sigma ({'significant' if statistically_significant else 'not significant'})"
+    return MetricResult(
+        name,
+        measured,
+        reference,
+        regression,
+        warn,
+        fail,
+        verdict,
+        message,
+        measured_samples=measured_samples,
+        reference_samples=reference_samples,
+        significance_metric=significance_metric,
+        significance_measured=significance_measured,
+        significance_reference=significance_reference,
+        significance_measured_std=significance_measured_std,
+        significance_reference_std=significance_reference_std,
+        significance_sigma=significance_sigma,
+        statistically_significant=statistically_significant,
+    )
 
 
 def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]) -> ComparisonReport:
@@ -188,15 +352,24 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
     missing_metrics = [name for name, _, _, _ in _METRICS if name not in metric_configs]
     if missing_metrics:
         raise ComparisonError(f"The matching baseline row is missing required metrics: {', '.join(missing_metrics)}")
+    values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
+    iteration_time_mean, iteration_time_std, fps_samples, steps_per_iteration = _fps_statistics(
+        bundle, values["total_fps"], identity["num_envs"]
+    )
 
     metrics = tuple(
         _metric_result(
             name,
-            _nested_number(bundle, path),
+            values[name],
             metric_configs[name],
             higher_is_worse=higher_is_worse,
+            measured_samples=fps_samples if name == "total_fps" else None,
+            require_significance=name == "total_fps",
+            significance_measured=iteration_time_mean if name == "total_fps" else None,
+            significance_measured_std=iteration_time_std if name == "total_fps" else None,
+            significance_scale=steps_per_iteration if name == "total_fps" else None,
         )
-        for name, _, path, higher_is_worse in _METRICS
+        for name, _, paths, higher_is_worse in _METRICS
     )
     verdict = "FAIL" if any(item.verdict == "FAIL" for item in metrics) else "WARN"
     if verdict == "WARN" and not any(item.verdict == "WARN" for item in metrics):
@@ -207,11 +380,29 @@ def compare(runtime_bundle: dict[str, object], baseline_table: dict[str, object]
 def skipped_report(runtime_bundle: dict[str, object], reason: str) -> ComparisonReport:
     """Build a report that records unavailable baseline configuration."""
     bundle = _mapping(runtime_bundle, "benchmark result")
-    metrics = tuple(
-        MetricResult(name, _nested_number(bundle, path), None, None, None, None, "SKIP", reason)
-        for name, _, path, _ in _METRICS
+    identity = _identity(bundle)
+    values = {name: _metric_value(bundle, name, paths) for name, _, paths, _ in _METRICS}
+    iteration_time_mean, iteration_time_std, fps_samples, _ = _fps_statistics(
+        bundle, values["total_fps"], identity["num_envs"]
     )
-    return ComparisonReport(_identity(bundle), metrics, "SKIP", reason)
+    metrics = tuple(
+        MetricResult(
+            name,
+            values[name],
+            None,
+            None,
+            None,
+            None,
+            "SKIP",
+            reason,
+            measured_samples=fps_samples if name == "total_fps" else None,
+            significance_metric="iteration_time_s" if name == "total_fps" else None,
+            significance_measured=iteration_time_mean if name == "total_fps" else None,
+            significance_measured_std=iteration_time_std if name == "total_fps" else None,
+        )
+        for name, _, paths, _ in _METRICS
+    )
+    return ComparisonReport(identity, metrics, "SKIP", reason)
 
 
 def _format_value(value: float | None) -> str:
@@ -233,16 +424,26 @@ def write_outputs(
         "",
         report.message,
         "",
-        "| Metric | Measured | Reference | Regression | Warn | Fail | Verdict |",
-        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+        "| Metric | Measured | Reference | Regression | Measured timing std [s] | Reference timing std [s] | "
+        "Significance | Warn | Fail | Verdict |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     for metric in report.metrics:
         regression = "-" if metric.regression_pct is None else f"{metric.regression_pct:+.2f}%"
         warn = "-" if metric.warn_regression_pct is None else f"{metric.warn_regression_pct:.2f}%"
         fail = "-" if metric.fail_regression_pct is None else f"{metric.fail_regression_pct:.2f}%"
+        if metric.statistically_significant is None:
+            significance = "-"
+        elif metric.significance_sigma is None:
+            significance = "infinite" if metric.statistically_significant else "0.00 sigma"
+        else:
+            significance = f"{metric.significance_sigma:.2f} sigma"
+        measured_timing_std = _format_value(metric.significance_measured_std)
+        reference_timing_std = _format_value(metric.significance_reference_std)
         lines.append(
             f"| {_LABELS.get(metric.name, metric.name)} | {_format_value(metric.measured)} | "
-            f"{_format_value(metric.reference)} | {regression} | {warn} | {fail} | {metric.verdict} |"
+            f"{_format_value(metric.reference)} | {regression} | {measured_timing_std} | "
+            f"{reference_timing_std} | {significance} | {warn} | {fail} | {metric.verdict} |"
         )
     markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     json_path.write_text(json.dumps(asdict(report), indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tools/test/test_performance_compare.py
+++ b/tools/test/test_performance_compare.py
@@ -81,7 +81,7 @@ def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) ->
     assert [metric.verdict for metric in report.metrics] == ["FAIL", "WARN", "PASS"]
 
 
-def test_compare_rejects_missing_or_duplicate_rows(runtime_bundle: dict) -> None:
+def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict) -> None:
     table = _baseline_table()
     table["baselines"][0]["task"] = "Another-Task"
     with pytest.raises(performance_compare.ComparisonError, match="No baseline row"):
@@ -90,6 +90,21 @@ def test_compare_rejects_missing_or_duplicate_rows(runtime_bundle: dict) -> None
     table = _baseline_table()
     table["baselines"].append(dict(table["baselines"][0]))
     with pytest.raises(performance_compare.ComparisonError, match="Multiple baseline rows"):
+        performance_compare.compare(runtime_bundle, table)
+
+    table = _baseline_table()
+    del table["baselines"][0]["metrics"]["ram_peak_gb"]
+    with pytest.raises(performance_compare.ComparisonError, match="missing required metrics: ram_peak_gb"):
+        performance_compare.compare(runtime_bundle, table)
+
+    table = _baseline_table()
+    table["baselines"][0]["metrics"]["total_fps"]["reference"] = float("inf")
+    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
+        performance_compare.compare(runtime_bundle, table)
+
+    table = _baseline_table()
+    table["baselines"][0]["metrics"]["total_fps"]["reference"] = 10**400
+    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
         performance_compare.compare(runtime_bundle, table)
 
 
@@ -101,8 +116,13 @@ def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path)
 
     performance_compare.write_outputs(report, markdown, output_json, junit)
 
-    assert "| Total FPS | 95" in markdown.read_text()
-    assert json.loads(output_json.read_text())["verdict"] == "FAIL"
+    markdown_text = markdown.read_text()
+    assert "| Total FPS | 95" in markdown_text
+    assert "| Warn | Fail |" in markdown_text
+    output = json.loads(output_json.read_text())
+    assert output["verdict"] == "FAIL"
+    assert output["metrics"][0]["warn_regression_pct"] == 5.0
+    assert output["metrics"][0]["fail_regression_pct"] == 10.0
     suite = ET.parse(junit).getroot()
     assert suite.attrib == {"name": "performance-comparison", "tests": "3", "failures": "1", "skipped": "0"}
     assert [case.attrib["name"] for case in suite.findall("testcase")] == [

--- a/tools/test/test_performance_compare.py
+++ b/tools/test/test_performance_compare.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import json
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -108,7 +107,6 @@ def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) ->
     assert report.metrics[0].regression_pct == 10.0
     assert report.metrics[0].significance_sigma == pytest.approx(1.6666666667)
     assert report.metrics[0].statistically_significant is False
-    assert report.metrics[0].significance_metric == "total_fps"
     assert report.metrics[0].verdict == "PASS"
 
     table = _baseline_table()
@@ -124,7 +122,7 @@ def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) ->
     assert report.metrics[1].verdict == "PASS"
 
 
-def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict) -> None:
+def test_compare_validates_input_contract(runtime_bundle: dict) -> None:
     table = _baseline_table()
     table["baselines"][0]["task"] = "Another-Task"
     with pytest.raises(performance_compare.ComparisonError, match="No baseline row"):
@@ -145,38 +143,15 @@ def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict)
     with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
         performance_compare.compare(runtime_bundle, table)
 
-    table = _baseline_table()
-    table["baselines"][0]["metrics"]["total_fps"]["reference"] = 10**400
-    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
-        performance_compare.compare(runtime_bundle, table)
-
-    table = _baseline_table()
-    table["baselines"][0]["metrics"]["total_fps"]["reference"] = 5e-324
-    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
-        performance_compare.compare(runtime_bundle, table)
-
-    startup = runtime_bundle["runtime"]["startup_time_s"]
-    startup["app_launch"] = startup["env_creation"] = startup["first_step"] = 1e308
-    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
-        performance_compare.compare(runtime_bundle, _baseline_table())
-    startup.update({"app_launch": 1.0, "env_creation": 2.0, "first_step": 0.5})
-
-    del runtime_bundle["runtime"]["startup_time_s"]["app_launch"]
-    with pytest.raises(performance_compare.ComparisonError, match="startup_time_s.app_launch"):
-        performance_compare.compare(runtime_bundle, _baseline_table())
-    runtime_bundle["runtime"]["startup_time_s"]["app_launch"] = 1.0
-
     runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = -1.0
     with pytest.raises(performance_compare.ComparisonError, match="must be non-negative"):
         performance_compare.compare(runtime_bundle, _baseline_table())
     runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 11.0
 
     total_fps_std = runtime_bundle["runtime"]["total_fps"].pop("std")
-    fps_samples = runtime_bundle["runtime"].pop("iterations_completed")
     with pytest.raises(performance_compare.ComparisonError, match="throughput statistics"):
         performance_compare.compare(runtime_bundle, _baseline_table())
     runtime_bundle["runtime"]["total_fps"]["std"] = total_fps_std
-    runtime_bundle["runtime"]["iterations_completed"] = fps_samples
 
     runtime_bundle["run"]["config"] = {
         "physics_backend": "newton_mjwarp",
@@ -194,15 +169,12 @@ def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict)
     assert report.identity["runtime_version"] == "newton:1.5.0rc2"
 
 
-def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path) -> None:
+def test_write_output_reports_all_metrics(runtime_bundle: dict, tmp_path: Path) -> None:
     report = performance_compare.compare(runtime_bundle, _baseline_table())
-    markdown = tmp_path / "comparison.md"
     output_json = tmp_path / "comparison.json"
-    junit = tmp_path / "comparison.xml"
 
-    performance_compare.write_outputs(report, markdown, output_json, junit)
+    markdown_text = performance_compare.write_output(report, output_json)
 
-    markdown_text = markdown.read_text()
     assert "| Total FPS | 95" in markdown_text
     assert "| Warn | Fail |" in markdown_text
     output = json.loads(output_json.read_text())
@@ -211,22 +183,11 @@ def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path)
     assert output["metrics"][0]["fail_regression_pct"] == 10.0
     assert output["metrics"][0]["measured_samples"] == 200
     assert output["metrics"][0]["reference_samples"] == 200
-    assert output["metrics"][0]["significance_metric"] == "total_fps"
-    assert output["metrics"][0]["significance_measured"] == 95.0
-    assert output["metrics"][0]["significance_reference"] == 100.0
-    assert output["metrics"][0]["significance_measured_std"] == 3.0
-    assert output["metrics"][0]["significance_reference_std"] == 3.0
+    assert output["metrics"][0]["measured_std"] == 3.0
+    assert output["metrics"][0]["reference_std"] == 3.0
     assert output["metrics"][0]["significance_sigma"] == pytest.approx(16.6666667)
     assert output["metrics"][0]["statistically_significant"] is True
     assert "| Measured FPS std | Reference FPS std | Significance |" in markdown_text
-    suite = ET.parse(junit).getroot()
-    assert suite.attrib == {"name": "performance-comparison", "tests": "4", "failures": "1", "skipped": "0"}
-    assert [case.attrib["name"] for case in suite.findall("testcase")] == [
-        "total_fps",
-        "startup_time_s",
-        "gpu_mem_peak_gb",
-        "ram_peak_gb",
-    ]
 
 
 def test_main_skips_only_when_baseline_is_not_configured(runtime_bundle: dict, tmp_path: Path) -> None:
@@ -235,12 +196,8 @@ def test_main_skips_only_when_baseline_is_not_configured(runtime_bundle: dict, t
     common_args = [
         "--benchmark_result",
         str(benchmark_path),
-        "--markdown",
-        str(tmp_path / "comparison.md"),
         "--output_json",
         str(tmp_path / "comparison.json"),
-        "--junit",
-        str(tmp_path / "comparison.xml"),
     ]
 
     assert performance_compare.main(common_args) == 0

--- a/tools/test/test_performance_compare.py
+++ b/tools/test/test_performance_compare.py
@@ -39,7 +39,7 @@ def runtime_bundle() -> dict:
             },
             "iterations_completed": 200,
             "steps_per_iteration": 4096,
-            "iteration_time_s": {"mean": 43.11578947368421, "std": 1.0, "peak": 50.0},
+            "iteration_time_s": {"mean": 44.0, "std": 1.0, "peak": 50.0},
             "total_fps": {"mean": 95.0, "std": 3.0, "peak": 98.0},
         },
         "resources": {
@@ -66,7 +66,7 @@ def _baseline_table() -> dict:
                     "total_fps": {
                         "reference": 100.0,
                         "reference_samples": 200,
-                        "reference_iteration_time_std_s": 1.0,
+                        "reference_std": 3.0,
                         **metric,
                     },
                     "startup_time_s": {"reference": 5.0, **metric},
@@ -92,7 +92,6 @@ def test_compare_uses_opposite_regression_directions_for_throughput_and_memory(r
 
 def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) -> None:
     runtime_bundle["runtime"]["total_fps"]["mean"] = 90.0
-    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 45.51111111111111
     runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 10.5
     runtime_bundle["resources"]["ram_gb"]["peak"] = 7.0
 
@@ -100,16 +99,16 @@ def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) ->
 
     assert [metric.verdict for metric in report.metrics] == ["FAIL", "PASS", "WARN", "PASS"]
 
-    runtime_bundle["runtime"]["iteration_time_s"]["std"] = 40.0
+    runtime_bundle["runtime"]["total_fps"]["std"] = 60.0
     table = _baseline_table()
-    table["baselines"][0]["metrics"]["total_fps"]["reference_iteration_time_std_s"] = 40.0
+    table["baselines"][0]["metrics"]["total_fps"]["reference_std"] = 60.0
 
     report = performance_compare.compare(runtime_bundle, table)
 
     assert report.metrics[0].regression_pct == 10.0
-    assert report.metrics[0].significance_sigma == pytest.approx(1.1377777778)
+    assert report.metrics[0].significance_sigma == pytest.approx(1.6666666667)
     assert report.metrics[0].statistically_significant is False
-    assert report.metrics[0].significance_metric == "iteration_time_s"
+    assert report.metrics[0].significance_metric == "total_fps"
     assert report.metrics[0].verdict == "PASS"
 
     table = _baseline_table()
@@ -172,17 +171,12 @@ def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict)
         performance_compare.compare(runtime_bundle, _baseline_table())
     runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 11.0
 
-    iteration_time_std = runtime_bundle["runtime"]["iteration_time_s"].pop("std")
+    total_fps_std = runtime_bundle["runtime"]["total_fps"].pop("std")
     fps_samples = runtime_bundle["runtime"].pop("iterations_completed")
-    with pytest.raises(performance_compare.ComparisonError, match="iteration-time statistics"):
+    with pytest.raises(performance_compare.ComparisonError, match="throughput statistics"):
         performance_compare.compare(runtime_bundle, _baseline_table())
-    runtime_bundle["runtime"]["iteration_time_s"]["std"] = iteration_time_std
+    runtime_bundle["runtime"]["total_fps"]["std"] = total_fps_std
     runtime_bundle["runtime"]["iterations_completed"] = fps_samples
-
-    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 40.96
-    with pytest.raises(performance_compare.ComparisonError, match="different aggregates"):
-        performance_compare.compare(runtime_bundle, _baseline_table())
-    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 43.11578947368421
 
     runtime_bundle["run"]["config"] = {
         "physics_backend": "newton_mjwarp",
@@ -217,14 +211,14 @@ def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path)
     assert output["metrics"][0]["fail_regression_pct"] == 10.0
     assert output["metrics"][0]["measured_samples"] == 200
     assert output["metrics"][0]["reference_samples"] == 200
-    assert output["metrics"][0]["significance_metric"] == "iteration_time_s"
-    assert output["metrics"][0]["significance_measured"] == pytest.approx(43.11578947368421)
-    assert output["metrics"][0]["significance_reference"] == 40.96
-    assert output["metrics"][0]["significance_measured_std"] == 1.0
-    assert output["metrics"][0]["significance_reference_std"] == 1.0
-    assert output["metrics"][0]["significance_sigma"] == pytest.approx(21.5578947)
+    assert output["metrics"][0]["significance_metric"] == "total_fps"
+    assert output["metrics"][0]["significance_measured"] == 95.0
+    assert output["metrics"][0]["significance_reference"] == 100.0
+    assert output["metrics"][0]["significance_measured_std"] == 3.0
+    assert output["metrics"][0]["significance_reference_std"] == 3.0
+    assert output["metrics"][0]["significance_sigma"] == pytest.approx(16.6666667)
     assert output["metrics"][0]["statistically_significant"] is True
-    assert "| Measured timing std [s] | Reference timing std [s] | Significance |" in markdown_text
+    assert "| Measured FPS std | Reference FPS std | Significance |" in markdown_text
     suite = ET.parse(junit).getroot()
     assert suite.attrib == {"name": "performance-comparison", "tests": "4", "failures": "1", "skipped": "0"}
     assert [case.attrib["name"] for case in suite.findall("testcase")] == [

--- a/tools/test/test_performance_compare.py
+++ b/tools/test/test_performance_compare.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for performance comparison against an authoritative baseline table."""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from tools import performance_compare
+
+
+@pytest.fixture
+def runtime_bundle() -> dict:
+    return {
+        "schema_version": "1.3",
+        "run": {
+            "task": "Isaac-Cartpole-Direct",
+            "config": {"physics_backend": "physx", "rendering_backend": "none", "presets": []},
+            "num_envs": 4096,
+        },
+        "versions": {"isaacsim": "6.1.0-test"},
+        "hardware": {
+            "gpu_devices": [{"name": "NVIDIA L40S", "mem_gb": 44.0, "compute_cap": "8.9"}],
+        },
+        "runtime": {"total_fps": {"mean": 95.0, "std": 1.0, "peak": 98.0}},
+        "resources": {
+            "gpu_mem_gb": {"mean": 9.0, "std": 0.5, "peak": 11.0},
+            "ram_gb": {"mean": 7.0, "std": 0.2, "peak": 8.0},
+        },
+    }
+
+
+def _baseline_table() -> dict:
+    metric = {"warn_regression_pct": 5.0, "fail_regression_pct": 10.0}
+    return {
+        "schema_version": 1,
+        "baselines": [
+            {
+                "task": "Isaac-Cartpole-Direct",
+                "physics_backend": "physx",
+                "rendering_backend": "none",
+                "presets": [],
+                "gpu_model": "l40s",
+                "isaacsim_version": "6.1.0-test",
+                "num_envs": 4096,
+                "metrics": {
+                    "total_fps": {"reference": 100.0, **metric},
+                    "gpu_mem_peak_gb": {"reference": 10.0, **metric},
+                    "ram_peak_gb": {"reference": 8.0, **metric},
+                },
+            }
+        ],
+    }
+
+
+def test_compare_uses_opposite_regression_directions_for_throughput_and_memory(runtime_bundle: dict) -> None:
+    report = performance_compare.compare(runtime_bundle, _baseline_table())
+
+    assert report.verdict == "FAIL"
+    assert [(metric.name, metric.regression_pct, metric.verdict) for metric in report.metrics] == [
+        ("total_fps", 5.0, "WARN"),
+        ("gpu_mem_peak_gb", 10.0, "FAIL"),
+        ("ram_peak_gb", 0.0, "PASS"),
+    ]
+
+
+def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) -> None:
+    runtime_bundle["runtime"]["total_fps"]["mean"] = 90.0
+    runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 10.5
+    runtime_bundle["resources"]["ram_gb"]["peak"] = 7.0
+
+    report = performance_compare.compare(runtime_bundle, _baseline_table())
+
+    assert [metric.verdict for metric in report.metrics] == ["FAIL", "WARN", "PASS"]
+
+
+def test_compare_rejects_missing_or_duplicate_rows(runtime_bundle: dict) -> None:
+    table = _baseline_table()
+    table["baselines"][0]["task"] = "Another-Task"
+    with pytest.raises(performance_compare.ComparisonError, match="No baseline row"):
+        performance_compare.compare(runtime_bundle, table)
+
+    table = _baseline_table()
+    table["baselines"].append(dict(table["baselines"][0]))
+    with pytest.raises(performance_compare.ComparisonError, match="Multiple baseline rows"):
+        performance_compare.compare(runtime_bundle, table)
+
+
+def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path) -> None:
+    report = performance_compare.compare(runtime_bundle, _baseline_table())
+    markdown = tmp_path / "comparison.md"
+    output_json = tmp_path / "comparison.json"
+    junit = tmp_path / "comparison.xml"
+
+    performance_compare.write_outputs(report, markdown, output_json, junit)
+
+    assert "| Total FPS | 95" in markdown.read_text()
+    assert json.loads(output_json.read_text())["verdict"] == "FAIL"
+    suite = ET.parse(junit).getroot()
+    assert suite.attrib == {"name": "performance-comparison", "tests": "3", "failures": "1", "skipped": "0"}
+    assert [case.attrib["name"] for case in suite.findall("testcase")] == [
+        "total_fps",
+        "gpu_mem_peak_gb",
+        "ram_peak_gb",
+    ]
+
+
+def test_main_skips_only_when_baseline_is_not_configured(runtime_bundle: dict, tmp_path: Path) -> None:
+    benchmark_path = tmp_path / "benchmark.json"
+    benchmark_path.write_text(json.dumps(runtime_bundle))
+    common_args = [
+        "--benchmark_result",
+        str(benchmark_path),
+        "--markdown",
+        str(tmp_path / "comparison.md"),
+        "--output_json",
+        str(tmp_path / "comparison.json"),
+        "--junit",
+        str(tmp_path / "comparison.xml"),
+    ]
+
+    assert performance_compare.main(common_args) == 0
+    assert json.loads((tmp_path / "comparison.json").read_text())["verdict"] == "SKIP"
+
+    malformed_baseline = tmp_path / "malformed.json"
+    malformed_baseline.write_text("{}")
+    assert performance_compare.main([*common_args, "--baseline", str(malformed_baseline)]) == 1
+    assert json.loads((tmp_path / "comparison.json").read_text())["verdict"] == "ERROR"

--- a/tools/test/test_performance_compare.py
+++ b/tools/test/test_performance_compare.py
@@ -25,11 +25,23 @@ def runtime_bundle() -> dict:
             "config": {"physics_backend": "physx", "rendering_backend": "none", "presets": []},
             "num_envs": 4096,
         },
-        "versions": {"isaacsim": "6.1.0-test"},
+        "versions": {"isaacsim": "6.1.0-test", "newton": "1.5.0rc2"},
         "hardware": {
             "gpu_devices": [{"name": "NVIDIA L40S", "mem_gb": 44.0, "compute_cap": "8.9"}],
         },
-        "runtime": {"total_fps": {"mean": 95.0, "std": 1.0, "peak": 98.0}},
+        "runtime": {
+            "startup_time_s": {
+                "app_launch": 1.0,
+                "env_creation": 2.0,
+                "first_step": 0.5,
+                "python_imports": None,
+                "task_config": None,
+            },
+            "iterations_completed": 200,
+            "steps_per_iteration": 4096,
+            "iteration_time_s": {"mean": 43.11578947368421, "std": 1.0, "peak": 50.0},
+            "total_fps": {"mean": 95.0, "std": 3.0, "peak": 98.0},
+        },
         "resources": {
             "gpu_mem_gb": {"mean": 9.0, "std": 0.5, "peak": 11.0},
             "ram_gb": {"mean": 7.0, "std": 0.2, "peak": 8.0},
@@ -48,10 +60,16 @@ def _baseline_table() -> dict:
                 "rendering_backend": "none",
                 "presets": [],
                 "gpu_model": "l40s",
-                "isaacsim_version": "6.1.0-test",
+                "runtime_version": "isaacsim:6.1.0-test",
                 "num_envs": 4096,
                 "metrics": {
-                    "total_fps": {"reference": 100.0, **metric},
+                    "total_fps": {
+                        "reference": 100.0,
+                        "reference_samples": 200,
+                        "reference_iteration_time_std_s": 1.0,
+                        **metric,
+                    },
+                    "startup_time_s": {"reference": 5.0, **metric},
                     "gpu_mem_peak_gb": {"reference": 10.0, **metric},
                     "ram_peak_gb": {"reference": 8.0, **metric},
                 },
@@ -66,6 +84,7 @@ def test_compare_uses_opposite_regression_directions_for_throughput_and_memory(r
     assert report.verdict == "FAIL"
     assert [(metric.name, metric.regression_pct, metric.verdict) for metric in report.metrics] == [
         ("total_fps", 5.0, "WARN"),
+        ("startup_time_s", -30.0, "PASS"),
         ("gpu_mem_peak_gb", 10.0, "FAIL"),
         ("ram_peak_gb", 0.0, "PASS"),
     ]
@@ -73,12 +92,37 @@ def test_compare_uses_opposite_regression_directions_for_throughput_and_memory(r
 
 def test_compare_applies_warning_and_failure_boundaries(runtime_bundle: dict) -> None:
     runtime_bundle["runtime"]["total_fps"]["mean"] = 90.0
+    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 45.51111111111111
     runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 10.5
     runtime_bundle["resources"]["ram_gb"]["peak"] = 7.0
 
     report = performance_compare.compare(runtime_bundle, _baseline_table())
 
-    assert [metric.verdict for metric in report.metrics] == ["FAIL", "WARN", "PASS"]
+    assert [metric.verdict for metric in report.metrics] == ["FAIL", "PASS", "WARN", "PASS"]
+
+    runtime_bundle["runtime"]["iteration_time_s"]["std"] = 40.0
+    table = _baseline_table()
+    table["baselines"][0]["metrics"]["total_fps"]["reference_iteration_time_std_s"] = 40.0
+
+    report = performance_compare.compare(runtime_bundle, table)
+
+    assert report.metrics[0].regression_pct == 10.0
+    assert report.metrics[0].significance_sigma == pytest.approx(1.1377777778)
+    assert report.metrics[0].statistically_significant is False
+    assert report.metrics[0].significance_metric == "iteration_time_s"
+    assert report.metrics[0].verdict == "PASS"
+
+    table = _baseline_table()
+    table["baselines"][0]["metrics"]["startup_time_s"] = {
+        "reference": 3.5,
+        "warn_regression_pct": 0.0,
+        "fail_regression_pct": 0.0,
+    }
+
+    report = performance_compare.compare(runtime_bundle, table)
+
+    assert report.metrics[1].regression_pct == 0.0
+    assert report.metrics[1].verdict == "PASS"
 
 
 def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict) -> None:
@@ -107,6 +151,54 @@ def test_compare_rejects_incomplete_or_ambiguous_baselines(runtime_bundle: dict)
     with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
         performance_compare.compare(runtime_bundle, table)
 
+    table = _baseline_table()
+    table["baselines"][0]["metrics"]["total_fps"]["reference"] = 5e-324
+    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
+        performance_compare.compare(runtime_bundle, table)
+
+    startup = runtime_bundle["runtime"]["startup_time_s"]
+    startup["app_launch"] = startup["env_creation"] = startup["first_step"] = 1e308
+    with pytest.raises(performance_compare.ComparisonError, match="must be finite"):
+        performance_compare.compare(runtime_bundle, _baseline_table())
+    startup.update({"app_launch": 1.0, "env_creation": 2.0, "first_step": 0.5})
+
+    del runtime_bundle["runtime"]["startup_time_s"]["app_launch"]
+    with pytest.raises(performance_compare.ComparisonError, match="startup_time_s.app_launch"):
+        performance_compare.compare(runtime_bundle, _baseline_table())
+    runtime_bundle["runtime"]["startup_time_s"]["app_launch"] = 1.0
+
+    runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = -1.0
+    with pytest.raises(performance_compare.ComparisonError, match="must be non-negative"):
+        performance_compare.compare(runtime_bundle, _baseline_table())
+    runtime_bundle["resources"]["gpu_mem_gb"]["peak"] = 11.0
+
+    iteration_time_std = runtime_bundle["runtime"]["iteration_time_s"].pop("std")
+    fps_samples = runtime_bundle["runtime"].pop("iterations_completed")
+    with pytest.raises(performance_compare.ComparisonError, match="iteration-time statistics"):
+        performance_compare.compare(runtime_bundle, _baseline_table())
+    runtime_bundle["runtime"]["iteration_time_s"]["std"] = iteration_time_std
+    runtime_bundle["runtime"]["iterations_completed"] = fps_samples
+
+    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 40.96
+    with pytest.raises(performance_compare.ComparisonError, match="different aggregates"):
+        performance_compare.compare(runtime_bundle, _baseline_table())
+    runtime_bundle["runtime"]["iteration_time_s"]["mean"] = 43.11578947368421
+
+    runtime_bundle["run"]["config"] = {
+        "physics_backend": "newton_mjwarp",
+        "rendering_backend": "none",
+        "presets": ["newton_mjwarp"],
+    }
+    runtime_bundle["versions"]["isaacsim"] = None
+    table = _baseline_table()
+    table["baselines"][0]["physics_backend"] = "newton_mjwarp"
+    table["baselines"][0]["presets"] = ["newton_mjwarp"]
+    table["baselines"][0]["runtime_version"] = "newton:1.5.0rc2"
+
+    report = performance_compare.compare(runtime_bundle, table)
+
+    assert report.identity["runtime_version"] == "newton:1.5.0rc2"
+
 
 def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path) -> None:
     report = performance_compare.compare(runtime_bundle, _baseline_table())
@@ -123,10 +215,21 @@ def test_write_outputs_reports_all_metrics(runtime_bundle: dict, tmp_path: Path)
     assert output["verdict"] == "FAIL"
     assert output["metrics"][0]["warn_regression_pct"] == 5.0
     assert output["metrics"][0]["fail_regression_pct"] == 10.0
+    assert output["metrics"][0]["measured_samples"] == 200
+    assert output["metrics"][0]["reference_samples"] == 200
+    assert output["metrics"][0]["significance_metric"] == "iteration_time_s"
+    assert output["metrics"][0]["significance_measured"] == pytest.approx(43.11578947368421)
+    assert output["metrics"][0]["significance_reference"] == 40.96
+    assert output["metrics"][0]["significance_measured_std"] == 1.0
+    assert output["metrics"][0]["significance_reference_std"] == 1.0
+    assert output["metrics"][0]["significance_sigma"] == pytest.approx(21.5578947)
+    assert output["metrics"][0]["statistically_significant"] is True
+    assert "| Measured timing std [s] | Reference timing std [s] | Significance |" in markdown_text
     suite = ET.parse(junit).getroot()
-    assert suite.attrib == {"name": "performance-comparison", "tests": "3", "failures": "1", "skipped": "0"}
+    assert suite.attrib == {"name": "performance-comparison", "tests": "4", "failures": "1", "skipped": "0"}
     assert [case.attrib["name"] for case in suite.findall("testcase")] == [
         "total_fps",
+        "startup_time_s",
         "gpu_mem_peak_gb",
         "ram_peak_gb",
     ]


### PR DESCRIPTION
# Description

This is a focused alternative to #6864. It uses IsaacLab's existing
`benchmark runtime` CLI to run the performance workloads and adds only the
missing comparison and CI wiring.

The PR:

- runs eight supported benchmark configurations against the exact PR CI image;
- compares total FPS, total startup time, peak GPU memory, and peak
  benchmark-process RSS;
- keeps the established arithmetic mean of per-step FPS by default, while
  exposing a single opt-in `--aggregate_throughput` flag;
- requires an FPS regression to cross both its percentage threshold and a
  two-standard-error significance threshold computed from coherent per-step
  FPS statistics;
- downloads a read-only authoritative baseline table from the repository
  variable `PERF_BASELINE_S3_URI`;
- publishes a Markdown workflow summary, a machine-readable JSON comparison,
  and the raw benchmark bundle;
- matches exact provider-qualified Isaac Sim or kit-less Newton runtime
  identities and fails closed on malformed, missing, ambiguous, or non-finite
  input; and
- adds no dependency, baseline-writing path, reseeding workflow, custom GitHub
  status, or parallel benchmark implementation.

Until the S3 bucket is provisioned, leaving `PERF_BASELINE_S3_URI` unset makes
the comparison explicitly report `SKIP`; benchmarks and artifacts are still
produced. Once configured, the workflow only requires `s3:GetObject` access.
Every matching baseline row must provide all four metrics. The FPS row also
stores the reference per-step FPS standard deviation and sample count so the
comparison can reject noisy percentage regressions that are not statistically
significant.

The implementation is 799 additions across eight files, including exactly six
focused tests. This is approximately 92% smaller than the current proposal
while retaining the gating and reporting behavior needed for CI.

Local validation:

- focused CPU-only checks covered both CLI modes, typed-request forwarding,
  and all five comparator scenarios;
- `./isaaclab.sh -f` passed immediately before commit and again immediately
  before push;
- real downloaded Newton CI bundles for Cartpole and G1 produce complete
  four-metric `SKIP` reports while S3 is unconfigured, including startup,
  memory, and measured per-step FPS deviation; and
- the earlier GPU smoke exercised the real runtime bundle and comparison
  outputs. No GPU benchmark was rerun for these reporting-only trims because
  the shared machine is currently busy.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable; this change affects CI reports and artifacts.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh -f`
- [x] Public API and CLI documentation are updated in the runtime request docstring and CLI help
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] I added the required `source/isaaclab/changelog.d/` fragment
- [x] My name already exists in `CONTRIBUTORS.md`
