### PR TITLE
fix(stack/so101): relax gripper-open tolerance in SO-101 joint-teleop success termination

### DIFF
--- a/source/isaaclab_tasks/changelog.d/rwiltz-fix-so101-joint-teleop-success-reset.rst
+++ b/source/isaaclab_tasks/changelog.d/rwiltz-fix-so101-joint-teleop-success-reset.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed the ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0`` environment not resetting after a
+  successful cube stack. The success termination used a 100 µrad gripper-open tolerance
+  (``atol=0.0001``) that the follower cannot reach when the leader arm's raw encoder angle does
+  not exactly match ``SO101_GRIPPER_OPEN`` due to calibration offsets or joint soft-limit ceilings.
+  The tolerance is now set to ``gripper_threshold`` (0.2 rad) in the joint-teleop env, consistent
+  with the threshold used elsewhere to classify the gripper as open vs. closed.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_teleop_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_teleop_env_cfg.py
@@ -7,6 +7,7 @@ from dataclasses import MISSING
 
 from isaaclab_teleop import IsaacTeleopCfg
 
+from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.contrib.stack import mdp
@@ -156,4 +157,16 @@ class SO101CubeStackEnvCfg(stack_joint_pos_env_cfg.SO101CubeStackEnvCfg):
             pipeline_builder=_build_so101_joint_teleop_pipeline,
             sim_device=self.sim.device,
             xr_cfg=self.xr,
+        )
+
+        # Relax the gripper-open check in the success termination. The default atol=0.0001 rad
+        # (100 µrad) is reachable when the gripper target is set to exactly SO101_GRIPPER_OPEN
+        # via an affine mapping (as in the IK-Abs env). In joint teleop the leader arm's raw
+        # encoder angle is mirrored 1:1, so the follower gripper may not reach the exact open
+        # value within 100 µrad due to calibration offsets or soft-limit ceilings. Using
+        # gripper_threshold (0.2 rad) as the tolerance matches the threshold already used by
+        # observations to classify the gripper as open vs. closed.
+        self.terminations.success = DoneTerm(
+            func=mdp.cubes_stacked,
+            params={"atol": self.gripper_threshold, "rtol": 0.0},
         )


### PR DESCRIPTION
# Description

  - The `cubes_stacked` success termination checks the gripper joint position against `SO101_GRIPPER_OPEN` (1.745 rad) with `atol=0.0001` (100 µrad, the function default).
  - In the **IK-Abs** env this threshold is reachable: when the controller trigger is fully released, the affine gripper mapping (`offset=1.745, scale=-1.745, closedness=0`) always produces exactly 1.745
  rad as the joint target. 
  - In **joint teleop** the leader arm's raw encoder angles are mirrored 1:1 onto the follower. Leader calibration offsets or the joint soft-limit ceiling can keep the actual follower gripper position
  more than 100 µrad below 1.745, so the termination never fires. The episode remains active even after the operator has successfully stacked all three cubes.

  Fix: override `terminations.success` in `SO101CubeStackEnvCfg` (joint-teleop) to pass `atol=gripper_threshold` (0.2 rad) to `cubes_stacked`. This matches the threshold already used by the `gripper_pos`
  observation to classify the gripper as open vs. closed, and is reachable from any normally-calibrated SO-101 leader arm.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there