### PR TITLE
[CI] Request workflow write permission

### DIFF
--- a/.github/workflows/nightly-isaacsim-image.yml
+++ b/.github/workflows/nightly-isaacsim-image.yml
@@ -62,6 +62,7 @@ jobs:
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
# Description

Request the `workflows: write` permission when minting the `isaaclab-bot`
installation token for the nightly Isaac Sim image updater.

The updater changes `.github/workflows/config.yaml`, so GitHub rejected the
bot branch push even though the App already had `contents: write`. The App
registration and repository installation now grant `workflows: write`, and
the bot is an always-allow bypass actor for the applicable branch rulesets.
This workflow input ensures the generated installation token carries the
newly approved permission.

Failed run: https://github.com/isaac-sim/IsaacLab/actions/runs/31424451461/job/93572726513

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- Confirmed the installed `isaaclab-bot` permissions include `workflows: write`
- `uv run isaaclab -f`
- `actionlint` with ShellCheck enabled, excluding its two known stale `v3`
  metadata diagnostics for the supported `client-id` input
- `git diff --check`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation changes are not required for this CI-only fix
- [x] My changes generate no new warnings
- [x] I have run focused workflow validation
- [x] A package changelog fragment is not required because no source package changed
- [x] My name already exists in `CONTRIBUTORS.md`
