### PR TITLE
Add serial port identification guidance to SO-101 leader-arm docs

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -404,7 +404,18 @@ Prerequisites
 
 * **Calibration**: The SO-101 arm must be calibrated before use. The plugin talks to the FEETECH
   servos directly -- it has no ``lerobot`` or FEETECH SDK dependency -- so calibrate with its own
-  ``calibrate`` subcommand, which needs no OpenXR runtime:
+  ``calibrate`` subcommand, which needs no OpenXR runtime.
+
+  First, identify which serial port the arm is on. On Linux, listing ``/dev/serial/by-id/``
+  shows all USB serial devices with descriptive names; the symlink target is the device path
+  (e.g. ``/dev/ttyACM0`` or ``/dev/ttyACM1``):
+
+  .. code-block:: bash
+
+     ls -la /dev/serial/by-id/
+
+  Alternatively, if you have LeRobot installed, ``lerobot-find-port`` (``uv pip install lerobot``)
+  identifies the port interactively. Substitute the result for ``/dev/ttyACM0`` below:
 
   .. code-block:: bash
 
@@ -482,7 +493,8 @@ Start the plugin
 Isaac Lab does not spawn the plugin for you. Launch the sim first -- it brings up the CloudXR
 runtime the plugin connects through -- then, in a **separate terminal**, source the environment
 file the runtime writes on startup (this points the OpenXR loader at CloudXR) and start the plugin
-on the leader's serial port:
+on the leader's serial port (replace ``/dev/ttyACM0`` with your device -- see the port-identification
+note in the Calibration step above):
 
 .. code-block:: bash
 

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -414,7 +414,7 @@ Prerequisites
 
   The kernel log will show the assigned device, e.g. ``[USB] ... ttyACM0``. Use that path
   (e.g. ``/dev/ttyACM0``, ``/dev/ttyACM1``) in the command below. Alternatively,
-  ``lerobot-find-port`` (``uv pip install lerobot``) can identify the port interactively.
+  ``uvx --from lerobot lerobot-find-port`` can identify the port interactively (no install needed).
 
   .. code-block:: bash
 

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -406,15 +406,22 @@ Prerequisites
   servos directly -- it has no ``lerobot`` or FEETECH SDK dependency -- so calibrate with its own
   ``calibrate`` subcommand, which needs no OpenXR runtime.
 
-  First, identify the serial port. Plug in the USB cable, then run:
+  First, identify the serial port. The easiest way is ``uvx``, which runs
+  ``lerobot-find-port`` in a temporary environment with no installation required:
 
   .. code-block:: bash
 
-     dmesg | grep tty | tail -5
+     uvx --from lerobot lerobot-find-port
 
-  The kernel log will show the assigned device, e.g. ``[USB] ... ttyACM0``. Use that path
-  (e.g. ``/dev/ttyACM0``, ``/dev/ttyACM1``) in the command below. Alternatively,
-  ``uvx --from lerobot lerobot-find-port`` can identify the port interactively (no install needed).
+  Alternatively, plug in the USB cable and immediately run:
+
+  .. code-block:: bash
+
+     dmesg | grep tty | tail -1
+
+  Because ``tail -1`` shows only the most recent kernel message, the output unambiguously
+  names the just-connected device, e.g. ``[12345.6] usb ... ttyACM0``.
+  Use that path (``/dev/ttyACM0``, ``/dev/ttyACM1``, etc.) in the command below.
 
   .. code-block:: bash
 

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -406,16 +406,15 @@ Prerequisites
   servos directly -- it has no ``lerobot`` or FEETECH SDK dependency -- so calibrate with its own
   ``calibrate`` subcommand, which needs no OpenXR runtime.
 
-  First, identify which serial port the arm is on. On Linux, listing ``/dev/serial/by-id/``
-  shows all USB serial devices with descriptive names; the symlink target is the device path
-  (e.g. ``/dev/ttyACM0`` or ``/dev/ttyACM1``):
+  First, identify the serial port. Plug in the USB cable, then run:
 
   .. code-block:: bash
 
-     ls -la /dev/serial/by-id/
+     dmesg | grep tty | tail -5
 
-  Alternatively, if you have LeRobot installed, ``lerobot-find-port`` (``uv pip install lerobot``)
-  identifies the port interactively. Substitute the result for ``/dev/ttyACM0`` below:
+  The kernel log will show the assigned device, e.g. ``[USB] ... ttyACM0``. Use that path
+  (e.g. ``/dev/ttyACM0``, ``/dev/ttyACM1``) in the command below. Alternatively,
+  ``lerobot-find-port`` (``uv pip install lerobot``) can identify the port interactively.
 
   .. code-block:: bash
 


### PR DESCRIPTION
# Description

  * Adds a port-identification step before the `calibrate` command with two options:
    - **Primary:** `uvx --from lerobot lerobot-find-port` — interactive, unambiguous
      regardless of how many devices are connected, no install required
    - **Fallback:** plug in the arm then run `dmesg | grep tty | tail -1` — `tail -1`
      ensures the output unambiguously names the just-connected device
  * Adds a back-reference at the "Start the plugin" command so both hardcoded
    `/dev/ttyACM0` occurrences are covered


Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there