### PR TITLE
Warn when XR mode silently falls back to CPU physics

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -257,6 +257,32 @@ To verify that the headset and controller tracking poses are reaching Isaac Lab,
 hand joints and RGB axes at tracked controller aim poses. See
 :ref:`isaac-teleop-tracking-debug-visualization` for details.
 
+.. note::
+
+   **In XR mode, physics runs on the CPU unless you pass** ``--device`` **explicitly.** Passing
+   ``--xr`` without ``--device`` overrides the usual ``cuda:0`` default and selects ``cpu``
+   instead. Isaac Lab warns when this happens:
+
+   .. code-block:: text
+
+      XR mode is enabled and no device was specified explicitly: running physics on the CPU.
+
+   CPU physics can reduce latency when only a single environment is present, which is why it is
+   the default for teleoperation. It is typically slower for larger or contact-rich scenes, where
+   the GPU pipeline wins instead. Which one is faster is scene-dependent, so measure both. To
+   force GPU physics, pass the device explicitly:
+
+   .. code-block:: bash
+
+      uv run --extra teleop isaaclab teleop run \
+          --task <task> \
+          --visualizer kit \
+          --xr \
+          --device cuda:0
+
+   Confirm the selection in the startup banner, which prints
+   ``Environment device    : cuda:0`` (or ``cpu``).
+
 .. attention::
 
    **First run — EULA acceptance required.**

--- a/source/isaaclab/changelog.d/warn-xr-cpu-physics-fallback.rst
+++ b/source/isaaclab/changelog.d/warn-xr-cpu-physics-fallback.rst
@@ -1,10 +1,9 @@
-Changed
-^^^^^^^
+Added
+^^^^^
 
-* Added a warning in :class:`~isaaclab.app.AppLauncher` when ``--xr`` is passed without an
-  explicit ``--device``. In that case the simulation falls back to CPU physics instead of the
-  usual ``cuda:0`` default. The fallback previously produced no console output, so the only way
-  to discover it was to read ``AppLauncher._resolve_device_settings`` or spot ``cpu`` in the
+* Added a warning when ``--xr`` is passed without an explicit ``--device``. In that case the
+  simulation falls back to CPU physics instead of the usual ``cuda:0`` default. The fallback
+  previously produced no console output, so the only way to notice it was to spot ``cpu`` in the
   environment banner. The warning names the fallback and how to override it.
 
-* Clarified the ``--device`` CLI help text to mention the XR fallback.
+* Added a note to the ``--device`` CLI help text describing the XR fallback.

--- a/source/isaaclab/changelog.d/warn-xr-cpu-physics-fallback.rst
+++ b/source/isaaclab/changelog.d/warn-xr-cpu-physics-fallback.rst
@@ -1,0 +1,10 @@
+Changed
+^^^^^^^
+
+* Added a warning in :class:`~isaaclab.app.AppLauncher` when ``--xr`` is passed without an
+  explicit ``--device``. In that case the simulation falls back to CPU physics instead of the
+  usual ``cuda:0`` default. The fallback previously produced no console output, so the only way
+  to discover it was to read ``AppLauncher._resolve_device_settings`` or spot ``cpu`` in the
+  environment banner. The warning names the fallback and how to override it.
+
+* Clarified the ``--device`` CLI help text to mention the XR fallback.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1074,23 +1074,13 @@ class AppLauncher:
         device = launcher_args.get("device", AppLauncher._APPLAUNCHER_CFG_INFO["device"][1])
 
         device_explicitly_passed = launcher_args.pop("device_explicit", False)
-        if self._xr and not device_explicitly_passed:
+        applied_xr_cpu_fallback = self._xr and not device_explicitly_passed
+        if applied_xr_cpu_fallback:
             # If no device is specified, default to the CPU device if we are running in XR
             device = "cpu"
 
             # Overwrite for downstream consumers
             launcher_args["device"] = "cpu"
-
-            # This fallback is otherwise silent, and it overrides the "cuda:0" default that applies
-            # outside XR. Whether CPU physics is the faster choice is scene-dependent, so surface the
-            # switch and the way to opt out of it.
-            logger.warning(
-                "XR mode is enabled and no device was specified explicitly: running physics on the CPU."
-                " Outside XR the default is '%s'. CPU physics can reduce latency for single-environment"
-                " teleoperation, but is typically slower for larger or contact-rich scenes. Pass --device"
-                " explicitly (for example '--device cuda:0') to override this fallback.",
-                AppLauncher._APPLAUNCHER_CFG_INFO["device"][1],
-            )
 
         if "cuda" not in device and "cpu" not in device:
             raise ValueError(
@@ -1150,6 +1140,19 @@ class AppLauncher:
 
         # Store the resolved device string for downstream consumers (e.g. sim_launcher)
         self.device = device
+
+        # The XR fallback above is otherwise silent, and it overrides the "cuda:0" default that
+        # applies outside XR. Report it only once the device is final, since the distributed branch
+        # may have replaced it with "cuda:<rank>". Whether CPU physics is the faster choice is
+        # scene-dependent, so surface the switch and the way to opt out of it.
+        if applied_xr_cpu_fallback and device == "cpu":
+            logger.warning(
+                "XR mode is enabled and no device was specified explicitly: running physics on the CPU."
+                " Outside XR the default is '%s'. CPU physics can reduce latency for single-environment"
+                " teleoperation, but is typically slower for larger or contact-rich scenes. Pass --device"
+                " explicitly (for example '--device cuda:0') to override this fallback.",
+                AppLauncher._APPLAUNCHER_CFG_INFO["device"][1],
+            )
 
         logger.info("Using device: %s", device)
 

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -580,7 +580,10 @@ class AppLauncher:
             type=str,
             action=ExplicitAction,
             default=AppLauncher._APPLAUNCHER_CFG_INFO["device"][1],
-            help='The device to run the simulation on. Can be "cpu", "cuda", "cuda:N", where N is the device ID',
+            help=(
+                'The device to run the simulation on. Can be "cpu", "cuda", "cuda:N", where N is the device ID.'
+                " When --xr is set and this flag is omitted, the simulation falls back to CPU physics."
+            ),
         )
         arg_group.add_argument(
             "--visualizer",
@@ -1077,6 +1080,17 @@ class AppLauncher:
 
             # Overwrite for downstream consumers
             launcher_args["device"] = "cpu"
+
+            # This fallback is otherwise silent, and it overrides the "cuda:0" default that applies
+            # outside XR. Whether CPU physics is the faster choice is scene-dependent, so surface the
+            # switch and the way to opt out of it.
+            logger.warning(
+                "XR mode is enabled and no device was specified explicitly: running physics on the CPU."
+                " Outside XR the default is '%s'. CPU physics can reduce latency for single-environment"
+                " teleoperation, but is typically slower for larger or contact-rich scenes. Pass --device"
+                " explicitly (for example '--device cuda:0') to override this fallback.",
+                AppLauncher._APPLAUNCHER_CFG_INFO["device"][1],
+            )
 
         if "cuda" not in device and "cpu" not in device:
             raise ValueError(


### PR DESCRIPTION
# Description

Passing `--xr` without `--device` overrides the usual `cuda:0` default and runs physics on the CPU:

https://github.com/isaac-sim/IsaacLab/blob/develop/source/isaaclab/isaaclab/app/app_launcher.py#L1073-L1079

```python
device_explicitly_passed = launcher_args.pop("device_explicit", False)
if self._xr and not device_explicitly_passed:
    # If no device is specified, default to the CPU device if we are running in XR
    device = "cpu"
    launcher_args["device"] = "cpu"
```

The fallback is deliberate — CPU physics can reduce latency when only a single environment is
present, which is the common teleoperation case. The problem is that it is **silent**. It emits no
console output, and on `develop` the CloudXR how-to does not mention the XR device default at all,
so the only ways to discover it are reading `_resolve_device_settings` or noticing `cpu` in the
environment banner.

On scenes where the GPU pipeline is the faster choice this is an easy, invisible performance loss.
I hit it running `Isaac-Stack-Cube-Franka-IK-Abs-v0` teleoperation on an RTX 5090 and spent a while
chasing latency before finding the fallback in the launcher source.

This PR does not change the default — only makes it discoverable:

- `AppLauncher._resolve_device_settings` logs a warning when the fallback is applied, naming both
  the behavior and the override.
- The `--device` help text mentions the XR fallback.
- The CloudXR teleoperation how-to documents it, with the override command and how to confirm the
  selection in the startup banner.

The warning text deliberately avoids claiming GPU is always faster, since which device wins is
scene-dependent:

```
XR mode is enabled and no device was specified explicitly: running physics on the CPU. Outside XR
the default is 'cuda:0'. CPU physics can reduce latency for single-environment teleoperation, but
is typically slower for larger or contact-rich scenes. Pass --device explicitly (for example
'--device cuda:0') to override this fallback.
```

Fixes # (no issue filed — happy to open one if preferred)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

N/A — console warning text is quoted above.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Notes on the two unchecked boxes

**Tests.** There is no existing test module for `AppLauncher`, so there was no harness to extend and
adding one felt out of scope for a warning. I verified the behavior by loading `app_launcher.py`
with the `isaaclab` package stubbed and calling `_resolve_device_settings` directly:

| case | resolved device | warnings |
| --- | --- | --- |
| `--xr`, no `--device` | `cpu` | 1 |
| `--xr --device cuda:0` | `cuda:0` | 0 |
| no `--xr` | `cuda:0` | 0 |

Glad to add a proper test module if you would like one.

**CONTRIBUTORS.md.** Not added yet — let me know if you would like me to add an entry.
