### PR TITLE
Fix bundled package import precedence

### DIFF
--- a/source/isaaclab/changelog.d/maximiliank-fix-warp-fastfinder-precedence.rst
+++ b/source/isaaclab/changelog.d/maximiliank-fix-warp-fastfinder-precedence.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed mixed package imports when Isaac Sim extensions bundle a different
+  version than the active Python environment.

--- a/source/isaaclab/isaaclab/__init__.py
+++ b/source/isaaclab/isaaclab/__init__.py
@@ -8,10 +8,11 @@
 import importlib.metadata
 import os
 import sys
+from importlib.machinery import PathFinder
 
 
 def _deprioritize_prebundle_paths():
-    """Move Isaac Sim ``pip_prebundle`` and known conflicting extension directories to the end of ``sys.path``.
+    """Deprioritize Isaac Sim's bundled Python packages during module resolution.
 
     Isaac Sim's ``setup_python_env.sh`` injects ``pip_prebundle`` directories
     onto ``PYTHONPATH``.  These contain older copies of packages like torch,
@@ -27,6 +28,11 @@ def _deprioritize_prebundle_paths():
     ``sympy`` that only exist in the prebundle), this function moves them to
     the **end** of ``sys.path`` so that pip-installed packages in
     ``site-packages`` take priority.
+
+    Kit's fast importer can also resolve extension modules before Python
+    consults ``sys.path``. Its finder is moved behind the standard path finder
+    so the corrected path ordering remains effective, while extension-only
+    modules continue to resolve through Kit.
 
     The ``PYTHONPATH`` environment variable is also rewritten so that child
     processes inherit the corrected ordering.
@@ -50,6 +56,22 @@ def _deprioritize_prebundle_paths():
             if frag.lower() in norm:
                 return True
         return False
+
+    # Kit installs one global finder for modules bundled by extensions. Keep it
+    # available, but let the active Python environment resolve packages first.
+    fast_finder = next(
+        (
+            finder
+            for finder in sys.meta_path
+            if getattr(finder, "__module__", None) == "omni.ext._impl.fast_importer"
+            and getattr(finder, "__name__", None) == "FastFinder"
+        ),
+        None,
+    )
+    if fast_finder is not None and fast_finder in sys.meta_path and PathFinder in sys.meta_path:
+        if sys.meta_path.index(fast_finder) < sys.meta_path.index(PathFinder):
+            sys.meta_path.remove(fast_finder)
+            sys.meta_path.insert(sys.meta_path.index(PathFinder) + 1, fast_finder)
 
     # Partition: keep non-conflicting in place, collect conflicting.
     clean = []

--- a/source/isaaclab/test/app/test_prebundle_path_sanitizer.py
+++ b/source/isaaclab/test/app/test_prebundle_path_sanitizer.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Kitless unit tests for Isaac Sim prebundle import sanitization."""
+
+import sys
+from importlib.machinery import PathFinder
+
+import pytest
+
+from isaaclab import _deprioritize_prebundle_paths
+
+pytestmark = pytest.mark.unit
+
+
+class FastFinder:
+    """Stand-in for Kit's global fast importer."""
+
+
+FastFinder.__module__ = "omni.ext._impl.fast_importer"
+
+
+def test_sanitizer_places_kit_fast_finder_after_path_finder(monkeypatch):
+    """Pip packages must resolve before identically named Kit extension modules."""
+    meta_path = [FastFinder, *(finder for finder in sys.meta_path if finder is not FastFinder)]
+    monkeypatch.setattr(sys, "meta_path", meta_path)
+    monkeypatch.setattr(sys, "path", ["/venv/lib/python3.12/site-packages"])
+
+    _deprioritize_prebundle_paths()
+
+    assert sys.meta_path.index(PathFinder) < sys.meta_path.index(FastFinder)
+
+    sanitized_meta_path = sys.meta_path.copy()
+    _deprioritize_prebundle_paths()
+    assert sys.meta_path == sanitized_meta_path


### PR DESCRIPTION
# Description

Kit's fast importer is registered ahead of Python's standard path finder. This lets Python modules bundled by Isaac Sim extensions bypass Isaac Lab's existing `sys.path` sanitization.

When `omni.replicator.core` enables `omni.warp.core`, `warp.fem` can consequently resolve from the bundled Warp 1.13 extension while the root `warp` package is already loaded from the active Warp 1.16 environment. Mixing those versions raises an `ImportError` for `warp._src.utils.warn`.

This change keeps Kit's fast importer available, but moves it behind Python's standard path finder when Isaac Lab sanitizes bundled package paths. Packages in the active environment therefore resolve first, while extension-only modules continue to fall back to Kit. The operation is idempotent.

No additional dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this changes Python import resolution.

## Validation

- Added a kitless regression test covering finder precedence and idempotency.
- Confirmed the regression test fails without the implementation and passes with it.
- Reproduced the mixed Warp 1.13/1.16 `ImportError` in a real Kit runtime with the previous finder order.
- Confirmed `warp.fem` resolves from the active Warp 1.16 environment with the new order.
- Ran `uv run isaaclab -f` successfully.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `uv run isaaclab -f`.
- [x] Documentation changes are not required for this internal import-resolution fix.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove the fix is effective.
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`.
- [x] My name already exists in `CONTRIBUTORS.md`.
