### PR TITLE
Restore Newton coverage in rigid-object-collection interface tests

### DIFF
--- a/source/isaaclab/test/assets/_rigid_object_collection_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_rigid_object_collection_iface_test_utils.py
@@ -20,6 +20,7 @@ from isaaclab.assets.rigid_object_collection.rigid_object_collection_cfg import 
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 BACKENDS: list[str] = []
+BACKEND_UNAVAILABLE_REASONS: dict[str, str] = {}
 
 try:
     from isaaclab_physx.assets.rigid_object_collection.rigid_object_collection import (
@@ -30,8 +31,8 @@ try:
     )
     from isaaclab_physx.physics import PhysxManager as SimulationManager
     from isaaclab_physx.test.fixtures.views import MockRigidBodyViewWarp as PhysXMockRigidBodyViewWarp
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["physx"] = f"{type(error).__name__}: {error}"
 else:
     # PhysX data classes need gravity even though interface tests do not create a physics scene.
     _mock_physics_sim_view = MagicMock()
@@ -47,10 +48,9 @@ try:
     from isaaclab_newton.assets.rigid_object_collection.rigid_object_collection_data import (
         RigidObjectCollectionData as NewtonRigidObjectCollectionData,
     )
-    from isaaclab_newton.test.fixtures.mock_newton import WrenchComposer as NewtonWrenchComposer
     from isaaclab_newton.test.fixtures.views import MockNewtonCollectionView as NewtonMockCollectionView
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["newton"] = f"{type(error).__name__}: {error}"
 else:
     BACKENDS.append("newton")
 
@@ -64,11 +64,13 @@ try:
         RigidObjectCollectionData as OvPhysxRigidObjectCollectionData,
     )
     from isaaclab_ovphysx.test.fixtures.views import MockOvPhysxBindingSet
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["ovphysx"] = f"{type(error).__name__}: {error}"
 else:
     if hasattr(OvPhysxRigidObjectCollection, "_create_buffers"):
         BACKENDS.append("ovphysx")
+    else:
+        BACKEND_UNAVAILABLE_REASONS["ovphysx"] = "RigidObjectCollection._create_buffers is missing"
 
 
 def create_physx_rigid_object_collection(
@@ -197,8 +199,8 @@ def create_newton_rigid_object_collection(
     data.body_names = body_names
 
     # Mock wrench composers (Newton-specific)
-    mock_inst_wrench = NewtonWrenchComposer(collection)
-    mock_perm_wrench = NewtonWrenchComposer(collection)
+    mock_inst_wrench = WrenchComposer(collection)
+    mock_perm_wrench = WrenchComposer(collection)
     object.__setattr__(collection, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(collection, "_permanent_wrench_composer", mock_perm_wrench)
 

--- a/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
@@ -19,14 +19,15 @@ from isaaclab.assets.rigid_object.rigid_object_cfg import RigidObjectCfg
 from isaaclab.utils.wrench_composer import WrenchComposer
 
 BACKENDS: list[str] = []
+BACKEND_UNAVAILABLE_REASONS: dict[str, str] = {}
 
 try:
     from isaaclab_physx.assets.rigid_object.rigid_object import RigidObject as PhysXRigidObject
     from isaaclab_physx.assets.rigid_object.rigid_object_data import RigidObjectData as PhysXRigidObjectData
     from isaaclab_physx.physics import PhysxManager as SimulationManager
     from isaaclab_physx.test.fixtures.views import MockRigidBodyViewWarp as PhysXMockRigidBodyViewWarp
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["physx"] = f"{type(error).__name__}: {error}"
 else:
     # PhysX data classes need gravity even though interface tests do not create a physics scene.
     _mock_physics_sim_view = MagicMock()
@@ -39,8 +40,8 @@ try:
     from isaaclab_newton.assets.rigid_object.rigid_object import RigidObject as NewtonRigidObject
     from isaaclab_newton.assets.rigid_object.rigid_object_data import RigidObjectData as NewtonRigidObjectData
     from isaaclab_newton.test.fixtures.views import MockNewtonArticulationView as NewtonMockArticulationView
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["newton"] = f"{type(error).__name__}: {error}"
 else:
     BACKENDS.append("newton")
 
@@ -50,8 +51,8 @@ try:
     from isaaclab_ovphysx.assets.rigid_object.rigid_object import RigidObject as OvPhysxRigidObject
     from isaaclab_ovphysx.assets.rigid_object.rigid_object_data import RigidObjectData as OvPhysxRigidObjectData
     from isaaclab_ovphysx.test.fixtures.views import MockOvPhysxBindingSet
-except ImportError:
-    pass
+except ImportError as error:
+    BACKEND_UNAVAILABLE_REASONS["ovphysx"] = f"{type(error).__name__}: {error}"
 else:
     BACKENDS.append("ovphysx")
 

--- a/source/isaaclab/test/assets/test_iface_test_utils.py
+++ b/source/isaaclab/test/assets/test_iface_test_utils.py
@@ -72,6 +72,38 @@ assert all(not any(backend.lower() == "physx" for backend in module.BACKENDS) fo
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+@pytest.mark.parametrize("backend", ["physx", "newton"])
+def test_iface_utilities_agree_on_backend_availability(backend: str) -> None:
+    """Fail when one utility drops a backend that its siblings kept.
+
+    All three utilities gate ``physx`` and ``newton`` on the same backend package being
+    importable, so a backend registered by some and not others means that utility's own imports
+    are broken rather than the backend being unavailable. ``ovphysx`` is excluded because the
+    collection utility additionally gates it on ``_create_buffers``.
+    """
+    script = f"""
+import importlib
+import sys
+
+sys.path.insert(0, {_ASSET_TEST_DIR.as_posix()!r})
+backend = {backend!r}
+registered = {{}}
+details = []
+for name in {_IFACE_UTIL_MODULES!r}:
+    module = importlib.import_module(name)
+    registered[name] = backend in module.BACKENDS
+    reason = module.BACKEND_UNAVAILABLE_REASONS.get(backend, "-")
+    details.append(name + ": registered=" + str(registered[name]) + " reason=" + reason)
+assert len(set(registered.values())) == 1, (
+    "interface utilities disagree on " + backend + ":\\n" + "\\n".join(details)
+)
+"""
+
+    result = _run_probe(script)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 @pytest.mark.parametrize("module_name", _IFACE_UTIL_MODULES)
 def test_iface_utility_handles_no_available_backends(module_name: str) -> None:
     script = f"""

--- a/source/isaaclab/test/assets/test_iface_test_utils.py
+++ b/source/isaaclab/test/assets/test_iface_test_utils.py
@@ -73,13 +73,13 @@ assert all(not any(backend.lower() == "physx" for backend in module.BACKENDS) fo
 
 
 @pytest.mark.parametrize("backend", ["physx", "newton"])
-def test_iface_utilities_agree_on_backend_availability(backend: str) -> None:
-    """Fail when one utility drops a backend that its siblings kept.
+def test_no_iface_utility_silently_drops_a_backend(backend: str) -> None:
+    """Fail when a backend disappears from one utility's test matrix.
 
-    All three utilities gate ``physx`` and ``newton`` on the same backend package being
-    importable, so a backend registered by some and not others means that utility's own imports
-    are broken rather than the backend being unavailable. ``ovphysx`` is excluded because the
-    collection utility additionally gates it on ``_create_buffers``.
+    Detected by cross-checking the three utilities: they gate ``physx`` and ``newton`` on the
+    same backend package being importable, so a backend registered by some and not others is a
+    broken import in that utility rather than an unavailable backend. ``ovphysx`` is excluded
+    because the collection utility additionally gates it on ``_create_buffers``.
     """
     script = f"""
 import importlib


### PR DESCRIPTION
# Description

`_rigid_object_collection_iface_test_utils.py` imports `WrenchComposer` from
`isaaclab_newton.test.fixtures.mock_newton`, which defines only `MockNewtonModel` and
`create_mock_newton_manager`. The import raises `ImportError`, the surrounding
`except ImportError` swallows it, and `"newton"` is never appended to `BACKENDS`.

Because the suite parametrizes over that filtered list, an empty list becomes skipped
parameters rather than a failure — so the Newton collection tests stopped running while the
suite stayed green. From `isaaclab (core) [3/3]` logs, same job, same container:

| Suite | physx | newton |
|---|---|---|
| `test_articulation_iface.py` | 1151 | 915 |
| `test_rigid_object_iface.py` | 384 | 398 |
| `test_rigid_object_collection_iface.py` | 657 | **0** (was 659) |

## Changes

- Use the `WrenchComposer` already imported at module scope. It is the class production
  Newton constructs (`isaaclab_newton/.../rigid_object_collection.py:1256`), so no
  backend-specific alias is warranted.
- Record the cause in `BACKEND_UNAVAILABLE_REASONS` in the two utilities that discarded it,
  matching `_articulation_iface_test_utils.py`.
- Add `test_iface_utilities_agree_on_backend_availability`: the three utilities gate physx
  and newton on the same package, so a backend registered by some and not others is a broken
  import and now fails the build.

## Validation

- `test_rigid_object_collection_iface.py -k "newton and cpu"` → 309 passed, 12 xfailed (was 651 skipped)
- Four interface suites + guard → 1887 passed, 0 failed
- Guard verified both ways: fails with the import reinstated, naming the module and the
  `ImportError`; passes once fixed
- `uv run isaaclab -f` clean

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
