### PR TITLE
[Visualizer] Render markers in Newton GL video capture

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/newton-video-capture.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-video-capture.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_visualizers.newton.NewtonGLVisualizer.render_rgb_array` omitting
+  visualization markers, so videos recorded with ``--viz newton_gl`` showed the scene without
+  its goal poses, command arrows, and other debug markers visible in the interactive viewer.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1836,6 +1836,16 @@ class NewtonGLVisualizer(NewtonVisualizer):
             self._viewer.begin_frame(self._sim_time)
             try:
                 self._viewer.log_state(self._state)
+                # The interactive render path logs markers every frame; a capture that
+                # skips them records the scene without its goal poses and command arrows.
+                if self.cfg.enable_markers:
+                    from isaaclab_newton.physics import NewtonManager
+
+                    render_newton_visualization_markers(
+                        self._viewer,
+                        self._resolved_visible_env_ids,
+                        num_envs=NewtonManager.get_num_envs(),
+                    )
             finally:
                 self._viewer.end_frame()
         return self._viewer.get_frame().numpy()


### PR DESCRIPTION
# Description

`NewtonGLVisualizer.render_rgb_array()` logged only the physics state between
`begin_frame` and `end_frame`, while the interactive render path also logs the
visualization markers each frame. Recorded videos therefore dropped goal poses,
command arrows, and every other debug marker that is visible when watching the
same scene live — most noticeably on the reorientation tasks, where the goal
cube marker is the only cue for what the policy is tracking.

This logs the markers on the capture path too, gated on the existing
`cfg.enable_markers` so callers that deliberately disable markers still get a
clean frame.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before: `--video --viz newton_gl` produced clips with no goal marker.
After: the goal cube appears in the recording, matching the interactive viewer.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added a changelog fragment under `source/isaaclab_visualizers/changelog.d/`
- [x] I have verified the fix by recording a clip with `--video --viz newton_gl` and confirming the markers render