### PR TITLE
Support video recording on the Warp frontend

### DIFF
--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -83,12 +83,13 @@ In Isaac Lab 3.0, the equivalent is:
        --viz kit --enable_cameras --headless --video
 
 As a convenience, passing ``--video`` without ``--viz`` still works: Isaac Lab
-auto-creates a headless Kit visualizer (falling back to Newton GL if Kit is unavailable)
-and sets ``source="visualizer:kit"`` on the default recorder, printing:
+auto-creates a headless visualizer and points the default recorder at it. The backend
+depends on the frontend — Kit with ``--frontend torch``, and Newton GL with
+``--frontend warp``, which is commonly run without a Kit install. It prints:
 
 .. code-block:: text
 
-   [INFO] --video specified without --viz: auto-creating a headless Kit visualizer
+   [INFO] --video specified without --viz: auto-creating a headless kit visualizer
    for video recording. Pass --viz <type> to choose a different visualizer, or
    set video_recorders in your env config to record from a scene sensor instead.
 

--- a/source/isaaclab_experimental/changelog.d/jichuanh-warp-video-recording.minor.rst
+++ b/source/isaaclab_experimental/changelog.d/jichuanh-warp-video-recording.minor.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added video recording to the Warp environments, so ``--video`` now works with
+  ``--frontend warp``. Recorders configured through ``env_cfg.video_recorders`` are created,
+  advanced once per step, and flushed on close by :class:`~isaaclab_experimental.envs.ManagerBasedEnvWarp`,
+  :class:`~isaaclab_experimental.envs.ManagerBasedRLEnvWarp`, and
+  :class:`~isaaclab_experimental.envs.DirectRLEnvWarp`. Previously the setting was ignored with a
+  warning, and silently ignored entirely on the direct environment.

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -28,6 +28,7 @@ from isaaclab.envs.common import VecEnvObs, VecEnvStepReturn
 from isaaclab.envs.direct_rl_env import DirectRLEnv
 from isaaclab.envs.direct_rl_env_cfg import DirectRLEnvCfg
 from isaaclab.envs.utils.spaces import sample_space, spec_to_gym_space
+from isaaclab.envs.utils.video_recorder import VideoRecorder
 from isaaclab.managers import EventManager
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
@@ -205,6 +206,8 @@ class DirectRLEnvWarp(DirectRLEnv):
         else:
             # if no window, then we don't need to store the window
             self._window = None
+
+        self.video_recorders: list[VideoRecorder] = [VideoRecorder(cfg, self) for cfg in self.cfg.video_recorders]
 
         # allocate dictionary to store metrics
         self.extras = {}
@@ -447,6 +450,10 @@ class DirectRLEnvWarp(DirectRLEnv):
         with Timer(name="visualize", msg="Visualize took:", enable=DEBUG_TIMERS):
             self._post_step_visualize()
 
+        # advance video recorders (after render and visualization, before obs)
+        for recorder in self.video_recorders:
+            recorder.step()
+
         # return observations, rewards, resets and extras
         # store the returned buffer so RslRlVecEnvWrapper.get_observations() can read env.obs_buf
         self.obs_buf = {"policy": self.torch_obs_buf.clone()}
@@ -599,6 +606,10 @@ class DirectRLEnvWarp(DirectRLEnv):
     def close(self):
         """Cleanup for the environment."""
         if not self._is_closed:
+            # flush any buffered video frames
+            for recorder in getattr(self, "video_recorders", []):
+                recorder.close()
+
             # close entities related to the environment
             # note: this is order-sensitive to avoid any dangling references
             if self.cfg.events:

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -450,7 +450,9 @@ class DirectRLEnvWarp(DirectRLEnv):
         with Timer(name="visualize", msg="Visualize took:", enable=DEBUG_TIMERS):
             self._post_step_visualize()
 
-        # advance video recorders (after render and visualization, before obs)
+        # Advance video recorders: after render and visualization, and outside the captured
+        # graph scope. Unlike the manager-based envs this runs *after* observations, which
+        # `_step_warp_end_post()` computes inside the graph; only the obs_buf clone follows.
         for recorder in self.video_recorders:
             recorder.step()
 

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -29,6 +29,7 @@ import warp as wp
 from isaaclab.envs.common import VecEnvObs
 from isaaclab.envs.manager_based_env_cfg import ManagerBasedEnvCfg
 from isaaclab.envs.utils.io_descriptors import export_articulations_data, export_scene_data
+from isaaclab.envs.utils.video_recorder import VideoRecorder
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import use_stage
 from isaaclab.utils.seed import configure_seed
@@ -74,14 +75,6 @@ class ManagerBasedEnvWarp:
         cfg.validate()
         # store inputs to class
         self.cfg = cfg
-        # Video recording is not supported on Warp environments.
-        if getattr(cfg, "video_recorders", None):
-            import logging as _logging
-
-            _logging.getLogger(__name__).warning(
-                "cfg.video_recorders is set but ManagerBasedEnvWarp does not support VideoRecorder. "
-                "No clips will be written. Use ManagerBasedEnv for video recording support."
-            )
         # initialize internal variables
         self._is_closed = False
         # temporary debug runtime config for manager source/call switching.
@@ -195,6 +188,8 @@ class ManagerBasedEnvWarp:
 
         # add timeline event to load managers
         self.load_managers()
+
+        self.video_recorders: list[VideoRecorder] = [VideoRecorder(cfg, self) for cfg in self.cfg.video_recorders]
 
         # Wire live plots into all active visualizers and build Kit omni.ui panels when present.
         self.setup_manager_visualizers()
@@ -561,6 +556,10 @@ class ManagerBasedEnvWarp:
         if "interval" in self.event_manager.available_modes:
             self.event_manager.apply(mode="interval", dt=self.step_dt)
 
+        # advance video recorders (after render, before obs)
+        for recorder in self.video_recorders:
+            recorder.step()
+
         # -- compute observations
         self.obs_buf = self.observation_manager.compute(update_history=True)
         self.recorder_manager.record_post_step()
@@ -591,6 +590,10 @@ class ManagerBasedEnvWarp:
     def close(self):
         """Cleanup for the environment."""
         if not self._is_closed:
+            # flush any buffered video frames
+            for recorder in getattr(self, "video_recorders", []):
+                recorder.close()
+
             # destructor is order-sensitive
             del self.action_manager
             del self.observation_manager

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_rl_env_warp.py
@@ -375,6 +375,10 @@ class ManagerBasedRLEnvWarp(ManagerBasedEnvWarp, gym.Env):
                 timer=DEBUG_TIMER_STEP,
             )
 
+        # -- advance video recorders (after render and resets, before final obs)
+        for recorder in self.video_recorders:
+            recorder.step()
+
         # -- compute observations
         # note: done after reset to get the correct observations for reset envs
         self.obs_buf = self._manager_call_switch.call_stage(

--- a/source/isaaclab_rl/changelog.d/jichuanh-warp-video-recording.minor.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-warp-video-recording.minor.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Removed the restriction that ``--video`` requires ``--frontend torch``. Video recording now
+  works on the Warp frontend.
+* Changed the visualizer auto-created for ``--video`` when no ``--viz`` is given: the Warp
+  frontend now gets a headless Newton GL visualizer instead of a headless Kit one, since the
+  Warp runtime does not initialise Kit. The Torch frontend is unchanged.

--- a/source/isaaclab_rl/changelog.d/jichuanh-warp-video-recording.minor.rst
+++ b/source/isaaclab_rl/changelog.d/jichuanh-warp-video-recording.minor.rst
@@ -4,5 +4,6 @@ Changed
 * Removed the restriction that ``--video`` requires ``--frontend torch``. Video recording now
   works on the Warp frontend.
 * Changed the visualizer auto-created for ``--video`` when no ``--viz`` is given: the Warp
-  frontend now gets a headless Newton GL visualizer instead of a headless Kit one, since the
-  Warp runtime does not initialise Kit. The Torch frontend is unchanged.
+  frontend now gets a headless Newton GL visualizer instead of a headless Kit one, which
+  requires a full Isaac Sim install. Pass ``--viz kit`` to record through Kit instead. The
+  Torch frontend is unchanged.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -784,13 +784,23 @@ def pre_launch_video_config(env_cfg: Any, log_dir: str | None = None, args_cli: 
     if not isinstance(getattr(sim_cfg, "visualizer_cfgs", None), list):
         sim_cfg.visualizer_cfgs = []
 
+    # The warp runtime never initialises Kit, so a Kit visualizer cannot serve as a frame
+    # source there. Newton GL is capture-capable and runs on both frontends.
+    frontend = getattr(args_cli, "frontend", "torch") or "torch"
     try:
-        from isaaclab_visualizers.kit import KitVisualizerCfg as _KitCfg
+        if frontend == "torch":
+            from isaaclab_visualizers.kit import KitVisualizerCfg as _CaptureCfg
 
-        sim_cfg.visualizer_cfgs.append(_KitCfg(headless=True))
+            name = "Kit"
+        else:
+            from isaaclab_visualizers.newton import NewtonGLVisualizerCfg as _CaptureCfg
+
+            name = "Newton GL"
+
+        sim_cfg.visualizer_cfgs.append(_CaptureCfg(headless=True))
         print(
-            "[INFO] pre_launch_video_config: pre-injecting a headless Kit visualizer so the launcher "
-            "includes the Kit runtime. Pass --viz <type> to choose a different visualizer."
+            f"[INFO] pre_launch_video_config: pre-injecting a headless {name} visualizer as the video "
+            "frame source. Pass --viz <type> to choose a different visualizer."
         )
     except (ImportError, ModuleNotFoundError):
         pass
@@ -825,14 +835,6 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
     """
     if not getattr(args_cli, "video", False):
         return
-
-    frontend = getattr(args_cli, "frontend", "torch") or "torch"
-    if frontend != "torch":
-        raise ValueError(
-            f"--video is not supported with --frontend {frontend!r}. "
-            "Video recording requires the standard torch frontend. "
-            "Remove --video or switch to --frontend torch."
-        )
 
     from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
 
@@ -927,15 +929,26 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
                 # pre-launch hook was skipped or failed (e.g. isaaclab_visualizers not installed).
                 if not isinstance(getattr(sim_cfg, "visualizer_cfgs", None), list):
                     sim_cfg.visualizer_cfgs = []
+                # Match pre_launch_video_config: Kit cannot be a frame source on the warp
+                # runtime, which never initialises it.
+                frontend = getattr(args_cli, "frontend", "torch") or "torch"
                 try:
-                    from isaaclab_visualizers.kit import KitVisualizerCfg as _KitCfg
+                    if frontend == "torch":
+                        from isaaclab_visualizers.kit import KitVisualizerCfg as _CaptureCfg
 
-                    sim_cfg.visualizer_cfgs.append(_KitCfg(headless=True))
-                    visualizer_source = "visualizer:kit"
+                        viz_name = "kit"
+                    else:
+                        from isaaclab_visualizers.newton import NewtonGLVisualizerCfg as _CaptureCfg
+
+                        viz_name = "newton_gl"
+
+                    sim_cfg.visualizer_cfgs.append(_CaptureCfg(headless=True))
+                    visualizer_source = f"visualizer:{viz_name}"
                     print(
-                        "[INFO] --video specified without --viz: auto-creating a headless Kit visualizer "
-                        "for video recording. Pass --viz <type> to choose a different visualizer, or "
-                        "set video_recorders in your env config to record from a scene sensor instead."
+                        f"[INFO] --video specified without --viz: auto-creating a headless {viz_name} "
+                        "visualizer for video recording. Pass --viz <type> to choose a different "
+                        "visualizer, or set video_recorders in your env config to record from a scene "
+                        "sensor instead."
                     )
                 except (ImportError, ModuleNotFoundError):
                     pass

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -739,7 +739,8 @@ def pre_launch_video_config(env_cfg: Any, log_dir: str | None = None, args_cli: 
     """Pre-inject a recording visualizer into env_cfg before launch_simulation().
 
     Must be called BEFORE :func:`~isaaclab.app.AppLauncher.launch_simulation` so the
-    launcher can include the Kit runtime requirement in its backend scan.
+    launcher can include the visualizer's runtime requirement in its backend scan.
+    The backend depends on the frontend: Kit on ``torch``, Newton GL on ``warp``.
 
     Only acts when:
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -784,8 +784,9 @@ def pre_launch_video_config(env_cfg: Any, log_dir: str | None = None, args_cli: 
     if not isinstance(getattr(sim_cfg, "visualizer_cfgs", None), list):
         sim_cfg.visualizer_cfgs = []
 
-    # The warp runtime never initialises Kit, so a Kit visualizer cannot serve as a frame
-    # source there. Newton GL is capture-capable and runs on both frontends.
+    # Kit can record on either frontend, but it needs a full Isaac Sim install and the warp
+    # runtime is commonly run kitless. Newton GL captures without one, so it is the safer
+    # default there.
     frontend = getattr(args_cli, "frontend", "torch") or "torch"
     try:
         if frontend == "torch":
@@ -929,8 +930,8 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
                 # pre-launch hook was skipped or failed (e.g. isaaclab_visualizers not installed).
                 if not isinstance(getattr(sim_cfg, "visualizer_cfgs", None), list):
                     sim_cfg.visualizer_cfgs = []
-                # Match pre_launch_video_config: Kit cannot be a frame source on the warp
-                # runtime, which never initialises it.
+                # Match pre_launch_video_config: prefer Newton GL on warp, which is
+                # commonly run without a Kit install.
                 frontend = getattr(args_cli, "frontend", "torch") or "torch"
                 try:
                     if frontend == "torch":

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -154,7 +154,7 @@ def test_apply_video_recording_allows_warp_frontend():
 
 
 def test_apply_video_recording_injects_newton_gl_visualizer_on_warp_frontend():
-    """--video without --viz injects Newton GL on warp; the warp runtime never initialises Kit."""
+    """--video without --viz injects Newton GL on warp; Kit would need a full Isaac Sim install."""
     import sys
 
     newton_cfg_instance = object()

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -145,6 +145,42 @@ def test_apply_video_recording_injects_kit_visualizer_when_no_concrete_visualize
     assert env_cfg.video_recorders[0].source == "visualizer:kit"
 
 
+def test_apply_video_recording_allows_warp_frontend():
+    """--video is accepted on the warp frontend; warp environments record video."""
+    env_cfg = _env_cfg()
+    apply_video_recording(env_cfg, "/my/log", _args(frontend="warp", visualizer=["newton_gl"]))
+    assert len(env_cfg.video_recorders) == 1
+    assert env_cfg.video_recorders[0].source == "visualizer:newton_gl"
+
+
+def test_apply_video_recording_injects_newton_gl_visualizer_on_warp_frontend():
+    """--video without --viz injects Newton GL on warp; the warp runtime never initialises Kit."""
+    import sys
+
+    newton_cfg_instance = object()
+    MockNewtonGLVisualizerCfg = MagicMock(return_value=newton_cfg_instance)
+
+    fake_newton_module = ModuleType("isaaclab_visualizers.newton")
+    fake_newton_module.NewtonGLVisualizerCfg = MockNewtonGLVisualizerCfg
+    fake_visualizers_module = ModuleType("isaaclab_visualizers")
+
+    sim_cfg = SimpleNamespace(visualizer_cfgs=[])
+    env_cfg = SimpleNamespace(video_recorders=[], sim=sim_cfg)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "isaaclab_visualizers": fake_visualizers_module,
+            "isaaclab_visualizers.newton": fake_newton_module,
+        },
+    ):
+        apply_video_recording(env_cfg, "/my/log", _args(frontend="warp"))
+
+    assert sim_cfg.visualizer_cfgs == [newton_cfg_instance]
+    MockNewtonGLVisualizerCfg.assert_called_once_with(headless=True)
+    assert env_cfg.video_recorders[0].source == "visualizer:newton_gl"
+
+
 def test_apply_video_recording_rejects_viz_none_with_video():
     """--viz none combined with --video raises ValueError with a clear message.
 

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -40,9 +40,10 @@ def _env_cfg():
 def _patch_kit_visualizer():
     """Stub isaaclab_visualizers.kit so tests run without Isaac Sim installed.
 
-    apply_video_recording() always injects KitVisualizerCfg(headless=True) when no
-    concrete visualizer is pre-configured. Without this stub the import would fail in
-    the CI environment where the isaacsim extra is not installed.
+    apply_video_recording() injects KitVisualizerCfg(headless=True) on the torch frontend
+    when no concrete visualizer is pre-configured (the warp frontend gets Newton GL
+    instead). Without this stub the import would fail in the CI environment where the
+    isaacsim extra is not installed.
     """
     fake_kit_cfg_instance = MagicMock()
     MockKitVisualizerCfg = MagicMock(return_value=fake_kit_cfg_instance)

--- a/source/isaaclab_tasks/test/core/test_video_recording.py
+++ b/source/isaaclab_tasks/test/core/test_video_recording.py
@@ -138,6 +138,32 @@ def _run_cartpole_warp(env_cfg, *, steps: int = _STEPS) -> None:
         env.close()
 
 
+def _cartpole_manager_cfg_newton(*, num_envs: int = 1):
+    from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
+
+    from isaaclab_tasks.core.cartpole.cartpole_manager_env_cfg import CartpoleEnvCfg
+
+    cfg = CartpoleEnvCfg()
+    cfg.scene.num_envs = num_envs
+    cfg.sim.physics = NewtonCfg(solver_cfg=MJWarpSolverCfg())
+    return cfg
+
+
+def _run_cartpole_manager_warp(env_cfg, *, steps: int = _STEPS) -> None:
+    """Build the manager-based Warp env the way the CLI does, via the frontend adapter."""
+    from isaaclab_experimental.envs.frontend import WarpFrontend
+
+    sim_utils.create_new_stage()
+    env = WarpFrontend.build_env(env_cfg, "Isaac-Cartpole")
+    try:
+        env.reset()
+        actions = torch.zeros(env.num_envs, *env.action_space.shape[1:], device=env.device)
+        for _ in range(steps):
+            env.step(actions)
+    finally:
+        env.close()
+
+
 def _run_cartpole_camera(env_cfg) -> None:
     from isaaclab_tasks.core.cartpole.cartpole_direct_camera_env import CartpoleCameraEnv
 
@@ -235,26 +261,36 @@ def test_newton_records_nonblack_clip():
         _assert_clip_nonblack(os.path.join(output_dir, "newton_0000.mp4"), "newton")
 
 
-def test_warp_env_records_and_flushes_clips():
-    """The Warp env drives recorders end to end: construction, per-step tick, close() flush.
+@pytest.mark.parametrize(
+    "make_cfg, run_env, label",
+    [
+        (_cartpole_cfg_newton, _run_cartpole_warp, "direct"),
+        (_cartpole_manager_cfg_newton, _run_cartpole_manager_warp, "manager"),
+    ],
+)
+def test_warp_env_records_and_flushes_clips(make_cfg, run_env, label):
+    """Each Warp env drives recorders end to end: construction, per-step tick, close() flush.
 
     The run is deliberately shorter than ``video_length``, so the clip never completes on its
     own and can only reach disk through the ``close()`` flush. Its frame count then equals the
     number of steps only if the recorder is advanced exactly once per step. Deleting any of
     the three hooks fails this test.
+
+    Both hierarchies are covered because ``DirectRLEnvWarp`` and the manager-based classes
+    are separate implementations with their own step and close paths.
     """
     from isaaclab_visualizers.newton import NewtonGLVisualizerCfg
 
     steps = _CLIP // 2
     with tempfile.TemporaryDirectory() as output_dir:
-        env_cfg = _cartpole_cfg_newton(num_envs=1)
+        env_cfg = make_cfg(num_envs=1)
         env_cfg.sim.visualizer_cfgs = [NewtonGLVisualizerCfg(window_width=320, window_height=240)]
-        env_cfg.video_recorders = [_recorder_cfg(output_dir, "visualizer:newton_gl", prefix="warp")]
-        _run_cartpole_warp(env_cfg, steps=steps)
+        env_cfg.video_recorders = [_recorder_cfg(output_dir, "visualizer:newton_gl", prefix=label)]
+        run_env(env_cfg, steps=steps)
 
-        clip = os.path.join(output_dir, "warp_0000.mp4")
+        clip = os.path.join(output_dir, f"{label}_0000.mp4")
         assert os.path.exists(clip), "close() did not flush the partial clip"
-        _assert_clip_nonblack(clip, "warp")
+        _assert_clip_nonblack(clip, label)
         # One frame per env step. Decoded counts round by ±1 against the clip duration, so
         # the bound is what is meaningful: a missing tick writes nothing, a doubled tick or a
         # tick hoisted out of the step loop lands far outside this range.

--- a/source/isaaclab_tasks/test/core/test_video_recording.py
+++ b/source/isaaclab_tasks/test/core/test_video_recording.py
@@ -124,6 +124,20 @@ def _run_cartpole(env_cfg) -> None:
         env.close()
 
 
+def _run_cartpole_warp(env_cfg, *, steps: int = _STEPS) -> None:
+    from isaaclab_tasks_experimental.core.cartpole.cartpole_warp_env import CartpoleWarpEnv
+
+    sim_utils.create_new_stage()
+    env = CartpoleWarpEnv(env_cfg)
+    try:
+        env.reset()
+        actions = torch.zeros(env.num_envs, *env.action_space.shape[1:], device=env.device)
+        for _ in range(steps):
+            env.step(actions)
+    finally:
+        env.close()
+
+
 def _run_cartpole_camera(env_cfg) -> None:
     from isaaclab_tasks.core.cartpole.cartpole_direct_camera_env import CartpoleCameraEnv
 
@@ -219,6 +233,32 @@ def test_newton_records_nonblack_clip():
         env_cfg.video_recorders = [_recorder_cfg(output_dir, "visualizer:newton", prefix="newton")]
         _run_cartpole(env_cfg)
         _assert_clip_nonblack(os.path.join(output_dir, "newton_0000.mp4"), "newton")
+
+
+def test_warp_env_records_and_flushes_clips():
+    """The Warp env drives recorders end to end: construction, per-step tick, close() flush.
+
+    The run is deliberately shorter than ``video_length``, so the clip never completes on its
+    own and can only reach disk through the ``close()`` flush. Its frame count then equals the
+    number of steps only if the recorder is advanced exactly once per step. Deleting any of
+    the three hooks fails this test.
+    """
+    from isaaclab_visualizers.newton import NewtonGLVisualizerCfg
+
+    steps = _CLIP // 2
+    with tempfile.TemporaryDirectory() as output_dir:
+        env_cfg = _cartpole_cfg_newton(num_envs=1)
+        env_cfg.sim.visualizer_cfgs = [NewtonGLVisualizerCfg(window_width=320, window_height=240)]
+        env_cfg.video_recorders = [_recorder_cfg(output_dir, "visualizer:newton_gl", prefix="warp")]
+        _run_cartpole_warp(env_cfg, steps=steps)
+
+        clip = os.path.join(output_dir, "warp_0000.mp4")
+        assert os.path.exists(clip), "close() did not flush the partial clip"
+        _assert_clip_nonblack(clip, "warp")
+        # One frame per env step. Decoded counts round by ±1 against the clip duration, so
+        # the bound is what is meaningful: a missing tick writes nothing, a doubled tick or a
+        # tick hoisted out of the step loop lands far outside this range.
+        assert steps <= len(_read_frames(clip)) <= steps + 1, "recorder was not advanced once per env step"
 
 
 def test_sensor_physx_records_moving_clip():


### PR DESCRIPTION
# Description

`--video` was rejected on `--frontend warp` with a hard `ValueError`. That was not a rendering
limitation: the Warp environment classes are a parallel hierarchy that never wired the
`VideoRecorder` hook, so `env_cfg.video_recorders` was dropped — `ManagerBasedEnvWarp` logged a
warning, `DirectRLEnvWarp` ignored it silently. The CLI guard existed only to turn that silent
no-op into an error.

This wires recording through both Warp hierarchies and removes the guard:

- `ManagerBasedEnvWarp`, `ManagerBasedRLEnvWarp` and `DirectRLEnvWarp` construct recorders,
  advance them once per step after render, and flush them on close — the same slots the Torch
  bases use.
- `--video` without `--viz` now auto-injects a headless **Newton GL** visualizer on the Warp
  frontend instead of a headless Kit one. Both record correctly on Warp, but Kit needs a full
  Isaac Sim install and Warp is commonly run kitless, where the Kit default would fail. Pass
  `--viz kit` to record through Kit. The Torch frontend is unchanged.

## Type of change

- New feature (non-breaking change which adds functionality)

## Validation

RTX A6000, 3 iterations, `--num_envs 32 --video_interval 1`. Pass condition is a fresh mp4
count, not the exit code.

Kitless env (`uv run --extra video`; `moviepy` lives in the `video` extra):

| Run | Clips |
| --- | --- |
| `DirectRLEnvWarp` — `--frontend warp --video --viz newton_gl` | 48 |
| `ManagerBasedRLEnvWarp` — `--frontend warp --video --viz newton_gl` | 72 |
| `DirectRLEnvWarp` — `--frontend warp --video`, no `--viz` | 48, auto-injected Newton GL |
| Torch frontend — `--video --viz newton_gl` (regression guard) | 48 |

With Isaac Sim available (`./isaaclab.sh -p`), confirming Kit records on both frontends:

| Run | Clips |
| --- | --- |
| Torch frontend — `--video --viz kit` | 48 |
| `DirectRLEnvWarp` — `--frontend warp --video --viz kit` | 48 |

No tracebacks and no frame-capture failures in any run.

Tests: `test_apply_video_recording.py` — 13 passed; the two added cases fail with `ValueError`
when the guard is restored. `test_video_recording.py::test_warp_env_records_and_flushes_clips`
drives a Warp cartpole env for fewer steps than one clip, so the mp4 reaches disk only via the
`close()` flush and its frame count pins the tick to once per env step; it fails when the
recorder hooks are reverted.

Note on ordering: #6947 documents the old restriction. Whichever lands second should drop that
note from `warp-environments.rst`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
