### PR TITLE
test: Xfail flaky OVRTX albedo rendering

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-mark-flaky-tests.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-mark-flaky-tests.skip
@@ -1,0 +1,1 @@
+Test-only: marked the homogeneous Lift Kuka OVRTX texture-readiness regression as an expected failure.

--- a/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
@@ -14,12 +14,20 @@ from rendering_test_utils import (
     make_generate_html_report_fixture,
     make_kitless_rendering_params_lift,
     make_require_ovlibs_install_fixture,
+    make_xfail_rendering_params,
     rendering_test_lift_kuka,
 )
 
 pytestmark = [pytest.mark.isaacsim_ci, pytest.mark.arm_ci]
 
-_RENDERING_PARAMS = make_kitless_rendering_params_lift()
+_OVRTX_TEXTURE_READINESS_XFAIL_REASON = "OVRTX 0.4 may return before textured materials are ready (NVBUG#6505191)."
+_RENDERING_PARAMS = make_xfail_rendering_params(
+    make_kitless_rendering_params_lift(),
+    {
+        (variant, "ovphysx", "ovrtx_renderer", "albedo"): _OVRTX_TEXTURE_READINESS_XFAIL_REASON
+        for variant in ("legacy", "ovstage")
+    },
+)
 _COMPARISON_SCORES: list[dict] = []
 
 _determinism_fixture = make_determinism_fixture()

--- a/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
@@ -14,20 +14,12 @@ from rendering_test_utils import (
     make_generate_html_report_fixture,
     make_kitless_rendering_params_lift,
     make_require_ovlibs_install_fixture,
-    make_xfail_rendering_params,
     rendering_test_lift_kuka,
 )
 
 pytestmark = [pytest.mark.isaacsim_ci, pytest.mark.arm_ci]
 
-_OVRTX_TEXTURE_READINESS_XFAIL_REASON = "OVRTX 0.4 may return before textured materials are ready (NVBUG#6505191)."
-_RENDERING_PARAMS = make_xfail_rendering_params(
-    make_kitless_rendering_params_lift(),
-    {
-        (variant, "ovphysx", "ovrtx_renderer", "albedo"): _OVRTX_TEXTURE_READINESS_XFAIL_REASON
-        for variant in ("legacy", "ovstage")
-    },
-)
+_RENDERING_PARAMS = make_kitless_rendering_params_lift(include_texture_readiness_xfail=True)
 _COMPARISON_SCORES: list[dict] = []
 
 _determinism_fixture = make_determinism_fixture()

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -316,13 +316,26 @@ KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS = make_xfail_rendering_params(
 )
 
 
-def make_kitless_rendering_params_lift() -> list[pytest.param]:
-    """Create kitless Lift parameters with known native-crash cases skipped."""
+def make_kitless_rendering_params_lift(*, include_texture_readiness_xfail: bool = False) -> list[pytest.param]:
+    """Create kitless Lift parameters with known failures isolated.
+
+    Args:
+        include_texture_readiness_xfail: Whether to mark the OVPhysX OVRTX albedo cases as expected failures.
+    """
+    params = make_kitless_rendering_params(KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS)
+    if include_texture_readiness_xfail:
+        params = make_xfail_rendering_params(
+            params,
+            {
+                (variant, "ovphysx", "ovrtx_renderer", "albedo"): _OVRTX_TEXTURE_READINESS_XFAIL_REASON
+                for variant in _KITLESS_STAGE_VARIANTS
+            },
+        )
+
     # Both backends can SIGSEGV on the MDL AOVs, which loses the JUnit report for the whole file,
-    # so xfail cannot express these. Albedo does not crash, so it keeps whatever the shared matrix
-    # assigns it.
+    # so xfail cannot express these.
     return make_skip_rendering_params(
-        make_kitless_rendering_params(KITLESS_PHYSICS_RENDERER_AOV_COMBINATIONS),
+        params,
         {
             (variant, physics_backend, "ovrtx_renderer", data_type): _LIFT_RENDERER_CRASH_SKIP_REASON
             for variant in _KITLESS_STAGE_VARIANTS

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -123,6 +123,16 @@ def test_lift_factory_applies_shared_native_crash_policy() -> None:
     assert "xfail" not in [mark.name for mark in params["legacy-ovphysx-ovrtx-albedo"].marks]
 
 
+def test_lift_factory_adds_texture_readiness_policy() -> None:
+    """Lift should scope the optional OVRTX texture-readiness xfail."""
+    params = {param.id: param for param in make_kitless_rendering_params_lift(include_texture_readiness_xfail=True)}
+
+    for variant in ("legacy", "ovstage"):
+        param = params[f"{variant}-ovphysx-ovrtx-albedo"]
+        assert [mark.name for mark in param.marks] == ["xfail"]
+        assert "NVBUG#6505191" in param.marks[0].kwargs["reason"]
+
+
 def test_franka_factory_adds_cloth_only_motion_policy() -> None:
     """Only the cloth suite should carry the motion-vector xfail."""
     soft_params = {param.id: param for param in make_kitless_rendering_params_franka()}

--- a/source/isaaclab_tasks/test/test_parametrization_helpers.py
+++ b/source/isaaclab_tasks/test/test_parametrization_helpers.py
@@ -123,16 +123,6 @@ def test_lift_factory_applies_shared_native_crash_policy() -> None:
     assert "xfail" not in [mark.name for mark in params["legacy-ovphysx-ovrtx-albedo"].marks]
 
 
-def test_lift_factory_adds_texture_readiness_policy() -> None:
-    """Lift should scope the optional OVRTX texture-readiness xfail."""
-    params = {param.id: param for param in make_kitless_rendering_params_lift(include_texture_readiness_xfail=True)}
-
-    for variant in ("legacy", "ovstage"):
-        param = params[f"{variant}-ovphysx-ovrtx-albedo"]
-        assert [mark.name for mark in param.marks] == ["xfail"]
-        assert "NVBUG#6505191" in param.marks[0].kwargs["reason"]
-
-
 def test_franka_factory_adds_cloth_only_motion_policy() -> None:
     """Only the cloth suite should carry the motion-vector xfail."""
     soft_params = {param.id: param for param in make_kitless_rendering_params_franka()}


### PR DESCRIPTION
# Description

OVRTX 0.4 can capture Lift Kuka before textured materials are ready. Mark both kitless stage variants as expected failures until NVBUG#6505191 is fixed.

## Type of change

- Test change

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there