### PR TITLE
Clarify backend presets and kit-less Docker workflow

### DIFF
--- a/docs/source/concepts/backends_and_presets.rst
+++ b/docs/source/concepts/backends_and_presets.rst
@@ -140,14 +140,16 @@ conventions:
    * - Name
      - Meaning
    * - ``isaacsim_rtx``
-     - Concrete Isaac Sim RTX renderer and the established default for
-       multi-backend camera tasks.
+     - Concrete Isaac Sim RTX renderer configuration. This is the default for
+       tasks that use the multi-backend renderer preset.
    * - ``rtx``
-     - Automatic RTX-family selection based on the resolved runtime.
+     - Automatic RTX-family selection. Isaac Sim RTX is used when physics,
+       visualization, livestreaming, or another runtime choice requires Kit;
+       otherwise OVRTX is used for a fully kit-less run.
    * - ``newton_renderer``
      - Newton Warp renderer.
    * - ``ovrtx``
-     - Concrete OVRTX renderer.
+     - Concrete OVRTX renderer configuration for supported kit-less workflows.
 
 Automatic selectors such as ``physics=physx`` and ``renderer=rtx`` are opt-in.
 Defaults are concrete so that running a task without selectors is predictable.

--- a/docs/source/features/include/docker_details.inc
+++ b/docs/source/features/include/docker_details.inc
@@ -291,10 +291,30 @@ release version tag.
 
     docker pull nvcr.io/nvidia/isaac-lab:<version>-kitless
 
-    docker run --rm --gpus all --network host \
-        nvcr.io/nvidia/isaac-lab:<version>-kitless \
+Start a named container in the background. The ``--interactive`` and ``--tty`` options keep the image's Bash
+process running so that you can execute multiple commands in the same container:
+
+.. code:: bash
+
+    docker run --name isaac-lab-kitless --detach --interactive --tty --gpus all --network host \
+        nvcr.io/nvidia/isaac-lab:<version>-kitless
+
+Train a policy in the running container:
+
+.. code:: bash
+
+    docker exec isaac-lab-kitless \
         isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct \
         --num_envs 16 presets=newton_mjwarp --max_iterations 5
+
+Then replay the latest checkpoint in the same container. The Viser web visualizer is reachable through the host
+network; stop playback with :kbd:`Ctrl+C` without stopping the container:
+
+.. code:: bash
+
+    docker exec --interactive --tty isaac-lab-kitless \
+        isaaclab play --rl_library rsl_rl --task Isaac-Cartpole-Direct \
+        --num_envs 16 presets=newton_mjwarp --checkpoint latest --viz viser
 
 Only ``linux/amd64`` images are published. The Dockerfile itself is architecture-agnostic, but the
 published manifest is limited to the architecture that is validated in CI.


### PR DESCRIPTION
# Description

Clarify two related kit-less backend workflows in the documentation.

This update:

- identifies `isaacsim_rtx` as the concrete default for tasks using the
  multi-backend renderer preset;
- explains that automatic `renderer=rtx` selection uses Isaac Sim RTX when
  another runtime choice requires Kit and OVRTX otherwise;
- identifies OVRTX as the concrete renderer for supported kit-less workflows;
- starts the published kit-less image as a named, persistent container; and
- shows separate `docker exec` commands for training and replaying the latest
  checkpoint with the Viser web visualizer.

The previous published-image example coupled `docker run --rm` directly to a
single training command. Separating the container lifecycle from its workloads
lets users train, play, and run further commands in the same instance.

## Type of change

- Documentation update

## Screenshots

Not applicable; these are wording and command-flow updates.

## Validation

- `uv run --isolated --extra test -- sphinx-build -W --keep-going -j auto docs docs/_build/current`
- `uv run isaaclab -f` (run before each commit and again before each push)
- Verified the generated `backends_and_presets.html` and `docker_cloud.html`
  content.
- Docker commands were not executed because Docker is unavailable on the
  Windows validation host. The lifecycle command matches the image's
  `CMD ["bash"]`; the training, checkpoint, and Viser options match maintained
  repository examples.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks.
- [x] I have made the corresponding documentation changes.
- [x] The documentation build completes with no warnings.
- [x] Tests are not applicable beyond documentation validation for these
  command and wording updates.
- [x] A changelog fragment is not required because no source package changed.
- [x] A contributor-list update is not applicable to this focused
  documentation change.
