### PR TITLE
[CI] Add nightly image update and publishing workflows

### DIFF
--- a/.github/workflows/nightly-isaacsim-image.yml
+++ b/.github/workflows/nightly-isaacsim-image.yml
@@ -1,0 +1,244 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Resolve the moving Isaac Sim ``latest-develop`` tag to its immutable
+# manifest digest and open (or refresh) a draft PR against ``develop``.
+#
+# Scheduled workflows register only from the default branch, so this file
+# must be present on the current default, ``release/3.0.0-beta2``. The job
+# deliberately checks out ``develop`` because that is where the CI image pin
+# is maintained.
+#
+# The isaaclab-bot GitHub App token is used instead of GITHUB_TOKEN so the
+# branch push and PR events trigger the normal CI workflows. The App must have
+# ``contents: write`` and ``pull requests: write`` on this repository.
+
+name: Nightly Isaac Sim Image Update
+
+on:
+  schedule:
+    # Run daily at 8 AM UTC, after the existing 4 AM and 5 AM workflows.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Resolve and report the latest digest without pushing a branch or opening a PR'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  # The App installation token below carries the write permissions. The
+  # workflow's GITHUB_TOKEN only needs read access.
+  contents: read
+
+concurrency:
+  group: nightly-isaacsim-image-update
+  cancel-in-progress: false
+
+env:
+  CONFIG_PATH: .github/workflows/config.yaml
+  SOURCE_IMAGE: nvcr.io/0947644777160149/internal/isaac-sim
+  SOURCE_TAG: latest-develop
+  TARGET_BRANCH: develop
+  UPDATE_BRANCH: ci/nightly-isaacsim-image-update
+
+jobs:
+  update-image-pin:
+    name: Update Isaac Sim image pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # Reuse the isaaclab-bot App already used by nightly-changelog.yml.
+      # Requesting the permissions explicitly makes a missing App permission
+      # fail here with a focused error instead of later at push or PR creation.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Log in to the Isaac Sim registry
+        env:
+          NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NGC_API_KEY" ]; then
+            echo "::error::NGC_API_KEY is required to inspect the private Isaac Sim image."
+            exit 1
+          fi
+          printf '%s' "$NGC_API_KEY" | docker login -u '$oauthtoken' --password-stdin nvcr.io
+
+      - name: Resolve and update the image digest
+        id: pin
+        run: |
+          set -euo pipefail
+
+          image=$(yq -r '.isaacsim_image_name // ""' "$CONFIG_PATH")
+          current=$(yq -r '.isaacsim_image_tag // ""' "$CONFIG_PATH")
+          if [ -z "$image" ] || [ -z "$current" ]; then
+            echo "::error::$CONFIG_PATH must define isaacsim_image_name and isaacsim_image_tag."
+            exit 1
+          fi
+          if [ "$image" != "$SOURCE_IMAGE" ]; then
+            echo "::error::$CONFIG_PATH must pin the expected Isaac Sim image: $SOURCE_IMAGE."
+            exit 1
+          fi
+
+          current_digest=${current#"$SOURCE_TAG@"}
+          if [ "$current_digest" = "$current" ] || ! [[ "$current_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::$CONFIG_PATH must pin $SOURCE_TAG with a sha256 digest; found '$current'."
+            exit 1
+          fi
+
+          digest=$(docker buildx imagetools inspect "$SOURCE_IMAGE:$SOURCE_TAG" --format '{{.Manifest.Digest}}')
+          digest=$(echo "$digest" | tr -d '[:space:]')
+          if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Registry returned an invalid manifest digest: '$digest'."
+            exit 1
+          fi
+
+          candidate="$SOURCE_TAG@$digest"
+          changed=false
+          branch_changed=false
+          if [ "$candidate" = "$current" ]; then
+            echo "Isaac Sim is already pinned to $candidate."
+          else
+            if [ "$(grep -c '^isaacsim_image_tag:' "$CONFIG_PATH")" -ne 1 ]; then
+              echo "::error::$CONFIG_PATH must contain exactly one isaacsim_image_tag key."
+              exit 1
+            fi
+            digest_value=${digest#sha256:}
+            sed -i -E \
+              "s|^(isaacsim_image_tag: $SOURCE_TAG@sha256:)[0-9a-f]{64}$|\\1$digest_value|" \
+              "$CONFIG_PATH"
+            changed=true
+            branch_changed=true
+            echo "Updating Isaac Sim from $current to $candidate."
+
+            remote_ref="refs/heads/$UPDATE_BRANCH"
+            if git ls-remote --exit-code origin "$remote_ref" >/dev/null 2>&1; then
+              git fetch origin "+$remote_ref:refs/remotes/origin/$UPDATE_BRANCH"
+              if remote_pin=$(git show "refs/remotes/origin/$UPDATE_BRANCH:$CONFIG_PATH" \
+                | yq -r '.isaacsim_image_tag // ""'); then
+                if [ "$remote_pin" = "$candidate" ]; then
+                  branch_changed=false
+                  echo "The existing update branch already carries $candidate."
+                fi
+              fi
+            fi
+          fi
+
+          {
+            echo "image=$image"
+            echo "current=$current"
+            echo "candidate=$candidate"
+            echo "digest=$digest"
+            echo "changed=$changed"
+            echo "branch_changed=$branch_changed"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push the update branch
+        if: ${{ steps.pin.outputs.branch_changed == 'true' && !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "isaaclab-bot[bot]"
+          git config user.email "282401363+isaaclab-bot[bot]@users.noreply.github.com"
+          git switch -C "$UPDATE_BRANCH"
+          git add "$CONFIG_PATH"
+          git commit -m "Bump Isaac Sim CI image digest"
+
+          remote_ref="refs/heads/$UPDATE_BRANCH"
+          if git ls-remote --exit-code origin "$remote_ref" >/dev/null 2>&1; then
+            git fetch origin "+$remote_ref:refs/remotes/origin/$UPDATE_BRANCH"
+            remote_sha=$(git rev-parse "refs/remotes/origin/$UPDATE_BRANCH")
+            git push --force-with-lease="$remote_ref:$remote_sha" origin "HEAD:$remote_ref"
+          else
+            git push --force-with-lease="$remote_ref:" origin "HEAD:$remote_ref"
+          fi
+
+      - name: Open or refresh the draft PR
+        if: ${{ steps.pin.outputs.changed == 'true' && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE: ${{ steps.pin.outputs.image }}
+          CURRENT_PIN: ${{ steps.pin.outputs.current }}
+          CANDIDATE_PIN: ${{ steps.pin.outputs.candidate }}
+          DIGEST: ${{ steps.pin.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          digest_value=${DIGEST#sha256:}
+          short_digest=${digest_value:0:12}
+          title="[CI] Bump Isaac Sim image to $short_digest"
+          body_file="$RUNNER_TEMP/isaacsim-image-update.md"
+          {
+            echo "This automated draft updates CI to the current Isaac Sim nightly image."
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            printf "| Image | \`%s\` |\n" "$IMAGE"
+            printf "| Moving tag | \`%s\` |\n" "$SOURCE_TAG"
+            printf "| Current pin | \`%s\` |\n" "$CURRENT_PIN"
+            printf "| Candidate pin | \`%s\` |\n" "$CANDIDATE_PIN"
+            echo
+            echo "Source: https://registry.ngc.nvidia.com/orgs/0947644777160149/teams/internal/containers/isaac-sim/tags"
+            echo
+            echo "New PRs are opened as drafts so maintainers can merge after the CI results are acceptable."
+          } > "$body_file"
+
+          repository_owner=${REPOSITORY%%/*}
+          pr_number=$(gh api --method GET "repos/$REPOSITORY/pulls" \
+            -f state=open \
+            -f base="$TARGET_BRANCH" \
+            -f head="$repository_owner:$UPDATE_BRANCH" \
+            --jq '.[0].number // empty')
+
+          if [ -n "$pr_number" ]; then
+            pr_url=$(gh api --method PATCH "repos/$REPOSITORY/pulls/$pr_number" \
+              -f title="$title" \
+              -F body=@"$body_file" \
+              --jq '.html_url')
+            echo "Refreshed draft PR: $pr_url"
+            echo "Draft PR: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            pr_url=$(gh api --method POST "repos/$REPOSITORY/pulls" \
+              -f title="$title" \
+              -f head="$UPDATE_BRANCH" \
+              -f base="$TARGET_BRANCH" \
+              -F body=@"$body_file" \
+              -F draft=true \
+              --jq '.html_url')
+            echo "Opened draft PR: $pr_url"
+            echo "Draft PR: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Report no-op or dry run
+        if: ${{ steps.pin.outputs.changed != 'true' || inputs.dry_run }}
+        env:
+          CURRENT_PIN: ${{ steps.pin.outputs.current }}
+          CANDIDATE_PIN: ${{ steps.pin.outputs.candidate }}
+        run: |
+          if [ "$CURRENT_PIN" = "$CANDIDATE_PIN" ]; then
+            echo "Isaac Sim is already pinned to \`$CURRENT_PIN\`." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Dry run: would update \`$CURRENT_PIN\` to \`$CANDIDATE_PIN\`." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Log out of the Isaac Sim registry
+        if: ${{ always() }}
+        run: docker logout nvcr.io || true

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,86 +6,89 @@
 name: Publish Docker Images
 
 on:
-  # Image publishing is owned by the nightly cron (registered on the default
-  # branch, main). No push triggers — pushes to develop / release no longer publish.
+  # Nightly build + publish from develop and release/3.0.0. No push triggers — workflow_dispatch
+  # also accepts any publishable branch. main is intentionally excluded: main images are built
+  # by postmerge-ci.yml on push instead.
+  schedule:
+    - cron: '0 2 * * *'  # 6pm PST / 7pm PDT
   workflow_dispatch:
-
-# Concurrency control to prevent parallel runs
-concurrency:
-  group: publish-images-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    inputs:
+      branch:
+        description: 'Branch to build and publish (e.g. develop, release/3.0.0-beta2)'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+# Branches the nightly cron publishes. Single source of truth — include only
+# active branches that receive new commits. Mirrors CRON_BRANCHES in
+# nightly-changelog.yml. Whitespace per entry is stripped. main is excluded on
+# purpose (it builds on the public isaac-sim base via postmerge-ci.yml).
 env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+  CRON_BRANCHES: develop,release/3.0.0
 
 jobs:
-  config:
-    name: Load Config
+  resolve-branches:
+    name: Resolve publish branches
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     outputs:
-      isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
-      isaacsim_image_tag: ${{ steps.load.outputs.isaacsim_image_tag }}
-      isaaclab_image_name: ${{ steps.load.outputs.isaaclab_image_name }}
+      branches: ${{ steps.b.outputs.branches }}
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 1
-        sparse-checkout: .github/workflows/config.yaml
-        sparse-checkout-cone-mode: false
-    - id: load
+    - id: b
+      env:
+        # Schedule → the CRON_BRANCHES list. Manual → the single branch the
+        # maintainer entered (required input). Same pattern as nightly-changelog.yml.
+        BRANCHES: ${{ github.event_name == 'schedule' && env.CRON_BRANCHES || inputs.branch }}
       run: |
-        set -euo pipefail
-        f=.github/workflows/config.yaml
-        echo "isaacsim_image_name=$(yq -r .isaacsim_image_name "$f")" >> "$GITHUB_OUTPUT"
-        echo "isaacsim_image_tag=$(yq -r .isaacsim_image_tag "$f")" >> "$GITHUB_OUTPUT"
-        echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
+        # CSV → newline, trimming surrounding whitespace per entry, then to a
+        # compact JSON array. Manual produces a 1-element array; cron N elements.
+        arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
+        if [ "$(echo "$arr" | jq 'length')" -eq 0 ]; then
+          echo "::error::No branches resolved for publishing"
+          exit 1
+        fi
+        echo "branches=$arr" >> "$GITHUB_OUTPUT"
+        echo "Resolved branches: $arr"
 
   build-and-push-images:
-    name: Build and Push (${{ matrix.key }})
-    needs: [config]
+    name: Build and Push (${{ matrix.branch }} / ${{ matrix.image.key }})
+    needs: resolve-branches
     runs-on: [self-hosted, gpu]
     timeout-minutes: 180
     strategy:
-      # Each published image is independent: a kit-less failure must not stop
-      # the base image from publishing, or vice versa.
       fail-fast: false
       matrix:
-        include:
+        branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}
+        image:
         - key: base
-          image_name: ${{ needs.config.outputs.isaaclab_image_name }}
           tag_suffix: ""
           dockerfile: docker/Dockerfile.base
+          isaacsim_base: "true"
           # Empty: follow whatever the Isaac Sim base image supports.
           platforms: ""
-          build_args: >-
-            --build-arg ISAACSIM_BASE_IMAGE_ARG=${{ needs.config.outputs.isaacsim_image_name }}
-            --build-arg ISAACSIM_VERSION_ARG=${{ needs.config.outputs.isaacsim_image_tag }}
-            --build-arg ISAACSIM_ROOT_PATH_ARG=/isaac-sim
-            --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab
-            --build-arg DOCKER_USER_HOME_ARG=/root
+          build_args: --build-arg DOCKER_USER_HOME_ARG=/root
         - key: kitless
-          # Shares the Isaac Lab repository and distinguishes itself with a tag
-          # suffix, so publishing needs no additional registry provisioning.
-          image_name: ${{ needs.config.outputs.isaaclab_image_name }}
+          # Same repository as the base image, distinguished by a tag suffix.
           tag_suffix: "-kitless"
           dockerfile: docker/Dockerfile.kitless
-          # ubuntu:24.04 is multiarch and ovrtx ships an aarch64 wheel, but no
-          # arm64 GPU runner exists to validate the result and the arm64 leg
-          # would build under QEMU emulation. Publish amd64 until an arm64
-          # validation path exists; the Dockerfile itself is arch-agnostic.
+          # Builds on ubuntu, so it takes none of the Isaac Sim build arguments.
+          isaacsim_base: "false"
+          # No arm64 GPU runner validates this build yet.
           platforms: linux/amd64
-          # BASE_IMAGE_ARG is intentionally omitted: docker/.env.kitless and the
-          # Dockerfile default are the single source of truth for the base image.
-          build_args: --build-arg ISAACLAB_PATH_ARG=/workspace/isaaclab
+          build_args: --build-arg DOCKER_USER_HOME_ARG=/home/isaaclab
+    concurrency:
+      group: publish-images-${{ matrix.branch }}-${{ matrix.image.key }}
+      cancel-in-progress: true
     environment:
       name: postmerge-production
       url: https://github.com/${{ github.repository }}
     env:
         DOCKER_HOST: unix:///var/run/docker.sock
         DOCKER_TLS_CERTDIR: ""
+        BRANCH_NAME: ${{ matrix.branch }}
 
     steps:
     - name: Checkout Code
@@ -93,6 +96,29 @@ jobs:
       with:
         fetch-depth: 1
         lfs: true
+        ref: ${{ matrix.branch }}
+
+    - name: Load branch config
+      id: config
+      run: |
+        set -euo pipefail
+        f=.github/workflows/config.yaml
+        read_config() {
+          sed -n "s/^$1:[[:space:]]*//p" "$f"
+        }
+
+        isaacsim_image_name="$(read_config isaacsim_image_name)"
+        isaacsim_image_tag="$(read_config isaacsim_image_tag)"
+        isaaclab_image_name="$(read_config isaaclab_image_name)"
+
+        if [ -z "$isaacsim_image_name" ] || [ -z "$isaacsim_image_tag" ] || [ -z "$isaaclab_image_name" ]; then
+          echo "::error::Missing required image configuration in $f on $BRANCH_NAME"
+          exit 1
+        fi
+
+        echo "isaacsim_image_name=$isaacsim_image_name" >> "$GITHUB_OUTPUT"
+        echo "isaacsim_image_tag=$isaacsim_image_tag" >> "$GITHUB_OUTPUT"
+        echo "isaaclab_image_name=$isaaclab_image_name" >> "$GITHUB_OUTPUT"
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -122,12 +148,10 @@ jobs:
 
     - name: Build and Push Docker Images
       run: |
-        BRANCH_NAME="${{ github.ref_name }}"
-        IMAGE_BASE_VERSION="${{ needs.config.outputs.isaacsim_image_tag }}"
-        SHA="${{ github.sha }}"
-        IMAGE="${{ matrix.image_name }}"
-        DOCKERFILE="${{ matrix.dockerfile }}"
-        SUFFIX="${{ matrix.tag_suffix }}"
+        IMAGE_BASE_VERSION="${{ steps.config.outputs.isaacsim_image_tag }}"
+        IMAGE="${{ steps.config.outputs.isaaclab_image_name }}"
+        DOCKERFILE="${{ matrix.image.dockerfile }}"
+        SUFFIX="${{ matrix.image.tag_suffix }}"
 
         # Not every publishable branch carries every Dockerfile. A branch cut
         # before an image was introduced skips it instead of failing the run.
@@ -136,46 +160,46 @@ jobs:
           exit 0
         fi
 
+        # Use the SHA actually checked out for this branch (the matrix ref), not
+        # github.sha — on a scheduled run github.sha is the default branch HEAD,
+        # which would mis-tag every nightly image.
+        FULL_SHA="$(git rev-parse HEAD)"
+
         echo "Branch: $BRANCH_NAME"
-        echo "Commit: $SHA"
-        echo "IsaacSim base image: ${{ needs.config.outputs.isaacsim_image_name }}:$IMAGE_BASE_VERSION"
+        echo "Commit: $FULL_SHA"
+        echo "IsaacSim base image: ${{ steps.config.outputs.isaacsim_image_name }}:$IMAGE_BASE_VERSION"
         echo "Target Isaac Lab image: $IMAGE"
 
-        # Build the list of tags based on the branch.
+        # Build the tag list for the branch (main is published separately via
+        # postmerge-ci.yml, so it is not handled here).
         #
-        # Tagging scheme (immutable tag uses the full commit SHA so it matches
-        # the nightly cron's tags on main; see publish-images.yaml there):
-        #   - Push to develop:    $IMAGE:latest-develop                          (moves to newest develop build)
-        #                         $IMAGE:latest-develop-<full-sha>               (immutable per-commit)
-        #   - Push to release/X:  $IMAGE:latest-release-X                        (moves to newest build on that release branch)
-        #                         $IMAGE:latest-release-X-<full-sha>             (immutable per-commit)
-        #   - Push to main:       $IMAGE:latest                                  (moves to newest main build)
-        #                         $IMAGE:v<VERSION>                              (from the VERSION file, e.g. v3.0.0)
+        # Tagging scheme:
+        #   - develop:    $IMAGE:latest-develop               (moves to newest develop build)
+        #                 $IMAGE:latest-develop-<full-sha>    (immutable per-commit)
+        #   - release/X:  $IMAGE:latest-release-X             (moves to newest build on that release branch)
+        #                 $IMAGE:latest-release-X-<full-sha>  (immutable per-commit)
         #
-        # $SUFFIX distinguishes images sharing one repository (empty for the base
-        # image, "-kitless" for the kit-less one) and is appended to every tag.
-        TAGS=()
+        # The immutable per-commit tag doubles as the "already published" marker:
+        # if it exists in the registry the branch has not advanced since the last
+        # publish, so the nightly build is skipped (see the guard below).
+        MOVING_TAG=""
+        IMMUTABLE_TAG=""
 
         case "$BRANCH_NAME" in
           develop)
-            TAGS+=("$IMAGE:latest-develop$SUFFIX")
-            TAGS+=("$IMAGE:latest-develop-$SHA$SUFFIX")
-            ;;
-          main)
-            TAGS+=("$IMAGE:latest$SUFFIX")
-            VERSION="$(tr -d '[:space:]' < VERSION)"
-            if [ -n "$VERSION" ]; then
-              TAGS+=("$IMAGE:v$VERSION$SUFFIX")
-            else
-              echo "🛑 ERROR: VERSION file is empty or missing. Cannot tag build with version tag."
-              exit 1
-            fi
+            MOVING_TAG="$IMAGE:latest-develop$SUFFIX"
+            IMMUTABLE_TAG="$IMAGE:latest-develop-$FULL_SHA$SUFFIX"
             ;;
           release/*)
             # Sanitize the part after release/ for use as a Docker tag suffix.
             RELEASE_SUFFIX=$(echo "${BRANCH_NAME#release/}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX$SUFFIX")
-            TAGS+=("$IMAGE:latest-release-$RELEASE_SUFFIX-$SHA$SUFFIX")
+            MOVING_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX$SUFFIX"
+            IMMUTABLE_TAG="$IMAGE:latest-release-$RELEASE_SUFFIX-$FULL_SHA$SUFFIX"
+            ;;
+          main)
+            # main is intentionally not published here; see postmerge-ci.yml for main.
+            echo "Branch 'main' is not published by this workflow; skipping. See postmerge-ci.yml for main."
+            exit 0
             ;;
           *)
             echo "Branch '$BRANCH_NAME' is not configured for publishing; skipping."
@@ -183,11 +207,21 @@ jobs:
             ;;
         esac
 
+        # Skip the (expensive) build when this exact commit was already published.
+        # The immutable per-commit tag is the source of truth for "git advanced":
+        # if it already exists in the registry, nothing new to build for this branch.
+        if docker manifest inspect "$IMMUTABLE_TAG" >/dev/null 2>&1; then
+          echo "🟢 $IMMUTABLE_TAG already exists — $BRANCH_NAME has not advanced since the last publish. Skipping."
+          exit 0
+        fi
+
+        TAGS=("$MOVING_TAG" "$IMMUTABLE_TAG")
+
         # Determine if multiarch is supported by inspecting the base image manifest
         echo "🔵 Checking if base image supports multiarch..."
-        BASE_IMAGE_FULL="${{ needs.config.outputs.isaacsim_image_name }}:${IMAGE_BASE_VERSION}"
-        EXPLICIT_PLATFORMS="${{ matrix.platforms }}"
+        BASE_IMAGE_FULL="${{ steps.config.outputs.isaacsim_image_name }}:${IMAGE_BASE_VERSION}"
         ARCHITECTURES=$(docker manifest inspect "$BASE_IMAGE_FULL" 2>/dev/null | grep -o '"architecture": "[^"]*"' | cut -d'"' -f4 | sort -u)
+        EXPLICIT_PLATFORMS="${{ matrix.image.platforms }}"
 
         if [ -n "$EXPLICIT_PLATFORMS" ]; then
           # An image that does not build on the Isaac Sim base pins its own
@@ -229,14 +263,28 @@ jobs:
           TAG_ARGS+=("-t" "$t")
         done
 
+        BUILD_ARG_FLAGS=(
+          --build-arg "ISAACLAB_PATH_ARG=/workspace/isaaclab"
+          ${{ matrix.image.build_args }}
+        )
+        # Only the Isaac Sim-based image declares these; passing them to an image
+        # that does not leaves unconsumed build arguments in the build log.
+        if [ "${{ matrix.image.isaacsim_base }}" = "true" ]; then
+          BUILD_ARG_FLAGS+=(
+            --build-arg "ISAACSIM_BASE_IMAGE_ARG=${{ steps.config.outputs.isaacsim_image_name }}"
+            --build-arg "ISAACSIM_VERSION_ARG=$IMAGE_BASE_VERSION"
+            --build-arg "ISAACSIM_ROOT_PATH_ARG=/isaac-sim"
+          )
+        fi
+
         echo "🔵 Building and pushing image with tags listed above..."
         if ! docker buildx build \
           --platform "$BUILD_PLATFORMS" \
           --progress=plain \
           "${TAG_ARGS[@]}" \
-          ${{ matrix.build_args }} \
-          --cache-from type=gha,scope=publish-${{ matrix.key }} \
-          --cache-to type=gha,mode=max,scope=publish-${{ matrix.key }} \
+          "${BUILD_ARG_FLAGS[@]}" \
+          --cache-from type=gha,scope=publish-${{ matrix.image.key }} \
+          --cache-to type=gha,mode=max,scope=publish-${{ matrix.image.key }} \
           -f "$DOCKERFILE" \
           --push .; then
           echo "🔴 docker buildx build/push failed for tags:"


### PR DESCRIPTION
## Description

Add the nightly image automation needed on `develop`:

- combine the nightly Isaac Sim image updater from #6994 and its required workflow-permission fix from #7002; and
- sync the default-branch Docker publisher into `develop`, configured to publish `develop` and `release/3.0.0` nightly without adding push triggers.

The Isaac Sim updater runs daily at 08:00 UTC, resolves the private `latest-develop` tag to its immutable manifest digest, and opens or refreshes a draft PR updating the shared CI image pin. It uses the existing `isaaclab-bot` GitHub App token and explicitly requests `contents: write`, `pull requests: write`, and `workflows: write`.

The Docker publisher uses branch-local image configuration, moving and immutable tags, and the same branch/image matrix already present on the current default branch. While `release/3.0.0-beta2` remains the default, its workflow owns the active cron through #7196. Carrying the workflow on `develop` ensures a future `release/3.0.0` branch cut from `develop` inherits the nightly publisher.

This is a CI-only change and does not require a package changelog fragment.

## Validation

- `uv run isaaclab -f`
- parsed the publisher YAML and asserted that `schedule` remains enabled, no `push` trigger exists, and `CRON_BRANCHES` is `develop,release/3.0.0`
- verified the publisher matches the default-branch implementation from #7196
- `git diff --check upstream/develop...HEAD`