### PR TITLE
Seal the OVStage write ordinal before attaching

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovphysx-attach-write-floor.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-attach-write-floor.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_ov.physics.OvPhysxManager` attaching its OVStage at an
+  unsealed write ordinal. ``ovstage.population.open_usd_from_string()`` only
+  completes population; it never commits the ordinal it wrote to. Newer
+  ``ovphysx`` releases fail the parse when attaching at an unsealed ordinal and
+  yield an empty scene, so every articulation, rigid body, and sensor binding
+  resolved to zero prims. The manager now calls ``advance_write_floor().wait()``
+  to seal the ordinal before ``attach_ovstage()``.

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -602,6 +602,10 @@ class OvPhysxManager(PhysicsManager):
                 # dependencies in physics-only population.
                 domains=ovstage.PopulationDomain.ALL,
             )
+            # ovphysx reads sealed data only: population completes the writes but never
+            # commits the ordinal, so attaching at an unsealed ordinal fails the parse
+            # and silently yields an empty scene.
+            stage.advance_write_floor(ordinal=1).wait()
             cls._physx.attach_ovstage(stage, read_ordinal=1)
         except Exception:
             stage.destroy()

--- a/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
@@ -459,9 +459,19 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
 
     events = []
 
+    class FakeWriteFloorOp:
+        def __init__(self, ordinal):
+            self._ordinal = ordinal
+
+        def wait(self):
+            events.append(("seal", self._ordinal))
+
     class FakeStage:
         def __init__(self, name):
             events.append(("stage", name))
+
+        def advance_write_floor(self, ordinal):
+            return FakeWriteFloorOp(ordinal)
 
         def destroy(self):
             events.append(("destroy",))
@@ -508,9 +518,12 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
         OvPhysxManager._physx = previous_physx
         OvPhysxManager._ovstage = previous_ovstage
 
+    # The seal must land between population and attach: ovphysx reads sealed data
+    # only, so attaching at an unsealed ordinal silently yields an empty scene.
     assert events == [
         ("stage", "isaaclab"),
         ("populate", stage, "#usda 1.0", 1, "all"),
+        ("seal", 1),
         ("attach", stage, 1),
         ("close_views", physx),
         ("reset",),


### PR DESCRIPTION
# Description

Seals the OVStage write ordinal before `attach_ovstage()`. **No version pins change in this PR** — it is the standalone fix, so QA can test against it directly.

`ovstage.population.open_usd_from_string()` completes its writes but never commits the ordinal it wrote to. `OvPhysxManager._attach_ovstage()` populated at ordinal 1 and attached at `read_ordinal=1` without ever sealing it.

Newer `ovphysx` releases require `read_ordinal` to be sealed by a completed write-floor advance. From the `attach_ovstage` docstring:

> Reads target sealed data, so attaching at an unsealed ordinal fails the parse and yields an empty scene.

Because it yields an empty scene rather than raising, the failure surfaces far from its cause. Every articulation, rigid body, and sensor binding resolves to zero prims, showing up as either:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

deep in asset initialization, or where a guard exists:

```
RuntimeError: OVPhysX could not create any articulation bindings for pattern '/World/Env_*/Robot'.
```

Both are the same root cause at different call sites.

## The fix

```python
stage.advance_write_floor(ordinal=1).wait()
cls._physx.attach_ovstage(stage, read_ordinal=1)
```

`isaaclab_ov/renderers/ovrtx_renderer.py` already did this before its own attach — the OvPhysX manager was the only site missing it. `advance_write_floor()` exists in the currently pinned ovstage, and on the currently pinned ovphysx the seal is simply redundant, so **this is safe to land ahead of any version bump**.

## Verification

Verified against a newer ovphysx where the bug reproduces. All three train for 5 iterations with no traceback; all three fail at env creation with the `NoneType + int` TypeError when the line is reverted:

| Task | Invocation | Result |
| --- | --- | --- |
| `Isaac-Velocity-Flat-AnymalD` | `presets=ovphysx` | `Training time: 7.19s` |
| `Isaac-Cartpole` | `physics=ovphysx` | `Training time: 2.36s` |
| `Isaac-Velocity-Flat-G1` | `presets=ovphysx` | `Training time: 16.08s` |

Also confirmed AnymalD still trains on the **currently pinned** ovphysx with this change applied, confirming backward compatibility.

`test_ovphysx_scene_data_backend.py` — 34 passed. The manager lifecycle test now asserts the seal lands **between** population and attach, so the ordering is guarded rather than just the call being present.

## Not verified

- The full `isaaclab_ovphysx` unit suite has not been run to completion. These files carry `pytest.mark.device_split` and must be invoked once per device in separate processes.
- **OvRTX is separately broken** with a newer ovstage — `Isaac-Cartpole-Camera` with `presets=ovphysx,ovrtx` fails during population with `write_attributes op failed for [metersPerUnit, kilogramsPerUnit, upAxis]: Stage reader/writer legacy interface is unavailable`. This happens *before* the attach, so it is unrelated to and unaffected by this fix. Whether it also reproduces on the currently pinned versions was not established. Tracked separately from this PR.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
