### PR TITLE
Fix SO-101 port identification: add hardware extra, sudo dmesg

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -411,13 +411,13 @@ Prerequisites
 
   .. code-block:: bash
 
-     uvx --from lerobot lerobot-find-port
+     uvx --from "lerobot[hardware]" lerobot-find-port
 
   Alternatively, plug in the USB cable and immediately run:
 
   .. code-block:: bash
 
-     dmesg | grep tty | tail -1
+     sudo dmesg | grep tty | tail -1
 
   Because ``tail -1`` shows only the most recent kernel message, the output unambiguously
   names the just-connected device, e.g. ``[12345.6] usb ... ttyACM0``.


### PR DESCRIPTION
# Description

  * `uvx --from lerobot lerobot-find-port` exits with an `ImportError` because
    `pyserial` ships in the `lerobot[hardware]` extra, not the base install.
    Fix: `uvx --from "lerobot[hardware]" lerobot-find-port`
  * `dmesg` requires `sudo` on systems where the kernel log is not world-readable
    (the default on many recent Ubuntu installs)

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there