### PR TITLE
Fix kernel-only Isaac Sim installations

### DIFF
--- a/source/isaaclab/changelog.d/fix-kernel-only-isaacsim-install.rst
+++ b/source/isaaclab/changelog.d/fix-kernel-only-isaacsim-install.rst
@@ -1,4 +1,4 @@
 Fixed
------
+^^^^^
 
-* Fixed Isaac Sim detection and installation when only the kernel package was installed.
+* Fixed Isaac Sim detection and installation when the installed ``isaacsim`` package did not expose ``SimulationApp``.

--- a/source/isaaclab/changelog.d/fix-kernel-only-isaacsim-install.rst
+++ b/source/isaaclab/changelog.d/fix-kernel-only-isaacsim-install.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed Isaac Sim detection and installation when only the kernel package was installed.

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -633,7 +633,7 @@ def _ensure_isaac_sim_available() -> None:
         "\n[ERROR] Isaac Sim is not installed or not found on PYTHONPATH.\n"
         "\n"
         "  This environment requires Isaac Sim and Omniverse Kit.\n"
-        "    PhysX backend and Kit visualizer require Isaac Sim.\n"
+        "    PhysX backend and Kit visualizer currently requires Isaac Sim.\n"
         "\n"
         f"{extra_hint}"
         "  To fix this, ensure Isaac Sim is installed and available in the current environment.\n"

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -613,7 +613,6 @@ def _ensure_isaac_sim_available() -> None:
         installed_version = None
 
     if installed_version:
-        installer = "isaaclab.bat" if sys.platform == "win32" else "./isaaclab.sh"
         logger.error(
             f"\n[ERROR] Isaac Sim {installed_version} is installed, but its full runtime is unavailable.\n"
             "\n"
@@ -622,8 +621,8 @@ def _ensure_isaac_sim_available() -> None:
             "\n"
             "  The current Python environment does not expose the SimulationApp API.\n"
             f"{extra_hint}"
-            "  If this pip installation contains only the kernel package, install the full bundle by running:\n"
-            f"    {installer} -i isaacsim\n"
+            "  Install the full Isaac Sim runtime from the Isaac Lab directory by running:\n"
+            "    uv run isaaclab -i isaacsim\n"
             "\n"
             "  See https://isaac-sim.github.io/IsaacLab/main/source/setup/installation for details.\n"
         )

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -13,6 +13,7 @@ the launcher inputs, then validate and launch.
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import logging
 import os
 import sys
@@ -606,11 +607,33 @@ def _ensure_isaac_sim_available() -> None:
             f"    {source}\n"
         )
 
+    try:
+        installed_version = importlib.metadata.version("isaacsim")
+    except importlib.metadata.PackageNotFoundError:
+        installed_version = None
+
+    if installed_version:
+        installer = "isaaclab.bat" if sys.platform == "win32" else "./isaaclab.sh"
+        logger.error(
+            f"\n[ERROR] Isaac Sim {installed_version} is installed, but its full runtime is unavailable.\n"
+            "\n"
+            "  This environment requires Isaac Sim and Omniverse Kit.\n"
+            "    PhysX backend and Kit visualizer require Isaac Sim.\n"
+            "\n"
+            "  The current Python environment does not expose the SimulationApp API.\n"
+            f"{extra_hint}"
+            "  If this pip installation contains only the kernel package, install the full bundle by running:\n"
+            f"    {installer} -i isaacsim\n"
+            "\n"
+            "  See https://isaac-sim.github.io/IsaacLab/main/source/setup/installation for details.\n"
+        )
+        raise SystemExit(1)
+
     logger.error(
         "\n[ERROR] Isaac Sim is not installed or not found on PYTHONPATH.\n"
         "\n"
         "  This environment requires Isaac Sim and Omniverse Kit.\n"
-        "    PhysX backend and Kit visualizer currently requires Isaac Sim.\n"
+        "    PhysX backend and Kit visualizer require Isaac Sim.\n"
         "\n"
         f"{extra_hint}"
         "  To fix this, ensure Isaac Sim is installed and available in the current environment.\n"

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -592,23 +592,37 @@ def _upgrade_extension_pip_dependencies(
 
 
 def _install_isaacsim() -> None:
-    """Install Isaac Sim pip package if not already present."""
+    """Install the full Isaac Sim pip runtime if not already present."""
     python_exe = extract_python_exe()
     pip_cmd = get_pip_command(python_exe)
 
-    # Check if already installed.
-    result = run_command(
+    version_result = run_command(
         [python_exe, "-c", "from importlib.metadata import version; print(version('isaacsim'))"],
         capture_output=True,
         text=True,
         check=False,
     )
-    if result.returncode == 0:
-        installed_ver = result.stdout.strip()
-        print_info(f"Isaac Sim {installed_ver} already installed.")
-        return
+    installed_ver = version_result.stdout.strip() if version_result.returncode == 0 else ""
+    if installed_ver:
+        runtime_result = run_command(
+            [
+                python_exe,
+                "-c",
+                "import isaacsim, sys; sys.exit(0 if getattr(isaacsim, 'SimulationApp', None) is not None else 1)",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if runtime_result.returncode == 0:
+            print_info(f"Isaac Sim {installed_ver} already installed.")
+            return
+        requirement = f"isaacsim[all,extscache]=={installed_ver}"
+        print_info(f"Completing Isaac Sim {installed_ver} installation with all and extscache extras...")
+    else:
+        requirement = _isaacsim_requirement()
+        print_info("Installing Isaac Sim...")
 
-    print_info("Installing Isaac Sim...")
     using_uv = pip_cmd[0] == "uv"
     extra_flags = []
     if using_uv:
@@ -620,7 +634,7 @@ def _install_isaacsim() -> None:
         pip_cmd
         + [
             "install",
-            _isaacsim_requirement(),
+            requirement,
             "--extra-index-url",
             NVIDIA_INDEX_URL,
         ]

--- a/source/isaaclab/test/app/test_launch_simulation_require_kit.py
+++ b/source/isaaclab/test/app/test_launch_simulation_require_kit.py
@@ -94,14 +94,14 @@ def test_kernel_only_isaac_sim_reports_missing_runtime(
     from isaaclab.app import AppLauncher
 
     monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
-    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "6.1.0rc3")
+    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "1.2.3")
     monkeypatch.setattr(sim_launcher.sys, "platform", platform)
 
     with caplog.at_level("ERROR"), pytest.raises(SystemExit) as exc_info:
         sim_launcher._ensure_isaac_sim_available()
 
     assert exc_info.value.code == 1
-    assert "Isaac Sim 6.1.0rc3 is installed, but its full runtime is unavailable" in caplog.text
+    assert "Isaac Sim 1.2.3 is installed, but its full runtime is unavailable" in caplog.text
     assert f"{installer} -i isaacsim" in caplog.text
     assert "Isaac Sim is not installed or not found on PYTHONPATH" not in caplog.text
 

--- a/source/isaaclab/test/app/test_launch_simulation_require_kit.py
+++ b/source/isaaclab/test/app/test_launch_simulation_require_kit.py
@@ -16,6 +16,7 @@ taken. No Kit/GPU required.
 """
 
 import argparse
+import importlib.metadata
 
 import pytest
 
@@ -84,3 +85,58 @@ def test_require_kit_false_does_not_suppress_a_kit_config(kit_branch_taken):
         pass
 
     assert kit_branch_taken == [True]
+
+
+@pytest.mark.parametrize(("platform", "installer"), [("linux", "./isaaclab.sh"), ("win32", "isaaclab.bat")])
+def test_kernel_only_isaac_sim_reports_missing_runtime(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, platform: str, installer: str
+):
+    from isaaclab.app import AppLauncher
+
+    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
+    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "6.1.0rc3")
+    monkeypatch.setattr(sim_launcher.sys, "platform", platform)
+
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit) as exc_info:
+        sim_launcher._ensure_isaac_sim_available()
+
+    assert exc_info.value.code == 1
+    assert "Isaac Sim 6.1.0rc3 is installed, but its full runtime is unavailable" in caplog.text
+    assert f"{installer} -i isaacsim" in caplog.text
+    assert "Isaac Sim is not installed or not found on PYTHONPATH" not in caplog.text
+
+
+def test_kernel_only_isaac_sim_keeps_local_activation_hint(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path
+):
+    from isaaclab.app import AppLauncher
+
+    local_sim = tmp_path / "_isaac_sim"
+    local_sim.mkdir()
+    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
+    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "6.1.0rc3")
+    monkeypatch.setenv("ISAACLAB_PATH", str(tmp_path))
+    monkeypatch.setattr(sim_launcher.sys, "platform", "linux")
+
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        sim_launcher._ensure_isaac_sim_available()
+
+    assert f"Found a local Isaac Sim at {local_sim}" in caplog.text
+    assert f'source "{local_sim}/setup_conda_env.sh"' in caplog.text
+    assert "./isaaclab.sh -i isaacsim" in caplog.text
+
+
+def test_missing_isaac_sim_keeps_installation_hint(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    from isaaclab.app import AppLauncher
+
+    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
+
+    def _missing(_name: str):
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", _missing)
+
+    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
+        sim_launcher._ensure_isaac_sim_available()
+
+    assert "Isaac Sim is not installed or not found on PYTHONPATH" in caplog.text

--- a/source/isaaclab/test/app/test_launch_simulation_require_kit.py
+++ b/source/isaaclab/test/app/test_launch_simulation_require_kit.py
@@ -106,26 +106,6 @@ def test_kernel_only_isaac_sim_reports_missing_runtime(
     assert "Isaac Sim is not installed or not found on PYTHONPATH" not in caplog.text
 
 
-def test_kernel_only_isaac_sim_keeps_local_activation_hint(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path
-):
-    from isaaclab.app import AppLauncher
-
-    local_sim = tmp_path / "_isaac_sim"
-    local_sim.mkdir()
-    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
-    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "6.1.0rc3")
-    monkeypatch.setenv("ISAACLAB_PATH", str(tmp_path))
-    monkeypatch.setattr(sim_launcher.sys, "platform", "linux")
-
-    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
-        sim_launcher._ensure_isaac_sim_available()
-
-    assert f"Found a local Isaac Sim at {local_sim}" in caplog.text
-    assert f'source "{local_sim}/setup_conda_env.sh"' in caplog.text
-    assert "./isaaclab.sh -i isaacsim" in caplog.text
-
-
 def test_missing_isaac_sim_keeps_installation_hint(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
     from isaaclab.app import AppLauncher
 

--- a/source/isaaclab/test/app/test_launch_simulation_require_kit.py
+++ b/source/isaaclab/test/app/test_launch_simulation_require_kit.py
@@ -16,7 +16,6 @@ taken. No Kit/GPU required.
 """
 
 import argparse
-import importlib.metadata
 
 import pytest
 
@@ -85,38 +84,3 @@ def test_require_kit_false_does_not_suppress_a_kit_config(kit_branch_taken):
         pass
 
     assert kit_branch_taken == [True]
-
-
-@pytest.mark.parametrize(("platform", "installer"), [("linux", "./isaaclab.sh"), ("win32", "isaaclab.bat")])
-def test_kernel_only_isaac_sim_reports_missing_runtime(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, platform: str, installer: str
-):
-    from isaaclab.app import AppLauncher
-
-    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
-    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", lambda _name: "1.2.3")
-    monkeypatch.setattr(sim_launcher.sys, "platform", platform)
-
-    with caplog.at_level("ERROR"), pytest.raises(SystemExit) as exc_info:
-        sim_launcher._ensure_isaac_sim_available()
-
-    assert exc_info.value.code == 1
-    assert "Isaac Sim 1.2.3 is installed, but its full runtime is unavailable" in caplog.text
-    assert f"{installer} -i isaacsim" in caplog.text
-    assert "Isaac Sim is not installed or not found on PYTHONPATH" not in caplog.text
-
-
-def test_missing_isaac_sim_keeps_installation_hint(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
-    from isaaclab.app import AppLauncher
-
-    monkeypatch.setattr(AppLauncher, "is_available", lambda: False)
-
-    def _missing(_name: str):
-        raise importlib.metadata.PackageNotFoundError
-
-    monkeypatch.setattr(sim_launcher.importlib.metadata, "version", _missing)
-
-    with caplog.at_level("ERROR"), pytest.raises(SystemExit):
-        sim_launcher._ensure_isaac_sim_available()
-
-    assert "Isaac Sim is not installed or not found on PYTHONPATH" in caplog.text

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -73,77 +73,27 @@ def _make_site_packages(
     return site_pkgs
 
 
-class TestInstallIsaacSim:
-    """Tests for full Isaac Sim runtime installation."""
+def test_kernel_only_install_adds_extras_at_installed_version():
+    with (
+        mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
+        mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
+        mock.patch(
+            "isaaclab.cli.commands.install.run_command",
+            side_effect=[_cp(0, "6.1.0rc3+release.45488.8127a152.gl"), _cp(1), _cp(0)],
+        ) as mock_run,
+    ):
+        _install_isaacsim()
 
-    def test_full_runtime_is_not_reinstalled(self):
-        calls: list[list[str]] = []
-
-        def _run(cmd, **kwargs):
-            calls.append(list(cmd))
-            return _cp(0, "6.1.0rc3")
-
-        with (
-            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
-            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
-            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
-        ):
-            _install_isaacsim()
-
-        assert all("install" not in call for call in calls)
-
-    def test_kernel_only_install_adds_extras_at_installed_version(self):
-        calls: list[list[str]] = []
-
-        def _run(cmd, **kwargs):
-            calls.append(list(cmd))
-            if len(calls) == 1:
-                return _cp(0, "6.1.0rc3+release.45488.8127a152.gl")
-            if len(calls) == 2:
-                return _cp(1)
-            return _cp(0)
-
-        with (
-            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
-            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
-            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
-        ):
-            _install_isaacsim()
-
-        assert calls[-1] == [
-            "uv",
-            "pip",
-            "install",
-            "isaacsim[all,extscache]==6.1.0rc3+release.45488.8127a152.gl",
-            "--extra-index-url",
-            install_cmd.NVIDIA_INDEX_URL,
-            "--index-strategy",
-            "unsafe-best-match",
-        ]
-
-    def test_missing_package_installs_pinned_requirement(self):
-        calls: list[list[str]] = []
-
-        def _run(cmd, **kwargs):
-            calls.append(list(cmd))
-            return _cp(1) if len(calls) == 1 else _cp(0)
-
-        with (
-            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
-            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["python", "-m", "pip"]),
-            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
-        ):
-            _install_isaacsim()
-
-        assert calls[-1] == [
-            "python",
-            "-m",
-            "pip",
-            "install",
-            install_cmd._isaacsim_requirement(),
-            "--extra-index-url",
-            install_cmd.NVIDIA_INDEX_URL,
-        ]
+    assert mock_run.call_args.args[0] == [
+        "uv",
+        "pip",
+        "install",
+        "isaacsim[all,extscache]==6.1.0rc3+release.45488.8127a152.gl",
+        "--extra-index-url",
+        install_cmd.NVIDIA_INDEX_URL,
+        "--index-strategy",
+        "unsafe-best-match",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -79,7 +79,7 @@ def test_kernel_only_install_adds_extras_at_installed_version():
         mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
         mock.patch(
             "isaaclab.cli.commands.install.run_command",
-            side_effect=[_cp(0, "6.1.0rc3+release.45488.8127a152.gl"), _cp(1), _cp(0)],
+            side_effect=[_cp(0, "1.2.3+local"), _cp(1), _cp(0)],
         ) as mock_run,
     ):
         _install_isaacsim()
@@ -88,7 +88,7 @@ def test_kernel_only_install_adds_extras_at_installed_version():
         "uv",
         "pip",
         "install",
-        "isaacsim[all,extscache]==6.1.0rc3+release.45488.8127a152.gl",
+        "isaacsim[all,extscache]==1.2.3+local",
         "--extra-index-url",
         install_cmd.NVIDIA_INDEX_URL,
         "--index-strategy",

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -22,6 +22,7 @@ import isaaclab.cli.commands.install as install_cmd
 from isaaclab.cli.commands.install import (
     _PREBUNDLE_REPOINT_PACKAGES,
     _ensure_cuda_torch,
+    _install_isaacsim,
     _maybe_uninstall_prebundled_torch,
     _repoint_prebundle_packages,
     _torch_first_on_sys_path_is_prebundle,
@@ -70,6 +71,80 @@ def _make_site_packages(
         for sub in subs:
             (site_pkgs / pkg / sub).mkdir(parents=True, exist_ok=True)
     return site_pkgs
+
+
+class TestInstallIsaacSim:
+    """Tests for full Isaac Sim runtime installation."""
+
+    def test_full_runtime_is_not_reinstalled(self):
+        calls: list[list[str]] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return _cp(0, "6.1.0rc3")
+
+        with (
+            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
+            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
+            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
+        ):
+            _install_isaacsim()
+
+        assert len(calls) == 2
+        assert all("install" not in call for call in calls)
+
+    def test_kernel_only_install_adds_extras_at_installed_version(self):
+        calls: list[list[str]] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if len(calls) == 1:
+                return _cp(0, "6.1.0rc3+release.45488.8127a152.gl")
+            if len(calls) == 2:
+                return _cp(1)
+            return _cp(0)
+
+        with (
+            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
+            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["uv", "pip"]),
+            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
+        ):
+            _install_isaacsim()
+
+        assert calls[-1] == [
+            "uv",
+            "pip",
+            "install",
+            "isaacsim[all,extscache]==6.1.0rc3+release.45488.8127a152.gl",
+            "--extra-index-url",
+            install_cmd.NVIDIA_INDEX_URL,
+            "--index-strategy",
+            "unsafe-best-match",
+        ]
+
+    def test_missing_package_installs_pinned_requirement(self):
+        calls: list[list[str]] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return _cp(1) if len(calls) == 1 else _cp(0)
+
+        with (
+            mock.patch("isaaclab.cli.commands.install.extract_python_exe", return_value="python"),
+            mock.patch("isaaclab.cli.commands.install.get_pip_command", return_value=["python", "-m", "pip"]),
+            mock.patch("isaaclab.cli.commands.install.run_command", side_effect=_run),
+        ):
+            _install_isaacsim()
+
+        assert calls[-1] == [
+            "python",
+            "-m",
+            "pip",
+            "install",
+            install_cmd._isaacsim_requirement(),
+            "--extra-index-url",
+            install_cmd.NVIDIA_INDEX_URL,
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -90,7 +90,6 @@ class TestInstallIsaacSim:
         ):
             _install_isaacsim()
 
-        assert len(calls) == 2
         assert all("install" not in call for call in calls)
 
     def test_kernel_only_install_adds_extras_at_installed_version(self):


### PR DESCRIPTION
# Description

Fixes NVBug 6587433

A kernel-only `isaacsim` pip installation is importable and has package metadata, but it does not expose `isaacsim.SimulationApp`. Isaac Lab previously reported this incomplete runtime as a missing Isaac Sim installation at launch, while `./isaaclab.sh -i isaacsim` treated it as complete and could not repair the environment.

This change:

- reports that Isaac Sim is installed but its full runtime is unavailable when `SimulationApp` cannot be loaded;
- preserves local binary-install activation guidance and recommends the platform-neutral `uv run isaaclab -i isaacsim` repair command;
- makes the installer verify the `SimulationApp` capability in addition to package metadata; and
- completes kernel-only installations with `isaacsim[all,extscache]` at the installed version, avoiding an unintended version change.

No new dependencies are introduced.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this change affects CLI diagnostics and installation behavior.

## Validation

- Verified that the installer regression test fails against unmodified `develop` and passes with this fix.
- `uv run --extra test python -m pytest source/isaaclab/test/cli/test_install_commands.py -q`: 60 passed.
- `uv run isaaclab -f`: passed.
- `uv run python tools/changelog/cli.py check develop`: passed.

Coverage includes completing an incomplete Isaac Sim installation at its existing version.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation changes are not required; CLI guidance and the changelog fragment are updated
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`