### PR TITLE
Support OVPhysX 0.5 and 0.6 lifecycle APIs

### DIFF
--- a/source/isaaclab_ovphysx/changelog.d/ovphysx-0-6-lifecycle.rst
+++ b/source/isaaclab_ovphysx/changelog.d/ovphysx-0-6-lifecycle.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Sealed OVStage population before attaching it to OVPhysX so articulation and
+  joint data are available at the selected read ordinal.
+* Added support for the OVPhysX 0.6 ``warmup()`` API while retaining the
+  released 0.5 ``warmup_gpu()`` path.

--- a/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
+++ b/source/isaaclab_ovphysx/isaaclab_ovphysx/physics/ovphysx_manager.py
@@ -542,6 +542,14 @@ class OvPhysxManager(PhysicsManager):
         operation = physx.reset_stage()
         physx.wait_op(operation)
 
+    @staticmethod
+    def _warmup_physx(physx: Any) -> None:
+        """Warm a GPU runtime through its current or legacy API."""
+        warmup = getattr(physx, "warmup", None)
+        if warmup is None:
+            warmup = physx.warmup_gpu
+        warmup()
+
     @classmethod
     def close(cls) -> None:
         """Release ovphysx resources and clean up."""
@@ -589,7 +597,7 @@ class OvPhysxManager(PhysicsManager):
 
     @classmethod
     def _attach_ovstage(cls, stage_usda: str) -> None:
-        """Populate an OVStage from USDA text and attach it to the runtime."""
+        """Populate and seal an OVStage from USDA text, then attach it to the runtime."""
         import ovstage  # noqa: PLC0415
 
         stage = ovstage.Stage("isaaclab")
@@ -602,6 +610,9 @@ class OvPhysxManager(PhysicsManager):
                 # dependencies in physics-only population.
                 domains=ovstage.PopulationDomain.ALL,
             )
+            # Population finishes the writes but does not seal the ordinal.
+            # OVPhysX reads sealed data, including articulation and joint data.
+            stage.advance_write_floor(ordinal=1).wait()
             cls._physx.attach_ovstage(stage, read_ordinal=1)
         except Exception:
             stage.destroy()
@@ -816,8 +827,8 @@ class OvPhysxManager(PhysicsManager):
         choice and registers process-exit cleanup. On a forced re-warm before
         :meth:`close`, it reuses the active instance, attaches the new USD through
         OVStage, rebuilds active clone recipes through full-stage materialization
-        or runtime replay, and (on GPU) re-runs ``warmup_gpu`` so the new stage's
-        bodies are resident.
+        or runtime replay, and (on GPU) re-runs the supported warmup entry point
+        so the new stage's bodies are resident.
 
         Raises:
             RuntimeError: If ``SimulationContext`` is not set, or if a device
@@ -891,7 +902,7 @@ class OvPhysxManager(PhysicsManager):
         # GPU bodies must be re-warmed after every OVStage attachment: the cached PhysX
         # instance carries its old buffer layout from the previous stage.
         if ovphysx_device == "gpu":
-            cls._physx.warmup_gpu()
+            cls._warmup_physx(cls._physx)
 
         # Initialize the SceneDataBackend now that the wheel's PhysX is live and
         # the OVStage is attached. The central

--- a/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ovphysx/test/assets/test_rigid_object.py
@@ -1253,19 +1253,20 @@ def test_write_state_functions_data_consistency(num_cubes, device, with_offset, 
             torch.testing.assert_close(root_com_vel_w[:, 3:], root_link_vel_w[:, 3:])
 
 
-def test_warmup_attach_stage_not_called_for_cpu():
-    """Regression test: ``physx.warmup_gpu()`` must not be called for CPU.
+def test_warmup_attach_stage_not_called_for_cpu(monkeypatch):
+    """Regression test: explicit OVPhysX warmup must not run for CPU.
 
     OVPhysX-equivalent of PhysX's ``test_warmup_attach_stage_not_called_for_cpu``:
     PhysX guards :meth:`attach_stage` with ``if is_gpu:`` so the CPU MBP
     broadphase is not double-initialised.  The OVPhysX manager has the same
-    structural guard around :meth:`OvPhysxManager._physx.warmup_gpu`: it is
-    only invoked when ``ovphysx_device == "gpu"``.
+    structural guard around :meth:`OvPhysxManager._warmup_physx`: it is only
+    invoked when ``ovphysx_device == "gpu"``.
 
-    We monkey-patch ``OvPhysxManager._physx`` with a :class:`MagicMock`
-    wrapping the live PhysX object so that ``warmup_gpu`` becomes a spy while
-    other calls continue to forward, then assert ``warmup_gpu.call_count == 0``
-    after a CPU-mode :meth:`sim.reset`.
+    After the first reset constructs the runtime, we replace
+    :meth:`OvPhysxManager._warmup_physx` with a :class:`MagicMock`, force the
+    manager to load the stage again, and assert the helper was not called.
+    Watching the compatibility helper keeps this regression test independent
+    of which warmup entry point the installed OVPhysX generation exposes.
 
     The test always runs CPU regardless of session parametrization, so it is
     skipped when the session-locked device is anything other than CPU.  The
@@ -1283,26 +1284,16 @@ def test_warmup_attach_stage_not_called_for_cpu():
         # Allocate a single rigid body so the manager has something to load.
         generate_cubes_scene(num_cubes=1, height=1.0, device="cpu")
 
-        # First reset constructs (or reuses) the real ovphysx.PhysX so we have
-        # a live instance to wrap.  The PhysX object is a C++ binding, so we
-        # cannot patch attributes directly — replace the class-level reference
-        # with a MagicMock(wraps=...) that forwards every call.
+        # First reset constructs (or reuses) the real ovphysx.PhysX instance.
         sim.reset()
-        original_physx = OvPhysxManager._physx
-        assert original_physx is not None, "PhysX should be constructed after sim.reset()"
-        spy = MagicMock(wraps=original_physx)
-        OvPhysxManager._physx = spy
+        assert OvPhysxManager._physx is not None, "PhysX should be constructed after sim.reset()"
+
+        warmup_spy = MagicMock()
+        monkeypatch.setattr(OvPhysxManager, "_warmup_physx", warmup_spy)
         # Force _warmup_and_load to run again on the next reset so the spy
-        # observes the warmup_gpu (or non-call) decision; close() resets
+        # observes the explicit-warmup (or non-call) decision; close() resets
         # _warmup_done back to False but we just called sim.reset() above.
         OvPhysxManager._warmup_done = False
-        try:
-            sim.reset()
-        finally:
-            OvPhysxManager._physx = original_physx
+        sim.reset()
 
-        assert spy.warmup_gpu.call_count == 0, (
-            f"warmup_gpu() was called {spy.warmup_gpu.call_count} time(s) during CPU warmup. "
-            "OvPhysxManager._warmup_and_load() must guard warmup_gpu() with "
-            "ovphysx_device == 'gpu' so the CPU pipeline is not mis-initialised."
-        )
+        warmup_spy.assert_not_called()

--- a/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ovphysx/test/physics/test_ovphysx_scene_data_backend.py
@@ -459,9 +459,19 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
 
     events = []
 
+    class FakeWriteFloorOp:
+        def __init__(self, ordinal):
+            self._ordinal = ordinal
+
+        def wait(self):
+            events.append(("seal", self._ordinal))
+
     class FakeStage:
         def __init__(self, name):
             events.append(("stage", name))
+
+        def advance_write_floor(self, ordinal):
+            return FakeWriteFloorOp(ordinal)
 
         def destroy(self):
             events.append(("destroy",))
@@ -511,6 +521,7 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
     assert events == [
         ("stage", "isaaclab"),
         ("populate", stage, "#usda 1.0", 1, "all"),
+        ("seal", 1),
         ("attach", stage, 1),
         ("close_views", physx),
         ("reset",),
@@ -518,6 +529,33 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
         ("release",),
         ("destroy",),
     ]
+
+
+def test_manager_prefers_current_warmup_api():
+    """The current warmup API wins when both API generations are visible."""
+    from isaaclab_ovphysx.physics import OvPhysxManager
+
+    calls = []
+    physx = SimpleNamespace(
+        warmup=lambda: calls.append("warmup"),
+        warmup_gpu=lambda: calls.append("warmup_gpu"),
+    )
+
+    OvPhysxManager._warmup_physx(physx)
+
+    assert calls == ["warmup"]
+
+
+def test_manager_supports_legacy_warmup_api():
+    """The released OVPhysX runtime keeps using its GPU-only warmup API."""
+    from isaaclab_ovphysx.physics import OvPhysxManager
+
+    calls = []
+    physx = SimpleNamespace(warmup_gpu=lambda: calls.append("warmup_gpu"))
+
+    OvPhysxManager._warmup_physx(physx)
+
+    assert calls == ["warmup_gpu"]
 
 
 def test_manager_destroys_ovstage_when_population_fails(monkeypatch):


### PR DESCRIPTION
# Description

Support both the released OVPhysX 0.5 lifecycle API and the current OVPhysX
0.6 lifecycle API without changing IsaacLab's dependency pins.

OVPhysX 0.6 requires two lifecycle details that the current manager does not
provide:

- An OVStage population ordinal must be sealed before it is attached. Without
  the seal, attachment can succeed while articulation and joint data are
  missing.
- The GPU warmup entry point was renamed from `warmup_gpu()` to `warmup()`.

This change seals OVStage before attachment and adds a small compatibility
adapter that prefers the current API while retaining the 0.5 path. It does not
bump OVPhysX, OVStage, or `uv.lock`.

Related to #7021. That PR includes the OVStage sealing change as part of a
broader dependency update; this PR keeps the lifecycle fix independent of the
package-version transition and also handles the OVPhysX 0.6 warmup rename.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- 36 focused `OvPhysxManager` and scene-data tests passed.
- The CPU no-warmup regression passed against the real pinned pair
  `ovphysx==0.5.9` / `ovstage==0.1.0.346039`.
- The same CPU regression passed against the real candidate pair
  `ovphysx==0.6.0+trunk.e15a64a2` / `ovstage==0.1.1.354763`.
- A real GPU correctness run passed with 4,096 `Isaac-Cartpole-Direct`
  environments on the 0.6 candidate. It verified the selected backend and
  device, tensor contracts, two physics steps per control update, deterministic
  motion, timeout/reset behavior, seeded state diversity, and local-only asset
  use.
- `uv run --frozen --extra ovphysx isaaclab -f` passed all checks.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_ovphysx/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
