### PR TITLE
Replace peak-magnitude scaling so absolute motion stays comparable across frames when saving RGB visualizations

### DIFF
--- a/source/isaaclab/changelog.d/huidongc-fix-noise-in-motion-vectors.rst
+++ b/source/isaaclab/changelog.d/huidongc-fix-noise-in-motion-vectors.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed :func:`~isaaclab.utils.images.normalize_camera_output_for_display` motion-vector
+  visualization to clamp UV channels to ``[-1, 1]`` instead of scaling by peak magnitude.
+  Absolute motion stays comparable across frames; values outside ``[-1, 1]`` are saturated.

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -109,16 +109,12 @@ def normalize_camera_output_for_display(tensor: torch.Tensor, data_type: str) ->
     elif data_type in {"normals"}:
         normalized = (normalized + 1.0) * 0.5
     elif data_type in {"motion_vectors"}:
-        # Motion vectors are per-pixel (u, v) offsets that can be positive or negative. Normalize by the
-        # peak magnitude to map into [-1, 1], remap to [0, 1], and pack the two channels into an RGB image
-        # (u -> R, v -> G, unused B -> 0) so the result can be composed into a grid and saved as an image.
-        uv = normalized[..., :2]
-        max_mag = uv.abs().max()
-        if max_mag > 0:
-            uv = uv / max_mag
+        # Motion vectors are per-pixel (u, v) offsets that can be positive or negative. Clamp to [-1, 1],
+        # remap to [0, 1], and pack the two channels into an RGB image (u -> R, v -> G, unused B -> 0)
+        # so the result can be composed into a grid and saved as an image.
+        uv = normalized[..., :2].clamp(-1.0, 1.0)
         uv = (uv + 1.0) * 0.5
-        blue = torch.zeros_like(uv[..., :1])
-        normalized = torch.cat([uv, blue], dim=-1)
+        normalized = torch.cat([uv, torch.zeros_like(uv[..., :1])], dim=-1)
     else:
         normalized = normalized / 255.0
 

--- a/source/isaaclab/test/utils/test_images.py
+++ b/source/isaaclab/test/utils/test_images.py
@@ -214,10 +214,11 @@ class TestNormalizeCameraOutputForDisplay:
     def test_motion_vectors_map_uv_to_rgb(self, device):
         from isaaclab.utils.images import normalize_camera_output_for_display
 
-        # (u, v) offsets; peak magnitude is 4.0, so values map to [-1, 1] -> [0, 1] and gain a zero B channel.
+        # (u, v) offsets are clamped to [-1, 1], remapped to [0, 1], and packed with a zero B channel.
+        # Values outside [-1, 1] saturate (e.g. 4.0 -> 1.0, -2.0 -> 0.0 after remap).
         src = torch.tensor([[[[4.0, -2.0], [0.0, 4.0]]]], device=device)
         out = normalize_camera_output_for_display(src, "motion_vectors")
-        expected = torch.tensor([[[[1.0, 0.25, 0.0], [0.5, 1.0, 0.0]]]], device=device)
+        expected = torch.tensor([[[[1.0, 0.0, 0.0], [0.5, 1.0, 0.0]]]], device=device)
         assert out.shape[-1] == 3
         torch.testing.assert_close(out, expected)
 

--- a/source/isaaclab_tasks/changelog.d/huidongc-fix-noise-in-motion-vectors.skip
+++ b/source/isaaclab_tasks/changelog.d/huidongc-fix-noise-in-motion-vectors.skip
@@ -1,0 +1,1 @@
+Internal: refreshed motion_vectors golden images for rendering correctness tests.

--- a/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/ovphysx-ovrtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38af61ab5aec95af280f7b6ee643ed136f359d847a2b34dc0a36852658585c53
-size 948
+oid sha256:f6eaa711657b634cf8381a4b45fbfd4728411b3ccf4ec240b6b85b52f2224406
+size 890

--- a/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/cartpole/physx-isaacsim_rtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:775e05e73db0f24afe0da1d7a917152a00b062a89e0d8b88818630bf074e4cfb
-size 19283
+oid sha256:ed526cdc4f457e4c1892b4bbeec7d6ac1d7435fdd811521f402a3657091bcce9
+size 19295

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-isaacsim_rtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-isaacsim_rtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78cfa9736ee67be69e3182917c07612b38e6eee27d880bcf90388f90f4a35e5b
-size 85214
+oid sha256:e367441f6f1e1eabd9589829c04b028ca235171897745c1a190f8cc2340daa82
+size 31457

--- a/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-ovrtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/franka_cloth/newton-ovrtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f61b3adb55662533b421e775a6183ee927859da906ea8da04c4f37bf9bf7edc7
-size 33927
+oid sha256:49503a4a0e7e79169712eda8421a9c52dd9c6b8abd903e45423e498f3819075d
+size 2252

--- a/source/isaaclab_tasks/test/golden_images/lift_kuka_homo/ovphysx-ovrtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/lift_kuka_homo/ovphysx-ovrtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2097d1ae77a7278b6ac0ce9f924d7221c47c87afdf282e9795f3786777004a9b
-size 2309
+oid sha256:6e72b387dc3b2876421edde21b437ea2b9754c540a7f31fc3b27ee38fd7d97e7
+size 1758

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/ovphysx-ovrtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/ovphysx-ovrtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1691f80f8d42b95ac0f9d7eb7872128efc44ad4fdf3a3559792d3b82faf22edb
-size 2990
+oid sha256:0f7009076462f09c4b640c2fe1ebce8dfc625c0adb29d4d55e0113cfdd63e47a
+size 4108

--- a/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-motion_vectors.png
+++ b/source/isaaclab_tasks/test/golden_images/shadow_hand/physx-isaacsim_rtx_renderer-motion_vectors.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c387e14db0c8662374d37709da3c657cb4b2488f4329f686c8d84b6e56d2b995
-size 28482
+oid sha256:767c09a404c99cfdde69233a7463939138abf97a62b6e7baed4b5f7ad0179fda
+size 29696


### PR DESCRIPTION
# Description

Replace peak-magnitude scaling so absolute motion stays comparable across frames when saving RGB visualizations.

Fixes NVBUG#6520028

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

| Before | After |
| ------ | ----- |
| <img width="262" height="262" alt="franka_pour-newton-isaacsim_rtx_renderer-motion_vectors (before)" src="https://github.com/user-attachments/assets/b303a709-aaea-4df0-b206-e5cd1bf8ebe6" /> | <img width="262" height="262" alt="franka_pour-newton-isaacsim_rtx_renderer-motion_vectors (after)" src="https://github.com/user-attachments/assets/1252634d-fa09-43d8-91f1-d20ed01baa2a" /> |

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
