### PR TITLE
Fix duplicate Newton RTX Simulation panel

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/maxkra15-fix-newton-rtx-ui-callbacks.rst
+++ b/source/isaaclab_visualizers/changelog.d/maxkra15-fix-newton-rtx-ui-callbacks.rst
@@ -1,4 +1,4 @@
 Fixed
 ^^^^^
 
-* Fixed duplicate Isaac Lab controls in the Newton RTX viewer after model resets.
+* Fixed duplicate Simulation panels in the Newton RTX viewer.

--- a/source/isaaclab_visualizers/changelog.d/maxkra15-fix-newton-rtx-ui-callbacks.rst
+++ b/source/isaaclab_visualizers/changelog.d/maxkra15-fix-newton-rtx-ui-callbacks.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed duplicate Isaac Lab controls in the Newton RTX viewer after model resets.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -132,9 +132,7 @@ class _NewtonViewerUIMixin:
 
     def _register_isaaclab_ui_callbacks(self) -> None:
         """Register model-dependent Isaac Lab viewer controls."""
-        registration = (self._render_training_controls, "side")
-        if registration not in getattr(self, "_pending_ui_callbacks", ()):
-            self.register_ui_callback(*registration)
+        self.register_ui_callback(self._render_training_controls, position="side")
 
     def _patch_scalar_plot_width(self) -> None:
         """Set up ImPlot and suppress Newton's built-in floating Plots window.
@@ -427,13 +425,6 @@ class _NewtonViewerUIMixin:
                 " training\nhigher values -> less responsive visualizer but faster training"
             )
 
-    def _render_physics_panel(self, imgui):
-        """Render Simulation collapsing section at the top of the Newton viewer panel."""
-        imgui.set_next_item_open(True, imgui.Cond_.appearing)
-        if imgui.collapsing_header("Simulation"):
-            imgui.separator()
-            imgui.text(f"Physics: {self._backend_display}")
-
     def _draw_streaming_view_controls(self) -> None:
         """Render streaming image panel selector in the HUD sidebar.
 
@@ -575,10 +566,9 @@ class NewtonViewerRTX(_NewtonViewerUIMixin, ViewerRTX):
         # UI patches must be deferred: ViewerRTX creates self.gui lazily in
         # _init_window() (called from _init_ovrtx() on the first end_frame()).
         # _patch_viewer_panel() sets gui._render_left_panel, which requires gui to
-        # exist.  Register the callbacks now (they are buffered by ViewerRTX until
+        # exist.  Register the training controls now (they are buffered by ViewerRTX until
         # the GUI is available); the panel patch is applied in _init_window() below.
         self.register_ui_callback(self._render_training_controls, position="side")
-        self.register_ui_callback(self._render_physics_panel, position="panel")
 
     def _init_window(self) -> None:
         """Create the viewer window and immediately apply Isaac Lab UI patches."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -132,7 +132,9 @@ class _NewtonViewerUIMixin:
 
     def _register_isaaclab_ui_callbacks(self) -> None:
         """Register model-dependent Isaac Lab viewer controls."""
-        self.register_ui_callback(self._render_training_controls, position="side")
+        registration = (self._render_training_controls, "side")
+        if registration not in getattr(self, "_pending_ui_callbacks", ()):
+            self.register_ui_callback(*registration)
 
     def _patch_scalar_plot_width(self) -> None:
         """Set up ImPlot and suppress Newton's built-in floating Plots window.

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -22,7 +22,7 @@ from isaaclab_visualizers.newton import (
 )
 from isaaclab_visualizers.newton import newton_visualization_markers as newton_markers
 from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
-from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, _eye_lookat_to_pitch_yaw
+from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, NewtonViewerRTX, _eye_lookat_to_pitch_yaw
 from isaaclab_visualizers.newton_adapter import (
     VISUALIZER_INFINITE_PLANE_SIZE,
     apply_viewer_visible_worlds,
@@ -510,6 +510,17 @@ def test_newton_visualizer_forwards_and_neutralizes_picking():
 
     callback(object())
     assert visualizer._viewer_picking_binding._retained_picking is None
+
+
+def test_newton_rtx_ui_callback_registration_does_not_duplicate_pending_callback():
+    viewer = object.__new__(NewtonViewerRTX)
+    registration = (viewer._render_training_controls, "side")
+    viewer.gui = None
+    viewer._pending_ui_callbacks = [registration]
+
+    viewer._register_isaaclab_ui_callbacks()
+
+    assert viewer._pending_ui_callbacks == [registration]
 
 
 def test_newton_visualizer_hard_reset_rebinds_viewer_model(monkeypatch):

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -22,7 +22,7 @@ from isaaclab_visualizers.newton import (
 )
 from isaaclab_visualizers.newton import newton_visualization_markers as newton_markers
 from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
-from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, NewtonViewerRTX, _eye_lookat_to_pitch_yaw
+from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, _eye_lookat_to_pitch_yaw
 from isaaclab_visualizers.newton_adapter import (
     VISUALIZER_INFINITE_PLANE_SIZE,
     apply_viewer_visible_worlds,
@@ -510,23 +510,6 @@ def test_newton_visualizer_forwards_and_neutralizes_picking():
 
     callback(object())
     assert visualizer._viewer_picking_binding._retained_picking is None
-
-
-def test_newton_rtx_viewer_does_not_register_redundant_physics_panel(monkeypatch):
-    from isaaclab.utils.backend_utils import FactoryBase
-
-    def _initialize_viewer_rtx(viewer, *args, **kwargs):
-        viewer.gui = None
-        viewer._pending_ui_callbacks = []
-
-    monkeypatch.setattr(newton_visualizer_module.ViewerRTX, "__init__", _initialize_viewer_rtx)
-    monkeypatch.setattr(FactoryBase, "_get_backend", lambda *args: "newton")
-
-    viewer = NewtonViewerRTX()
-
-    assert [(callback.__name__, position) for callback, position in viewer._pending_ui_callbacks] == [
-        ("_render_training_controls", "side")
-    ]
 
 
 def test_newton_visualizer_hard_reset_rebinds_viewer_model(monkeypatch):

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -512,15 +512,21 @@ def test_newton_visualizer_forwards_and_neutralizes_picking():
     assert visualizer._viewer_picking_binding._retained_picking is None
 
 
-def test_newton_rtx_ui_callback_registration_does_not_duplicate_pending_callback():
-    viewer = object.__new__(NewtonViewerRTX)
-    registration = (viewer._render_training_controls, "side")
-    viewer.gui = None
-    viewer._pending_ui_callbacks = [registration]
+def test_newton_rtx_viewer_does_not_register_redundant_physics_panel(monkeypatch):
+    from isaaclab.utils.backend_utils import FactoryBase
 
-    viewer._register_isaaclab_ui_callbacks()
+    def _initialize_viewer_rtx(viewer, *args, **kwargs):
+        viewer.gui = None
+        viewer._pending_ui_callbacks = []
 
-    assert viewer._pending_ui_callbacks == [registration]
+    monkeypatch.setattr(newton_visualizer_module.ViewerRTX, "__init__", _initialize_viewer_rtx)
+    monkeypatch.setattr(FactoryBase, "_get_backend", lambda *args: "newton")
+
+    viewer = NewtonViewerRTX()
+
+    assert [(callback.__name__, position) for callback, position in viewer._pending_ui_callbacks] == [
+        ("_render_training_controls", "side")
+    ]
 
 
 def test_newton_visualizer_hard_reset_rebinds_viewer_model(monkeypatch):


### PR DESCRIPTION
# Description

Remove a redundant Newton RTX physics-panel callback that rendered a second `Simulation` header alongside Isaac Lab’s patched viewer panel. Both headers shared the same ImGui ID, producing the visible conflicting-ID warning.

The patched panel remains the single source for the Physics, Up Axis, Gravity, pause, and reset controls. GL behavior is unchanged.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- Regression test verified to fail with the redundant panel callback and pass after its removal.
- `uv run --extra test python -m pytest source/isaaclab_visualizers/test/test_newton_adapter.py -q` (47 passed)
- Changelog validation against the exact upstream base
- `uv run isaaclab -f`
- Inspected the live RTX callback registry during initialization

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added a regression test
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in `CONTRIBUTORS.md`