### PR TITLE
Fix Franka Reach OSC effort limiting

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-franka-reach-osc-effort-limits.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-franka-reach-osc-effort-limits.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``Isaac-Reach-Franka-OSC`` instability on Newton MJWarp by enforcing the
+  Franka asset's authored arm effort limits in the actuator model.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_osc_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_osc_env_cfg.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab.actuators import IdealPDActuatorCfg
 from isaaclab.controllers.operational_space_cfg import OperationalSpaceControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import OperationalSpaceControllerActionCfg
 from isaaclab.utils.configclass import configclass
@@ -16,9 +17,14 @@ class FrankaReachEnvCfg(franka_reach_env_cfg.FrankaReachEnvCfg):
         # post init of parent
         super().__post_init__()
 
-        # Remove stiffness and damping from the arm for effort control.
-        self.scene.robot.actuators["panda_arm"].stiffness = 0.0
-        self.scene.robot.actuators["panda_arm"].damping = 0.0
+        # Use an explicit actuator to enforce the USD-authored effort limits for effort control.
+        arm_actuator = self.scene.robot.actuators["panda_arm"]
+        self.scene.robot.actuators["panda_arm"] = IdealPDActuatorCfg(
+            joint_names_expr=arm_actuator.joint_names_expr,
+            velocity_limit_sim=arm_actuator.velocity_limit_sim,
+            stiffness=0.0,
+            damping=0.0,
+        )
         self.scene.robot.spawn.rigid_props.disable_gravity = True
 
         # If closed-loop contact force control is desired, contact sensors should be enabled for the robot

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -10,6 +10,7 @@ import torch
 from gymnasium.envs.registration import registry
 
 import isaaclab.envs.mdp as mdp
+from isaaclab.actuators import IdealPDActuatorCfg
 from isaaclab.controllers.differential_ik import DifferentialIKController
 
 import isaaclab_tasks  # noqa: F401
@@ -184,12 +185,15 @@ def test_reach_success_requires_position_and_orientation():
     assert torch.equal(position_only_succeeded, torch.tensor([True, False, True]))
 
 
-def test_reach_osc_uses_menagerie_franka_effort_actuator():
+def test_reach_osc_uses_explicit_effort_limited_actuator():
     cfg = load_cfg_from_registry(_OSC_TASK, "env_cfg_entry_point")
+    arm_actuator = cfg.scene.robot.actuators["panda_arm"]
 
     assert cfg.scene.robot.spawn.usd_path.endswith("/Robots/FrankaEmika/franka_panda.usda")
-    assert cfg.scene.robot.actuators["panda_arm"].stiffness == 0.0
-    assert cfg.scene.robot.actuators["panda_arm"].damping == 0.0
+    assert isinstance(arm_actuator, IdealPDActuatorCfg)
+    assert arm_actuator.effort_limit is None
+    assert arm_actuator.stiffness == 0.0
+    assert arm_actuator.damping == 0.0
 
 
 def test_reach_newton_uses_high_frequency_solver_timing():


### PR DESCRIPTION
## Summary

- Use a zero-gain explicit actuator for Franka Reach OSC so the asset-authored arm effort limits are enforced before simulation.
- Add focused preset coverage and a changelog entry.

## Why

Newton MJWarp does not apply solver-side limits to implicit feed-forward OSC efforts. Large exploration torques can therefore destabilize the robot and produce NaN rewards.

## Validation

- Focused preset tests: 25 passed
- Ruff and diff checks passed
- Newton MJWarp and PhysX: 1,000 training iterations each, about 92.5% final training success, no NaNs
- Deterministic evaluation: 1,024/1,024 Newton and 1,026/1,026 PhysX episodes succeeded
