### PR TITLE
Fix raycast_mesh distance and face-id shapes for rays with any leading dimensions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -182,6 +182,7 @@ Guidelines for modifications:
 * Ryan Gresia
 * Ryley McCarroll
 * Sahara Yuta
+* Samir Bhattarai
 * Sergey Grizan
 * Shafeef Omar
 * Shane Reetz

--- a/source/isaaclab/changelog.d/raycast-mesh-ray-dimensions.rst
+++ b/source/isaaclab/changelog.d/raycast-mesh-ray-dimensions.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.utils.warp.raycast_mesh` shaping its distance and face-id outputs from only
+  the first two ray dimensions. Whenever :attr:`return_distance` or :attr:`return_face_id` was
+  enabled, rays with any shape other than ``(B, N, 3)`` either raised an error — including the
+  documented ``(N, 3)`` input — or, when the leading dimensions happened to multiply out, silently
+  returned a wrong-shaped tensor. Both outputs now keep the ray dimensions of the input.

--- a/source/isaaclab/changelog.d/raycast-mesh-ray-dimensions.rst
+++ b/source/isaaclab/changelog.d/raycast-mesh-ray-dimensions.rst
@@ -1,3 +1,12 @@
+Changed
+^^^^^^^
+
+* Changed :func:`~isaaclab.utils.warp.raycast_mesh` to raise a :class:`ValueError` unless
+  ``ray_directions`` has the same shape as ``ray_starts``. Fewer directions than rays previously read
+  past the end of ``ray_directions`` and returned undefined results, while surplus directions and
+  differently shaped direction tensors were silently reinterpreted. Callers that relied on either
+  must reshape ``ray_directions`` to match ``ray_starts``.
+
 Fixed
 ^^^^^
 

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -93,8 +93,8 @@ def raycast_mesh(
     and data types to ensure proper execution. Additionally, they all must be in the same frame.
 
     Args:
-        ray_starts: The starting position of the rays. Shape (N, 3).
-        ray_directions: The ray directions for each ray. Shape (N, 3).
+        ray_starts: The starting position of the rays. Shape (..., 3).
+        ray_directions: The ray directions for each ray. Shape (..., 3).
         mesh: The warp mesh to ray-cast against.
         max_dist: The maximum distance to ray-cast. Defaults to 1e6.
         return_distance: Whether to return the distance of the ray until it hits the mesh. Defaults to False.
@@ -102,17 +102,19 @@ def raycast_mesh(
         return_face_id: Whether to return the face id of the mesh face the ray hits. Defaults to False.
 
     Returns:
-        The ray hit position. Shape (N, 3).
+        The ray hit position. Shape (..., 3).
             The returned tensor contains :obj:`float('inf')` for missed hits.
-        The ray hit distance. Shape (N,).
+        The ray hit distance. Shape (...,).
             Will only return if :attr:`return_distance` is True, else returns None.
             The returned tensor contains :obj:`float('inf')` for missed hits.
-        The ray hit normal. Shape (N, 3).
+        The ray hit normal. Shape (..., 3).
             Will only return if :attr:`return_normal` is True else returns None.
             The returned tensor contains :obj:`float('inf')` for missed hits.
-        The ray hit face id. Shape (N,).
+        The ray hit face id. Shape (...,).
             Will only return if :attr:`return_face_id` is True else returns None.
             The returned tensor contains :obj:`int(-1)` for missed hits.
+
+    The leading dimensions of the rays are arbitrary and are preserved in every output.
     """
     # extract device and shape information
     shape = ray_starts.shape
@@ -175,11 +177,11 @@ def raycast_mesh(
     wp.synchronize()
 
     if return_distance:
-        ray_distance = ray_distance.to(device).view(shape[0], shape[1])
+        ray_distance = ray_distance.to(device).view(shape[:-1])
     if return_normal:
         ray_normal = ray_normal.to(device).view(shape)
     if return_face_id:
-        ray_face_id = ray_face_id.to(device).view(shape[0], shape[1])
+        ray_face_id = ray_face_id.to(device).view(shape[:-1])
 
     return ray_hits.to(device).view(shape), ray_distance, ray_normal, ray_face_id
 

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -114,10 +114,16 @@ def raycast_mesh(
             Will only return if :attr:`return_face_id` is True else returns None.
             The returned tensor contains :obj:`int(-1)` for missed hits.
 
-    The leading dimensions of the rays are arbitrary and are preserved in every output.
+    Raises:
+        ValueError: If :attr:`ray_directions` does not have the same shape as :attr:`ray_starts`.
     """
     # extract device and shape information
     shape = ray_starts.shape
+    if ray_directions.shape != shape:
+        raise ValueError(
+            "Expected ray_directions to have the same shape as ray_starts. Received ray_starts"
+            f" {tuple(shape)} and ray_directions {tuple(ray_directions.shape)}."
+        )
     device = ray_starts.device
     # device of the mesh
     torch_device = wp.device_to_torch(mesh.device)

--- a/source/isaaclab/test/utils/warp/test_ops.py
+++ b/source/isaaclab/test/utils/warp/test_ops.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the warp ray-casting wrappers in :mod:`isaaclab.utils.warp.ops`."""
+
+import numpy as np
+import pytest
+import torch
+
+from isaaclab.utils.warp.ops import convert_to_warp_mesh, raycast_mesh
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def plane_mesh():
+    """A unit square in the z=0 plane, built from two triangles."""
+    points = np.array([[-1.0, -1.0, 0.0], [1.0, -1.0, 0.0], [1.0, 1.0, 0.0], [-1.0, 1.0, 0.0]])
+    indices = np.array([[0, 1, 2], [0, 2, 3]])
+    return convert_to_warp_mesh(points, indices, "cpu")
+
+
+@pytest.mark.parametrize("ray_shape", [(2,), (1, 2), (3, 1, 2), (2, 3, 1)])
+def test_raycast_mesh_preserves_ray_dimensions(plane_mesh, ray_shape):
+    """Every output keeps the ray dimensions of the input, for any number of them."""
+    num_rays = int(np.prod(ray_shape))
+    # Give every ray a different start height so the outputs also pin down the ordering.
+    depths = torch.arange(1, num_rays + 1, dtype=torch.float32)
+    ray_starts = torch.zeros(num_rays, 3)
+    # Aim inside one triangle rather than at the diagonal the two triangles share.
+    ray_starts[:, 0] = 0.5
+    ray_starts[:, 1] = -0.25
+    ray_starts[:, 2] = -depths
+    ray_starts = ray_starts.view(*ray_shape, 3)
+    ray_directions = torch.tensor([0.0, 0.0, 1.0]).repeat(num_rays, 1).view(*ray_shape, 3)
+
+    ray_hits, ray_distance, ray_normal, ray_face_id = raycast_mesh(
+        ray_starts,
+        ray_directions,
+        plane_mesh,
+        return_distance=True,
+        return_normal=True,
+        return_face_id=True,
+    )
+
+    assert ray_hits.shape == (*ray_shape, 3)
+    assert ray_normal.shape == (*ray_shape, 3)
+    assert ray_distance.shape == ray_shape
+    assert ray_face_id.shape == ray_shape
+    torch.testing.assert_close(ray_distance, depths.view(ray_shape))

--- a/source/isaaclab/test/utils/warp/test_ops.py
+++ b/source/isaaclab/test/utils/warp/test_ops.py
@@ -50,3 +50,13 @@ def test_raycast_mesh_preserves_ray_dimensions(plane_mesh, ray_shape):
     assert ray_distance.shape == ray_shape
     assert ray_face_id.shape == ray_shape
     torch.testing.assert_close(ray_distance, depths.view(ray_shape))
+
+
+@pytest.mark.parametrize("direction_shape", [(2, 3), (5, 3), (4, 2), (2, 2, 3)])
+def test_raycast_mesh_rejects_direction_shape_mismatch(plane_mesh, direction_shape):
+    """Directions that do not match the ray starts are rejected rather than reinterpreted."""
+    ray_starts = torch.zeros(4, 3)
+    ray_directions = torch.zeros(direction_shape)
+
+    with pytest.raises(ValueError, match="same shape as ray_starts"):
+        raycast_mesh(ray_starts, ray_directions, plane_mesh)


### PR DESCRIPTION
# Description

`raycast_mesh` flattens the rays with `.view(-1, 3)`, but reshaped the distance and face-id
outputs with `.view(shape[0], shape[1])`. That reshape is only correct when the rays have
exactly two leading dimensions, so every other input shape was mishandled — including the
`(N, 3)` shape the docstring advertises:

| `ray_starts` shape | `ray_distance` before | after |
| --- | --- | --- |
| `(N, 3)` (documented) | `RuntimeError` | `(N,)` |
| `(B, N, 3)` | `(B, N)` | `(B, N)` — unchanged |
| `(3, 1, 2, 3)` | `RuntimeError` | `(3, 1, 2)` |
| `(2, 3, 1, 3)` | `(2, 3)` — **silently wrong shape, no error** | `(2, 3, 1)` |

The silent case is the one worth highlighting: when the leading dimensions happen to multiply
out to `shape[0] * shape[1]`, the old reshape succeeded and returned a tensor whose shape did
not match the rays it came from.

Both reshapes now use `.view(shape[:-1])`, which is the same generic idiom the neighbouring
`ray_normal` line already used. For any 3-D input `shape[:-1]` *is* `(shape[0], shape[1])`, so the
reshape change alone is a strict superset of the current behaviour. The direction-shape guard in the
second commit is not — see below.

`raycast_dynamic_meshes` is deliberately untouched: it documents `(B, N, 3)` explicitly, so
`view(shape[:2])` is correct for its contract.

Fixes #2416

### On the second commit

`fix(warp): require raycast_mesh directions to match ray starts` is adjacent to the issue and can be
dropped if you would rather keep this PR to the reshape alone.

The kernel launches with `dim=num_rays` derived from `ray_starts` and indexes
`ray_directions_wp[tid]` unconditionally. Passing fewer directions than rays therefore reads past the
end of the direction array, and the values it reads are not stable between calls — four rays as
`(1, 4, 3)` with two directions, all starting at `z = -1` above a plane at `z = 0` so every distance
should be `1.0`, returns `[1.0, 1.0, 136.86, inf]`, then `[1.0, 1.0, 136.59, inf]`, then
`[1.0, 1.0, 137.91, inf]` on successive calls. On CUDA an out-of-bounds read of a Warp array is an
illegal memory access.

The guard requires `ray_directions` to have the same shape as `ray_starts`, and runs before the
`.view(-1, 3)` flatten. Comparing counts after the flatten is not enough: the flatten reinterprets
whatever it is handed, so `(4, 3)` starts with `(4, 2)` or `(2, 2, 3)` directions both yield four
rows and pass a count check.

This is a behaviour change. Calls that passed surplus directions, or a direction tensor whose layout
differed from the ray starts, worked before and now raise. No in-tree caller is affected:
`terrains/utils.py:245` is the only call site outside tests and passes `points.view(-1, 3)` and
`dirs.view(-1, 3)`, which always have the same shape. The changelog fragment carries this as a
`Changed` entry with migration guidance; I left it at the patch tier on the reading that this closes
undefined behaviour rather than removing a feature, but that is a maintainer call and moving it to
`.major.rst` is a rename away.

### Note

`isaaclab/terrains/utils.py` already works around this bug: it calls
`raycast_mesh(points.view(-1, 3), dirs.view(-1, 3), wp_mesh)` and then restores the shape itself
with `ray_hits.view(points.shape)`. It avoids the crash only because it leaves `return_distance`
at its default. That workaround becomes unnecessary with this change, but I have left it alone to
keep the diff focused.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (existing functionality will not work without user modification)

## Testing

Added `source/isaaclab/test/utils/warp/test_ops.py`. It needs neither a GPU nor Isaac Sim — the
module under test imports only numpy, torch and warp — so it runs as a `unit` test alongside the
existing `test/utils/warp/test_proxy_array.py`.

The shape test is parametrized over `(2,)`, `(1, 2)`, `(3, 1, 2)` and `(2, 3, 1)` ray dimensions.
With the two reshapes reverted, three of the four fail; `(1, 2)` passes either way and is kept as
the control, since it is the only shape the existing suite covered. Ray depths are staggered so
the assertions also pin down the row-major ordering between the flatten and the unflatten, not
just the output shape.

The guard is covered by a second test parametrized over four mismatched direction shapes — too few,
too many, a wrong trailing dimension, and a different layout with a matching element count. Deleting
the guard fails all four; weakening it to a flattened-count comparison still fails the last.

I verified separately that for 3-D input the new reshape is byte-identical to the old one: 4344
output elements compared across batch shapes `(1, 1)`, `(1, 2)`, `(4, 7)` and `(16, 32)`, 0
differences, 403 misses (`inf` distances, `-1` face ids) included.

Please note what I could not run: I do not have an NVIDIA GPU, so I have not executed
`test/sensors/test_ray_caster.py` (it launches Kit) or anything on CUDA. The change is a pure
`torch.Tensor.view` on the host side plus a shape comparison, and is device-independent, but a GPU CI
run is worth having.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there