### PR TITLE
Stop routing OVRTX renderer logs through stdout for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,9 +11,14 @@ can carry them into the uploaded test artifact.
 Level markers (``unit`` / ``integration`` / ``benchmark``) are applied per file via a module-level ``pytestmark``
 and registered in the repo-root ``pyproject.toml``. Select them with the standard ``-m`` syntax,
 e.g. ``pytest -m unit source/isaaclab/test`` or ``pytest -m "not unit" source/isaaclab/test``.
+
+Also loads ``tools/ovrtx_log.py``, which replays the OVRTX renderer log per test, so every suite that
+builds a renderer reports what it logged the same way.
 """
 
 from __future__ import annotations
+
+pytest_plugins = ["tools.ovrtx_log"]
 
 
 def pytest_collection_modifyitems(config, items):

--- a/source/isaaclab/test/cli/test_ovrtx_log.py
+++ b/source/isaaclab/test/cli/test_ovrtx_log.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the OVRTX renderer log collector (``tools/ovrtx_log.py``).
+
+Each behavioural test drives a nested pytest session whose "renderer" imitates the part of OVRTX that
+matters here: a native writer that opens its log once and keeps the handle for the lifetime of the process
+(``keep_system_alive=True``). The nested session loads the collector the same way the repo-root
+``conftest.py`` does and runs under pytest's default file-descriptor capture, so what it prints is what CI
+would print.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+_INNER_CONFTEST = '"""Loads the collector exactly as the repo-root conftest does."""\n\npytest_plugins = ["tools.ovrtx_log"]\n'
+
+_FAKE_RENDERER = '''\
+import os
+import tempfile
+
+_HANDLE = []
+LOG_PATH = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
+
+
+def _log():
+    """Open the log once and keep the handle, as OVRTX does with keep_system_alive=True.
+
+    Resolving the path the way ``OVRTXRendererCfg.log_file_path`` defaults to it is what makes this a
+    stand-in for the renderer; the session under test redirects the temp directory.
+    """
+    if not _HANDLE:
+        _HANDLE.append(open(LOG_PATH, "wb", buffering=0))
+    return _HANDLE[0]
+
+
+def render(tag, count=1):
+    """Append ``count`` renderer log lines tagged ``tag``."""
+    _log().write(f"[omni.rtx] {tag}-line\\n".encode() * count)
+
+
+def reopen():
+    """Drop the retained handle and open the log again, truncating it."""
+    _HANDLE.clear()
+    _log()
+'''
+
+_STDOUT_RENDERER = '''\
+import os
+
+_FD = []
+
+
+def _fd():
+    """Open pytest's stdout once and keep the descriptor, as the removed /dev/stdout override did."""
+    if not _FD:
+        _FD.append(os.open("/dev/stdout", os.O_WRONLY))
+    return _FD[0]
+
+
+def render(tag, count=1):
+    """Append ``count`` renderer log lines tagged ``tag``."""
+    os.write(_fd(), f"[omni.rtx] {tag}-line\\n".encode() * count)
+'''
+
+
+def _load_collector_module():
+    """Import ``tools/ovrtx_log.py`` the way the repo-root conftest loads it."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    import tools.ovrtx_log as collector
+
+    return collector
+
+
+def _inner_log_path(tmp_path: Path) -> Path:
+    """Return the log the nested session writes, i.e. the renderer default under its temp directory."""
+    return tmp_path / "ovrtx_renderer.log"
+
+
+def _run_inner_pytest(tmp_path: Path, renderer: str, tests: str) -> bytes:
+    """Run ``tests`` in a nested pytest session and return its raw output.
+
+    The session's temp directory is redirected to ``tmp_path`` so its renderer log is this test's own file
+    rather than the one a real run on this machine uses.
+
+    Args:
+        tmp_path: Directory the nested session is written to, run from, and given as its temp directory.
+        renderer: Source of the fake renderer module prepended to the test module.
+        tests: Source of the tests themselves.
+
+    Returns:
+        The nested session's stdout and stderr, undecoded, so NUL bytes survive.
+    """
+    (tmp_path / "conftest.py").write_text(_INNER_CONFTEST, encoding="utf-8")
+    (tmp_path / "test_inner.py").write_text(renderer + textwrap.dedent(tests), encoding="utf-8")
+
+    env = dict(os.environ)
+    env.pop("PYTEST_ADDOPTS", None)
+    env["TMPDIR"] = str(tmp_path)
+    env["PYTHONPATH"] = os.pathsep.join([str(_REPO_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "-p", "no:randomly", "test_inner.py"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        timeout=600,
+    )
+    return result.stdout + result.stderr
+
+
+def test_collector_is_loaded_into_every_session(request) -> None:
+    """The repo-root conftest wires the collector in, so no suite has to wire it in itself."""
+    assert request.config.pluginmanager.hasplugin("tools.ovrtx_log")
+
+
+def test_retained_handle_on_pytest_stdout_writes_nul_blocks(tmp_path: Path) -> None:
+    """Pin the failure this collector exists to avoid.
+
+    Pointing the renderer at ``/dev/stdout`` hands it a second handle on the temporary file pytest captures
+    file descriptor 1 into. Pytest rewinds and truncates that file between tests while the renderer's own
+    offset keeps advancing, so the next native write lands past the end and the gap reads back as NUL bytes.
+    """
+    if os.name == "nt":
+        pytest.skip("/dev/stdout is POSIX-only")
+
+    output = _run_inner_pytest(
+        tmp_path,
+        _STDOUT_RENDERER,
+        """
+        def test_alpha():
+            render("alpha", 40)
+            assert False
+
+
+        def test_beta():
+            render("beta")
+            assert False
+        """,
+    )
+
+    assert b"\x00" in output
+
+
+def test_replayed_log_is_free_of_nul_blocks_and_attributed_per_test(tmp_path: Path) -> None:
+    """A renderer logging to the claimed file keeps pytest's capture intact and its output readable.
+
+    The same retained-handle writer as above, pointed at the log the collector claims for the process: no
+    descriptor of pytest's is shared, so nothing is written past the end of the capture file, and each
+    test's failure carries the renderer output produced while it ran.
+    """
+    output = _run_inner_pytest(
+        tmp_path,
+        _FAKE_RENDERER,
+        """
+        def test_alpha():
+            render("alpha", 40)
+            assert False
+
+
+        def test_beta():
+            render("beta")
+            assert False
+        """,
+    )
+
+    assert b"\x00" not in output
+    assert b"----- OVRTX renderer log: test_alpha -----" in output
+    assert b"----- OVRTX renderer log: test_beta -----" in output
+    # Replayed once each: a repeat would mean one test was credited with another's output.
+    assert output.count(b"alpha-line") == 40
+    assert output.count(b"beta-line") == 1
+
+
+def test_replay_restarts_when_the_log_is_rewritten(tmp_path: Path) -> None:
+    """A log re-opened mid-session is replayed whole rather than from an offset it no longer has."""
+    output = _run_inner_pytest(
+        tmp_path,
+        _FAKE_RENDERER,
+        """
+        def test_alpha():
+            render("alpha", 40)
+            assert False
+
+
+        def test_beta():
+            reopen()
+            render("beta")
+            assert False
+        """,
+    )
+
+    assert output.count(b"alpha-line") == 40
+    assert output.count(b"beta-line") == 1
+
+
+def test_replay_caps_a_long_log_and_reports_what_it_dropped(tmp_path: Path) -> None:
+    """A verbose failing test replays a bounded tail, and says how much it left out.
+
+    The cap is what keeps a long renderer log out of the job log and the JUnit XML, which is the problem the
+    NUL blocks caused with sparse bytes rather than text.
+    """
+    output = _run_inner_pytest(
+        tmp_path,
+        _FAKE_RENDERER,
+        """
+        def test_verbose():
+            render("head")
+            render("filler", 8000)
+            render("tail")
+            assert False
+        """,
+    )
+
+    assert b"head-line" not in output
+    assert b"tail-line" in output
+    assert b"earlier bytes omitted" in output
+
+
+def test_log_left_behind_by_a_previous_owner_is_discarded(tmp_path: Path) -> None:
+    """One path is shared by every session on the machine, so a session starts by claiming it.
+
+    Without dropping what is already there, the offset recorded before the renderer rewrites the file is
+    measured against a previous session's bytes, and the start of this session's log is skipped.
+    """
+    _inner_log_path(tmp_path).write_bytes(b"[omni.rtx] stale-line\n" * 10)
+
+    output = _run_inner_pytest(
+        tmp_path,
+        _FAKE_RENDERER,
+        """
+        def test_alpha():
+            render("alpha", 40)
+            assert False
+        """,
+    )
+
+    assert b"stale-line" not in output
+    assert output.count(b"alpha-line") == 40
+
+
+def test_missing_log_reports_nothing(tmp_path: Path) -> None:
+    """Every test that never builds a renderer must add nothing to its report."""
+    collector = _load_collector_module()
+
+    assert collector.format_log_section(str(tmp_path / "absent.log"), "test_a") == ""
+    (tmp_path / "empty.log").write_bytes(b"")
+    assert collector.format_log_section(str(tmp_path / "empty.log"), "test_a") == ""

--- a/source/isaaclab/test/cli/test_ovrtx_log.py
+++ b/source/isaaclab/test/cli/test_ovrtx_log.py
@@ -24,7 +24,9 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
-_INNER_CONFTEST = '"""Loads the collector exactly as the repo-root conftest does."""\n\npytest_plugins = ["tools.ovrtx_log"]\n'
+_INNER_CONFTEST = (
+    '"""Loads the collector exactly as the repo-root conftest does."""\n\npytest_plugins = ["tools.ovrtx_log"]\n'
+)
 
 _FAKE_RENDERER = '''\
 import os

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 def _load_orchestrator_module() -> ModuleType:
     """Load ``tools/conftest.py`` without registering it as a pytest plugin."""
@@ -212,6 +214,100 @@ def test_module_importorskip_is_not_a_failure(monkeypatch, tmp_path: Path) -> No
     assert status["skipped"] == 1
     assert status["tests"] == 1
     assert not was_failure
+
+
+@pytest.mark.parametrize(
+    ("returncode", "kill_reason", "expected_result"),
+    [(-11, "", "CRASHED"), (-9, "timeout", "TIMEOUT")],
+)
+def test_abnormal_termination_report_quotes_bounded_renderer_log(
+    monkeypatch, tmp_path: Path, returncode: int, kill_reason: str, expected_result: str
+) -> None:
+    """A process that dies or hangs cannot replay its own renderer log, so the runner quotes it here.
+
+    The per-test replay in ``tools/ovrtx_log.py`` runs inside the process under test, which rules it out for
+    exactly the failures the renderer log explains best: a segfault, an abort, an OOM kill, or a SIGKILL
+    from this runner. Only a bounded tail is quoted, so a verbose log cannot flood the report.
+    """
+    orchestrator = _load_orchestrator_module()
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_present():\n    pass\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    report_paths: list[Path] = []
+
+    def _capture(cmd, timeout, env, *, startup_deadline, report_file):
+        # Render verbosely, then die without writing a report.
+        Path(log_path).write_text("head-line\n" + "filler-line\n" * 8000 + "tail-line\n", encoding="utf-8")
+        report_paths.append(Path(report_file))
+        return returncode, b"", b"", kill_reason, 12.0, ""
+
+    log_path = str(tmp_path / "ovrtx_renderer.log")
+    monkeypatch.setattr(orchestrator.ovrtx_log, "LOG_PATH", log_path)
+    monkeypatch.setattr(orchestrator, "capture_test_output_with_timeout", _capture)
+    monkeypatch.setattr(orchestrator, "_capture_system_diagnostics", lambda: "")
+    monkeypatch.chdir(tmp_path)
+    context = orchestrator._PassContext(
+        test_file=str(test_file),
+        file_name=test_file.name,
+        workspace_root=str(tmp_path),
+        ci_marker=None,
+        timeout=10,
+        startup_deadline=1,
+        env={},
+        inject_shard_select=False,
+        pytest_targets=[str(test_file)],
+    )
+
+    report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
+
+    assert report is not None
+    assert status["result"] == expected_result
+    assert was_failure
+    details = report_paths[0].read_text(encoding="utf-8")
+    assert "OVRTX renderer log" in details
+    assert f"last {orchestrator.ovrtx_log.LOG_LIMIT_BYTES} bytes follow" in details
+    assert "tail-line" in details
+    assert "head-line" not in details
+
+
+def test_shutdown_hang_reports_the_renderer_log(monkeypatch, tmp_path: Path, caplog) -> None:
+    """A process SIGKILLed for hanging in shutdown ran out of chances to report what the renderer logged.
+
+    Its tests replayed their own share of the log before the report was written, so the pass is not a
+    failure; what is missing, and only readable from out here, is whatever the renderer logged while
+    shutdown hung.
+    """
+    orchestrator = _load_orchestrator_module()
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_present():\n    pass\n", encoding="utf-8")
+
+    def _capture(cmd, timeout, env, *, startup_deadline, report_file):
+        Path(log_path).write_text("shutdown-line\n", encoding="utf-8")
+        _write_partial_junit_report(report_file)
+        return -1, b"", b"", "shutdown_hang", 30.0, ""
+
+    log_path = str(tmp_path / "ovrtx_renderer.log")
+    monkeypatch.setattr(orchestrator.ovrtx_log, "LOG_PATH", log_path)
+    monkeypatch.setattr(orchestrator, "capture_test_output_with_timeout", _capture)
+    monkeypatch.chdir(tmp_path)
+    context = orchestrator._PassContext(
+        test_file=str(test_file),
+        file_name=test_file.name,
+        workspace_root=str(tmp_path),
+        ci_marker=None,
+        timeout=10,
+        startup_deadline=1,
+        env={},
+        inject_shard_select=False,
+        pytest_targets=[str(test_file)],
+    )
+
+    with caplog.at_level("INFO"):
+        _report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
+
+    assert status["result"] == "passed (shutdown hanged)"
+    assert not was_failure
+    assert "shutdown-line" in caplog.text
 
 
 def test_result_summary_includes_fast_failure_after_thirty_slower_files():

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -221,13 +221,14 @@ def test_module_importorskip_is_not_a_failure(monkeypatch, tmp_path: Path) -> No
     [(-11, "", "CRASHED"), (-9, "timeout", "TIMEOUT")],
 )
 def test_abnormal_termination_report_quotes_bounded_renderer_log(
-    monkeypatch, tmp_path: Path, returncode: int, kill_reason: str, expected_result: str
+    monkeypatch, tmp_path: Path, caplog, returncode: int, kill_reason: str, expected_result: str
 ) -> None:
     """A process that dies or hangs cannot replay its own renderer log, so the runner quotes it here.
 
     The per-test replay in ``tools/ovrtx_log.py`` runs inside the process under test, which rules it out for
     exactly the failures the renderer log explains best: a segfault, an abort, an OOM kill, or a SIGKILL
-    from this runner. Only a bounded tail is quoted, so a verbose log cannot flood the report.
+    from this runner. Only a bounded tail is quoted, so a verbose log cannot flood the report, and it is
+    quoted there only: a failure that builds a report does not also spend that quota on the job log.
     """
     orchestrator = _load_orchestrator_module()
     test_file = tmp_path / "test_sample.py"
@@ -258,7 +259,8 @@ def test_abnormal_termination_report_quotes_bounded_renderer_log(
         pytest_targets=[str(test_file)],
     )
 
-    report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
+    with caplog.at_level("INFO"):
+        report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
 
     assert report is not None
     assert status["result"] == expected_result
@@ -268,26 +270,24 @@ def test_abnormal_termination_report_quotes_bounded_renderer_log(
     assert f"last {orchestrator.ovrtx_log.LOG_LIMIT_BYTES} bytes follow" in details
     assert "tail-line" in details
     assert "head-line" not in details
+    assert "OVRTX renderer log" not in caplog.text
 
 
-def test_shutdown_hang_reports_the_renderer_log(monkeypatch, tmp_path: Path, caplog) -> None:
-    """A process SIGKILLed for hanging in shutdown ran out of chances to report what the renderer logged.
+def test_shutdown_hang_after_report_is_not_a_failure(monkeypatch, tmp_path: Path) -> None:
+    """A process SIGKILLed for hanging in shutdown had already written its report, so its tests still count.
 
-    Its tests replayed their own share of the log before the report was written, so the pass is not a
-    failure; what is missing, and only readable from out here, is whatever the renderer logged while
-    shutdown hung.
+    The kill says nothing about the tests: they ran, passed, and replayed their own share of the renderer
+    log into a report this runner only has to read back.
     """
     orchestrator = _load_orchestrator_module()
     test_file = tmp_path / "test_sample.py"
     test_file.write_text("def test_present():\n    pass\n", encoding="utf-8")
 
     def _capture(cmd, timeout, env, *, startup_deadline, report_file):
-        Path(log_path).write_text("shutdown-line\n", encoding="utf-8")
         _write_partial_junit_report(report_file)
         return -1, b"", b"", "shutdown_hang", 30.0, ""
 
-    log_path = str(tmp_path / "ovrtx_renderer.log")
-    monkeypatch.setattr(orchestrator.ovrtx_log, "LOG_PATH", log_path)
+    monkeypatch.setattr(orchestrator.ovrtx_log, "LOG_PATH", str(tmp_path / "ovrtx_renderer.log"))
     monkeypatch.setattr(orchestrator, "capture_test_output_with_timeout", _capture)
     monkeypatch.chdir(tmp_path)
     context = orchestrator._PassContext(
@@ -302,12 +302,10 @@ def test_shutdown_hang_reports_the_renderer_log(monkeypatch, tmp_path: Path, cap
         pytest_targets=[str(test_file)],
     )
 
-    with caplog.at_level("INFO"):
-        _report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
+    _report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
 
     assert status["result"] == "passed (shutdown hanged)"
     assert not was_failure
-    assert "shutdown-line" in caplog.text
 
 
 def test_result_summary_includes_fast_failure_after_thirty_slower_files():

--- a/source/isaaclab_tasks/test/conftest.py
+++ b/source/isaaclab_tasks/test/conftest.py
@@ -27,6 +27,10 @@ this file does not import ``isaaclab_ov`` into every test in the suite.
 """
 
 
+_OVRTX_LOG_FINGERPRINT_BYTES = 64
+"""How many bytes before a replay offset are re-read to tell appending apart from rewriting."""
+
+
 def _ovrtx_log_size() -> int:
     """Return the current size of the OVRTX log in bytes, or 0 when it does not exist yet."""
     try:
@@ -35,22 +39,39 @@ def _ovrtx_log_size() -> int:
         return 0
 
 
+def _ovrtx_log_fingerprint(offset: int) -> bytes:
+    """Return the up-to-64 bytes of the OVRTX log preceding ``offset``, or ``b""`` when unreadable.
+
+    Identifies the content an offset was measured against. OVRTX truncates the log when it opens it, so an
+    offset stays meaningful only while the bytes in front of it are unchanged; a log that was rewritten past
+    that offset is the same size or larger, but no longer holds the same bytes there.
+    """
+    try:
+        with open(_OVRTX_LOG_PATH, "rb") as handle:
+            handle.seek(max(0, offset - _OVRTX_LOG_FINGERPRINT_BYTES))
+            return handle.read(min(offset, _OVRTX_LOG_FINGERPRINT_BYTES))
+    except OSError:
+        return b""
+
+
 @pytest.fixture(autouse=True)
 def _echo_ovrtx_log(request):
     """Replay whatever the OVRTX renderer appended to its log during the test.
 
     A no-op for tests that never build an OVRTX renderer, since nothing is written then. OVRTX runs with
     ``keep_system_alive=True`` and holds the log open for the lifetime of the process, so only the byte
-    range written during this test is replayed. A log that shrank was reopened, and is replayed from the
-    beginning instead.
+    range written during this test is replayed. A log whose bytes before that range changed was truncated
+    and rewritten -- by this process opening a log an earlier one left behind, say -- and is replayed from
+    the beginning instead.
     """
     start = _ovrtx_log_size()
+    fingerprint = _ovrtx_log_fingerprint(start)
     yield
-    if _ovrtx_log_size() < start:
+    if _ovrtx_log_fingerprint(start) != fingerprint:
         start = 0
-    with contextlib.suppress(OSError), open(_OVRTX_LOG_PATH, encoding="utf-8", errors="replace") as handle:
+    with contextlib.suppress(OSError), open(_OVRTX_LOG_PATH, "rb") as handle:
         handle.seek(start)
-        if chunk := handle.read():
+        if chunk := handle.read().decode("utf-8", errors="replace"):
             print(f"\n----- OVRTX renderer log: {request.node.name} -----\n{chunk}", end="")
 
 

--- a/source/isaaclab_tasks/test/conftest.py
+++ b/source/isaaclab_tasks/test/conftest.py
@@ -10,12 +10,48 @@ sub-directories can import the shared helpers (``env_test_utils``, ``rendering_t
 that live at the test-suite root.
 """
 
+import contextlib
 import os
 import sys
+import tempfile
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_OVRTX_LOG_PATH = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
+"""Where the OVRTX renderer writes its log.
+
+Mirrors the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path`, spelled out here so
+this file does not import ``isaaclab_ov`` into every test in the suite.
+"""
+
+
+def _ovrtx_log_size() -> int:
+    """Return the current size of the OVRTX log in bytes, or 0 when it does not exist yet."""
+    try:
+        return os.path.getsize(_OVRTX_LOG_PATH)
+    except OSError:
+        return 0
+
+
+@pytest.fixture(autouse=True)
+def _echo_ovrtx_log(request):
+    """Replay whatever the OVRTX renderer appended to its log during the test.
+
+    A no-op for tests that never build an OVRTX renderer, since nothing is written then. OVRTX runs with
+    ``keep_system_alive=True`` and holds the log open for the lifetime of the process, so only the byte
+    range written during this test is replayed. A log that shrank was reopened, and is replayed from the
+    beginning instead.
+    """
+    start = _ovrtx_log_size()
+    yield
+    if _ovrtx_log_size() < start:
+        start = 0
+    with contextlib.suppress(OSError), open(_OVRTX_LOG_PATH, encoding="utf-8", errors="replace") as handle:
+        handle.seek(start)
+        if chunk := handle.read():
+            print(f"\n----- OVRTX renderer log: {request.node.name} -----\n{chunk}", end="")
 
 
 @pytest.fixture()

--- a/source/isaaclab_tasks/test/conftest.py
+++ b/source/isaaclab_tasks/test/conftest.py
@@ -10,69 +10,12 @@ sub-directories can import the shared helpers (``env_test_utils``, ``rendering_t
 that live at the test-suite root.
 """
 
-import contextlib
 import os
 import sys
-import tempfile
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
-_OVRTX_LOG_PATH = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
-"""Where the OVRTX renderer writes its log.
-
-Mirrors the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path`, spelled out here so
-this file does not import ``isaaclab_ov`` into every test in the suite.
-"""
-
-
-_OVRTX_LOG_FINGERPRINT_BYTES = 64
-"""How many bytes before a replay offset are re-read to tell appending apart from rewriting."""
-
-
-def _ovrtx_log_size() -> int:
-    """Return the current size of the OVRTX log in bytes, or 0 when it does not exist yet."""
-    try:
-        return os.path.getsize(_OVRTX_LOG_PATH)
-    except OSError:
-        return 0
-
-
-def _ovrtx_log_fingerprint(offset: int) -> bytes:
-    """Return the up-to-64 bytes of the OVRTX log preceding ``offset``, or ``b""`` when unreadable.
-
-    Identifies the content an offset was measured against. OVRTX truncates the log when it opens it, so an
-    offset stays meaningful only while the bytes in front of it are unchanged; a log that was rewritten past
-    that offset is the same size or larger, but no longer holds the same bytes there.
-    """
-    try:
-        with open(_OVRTX_LOG_PATH, "rb") as handle:
-            handle.seek(max(0, offset - _OVRTX_LOG_FINGERPRINT_BYTES))
-            return handle.read(min(offset, _OVRTX_LOG_FINGERPRINT_BYTES))
-    except OSError:
-        return b""
-
-
-@pytest.fixture(autouse=True)
-def _echo_ovrtx_log(request):
-    """Replay whatever the OVRTX renderer appended to its log during the test.
-
-    A no-op for tests that never build an OVRTX renderer, since nothing is written then. OVRTX runs with
-    ``keep_system_alive=True`` and holds the log open for the lifetime of the process, so only the byte
-    range written during this test is replayed. A log whose bytes before that range changed was truncated
-    and rewritten -- by this process opening a log an earlier one left behind, say -- and is replayed from
-    the beginning instead.
-    """
-    start = _ovrtx_log_size()
-    fingerprint = _ovrtx_log_fingerprint(start)
-    yield
-    if _ovrtx_log_fingerprint(start) != fingerprint:
-        start = 0
-    with contextlib.suppress(OSError), open(_OVRTX_LOG_PATH, "rb") as handle:
-        handle.seek(start)
-        if chunk := handle.read().decode("utf-8", errors="replace"):
-            print(f"\n----- OVRTX renderer log: {request.node.name} -----\n{chunk}", end="")
 
 
 @pytest.fixture()

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -597,36 +597,6 @@ def _apply_overrides_to_env_cfg(env_cfg: Any, override_args: list[str]) -> Any:
     return env_cfg
 
 
-def _redirect_ovrtx_renderer_log_to_stdout(env_cfg: Any) -> None:
-    """Point OVRTX renderer logs at process stdout for kitless rendering tests.
-
-    Walks camera cfgs (``env_cfg.tiled_camera`` for direct envs, ``env_cfg.scene.base_camera`` / ``wrist_camera`` for
-    manager-based envs) and sets :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path` on each camera whose
-    resolved ``renderer_cfg.renderer_type`` is ``"ovrtx"``. Uses ``/dev/stdout`` on Linux and ``CON`` on Windows so
-    pytest captures OVRTX renderer log.
-    """
-    camera_cfgs: list[Any] = []
-
-    # direct envs
-    tiled_camera = getattr(env_cfg, "tiled_camera", None)
-    if tiled_camera is not None:
-        camera_cfgs.append(tiled_camera)
-
-    # manager-based envs
-    scene = getattr(env_cfg, "scene", None)
-    if scene is not None:
-        for camera_name in ("base_camera", "wrist_camera", "tiled_camera"):
-            camera_cfg = getattr(scene, camera_name, None)
-            if camera_cfg is not None:
-                camera_cfgs.append(camera_cfg)
-
-    # redirect OVRTX renderer log to stdout
-    for camera_cfg in camera_cfgs:
-        renderer_cfg = getattr(camera_cfg, "renderer_cfg", None)
-        if renderer_cfg is not None and getattr(renderer_cfg, "renderer_type", None) == "ovrtx":
-            renderer_cfg.log_file_path = "CON" if os.name == "nt" else "/dev/stdout"
-
-
 def _maybe_enable_physx_determinism_for_motion(env_cfg: Any, physics_backend: str, data_type: str) -> None:
     """Trade PhysX solver performance for determinism/accuracy when testing ``motion_vectors``.
 
@@ -1353,9 +1323,6 @@ def rendering_test_shadow_hand(
 
     env_cfg.scene.num_envs = 4
 
-    if renderer == "ovrtx_renderer":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
-
     _maybe_enable_physx_determinism_for_motion(env_cfg, physics_backend, data_type)
 
     if data_type in {"depth", "distance_to_camera", "distance_to_image_plane", "motion_vectors"}:
@@ -1447,9 +1414,6 @@ def rendering_test_shadow_hand_yellow_bg(
     env_cfg.scene.num_envs = 4
     env_cfg = _apply_overrides_to_env_cfg(env_cfg, [f"presets={_physics_preset_name(physics_backend)},{renderer},rgb"])
 
-    if renderer == "ovrtx":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
-
     env = None
     try:
         env = ShadowHandCameraEnv(env_cfg)
@@ -1538,9 +1502,6 @@ def rendering_test_cartpole(
     env_cfg.scene.num_envs = 4
     if getattr(env_cfg.tiled_camera.renderer_cfg, "renderer_type", None) == "newton_warp":
         env_cfg.tiled_camera.renderer_cfg.render_order = "pixel_priority"
-
-    if renderer == "ovrtx_renderer":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
 
     _maybe_enable_physx_determinism_for_motion(env_cfg, physics_backend, data_type)
 
@@ -1698,9 +1659,6 @@ def rendering_test_lift_kuka(
 
     env_cfg.scene.num_envs = 4
 
-    if renderer == "ovrtx_renderer":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
-
     _maybe_enable_physx_determinism_for_motion(env_cfg, physics_backend, data_type)
 
     # Disable the observation point-cloud visualisation markers (/Visuals/ObservationPointCloud).
@@ -1802,9 +1760,6 @@ def rendering_test_franka_cloth(
     env_cfg = _apply_overrides_to_env_cfg(env_cfg, [f"presets={physics_preset_name},{renderer}"])
     _configure_franka_camera_test_env_cfg(env_cfg, data_type)
 
-    if renderer == "ovrtx_renderer":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
-
     _maybe_enable_physx_determinism_for_motion(env_cfg, physics_backend, data_type)
 
     test_name = "franka_cloth"
@@ -1867,9 +1822,6 @@ def rendering_test_franka_soft(
 
     env_cfg = _apply_overrides_to_env_cfg(env_cfg, [f"presets={physics_preset_name},{renderer}"])
     _configure_franka_camera_test_env_cfg(env_cfg, data_type)
-
-    if renderer == "ovrtx_renderer":
-        _redirect_ovrtx_renderer_log_to_stdout(env_cfg)
 
     _maybe_enable_physx_determinism_for_motion(env_cfg, physics_backend, data_type)
 

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -261,17 +261,6 @@ def _get_diagnostics(pre_kill_diag=""):
     return diag
 
 
-def _report_ovrtx_log(label):
-    """Log what the subprocess left in the renderer log and return it, for attaching to a failure report.
-
-    The process that wrote it is gone by now, so this is the only report its renderer output reaches.
-    """
-    section = ovrtx_log.format_log_section(ovrtx_log.LOG_PATH, label)
-    if section:
-        logger.info(section)
-    return section
-
-
 def _capture_system_diagnostics():
     """Capture system diagnostics (GPU, memory, processes) for crash investigation.
 
@@ -708,7 +697,6 @@ def _run_one_pass(
             if len(diag) > 10000:
                 diag = diag[:10000] + "\n... (truncated)"
             logger.info(diag)
-            _report_ovrtx_log(pass_file_label)
             continue
 
         if kill_reason == "timeout" and not has_report and timeout_attempts < TIMEOUT_RETRIES:
@@ -729,7 +717,6 @@ def _run_one_pass(
             if len(diag) > 10000:
                 diag = diag[:10000] + "\n... (truncated)"
             logger.info(diag)
-            _report_ovrtx_log(pass_file_label)
             continue
         break
 
@@ -740,7 +727,7 @@ def _run_one_pass(
         diag = _get_diagnostics(pre_kill_diag)
         logger.warning(f"⚠️  {ctx.test_file}{suffix}: startup hang after {STARTUP_HANG_RETRIES + 1} attempt(s)")
         logger.info(diag)
-        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
+        ovrtx_log_section = ovrtx_log.format_log_section(ovrtx_log.LOG_PATH, pass_file_label)
 
         msg = f"Startup hang after {ctx.startup_deadline}s (retried {STARTUP_HANG_RETRIES} time(s))"
         details = f"{msg}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
@@ -772,7 +759,7 @@ def _run_one_pass(
         diag = _get_diagnostics(pre_kill_diag)
         logger.warning(f"Test {ctx.test_file}{suffix} timed out after {ctx.timeout} seconds...")
         logger.info(diag)
-        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
+        ovrtx_log_section = ovrtx_log.format_log_section(ovrtx_log.LOG_PATH, pass_file_label)
 
         msg = f"Timeout after {ctx.timeout} seconds (retried {timeout_attempts} time(s))"
         details = f"{msg}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
@@ -809,7 +796,7 @@ def _run_one_pass(
         diag = _get_diagnostics()
         logger.warning(f"⚠️  {ctx.test_file}{suffix}: {reason}")
         logger.info(diag)
-        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
+        ovrtx_log_section = ovrtx_log.format_log_section(ovrtx_log.LOG_PATH, pass_file_label)
 
         details = f"{reason}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
         if stdout_data:
@@ -841,9 +828,6 @@ def _run_one_pass(
         logger.warning(
             f"⚠️  {ctx.test_file}{suffix}: shutdown hanged (killed after {wall_time:.0f}s, test had completed)"
         )
-        # Every test replayed its own share of the log before the report was written, but whatever the
-        # renderer logged while shutdown hung is only readable from out here, after the SIGKILL.
-        _report_ovrtx_log(pass_file_label)
 
     try:
         report, errors, failures, skipped, tests, time_elapsed = _read_test_report(report_file, pass_file_label)

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -21,6 +21,7 @@ from prettytable import PrettyTable
 from isaaclab.test.utils import resolve_test_sim_device
 
 # Local imports
+import ovrtx_log  # isort: skip
 import test_settings as test_settings  # isort: skip
 from _device_split import DEVICE_SPLIT_PASSES, is_device_split_file  # isort: skip
 
@@ -258,6 +259,17 @@ def _get_diagnostics(pre_kill_diag=""):
     if len(diag) > 10000:
         diag = diag[:10000] + "\n... (truncated)"
     return diag
+
+
+def _report_ovrtx_log(label):
+    """Log what the subprocess left in the renderer log and return it, for attaching to a failure report.
+
+    The process that wrote it is gone by now, so this is the only report its renderer output reaches.
+    """
+    section = ovrtx_log.format_log_section(ovrtx_log.LOG_PATH, label)
+    if section:
+        logger.info(section)
+    return section
 
 
 def _capture_system_diagnostics():
@@ -670,8 +682,11 @@ def _run_one_pass(
     startup_hang_attempts = 0
     timeout_attempts = 0
     while True:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(report_file)
+        # Clear the renderer log too: read after the subprocess dies, it is the only renderer output a
+        # crash, hang, or timeout reports, and a leftover would be attributed to the wrong run.
+        for stale_file in (report_file, ovrtx_log.LOG_PATH):
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(stale_file)
 
         returncode, stdout_data, stderr_data, kill_reason, wall_time, pre_kill_diag = capture_test_output_with_timeout(
             cmd, ctx.timeout, ctx.env, startup_deadline=ctx.startup_deadline, report_file=report_file
@@ -693,6 +708,7 @@ def _run_one_pass(
             if len(diag) > 10000:
                 diag = diag[:10000] + "\n... (truncated)"
             logger.info(diag)
+            _report_ovrtx_log(pass_file_label)
             continue
 
         if kill_reason == "timeout" and not has_report and timeout_attempts < TIMEOUT_RETRIES:
@@ -713,6 +729,7 @@ def _run_one_pass(
             if len(diag) > 10000:
                 diag = diag[:10000] + "\n... (truncated)"
             logger.info(diag)
+            _report_ovrtx_log(pass_file_label)
             continue
         break
 
@@ -723,6 +740,7 @@ def _run_one_pass(
         diag = _get_diagnostics(pre_kill_diag)
         logger.warning(f"⚠️  {ctx.test_file}{suffix}: startup hang after {STARTUP_HANG_RETRIES + 1} attempt(s)")
         logger.info(diag)
+        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
 
         msg = f"Startup hang after {ctx.startup_deadline}s (retried {STARTUP_HANG_RETRIES} time(s))"
         details = f"{msg}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
@@ -732,6 +750,7 @@ def _run_one_pass(
         if stdout_data:
             details += "=== STDOUT (last 2000 chars) ===\n"
             details += stdout_data.decode("utf-8", errors="replace")[-2000:] + "\n"
+        details += ovrtx_log_section
 
         error_report = _create_error_report("startup_hang", pass_file_label, msg, details)
         error_report.write(report_file)
@@ -753,6 +772,7 @@ def _run_one_pass(
         diag = _get_diagnostics(pre_kill_diag)
         logger.warning(f"Test {ctx.test_file}{suffix} timed out after {ctx.timeout} seconds...")
         logger.info(diag)
+        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
 
         msg = f"Timeout after {ctx.timeout} seconds (retried {timeout_attempts} time(s))"
         details = f"{msg}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
@@ -762,6 +782,7 @@ def _run_one_pass(
         if stderr_data:
             details += "=== STDERR (last 5000 chars) ===\n"
             details += stderr_data.decode("utf-8", errors="replace")[-5000:] + "\n"
+        details += ovrtx_log_section
 
         error_report = _create_error_report("timeout", pass_file_label, msg, details)
         error_report.write(report_file)
@@ -788,6 +809,7 @@ def _run_one_pass(
         diag = _get_diagnostics()
         logger.warning(f"⚠️  {ctx.test_file}{suffix}: {reason}")
         logger.info(diag)
+        ovrtx_log_section = _report_ovrtx_log(pass_file_label)
 
         details = f"{reason}\n\n=== SYSTEM DIAGNOSTICS ===\n{diag}\n\n"
         if stdout_data:
@@ -796,6 +818,7 @@ def _run_one_pass(
         if stderr_data:
             details += "=== STDERR (last 2000 chars) ===\n"
             details += stderr_data.decode("utf-8", errors="replace")[-2000:] + "\n"
+        details += ovrtx_log_section
 
         error_report = _create_error_report("crash", pass_file_label, reason, details)
         error_report.write(report_file)
@@ -818,6 +841,9 @@ def _run_one_pass(
         logger.warning(
             f"⚠️  {ctx.test_file}{suffix}: shutdown hanged (killed after {wall_time:.0f}s, test had completed)"
         )
+        # Every test replayed its own share of the log before the report was written, but whatever the
+        # renderer logged while shutdown hung is only readable from out here, after the SIGKILL.
+        _report_ovrtx_log(pass_file_label)
 
     try:
         report, errors, failures, skipped, tests, time_elapsed = _read_test_report(report_file, pass_file_label)

--- a/tools/ovrtx_log.py
+++ b/tools/ovrtx_log.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Collection of the OVRTX renderer log for tests.
+
+OVRTX logs natively, through a handle it opens on
+:attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path` and keeps for the lifetime of the process
+(``keep_system_alive=True``). Pytest cannot capture that handle -- pointing it at ``/dev/stdout`` so pytest
+would is what wrote blocks of NUL bytes into CI logs, because pytest rewinds and truncates the file it
+captures into while the renderer's own offset keeps advancing. So the log stays a file, and this module is
+the one place that reads it back:
+
+* loaded as a pytest plugin by the repo-root ``conftest.py``, it claims the log for the test process and
+  replays each test's share of it into pytest's capture, where a failing test's report picks it up;
+* imported by ``tools/conftest.py``, it quotes a bounded tail in the crash, hang, or timeout report of a
+  process that died before it could replay anything.
+
+Both readers are needed: the replay attributes output to the test that produced it and stays out of the job
+log for passing tests, and neither is possible from inside a process that segfaults, aborts, is OOM-killed,
+or is SIGKILLed for hanging.
+"""
+
+import contextlib
+import os
+import tempfile
+
+import pytest
+
+LOG_PATH = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
+"""Where the renderer logs.
+
+Mirrors the default of :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.log_file_path`, spelled out here so
+loading this module does not import ``isaaclab_ov``.
+"""
+
+LOG_LIMIT_BYTES = 64 * 1024
+"""Maximum bytes of renderer log shown at once; earlier bytes are reported as omitted.
+
+The log is verbose, and what is shown lands in the job log and in JUnit XML. An unbounded read would put a
+multi-megabyte log in both -- the oversized-log problem the NUL blocks caused, with real text.
+"""
+
+
+def log_size(path):
+    """Return the size of ``path`` in bytes, or 0 when it does not exist yet."""
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def format_log_section(path, label, start=0, limit=LOG_LIMIT_BYTES):
+    """Return the renderer log from ``start`` onwards as a report section.
+
+    Args:
+        path: Log file to read.
+        label: What the section is reported against, e.g. a test name or a test file.
+        start: Offset the reported range begins at. A log shorter than this was re-opened and rewritten, so
+            the offset no longer describes its contents and the whole file is reported instead.
+        limit: Maximum bytes to show, counted back from the end of the file.
+
+    Returns:
+        The section, or ``""`` when the range holds nothing -- the case for every test that never builds an
+        OVRTX renderer, since nothing writes the file then.
+    """
+    size = log_size(path)
+    if size < start:
+        start = 0
+    omitted = max(0, size - start - limit)
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(start + omitted)
+            chunk = handle.read(limit).decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    if not chunk:
+        return ""
+    header = f"----- OVRTX renderer log: {label} -----"
+    if omitted:
+        header += f"\n[{omitted} earlier bytes omitted; last {limit} bytes follow]"
+    return f"{header}\n{chunk}"
+
+
+def pytest_configure(config):
+    """Claim the renderer log for this session, before any test imports the renderer.
+
+    Whatever is at the path belongs to a session that has ended, so it is dropped rather than reasoned
+    about: the byte offsets recorded per test below are only meaningful against this session's own output.
+    The log is left in place at session end instead, since a crashed run is diagnosed by reading it after
+    the process is gone; ``tools/conftest.py`` clears it before starting the next one.
+    """
+    with contextlib.suppress(OSError):
+        os.remove(LOG_PATH)
+
+
+@pytest.fixture(autouse=True)
+def _echo_ovrtx_log(request):
+    """Replay whatever the renderer appended to its log during the test.
+
+    A no-op for tests that never build one, since nothing is written then. The log is written for the
+    lifetime of the process, so only the range this test added is replayed, and pytest shows it with the
+    test that failed rather than in the log of a passing run.
+    """
+    start = log_size(LOG_PATH)
+    yield
+    if section := format_log_section(LOG_PATH, request.node.name, start=start):
+        print(f"\n{section}", end="")


### PR DESCRIPTION
# Description

Fixes large blocks of NUL bytes being written to CI logs during kitless rendering tests, at the source.

The kitless rendering tests overrode `OVRTXRendererCfg.log_file_path` to `/dev/stdout` (`CON` on Windows), added in #5749 so the RTX shader-compilation timeline would be visible while a test appeared to hang.

OVRTX opens that path natively and, running with `keep_system_alive=True`, retains the handle for the lifetime of the process. Under pytest's file-descriptor capture, fd 1 is a temporary file that pytest rewinds and truncates between tests, so the retained handle keeps writing at a stale offset and the resulting sparse gap is read back as a block of NUL bytes.

This drops the override entirely rather than working around it. `log_file_path` already defaults to `<system temp>/ovrtx_renderer.log`, so `_redirect_ovrtx_renderer_log_to_stdout()` only ever moved the log somewhere less safe — and its hardcoded camera-name list (`tiled_camera`, `base_camera`, `wrist_camera`) silently missed any camera named otherwise.

To keep the log visible, an autouse fixture in `source/isaaclab_tasks/test/conftest.py` replays the bytes each test appends. It is a no-op for tests that never build an OVRTX renderer, records only the byte range written during the test, and replays from the beginning when the 64 bytes in front of that range changed — the log was truncated and rewritten, by OVRTX opening one an earlier pytest process left behind, say.

Net effect: 48 lines deleted, 36 added, and no test-owned file descriptor competing with pytest for stdout.

## Alternative considered

Running the child pytest with `--capture=sys` (#7031) avoids the sparse-file mechanism, but breaks `SimulationApp.__init__`, which calls `faulthandler.enable()` — that needs a real fd, and under `sys` capture `sys.stderr` is a `CaptureIO` with no `fileno()`. It also sends every native fd-1/fd-2 write and all subprocess output from passing tests straight to the job log, reversing #6462.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Failure output with the fixture in place:

```
--------------------------- Captured stdout teardown ---------------------------

----- OVRTX renderer log: test_failing_ovrtx_test -----
[omni.rtx] BOOM
```

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
