### PR TITLE
Add runtime scene attribute updates

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -181,6 +181,7 @@ Guidelines for modifications:
 * Ruben Grandia
 * Ryan Gresia
 * Ryley McCarroll
+* ruziniuuuuu
 * Sahara Yuta
 * Sergey Grizan
 * Shafeef Omar

--- a/source/isaaclab/changelog.d/ruziniuuuuu-runtime-scene-attributes.minor.rst
+++ b/source/isaaclab/changelog.d/ruziniuuuuu-runtime-scene-attributes.minor.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added a renderer-neutral API for synchronizing targeted scene attributes at runtime.

--- a/source/isaaclab/isaaclab/renderers/base_renderer.py
+++ b/source/isaaclab/isaaclab/renderers/base_renderer.py
@@ -126,6 +126,30 @@ class BaseRenderer(ABC):
         """
         pass
 
+    def update_scene_attribute(
+        self,
+        prim_paths: list[str],
+        attribute_name: str,
+        values: Any,
+        *,
+        is_asset_path: bool = False,
+    ) -> None:
+        """Update one scalar scene attribute across a set of prims.
+
+        This hook is for authored scene state that is neither a transform nor mutable geometry,
+        such as light parameters and material inputs. Backends that render directly from the live
+        USD stage may keep the default no-op implementation. Backends with a private scene
+        representation override it to synchronize the values.
+
+        Args:
+            prim_paths: Target prim paths. Each path corresponds to one element in ``values``.
+            attribute_name: USD attribute name shared by the target prims.
+            values: Per-prim scalar values as a NumPy array, tensor, or list.
+            is_asset_path: Whether string values carry the USD ``asset`` semantic rather than the
+                default numeric or token-string semantic.
+        """
+        return
+
     @abstractmethod
     def update_camera(
         self,

--- a/source/isaaclab/isaaclab/renderers/render_context.py
+++ b/source/isaaclab/isaaclab/renderers/render_context.py
@@ -141,6 +141,35 @@ class RenderContext:
 
         self._last_scene_state_step = physics_step_count
 
+    def update_scene_attribute(
+        self,
+        prim_paths: list[str],
+        attribute_name: str,
+        values: Any,
+        *,
+        is_asset_path: bool = False,
+    ) -> None:
+        """Synchronize one scalar scene attribute to every registered renderer.
+
+        Environment code should author the same values on the live USD stage before calling this
+        method. Renderers that consume live USD need no additional work, while renderers that own
+        a private stage receive the targeted update through :class:`BaseRenderer`.
+
+        Args:
+            prim_paths: Target prim paths. Each path corresponds to one element in ``values``.
+            attribute_name: USD attribute name shared by the target prims.
+            values: Per-prim scalar values as a NumPy array, tensor, or list.
+            is_asset_path: Whether string values carry the USD ``asset`` semantic rather than the
+                default numeric or token-string semantic.
+        """
+        for _cfg, renderer in self._renderer_entries:
+            renderer.update_scene_attribute(
+                prim_paths,
+                attribute_name,
+                values,
+                is_asset_path=is_asset_path,
+            )
+
     def render_into_camera(
         self,
         renderer: BaseRenderer,

--- a/source/isaaclab/test/renderers/test_simulation_render_context.py
+++ b/source/isaaclab/test/renderers/test_simulation_render_context.py
@@ -36,6 +36,7 @@ class _FakeBackend(BaseRenderer):
         "_prepare_hits",
         "_update_transforms_hits",
         "_update_geometries_hits",
+        "_scene_attribute_updates",
         "_event_log",
         "_close_hits",
         "_close_raises",
@@ -47,6 +48,7 @@ class _FakeBackend(BaseRenderer):
         prepare_hits: list[int] | None = None,
         update_transforms_hits: list[int] | None = None,
         update_geometries_hits: list[int] | None = None,
+        scene_attribute_updates: list[tuple[list[str], str, Any, bool]] | None = None,
         event_log: list[str] | None = None,
         close_hits: list[Any] | None = None,
         close_raises: bool = False,
@@ -55,6 +57,7 @@ class _FakeBackend(BaseRenderer):
         self._prepare_hits = prepare_hits
         self._update_transforms_hits = update_transforms_hits
         self._update_geometries_hits = update_geometries_hits
+        self._scene_attribute_updates = scene_attribute_updates
         self._event_log = event_log
         self._close_hits = close_hits
         self._close_raises = close_raises
@@ -83,6 +86,17 @@ class _FakeBackend(BaseRenderer):
             self._update_geometries_hits.append(1)
         if self._event_log is not None:
             self._event_log.append("geo")
+
+    def update_scene_attribute(
+        self,
+        prim_paths: list[str],
+        attribute_name: str,
+        values: Any,
+        *,
+        is_asset_path: bool = False,
+    ) -> None:
+        if self._scene_attribute_updates is not None:
+            self._scene_attribute_updates.append((prim_paths, attribute_name, values, is_asset_path))
 
     def update_camera(self, render_data: Any, positions: Any, orientations: Any, intrinsics: Any) -> None:
         pass
@@ -183,6 +197,37 @@ def test_update_scene_state_dedupes_per_physics_step():
     ctx.update_scene_state(2)
     assert len(transform_hits) == 2
     assert len(geometry_hits) == 2
+
+
+def test_update_scene_attribute_dispatches_to_every_backend():
+    """Targeted scene updates reach all registered renderers without backend inspection."""
+    ctx = RenderContext()
+    updates: list[tuple[list[str], str, Any, bool]] = []
+    first = _FakeBackend(scene_attribute_updates=updates)
+    second = _FakeBackend(scene_attribute_updates=updates)
+    _set_entries(ctx, (IsaacRtxRendererCfg(), first), (NewtonWarpRendererCfg(), second))
+
+    paths = ["/World/envs/env_0/Light", "/World/envs/env_1/Light"]
+    values = [1000.0, 1200.0]
+    ctx.update_scene_attribute(paths, "intensity", values)
+
+    assert updates == [
+        (paths, "intensity", values, False),
+        (paths, "intensity", values, False),
+    ]
+
+
+def test_update_scene_attribute_marks_asset_path_values():
+    """The USD asset-path semantic is forwarded explicitly to renderer backends."""
+    ctx = RenderContext()
+    updates: list[tuple[list[str], str, Any, bool]] = []
+    _set_entries(ctx, (IsaacRtxRendererCfg(), _FakeBackend(scene_attribute_updates=updates)))
+
+    paths = ["/World/envs/env_0/Light"]
+    values = ["/textures/studio.hdr"]
+    ctx.update_scene_attribute(paths, "texture:file", values, is_asset_path=True)
+
+    assert updates == [(paths, "texture:file", values, True)]
 
 
 def test_render_into_camera_calls_update_render_read_order():

--- a/source/isaaclab_ov/changelog.d/ruziniuuuuu-runtime-scene-attributes.minor.rst
+++ b/source/isaaclab_ov/changelog.d/ruziniuuuuu-runtime-scene-attributes.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added runtime scene-attribute synchronization for legacy and ovstage OVRTX stages, including
+  correct scalar asset semantics on ovstage.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -383,6 +383,7 @@ class OVRTXRenderer(BaseRenderer):
         self._particle_visual_offsets: list[int] = []
         self._particle_visual_counts: list[int] = []
         self._initialized_scene = False
+        self._pending_scene_attribute_updates: list[tuple[list[str], str, Any, bool]] = []
         self._exported_usd_string: str | None = None
         self._camera_rel_path: str | None = None
         self._output_id_color_buffers: dict[str, wp.array] = {}
@@ -541,6 +542,7 @@ class OVRTXRenderer(BaseRenderer):
             )
 
         self._initialized_scene = True
+        self._flush_pending_scene_attribute_updates()
 
         self._camera_xform_binding = self._renderer.bind_attribute(
             prim_paths=camera_paths,
@@ -1455,6 +1457,7 @@ class OVRTXRenderer(BaseRenderer):
         self._render_product_paths.clear()
         self._output_id_color_buffers.clear()
         self._initialized_scene = False
+        self._pending_scene_attribute_updates.clear()
 
     # ---------------------------------------------------------------------------
     # Dispatch methods — route to ovstage or legacy implementation
@@ -1503,6 +1506,123 @@ class OVRTXRenderer(BaseRenderer):
             self._update_geometries_ovstage()
         else:
             self._update_geometries_legacy()
+
+    def update_scene_attribute(
+        self,
+        prim_paths: list[str],
+        attribute_name: str,
+        values: Any,
+        *,
+        is_asset_path: bool = False,
+    ) -> None:
+        """Synchronize one scalar scene attribute to the private OVRTX stage.
+
+        Updates submitted before the stage is initialized are copied and applied after OVRTX has
+        loaded and cloned the scene. This lets pre-startup environment events use the same API as
+        reset and interval events.
+
+        Args:
+            prim_paths: Target prim paths. Each path corresponds to one element in ``values``.
+            attribute_name: USD attribute name shared by the target prims.
+            values: Per-prim scalar values as a NumPy array, tensor, or list.
+            is_asset_path: Whether string values carry the USD ``asset`` semantic.
+        """
+        if not self._initialized_scene:
+            self._pending_scene_attribute_updates.append(
+                (list(prim_paths), attribute_name, self._copy_scene_attribute_values(values), is_asset_path)
+            )
+            return
+        self._write_scene_attribute(prim_paths, attribute_name, values, is_asset_path)
+
+    @staticmethod
+    def _copy_scene_attribute_values(values: Any) -> Any:
+        """Copy caller-owned values retained until scene initialization."""
+        if isinstance(values, np.ndarray):
+            return values.copy()
+        if isinstance(values, torch.Tensor):
+            return values.clone()
+        if isinstance(values, list):
+            return list(values)
+        if isinstance(values, tuple):
+            return tuple(values)
+        return values
+
+    def _flush_pending_scene_attribute_updates(self) -> None:
+        """Apply queued scene updates in submission order after initialization."""
+        while self._pending_scene_attribute_updates:
+            prim_paths, attribute_name, values, is_asset_path = self._pending_scene_attribute_updates[0]
+            self._write_scene_attribute(prim_paths, attribute_name, values, is_asset_path)
+            self._pending_scene_attribute_updates.pop(0)
+
+    def _write_scene_attribute(
+        self,
+        prim_paths: list[str],
+        attribute_name: str,
+        values: Any,
+        is_asset_path: bool,
+    ) -> None:
+        """Write an attribute through the selected OVRTX stage API."""
+        if self._use_ovstage:
+            if self._stage is None or self._stage_paths is None:
+                raise RuntimeError("OVRTX ovstage scene is marked initialized without a stage")
+            path_list = self._stage_paths.create_path_list_from_strings(prim_paths)
+            try:
+                with self._stage.query_from_path_list(path_list) as query:
+                    if is_asset_path:
+                        if not isinstance(values, (list, tuple)) or not all(isinstance(value, str) for value in values):
+                            raise TypeError("Asset-path scene attributes require a list or tuple of strings")
+                        if not all(os.path.isabs(value) for value in values):
+                            raise ValueError("Asset-path scene attributes require absolute paths")
+                        # USD population stores scalar assets in a fixed-width token-pair column,
+                        # while ovstage runtime asset writes use ragged ASSET_STRING rows. Recreate
+                        # the column at the same ordinal before publishing the write floor so
+                        # consumers only observe the correctly typed replacement.
+                        self._stage.delete_attributes(
+                            query,
+                            [attribute_name],
+                            ordinal=self._current_ordinal,
+                        ).wait()
+                        byte_rows = [np.frombuffer(value.encode("utf-8"), dtype=np.uint8) for value in values]
+                        self._stage.write_attribute(
+                            query,
+                            attribute_name,
+                            ordinal=self._current_ordinal,
+                            tensors=byte_rows,
+                            is_array=True,
+                            semantic=ovstage.AttributeSemantic.ASSET_STRING,
+                        ).wait()
+                    elif isinstance(values, (list, tuple)) and all(isinstance(value, str) for value in values):
+                        token_ids = np.array(
+                            [self._stage_paths.intern_token(value) for value in values],
+                            dtype=np.uint64,
+                        )
+                        self._stage.write_attribute(
+                            query,
+                            attribute_name,
+                            ordinal=self._current_ordinal,
+                            tensors=token_ids,
+                            is_array=False,
+                            semantic=ovstage.AttributeSemantic.TOKEN_ID,
+                        ).wait()
+                    else:
+                        self._stage.write_attribute(
+                            query,
+                            attribute_name,
+                            ordinal=self._current_ordinal,
+                            tensors=values,
+                            is_array=False,
+                        ).wait()
+            finally:
+                self._stage_paths.destroy_path_list(path_list)
+            return
+
+        if self._renderer is None:
+            raise RuntimeError("OVRTX scene is marked initialized without a renderer")
+        self._renderer.write_attribute(
+            prim_paths=prim_paths,
+            attribute_name=attribute_name,
+            tensor=values,
+        )
 
     def update_camera(
         self,
@@ -1631,6 +1751,7 @@ class OVRTXRenderer(BaseRenderer):
             self._update_scene_partitions_after_clone_ovstage(num_envs)
 
         self._initialized_scene = True
+        self._flush_pending_scene_attribute_updates()
 
         camera_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
 
@@ -2244,3 +2365,4 @@ class OVRTXRenderer(BaseRenderer):
         self._output_id_color_buffers.clear()
         self._initialized_scene = False
         self._current_ordinal = 0
+        self._pending_scene_attribute_updates.clear()

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -7,6 +7,7 @@
 
 import importlib.util
 
+import numpy as np
 import pytest
 import torch
 import warp as wp
@@ -73,7 +74,201 @@ def _make_ovrtx_render_data() -> OVRTXRenderData:
 def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     renderer = OVRTXRenderer.__new__(OVRTXRenderer)
     renderer.cfg = OVRTXRendererCfg()
+    renderer._pending_scene_attribute_updates = []
     return renderer
+
+
+def test_ovrtx_scene_attribute_update_waits_for_scene_initialization():
+    """Pre-initialization updates are copied and retained until OVRTX has a stage."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._initialized_scene = False
+    values = np.array([1000.0, 1200.0], dtype=np.float32)
+
+    renderer.update_scene_attribute(
+        ["/World/envs/env_0/Light", "/World/envs/env_1/Light"],
+        "intensity",
+        values,
+    )
+    values[:] = 0.0
+
+    pending = renderer._pending_scene_attribute_updates
+    assert len(pending) == 1
+    assert pending[0][0] == ["/World/envs/env_0/Light", "/World/envs/env_1/Light"]
+    assert pending[0][1] == "intensity"
+    np.testing.assert_array_equal(pending[0][2], [1000.0, 1200.0])
+    assert pending[0][3] is False
+
+
+def test_ovrtx_scene_attribute_update_uses_legacy_renderer():
+    """Initialized legacy OVRTX stages receive targeted attribute writes immediately."""
+
+    class Backend:
+        def __init__(self):
+            self.calls = []
+
+        def write_attribute(self, **kwargs):
+            self.calls.append(kwargs)
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._initialized_scene = True
+    renderer._use_ovstage = False
+    renderer._renderer = Backend()
+    values = np.array([1000.0, 1200.0], dtype=np.float32)
+
+    renderer.update_scene_attribute(
+        ["/World/envs/env_0/Light", "/World/envs/env_1/Light"],
+        "intensity",
+        values,
+    )
+
+    assert len(renderer._renderer.calls) == 1
+    call = renderer._renderer.calls[0]
+    assert call["prim_paths"] == ["/World/envs/env_0/Light", "/World/envs/env_1/Light"]
+    assert call["attribute_name"] == "intensity"
+    assert call["tensor"] is values
+
+
+def test_ovrtx_scene_attribute_update_uses_ovstage_asset_semantics():
+    """USD-populated assets are recreated with ovstage's runtime asset semantic."""
+    events = []
+
+    class Completion:
+        def wait(self):
+            events.append("wait")
+
+    class Query:
+        def __enter__(self):
+            events.append("query_enter")
+            return "query"
+
+        def __exit__(self, *_args):
+            events.append("query_exit")
+
+    class Stage:
+        def query_from_path_list(self, path_list):
+            events.append(("query", path_list))
+            return Query()
+
+        def write_attribute(self, query, attribute_name, **kwargs):
+            events.append(("write", query, attribute_name, kwargs))
+            return Completion()
+
+        def delete_attributes(self, query, attributes, **kwargs):
+            events.append(("delete", query, attributes, kwargs))
+            return Completion()
+
+    class StagePaths:
+        def create_path_list_from_strings(self, paths):
+            events.append(("create", paths))
+            return "paths"
+
+        def destroy_path_list(self, path_list):
+            events.append(("destroy", path_list))
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._initialized_scene = True
+    renderer._use_ovstage = True
+    renderer._stage = Stage()
+    renderer._stage_paths = StagePaths()
+    renderer._current_ordinal = 7
+
+    renderer.update_scene_attribute(
+        ["/World/envs/env_0/Light", "/World/envs/env_1/Light"],
+        "texture:file",
+        ["/textures/studio.hdr", "/textures/atrium.hdr"],
+        is_asset_path=True,
+    )
+
+    delete = next(event for event in events if event[0] == "delete")
+    assert delete == (
+        "delete",
+        "query",
+        ["texture:file"],
+        {"ordinal": 7},
+    )
+    write = next(event for event in events if event[0] == "write")
+    assert write[1:3] == ("query", "texture:file")
+    kwargs = write[3]
+    assert kwargs["ordinal"] == 7
+    assert [bytes(row).decode("utf-8") for row in kwargs["tensors"]] == [
+        "/textures/studio.hdr",
+        "/textures/atrium.hdr",
+    ]
+    assert all(row.dtype == np.uint8 for row in kwargs["tensors"])
+    assert kwargs["is_array"] is True
+    assert kwargs["semantic"] == ovrtx_renderer_module.ovstage.AttributeSemantic.ASSET_STRING
+    assert events[-1] == ("destroy", "paths")
+
+
+def test_ovrtx_scene_attribute_update_interns_ovstage_token_strings():
+    """ovstage string values use token IDs instead of unsupported object arrays."""
+    calls = []
+
+    class Completion:
+        def wait(self):
+            return
+
+    class Query:
+        def __enter__(self):
+            return "query"
+
+        def __exit__(self, *_args):
+            return
+
+    class Stage:
+        def query_from_path_list(self, _path_list):
+            return Query()
+
+        def write_attribute(self, query, attribute_name, **kwargs):
+            calls.append((query, attribute_name, kwargs))
+            return Completion()
+
+    class StagePaths:
+        def create_path_list_from_strings(self, _paths):
+            return "paths"
+
+        def intern_token(self, value):
+            return {"Oak": 41, "Concrete": 73}[value]
+
+        def destroy_path_list(self, _path_list):
+            return
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._initialized_scene = True
+    renderer._use_ovstage = True
+    renderer._stage = Stage()
+    renderer._stage_paths = StagePaths()
+    renderer._current_ordinal = 9
+
+    renderer.update_scene_attribute(
+        ["/World/envs/env_0/Looks/Table", "/World/envs/env_1/Looks/Table"],
+        "info:mdl:sourceAsset:subIdentifier",
+        ["Oak", "Concrete"],
+    )
+
+    query, attribute_name, kwargs = calls[0]
+    assert query == "query"
+    assert attribute_name == "info:mdl:sourceAsset:subIdentifier"
+    np.testing.assert_array_equal(kwargs["tensors"], np.array([41, 73], dtype=np.uint64))
+    assert kwargs["is_array"] is False
+    assert kwargs["semantic"] == ovrtx_renderer_module.ovstage.AttributeSemantic.TOKEN_ID
+
+
+def test_ovrtx_flushes_pending_scene_attribute_updates_in_order():
+    """Initialization drains queued updates in submission order without dropping failures."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._initialized_scene = True
+    renderer._pending_scene_attribute_updates = [
+        (["/World/Light"], "intensity", np.array([1000.0]), False),
+        (["/World/Light"], "colorTemperature", np.array([5000.0]), False),
+    ]
+    applied = []
+    renderer._write_scene_attribute = lambda *args: applied.append(args)
+
+    renderer._flush_pending_scene_attribute_updates()
+
+    assert [item[1] for item in applied] == ["intensity", "colorTemperature"]
+    assert renderer._pending_scene_attribute_updates == []
 
 
 def test_ovrtx_supported_output_types_key_set():


### PR DESCRIPTION
# Description

Add a renderer-neutral runtime scene-attribute update hook and implement it for
both OVRTX stage backends. Updates submitted before OVRTX initialization are
retained and applied after scene loading, while live updates are written to the
private renderer stage immediately.

For the ovstage backend, scalar USD assets are replaced using the documented
UTF-8 byte-row representation with `AttributeSemantic.ASSET_STRING`. Because
USD population currently creates those columns with a different fixed-width
representation, the implementation deletes and recreates only the target
attribute at the same unpublished ordinal before the next render advances the
write floor.

This fixes runtime HDRI and MDL source changes retaining a stale resource
resolution directory and producing OVRTX `Texture upload failed` errors.

No new dependencies are required.

Fixes #7038

Related lower-level ovstage gap: NVIDIA-Omniverse/ovstage#1

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking runtime synchronization hook)

## Validation

- `uv run isaaclab -f`
- `python tools/changelog/cli.py check develop`
- `pytest` for the OVRTX renderer contract and renderer-neutral render context:
  40 passed
- End-to-end downstream rollout with one CUDA environment, Newton physics,
  `viewer=rtx`, `renderer=ovrtx`, and randomized HDRI/MDL assets:
  one episode completed, manifest published, and the captured log contained no
  `Texture upload failed` or `INVALID_ARGUMENT` messages

The end-to-end test was also run before the asset-semantic fix and reproduced
the stale `Stone/textures/...` resolution failures for a selected Wood MDL.

## Screenshots

Not applicable; this changes runtime asset synchronization and is covered by
contract tests plus an end-to-end renderer rollout.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have added changelog fragments for both touched packages
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added my name to `CONTRIBUTORS.md`
