### PR TITLE
Fix relative deformable scene state

### DIFF
--- a/source/isaaclab/changelog.d/mmichelis-fix-deformable-relative-state.rst
+++ b/source/isaaclab/changelog.d/mmichelis-fix-deformable-relative-state.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed relative deformable nodal positions in :class:`~isaaclab.scene.InteractiveScene` state snapshots.

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -619,7 +619,7 @@ class InteractiveScene:
             asset_state = state["deformable_object"][asset_name]
             nodal_position = asset_state["nodal_position"].clone().to(self.device)
             if is_relative:
-                nodal_position[:, :3] += self.env_origins[env_ids]
+                nodal_position += self.env_origins[env_ids, None, :]
             nodal_velocity = asset_state["nodal_velocity"].clone().to(self.device)
             deformable_object.write_nodal_pos_to_sim(nodal_position, env_ids=env_ids)
             deformable_object.write_nodal_velocity_to_sim(nodal_velocity, env_ids=env_ids)
@@ -726,7 +726,7 @@ class InteractiveScene:
             asset_state = dict()
             asset_state["nodal_position"] = deformable_object.data.nodal_pos_w.torch.clone()
             if is_relative:
-                asset_state["nodal_position"][:, :3] -= self.env_origins
+                asset_state["nodal_position"] -= self.env_origins[:, None, :]
             asset_state["nodal_velocity"] = deformable_object.data.nodal_vel_w.torch.clone()
             state["deformable_object"][asset_name] = asset_state
         # rigid objects

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -107,6 +107,66 @@ def test_relative_flag(device, setup_scene):
     assert_state_equal(prev_state, scene.get_state(is_relative=True))
 
 
+def test_get_relative_deformable_state_offsets_all_nodes():
+    env_origins = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    nodal_position = torch.arange(60, dtype=torch.float32).reshape(4, 5, 3)
+    nodal_velocity = torch.zeros_like(nodal_position)
+    deformable = SimpleNamespace(
+        data=SimpleNamespace(
+            nodal_pos_w=SimpleNamespace(torch=nodal_position),
+            nodal_vel_w=SimpleNamespace(torch=nodal_velocity),
+        )
+    )
+    scene = SimpleNamespace(
+        env_origins=env_origins,
+        _articulations={},
+        _cable_objects={},
+        _deformable_objects={"object": deformable},
+        _rigid_objects={},
+        _surface_grippers={},
+    )
+
+    state = InteractiveScene.get_state(scene, is_relative=True)
+
+    torch.testing.assert_close(
+        state["deformable_object"]["object"]["nodal_position"], nodal_position - env_origins[:, None, :]
+    )
+
+
+def test_reset_to_relative_deformable_state_offsets_all_nodes():
+    env_origins = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    env_ids = torch.tensor([3, 1])
+    nodal_position = torch.arange(30, dtype=torch.float32).reshape(2, 5, 3)
+    nodal_velocity = torch.zeros_like(nodal_position)
+    written_state = {}
+    deformable = SimpleNamespace(
+        write_nodal_pos_to_sim=lambda value, env_ids: written_state.update(position=value, env_ids=env_ids),
+        write_nodal_velocity_to_sim=lambda value, env_ids: written_state.update(velocity=value),
+    )
+    scene = SimpleNamespace(
+        device="cpu",
+        env_origins=env_origins,
+        _articulations={},
+        _cable_objects={},
+        _deformable_objects={"object": deformable},
+        _rigid_objects={},
+        _surface_grippers={},
+        _rigid_object_collections={},
+        write_data_to_sim=lambda: None,
+    )
+    state = {
+        "deformable_object": {
+            "object": {"nodal_position": nodal_position, "nodal_velocity": nodal_velocity},
+        }
+    }
+
+    InteractiveScene.reset_to(scene, state, env_ids=env_ids, is_relative=True)
+
+    torch.testing.assert_close(written_state["position"], nodal_position + env_origins[env_ids, None, :])
+    torch.testing.assert_close(written_state["velocity"], nodal_velocity)
+    torch.testing.assert_close(written_state["env_ids"], env_ids)
+
+
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_reset_to_env_ids_input_types(device, setup_scene):
     make_scene, sim = setup_scene

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -107,39 +107,16 @@ def test_relative_flag(device, setup_scene):
     assert_state_equal(prev_state, scene.get_state(is_relative=True))
 
 
-def test_get_relative_deformable_state_offsets_all_nodes():
+def test_relative_deformable_state():
     env_origins = torch.arange(12, dtype=torch.float32).reshape(4, 3)
     nodal_position = torch.arange(60, dtype=torch.float32).reshape(4, 5, 3)
     nodal_velocity = torch.zeros_like(nodal_position)
+    written_state = {}
     deformable = SimpleNamespace(
         data=SimpleNamespace(
             nodal_pos_w=SimpleNamespace(torch=nodal_position),
             nodal_vel_w=SimpleNamespace(torch=nodal_velocity),
-        )
-    )
-    scene = SimpleNamespace(
-        env_origins=env_origins,
-        _articulations={},
-        _cable_objects={},
-        _deformable_objects={"object": deformable},
-        _rigid_objects={},
-        _surface_grippers={},
-    )
-
-    state = InteractiveScene.get_state(scene, is_relative=True)
-
-    torch.testing.assert_close(
-        state["deformable_object"]["object"]["nodal_position"], nodal_position - env_origins[:, None, :]
-    )
-
-
-def test_reset_to_relative_deformable_state_offsets_all_nodes():
-    env_origins = torch.arange(12, dtype=torch.float32).reshape(4, 3)
-    env_ids = torch.tensor([3, 1])
-    nodal_position = torch.arange(30, dtype=torch.float32).reshape(2, 5, 3)
-    nodal_velocity = torch.zeros_like(nodal_position)
-    written_state = {}
-    deformable = SimpleNamespace(
+        ),
         write_nodal_pos_to_sim=lambda value, env_ids: written_state.update(position=value, env_ids=env_ids),
         write_nodal_velocity_to_sim=lambda value, env_ids: written_state.update(velocity=value),
     )
@@ -154,16 +131,29 @@ def test_reset_to_relative_deformable_state_offsets_all_nodes():
         _rigid_object_collections={},
         write_data_to_sim=lambda: None,
     )
-    state = {
+
+    state = InteractiveScene.get_state(scene, is_relative=True)
+
+    torch.testing.assert_close(
+        state["deformable_object"]["object"]["nodal_position"], nodal_position - env_origins[:, None, :]
+    )
+
+    env_ids = torch.tensor([3, 1])
+    reset_nodal_position = torch.arange(30, dtype=torch.float32).reshape(2, 5, 3)
+    reset_nodal_velocity = torch.ones_like(reset_nodal_position)
+    reset_state = {
         "deformable_object": {
-            "object": {"nodal_position": nodal_position, "nodal_velocity": nodal_velocity},
+            "object": {
+                "nodal_position": reset_nodal_position,
+                "nodal_velocity": reset_nodal_velocity,
+            },
         }
     }
 
-    InteractiveScene.reset_to(scene, state, env_ids=env_ids, is_relative=True)
+    InteractiveScene.reset_to(scene, reset_state, env_ids=env_ids, is_relative=True)
 
-    torch.testing.assert_close(written_state["position"], nodal_position + env_origins[env_ids, None, :])
-    torch.testing.assert_close(written_state["velocity"], nodal_velocity)
+    torch.testing.assert_close(written_state["position"], reset_nodal_position + env_origins[env_ids, None, :])
+    torch.testing.assert_close(written_state["velocity"], reset_nodal_velocity)
     torch.testing.assert_close(written_state["env_ids"], env_ids)
 
 


### PR DESCRIPTION
# Description

Fix relative deformable nodal positions in `InteractiveScene.get_state()` and `InteractiveScene.reset_to()` by broadcasting each environment origin across all nodes. Add focused regression tests for both state serialization and restoration, including reordered environment indices.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- Before the fix, both new regression tests fail with tensor broadcasting errors.
- After the fix, both focused tests pass.
- `source/isaaclab/test/scene/test_interactive_scene.py`: 13 passed.
- `uv run isaaclab -f`: passed.
- `uv run --extra test python tools/changelog/cli.py check develop`: passed.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] No documentation changes are required
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`