### PR TITLE
[Fix] Handle asset cleanup after partial initialization

### DIFF
--- a/source/isaaclab/changelog.d/nvbug-noteterror.rst
+++ b/source/isaaclab/changelog.d/nvbug-noteterror.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed asset destruction after partial initialization so constructor errors are not masked by callback cleanup.

--- a/source/isaaclab/isaaclab/assets/asset_base.py
+++ b/source/isaaclab/isaaclab/assets/asset_base.py
@@ -501,13 +501,13 @@ class AssetBase(ABC):
 
     def _clear_callbacks(self) -> None:
         """Clears all registered callbacks."""
-        if self._initialize_handle is not None:
+        if getattr(self, "_initialize_handle", None) is not None:
             self._initialize_handle.deregister()
             self._initialize_handle = None
-        if self._invalidate_initialize_handle is not None:
+        if getattr(self, "_invalidate_initialize_handle", None) is not None:
             self._invalidate_initialize_handle.deregister()
             self._invalidate_initialize_handle = None
-        if self._prim_deletion_handle is not None:
+        if getattr(self, "_prim_deletion_handle", None) is not None:
             self._prim_deletion_handle.deregister()
             self._prim_deletion_handle = None
         sim_ctx = SimulationContext.instance()

--- a/source/isaaclab/test/assets/test_asset_selector_cache.py
+++ b/source/isaaclab/test/assets/test_asset_selector_cache.py
@@ -54,6 +54,12 @@ def _find(asset: _TestAsset, indices, *, domain: str = "joint", as_proxy: bool =
     )
 
 
+def test_destructor_tolerates_partial_initialization():
+    asset = object.__new__(_TestAsset)
+
+    asset.__del__()
+
+
 def test_equivalent_indices_reuse_proxy_and_storage():
     asset = _make_asset()
 

--- a/source/isaaclab/test/assets/test_asset_selector_cache.py
+++ b/source/isaaclab/test/assets/test_asset_selector_cache.py
@@ -54,12 +54,6 @@ def _find(asset: _TestAsset, indices, *, domain: str = "joint", as_proxy: bool =
     )
 
 
-def test_destructor_tolerates_partial_initialization():
-    asset = object.__new__(_TestAsset)
-
-    asset.__del__()
-
-
 def test_equivalent_indices_reuse_proxy_and_storage():
     asset = _make_asset()
 


### PR DESCRIPTION
# Description

Guard asset callback handles during cleanup so destructors tolerate objects whose constructors fail before callback registration completes. This preserves the original constructor exception instead of masking it with an `AttributeError` from `AssetBase.__del__`.

This occurs when spawning a volume deformable without the optional tetrahedralization dependencies: the actionable dependency error is raised before callback registration, so callback cleanup must finish gracefully without obscuring it.

Fixes NVBug 6591313.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- `uv run --frozen isaaclab -f`
- Manual partial-initialization reproduction (failed with the reported `AttributeError` before the fix and passed after the fix)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation changes are not required
- [x] My changes generate no new warnings
- [ ] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] I have added my name to `CONTRIBUTORS.md` or my name already exists there