### PR TITLE
hardcode thread limit for leapp tests

### DIFF
--- a/scripts/reinforcement_learning/leapp/export_utils.py
+++ b/scripts/reinforcement_learning/leapp/export_utils.py
@@ -69,6 +69,7 @@ def add_common_export_args(parser: argparse.ArgumentParser, *, agent_default: st
         help="Disable LEAPP graph visualization during compile_graph().",
     )
     AppLauncher.add_app_launcher_args(parser)
+    parser.add_argument("--limit_cpu_threads", type=int, default=argparse.SUPPRESS, help=argparse.SUPPRESS)
 
 
 def finalize_export_args(

--- a/source/isaaclab_rl/test/export/leapp_initialized_checkpoints.py
+++ b/source/isaaclab_rl/test/export/leapp_initialized_checkpoints.py
@@ -344,7 +344,9 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     from isaaclab.app import AppLauncher
 
-    app_launcher = AppLauncher(headless=True)
+    # TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases
+    # can corrupt the heap while parsing the Newton Franka payload concurrently.
+    app_launcher = AppLauncher(headless=True, limit_cpu_threads=1)
     simulation_app = app_launcher.app
 
     from isaaclab.app.settings_manager import get_settings_manager

--- a/source/isaaclab_rl/test/export/test_leapp_export_flow.py
+++ b/source/isaaclab_rl/test/export/test_leapp_export_flow.py
@@ -11,7 +11,6 @@ backend/task export then runs in its own subprocess against those checkpoints.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import tempfile
@@ -30,7 +29,6 @@ _CHECKPOINT_BATCH_TIMEOUT = 1200
 _OUTPUT_TAIL_CHARS = 5000
 # TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases
 # can corrupt the heap while parsing the Newton Franka payload concurrently.
-# These settings mirror SimulationApp(limit_cpu_threads=1) for the export subprocess.
 _LEAPP_TEST_CPU_THREAD_LIMIT = 1
 
 
@@ -136,11 +134,6 @@ def _run_checked(
             capture_output=True,
             text=True,
             timeout=timeout,
-            env={
-                **os.environ,
-                "PXR_WORK_THREAD_LIMIT": str(_LEAPP_TEST_CPU_THREAD_LIMIT),
-                "OPENBLAS_NUM_THREADS": str(_LEAPP_TEST_CPU_THREAD_LIMIT),
-            },
         )
     except subprocess.TimeoutExpired as exc:
         stdout = _ensure_text(exc.stdout)
@@ -217,11 +210,8 @@ def _run_export(backend: ExportFlowBackend, task_name: str, checkpoint_path: Pat
         "--export_save_path",
         str(export_root),
         "--disable_graph_visualization",
-        "--kit_args",
-        (
-            f"--/plugins/carb.tasking.plugin/threadCount={_LEAPP_TEST_CPU_THREAD_LIMIT} "
-            f"--/plugins/omni.tbb.globalcontrol/maxThreadCount={_LEAPP_TEST_CPU_THREAD_LIMIT}"
-        ),
+        "--limit_cpu_threads",
+        str(_LEAPP_TEST_CPU_THREAD_LIMIT),
     ]
     preset = _preset_for_task(task_name)
     if preset is not None:

--- a/source/isaaclab_rl/test/export/test_leapp_export_flow.py
+++ b/source/isaaclab_rl/test/export/test_leapp_export_flow.py
@@ -11,6 +11,7 @@ backend/task export then runs in its own subprocess against those checkpoints.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -27,6 +28,10 @@ _CHECKPOINT_SCRIPT = Path(__file__).resolve().parent / "leapp_initialized_checkp
 _SUBPROCESS_TIMEOUT = 600
 _CHECKPOINT_BATCH_TIMEOUT = 1200
 _OUTPUT_TAIL_CHARS = 5000
+# TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases
+# can corrupt the heap while parsing the Newton Franka payload concurrently.
+# These settings mirror SimulationApp(limit_cpu_threads=1) for the export subprocess.
+_LEAPP_TEST_CPU_THREAD_LIMIT = 1
 
 
 @dataclass(frozen=True)
@@ -131,6 +136,11 @@ def _run_checked(
             capture_output=True,
             text=True,
             timeout=timeout,
+            env={
+                **os.environ,
+                "PXR_WORK_THREAD_LIMIT": str(_LEAPP_TEST_CPU_THREAD_LIMIT),
+                "OPENBLAS_NUM_THREADS": str(_LEAPP_TEST_CPU_THREAD_LIMIT),
+            },
         )
     except subprocess.TimeoutExpired as exc:
         stdout = _ensure_text(exc.stdout)
@@ -207,6 +217,11 @@ def _run_export(backend: ExportFlowBackend, task_name: str, checkpoint_path: Pat
         "--export_save_path",
         str(export_root),
         "--disable_graph_visualization",
+        "--kit_args",
+        (
+            f"--/plugins/carb.tasking.plugin/threadCount={_LEAPP_TEST_CPU_THREAD_LIMIT} "
+            f"--/plugins/omni.tbb.globalcontrol/maxThreadCount={_LEAPP_TEST_CPU_THREAD_LIMIT}"
+        ),
     ]
     preset = _preset_for_task(task_name)
     if preset is not None:


### PR DESCRIPTION
# Description

There is a race condition in the current usd version that causes some environment setup to fail. this is especially prevalent in the leapp tests becuase leapp performs multiple environment setups per run. This PR sets the CPU thread count to 1. This provides a temporary fix by mitigating the issue.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

