### PR TITLE
fix gets around the problematic code that reports the error on sb3

### DIFF
--- a/scripts/reinforcement_learning/leapp/sb3/export.py
+++ b/scripts/reinforcement_learning/leapp/sb3/export.py
@@ -274,6 +274,13 @@ def export_sb3_agent(
 
     env = None
     leapp_started = False
+    # SB3 constructs torch.distributions.Normal even for deterministic PPO
+    # inference. Its eager argument validation reduces tensor predicates to
+    # Python booleans, which is not representable in a LEAPP static graph and
+    # is unrelated to the action computation. Disable it only while tracing
+    # and restore the process-wide default before returning.
+    previous_validate_args = torch.distributions.Distribution._validate_args
+    torch.distributions.Distribution.set_default_validate_args(False)
     try:
         env = gym.make(args_cli.task, cfg=env_cfg, render_mode=None)
         if not isinstance(env.unwrapped, ManagerBasedRLEnv):
@@ -344,6 +351,7 @@ def export_sb3_agent(
         validate = args_cli.validation_steps > 0
         leapp.compile_graph(visualize=not args_cli.disable_graph_visualization, validate=validate)
     finally:
+        torch.distributions.Distribution.set_default_validate_args(previous_validate_args)
         if leapp_started:
             with contextlib.suppress(Exception):
                 leapp.stop()

--- a/source/isaaclab/changelog.d/frlai-fix_sb3_error_message.rst
+++ b/source/isaaclab/changelog.d/frlai-fix_sb3_error_message.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Stable-Baselines3 LEAPP policy export emitting spurious traced-tensor boolean-context errors during deterministic PPO inference.


### PR DESCRIPTION
# Description

Fixes SB3 LEAPP exports reporting false traced-tensor boolean errors during deterministic PPO inference. Previously sb3 performs a validation after return values which uses a derrived tensor as a boolean condition which leapp cannot trace. This validation was safely outside of tracing so the leapp emitted error was innocuous but looked concerning. This fix disables this validation for export only so the message doesn't show up anymore.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
