### PR TITLE
Run Docker CI from PR comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,7 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 
 ## Checklist
 
-Docker and GPU tests run on demand. Comment `/run-docker-ci` on the pull request
+Docker and GPU tests run on demand. Comment `run-ci` on the pull request
 when the changes are ready for CI.
 
 - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,8 +47,8 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 
 ## Checklist
 
-Docker and GPU tests run on demand. Comment `run-ci` on the pull request
-when the changes are ready for CI.
+Docker and GPU tests run on demand. Push the commits you want tested, then
+comment `run-ci` on the pull request.
 
 - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
 - [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,9 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 
 ## Checklist
 
+Docker and GPU tests run on demand. Comment `/run-docker-ci` on the pull request
+when the changes are ready for CI.
+
 - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
 - [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
 - [ ] I have made corresponding changes to the documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # region help
-# Docker builds and their dependent tests run only on an authorized label or
-# a manual workflow dispatch.
+# Docker builds and their dependent tests run only on a labeled PR event or a
+# manual workflow dispatch. Do not filter the label with a job-level ``if``:
+# GitHub treats skipped required jobs as successful status checks.
 #
 # =============================================================================
 # CI DEBUGGING TIPS
@@ -73,9 +74,6 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.label.name == 'ci:run-docker' && github.actor == 'isaaclab-bot[bot]')
     runs-on: ubuntu-latest
     outputs:
       run_docker_tests: ${{ steps.detect.outputs.run_docker_tests }}
@@ -180,9 +178,6 @@ jobs:
 
   config:
     name: Load Config
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.label.name == 'ci:run-docker' && github.actor == 'isaaclab-bot[bot]')
     runs-on: ubuntu-latest
     outputs:
       isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,10 +196,19 @@ jobs:
         echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
 
   #region build jobs
+  approve-docker-builds:
+    name: Approve Docker Builds
+    runs-on: ubuntu-latest
+    needs: [changes, config]
+    if: needs.changes.outputs.run_docker_tests == 'true'
+    environment: premerge-verification
+    steps:
+    - run: echo "Docker builds approved"
+
   build:
     name: Build Base Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [changes, config]
+    needs: [changes, config, approve-docker-builds]
     if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code
@@ -220,7 +229,7 @@ jobs:
   build-curobo:
     name: Build cuRobo Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [changes, config]
+    needs: [changes, config, approve-docker-builds]
     if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # region help
-# Docker builds and their dependent tests run only for non-draft PRs.
+# Docker builds and their dependent tests run only on an authorized label or
+# a manual workflow dispatch.
 #
 # =============================================================================
 # CI DEBUGGING TIPS
@@ -47,7 +48,7 @@ name: Docker + Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [labeled]
     branches:
       - main
       - develop
@@ -72,6 +73,9 @@ env:
 jobs:
   changes:
     name: Detect Changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'ci:run-docker' && github.actor == 'isaaclab-bot[bot]')
     runs-on: ubuntu-latest
     outputs:
       run_docker_tests: ${{ steps.detect.outputs.run_docker_tests }}
@@ -176,6 +180,9 @@ jobs:
 
   config:
     name: Load Config
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.label.name == 'ci:run-docker' && github.actor == 'isaaclab-bot[bot]')
     runs-on: ubuntu-latest
     outputs:
       isaacsim_image_name: ${{ steps.load.outputs.isaacsim_image_name }}
@@ -200,9 +207,7 @@ jobs:
     name: Build Base Docker Image
     runs-on: [self-hosted, gpu]
     needs: [changes, config]
-    if: >-
-      needs.changes.outputs.run_docker_tests == 'true' &&
-      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -223,9 +228,7 @@ jobs:
     name: Build cuRobo Docker Image
     runs-on: [self-hosted, gpu]
     needs: [changes, config]
-    if: >-
-      needs.changes.outputs.run_docker_tests == 'true' &&
-      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
+    if: needs.changes.outputs.run_docker_tests == 'true'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,11 @@
 # manual workflow dispatch. Do not filter the label with a job-level ``if``:
 # GitHub treats skipped required jobs as successful status checks.
 #
+# GitHub cannot filter label names at trigger time, so adding any label to a PR
+# starts this workflow. Only a ``ci:run-docker`` event cancels an in-flight run;
+# other label events queue behind it so that a triage label cannot cancel a
+# build whose required checks have already been reported.
+#
 # =============================================================================
 # CI DEBUGGING TIPS
 # =============================================================================
@@ -59,7 +64,7 @@ on:
 # Concurrency control to prevent parallel runs on the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.label.name == 'ci:run-docker' }}
 
 permissions:
   contents: read

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # region help
-# Every test job runs on every PR.
+# Docker builds and their dependent tests run only for non-draft PRs.
 #
 # =============================================================================
 # CI DEBUGGING TIPS
@@ -47,7 +47,7 @@ name: Docker + Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - develop
@@ -196,20 +196,13 @@ jobs:
         echo "isaaclab_image_name=$(yq -r .isaaclab_image_name "$f")" >> "$GITHUB_OUTPUT"
 
   #region build jobs
-  approve-docker-builds:
-    name: Approve Docker Builds
-    runs-on: ubuntu-latest
-    needs: [changes, config]
-    if: needs.changes.outputs.run_docker_tests == 'true'
-    environment: premerge-verification
-    steps:
-    - run: echo "Docker builds approved"
-
   build:
     name: Build Base Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [changes, config, approve-docker-builds]
-    if: needs.changes.outputs.run_docker_tests == 'true'
+    needs: [changes, config]
+    if: >-
+      needs.changes.outputs.run_docker_tests == 'true' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -229,8 +222,10 @@ jobs:
   build-curobo:
     name: Build cuRobo Docker Image
     runs-on: [self-hosted, gpu]
-    needs: [changes, config, approve-docker-builds]
-    if: needs.changes.outputs.run_docker_tests == 'true'
+    needs: [changes, config]
+    if: >-
+      needs.changes.outputs.run_docker_tests == 'true' &&
+      (github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false)
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -30,14 +30,15 @@ jobs:
       - name: Authorize the request
         env:
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          read -r pr_author pr_state < <(
-            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '[.user.login, .state] | @tsv'
+          read -r pr_author pr_state head_sha < <(
+            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '[.user.login, .state, .head.sha] | @tsv'
           )
           if [ "$pr_state" != "open" ]; then
             echo "::error::PR #$PR_NUMBER is not open."
@@ -55,6 +56,17 @@ jobs:
                 exit 1
                 ;;
             esac
+          fi
+
+          # The label starts Docker CI against whatever the PR head is at that
+          # moment, so a comment older than the head commit would run code the
+          # commenter never saw. Push first, then ask for CI.
+          head_committed_at="$(
+            gh api "repos/$REPOSITORY/commits/$head_sha" --jq '.commit.committer.date'
+          )"
+          if [ "$(date -u -d "$COMMENT_CREATED_AT" +%s)" -le "$(date -u -d "$head_committed_at" +%s)" ]; then
+            echo "::error::Head commit ${head_sha:0:7} ($head_committed_at) is not older than this comment ($COMMENT_CREATED_AT). Comment 'run-ci' again to test the current head."
+            exit 1
           fi
 
       - name: Create isaaclab-bot token

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -80,9 +80,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The label starts Docker CI against whatever the PR head is at that
-          # moment, so a push that lands while this request is being processed
-          # would be built without anyone asking for it.
+          # GitHub resolves the head when it processes the label, so labeling a
+          # PR whose head has already moved on builds a revision nobody asked
+          # for. Skip the request instead of spending GPU minutes on it.
           head_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
           if [ "$head_sha" != "$EXPECTED_HEAD_SHA" ]; then
             echo "::error::PR #$PR_NUMBER moved from ${EXPECTED_HEAD_SHA:0:7} to ${head_sha:0:7} while this request was processed. Comment 'run-ci' again to test the current head."
@@ -94,4 +94,14 @@ jobs:
           gh api --method POST "$endpoint" -f "labels[]=$LABEL" --silent
           gh api --method DELETE "$endpoint/$LABEL" --silent
 
-          echo "Requested Docker CI for PR #$PR_NUMBER at ${head_sha:0:7}." >> "$GITHUB_STEP_SUMMARY"
+          # A push can still land between the check above and GitHub processing
+          # the label; nothing can make those two steps atomic. Re-read the head
+          # so the mismatch is reported rather than silently testing a revision
+          # the requester never saw.
+          built_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [ "$built_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER moved to ${built_sha:0:7} as the label was applied, so Docker CI is testing that revision and not the requested ${EXPECTED_HEAD_SHA:0:7}. Comment 'run-ci' again to test the current head."
+            exit 1
+          fi
+
+          echo "Requested Docker CI for PR #$PR_NUMBER at ${EXPECTED_HEAD_SHA:0:7}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -44,8 +44,17 @@ jobs:
             exit 1
           fi
           if [ "${COMMENT_AUTHOR,,}" != "${pr_author,,}" ]; then
-            echo "::error::Only PR author @$pr_author can request Docker CI."
-            exit 1
+            commenter_permission="$(
+              gh api "repos/$REPOSITORY/collaborators/$COMMENT_AUTHOR/permission" \
+                --jq '.permission' 2>/dev/null || printf 'none'
+            )"
+            case "$commenter_permission" in
+              admin|write) ;;
+              *)
+                echo "::error::Only PR author @$pr_author or a user with write access can request Docker CI."
+                exit 1
+                ;;
+            esac
           fi
 
       - name: Create isaaclab-bot token

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create isaaclab-bot token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
           client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
           private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -7,6 +7,8 @@ name: Run Docker CI Command
 run-name: Run Docker CI for PR #${{ github.event.issue.number }}
 
 on:
+  # GitHub always runs ``issue_comment`` workflows from the repository default
+  # branch, so this file has to land there for the ``run-ci`` command to work.
   issue_comment:
     types: [created]
 
@@ -28,9 +30,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Authorize the request
+        id: authorize
         env:
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
-          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPOSITORY: ${{ github.repository }}
@@ -58,16 +60,7 @@ jobs:
             esac
           fi
 
-          # The label starts Docker CI against whatever the PR head is at that
-          # moment, so a comment older than the head commit would run code the
-          # commenter never saw. Push first, then ask for CI.
-          head_committed_at="$(
-            gh api "repos/$REPOSITORY/commits/$head_sha" --jq '.commit.committer.date'
-          )"
-          if [ "$(date -u -d "$COMMENT_CREATED_AT" +%s)" -le "$(date -u -d "$head_committed_at" +%s)" ]; then
-            echo "::error::Head commit ${head_sha:0:7} ($head_committed_at) is not older than this comment ($COMMENT_CREATED_AT). Comment 'run-ci' again to test the current head."
-            exit 1
-          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Create isaaclab-bot token
         id: app-token
@@ -79,6 +72,7 @@ jobs:
 
       - name: Trigger Docker CI
         env:
+          EXPECTED_HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           LABEL: ci:run-docker
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -86,9 +80,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The label starts Docker CI against whatever the PR head is at that
+          # moment, so a push that lands while this request is being processed
+          # would be built without anyone asking for it.
+          head_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [ "$head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER moved from ${EXPECTED_HEAD_SHA:0:7} to ${head_sha:0:7} while this request was processed. Comment 'run-ci' again to test the current head."
+            exit 1
+          fi
+
           endpoint="repos/$REPOSITORY/issues/$PR_NUMBER/labels"
           gh api --method DELETE "$endpoint/$LABEL" --silent >/dev/null 2>&1 || true
           gh api --method POST "$endpoint" -f "labels[]=$LABEL" --silent
           gh api --method DELETE "$endpoint/$LABEL" --silent
 
-          echo "Requested Docker CI for PR #$PR_NUMBER." >> "$GITHUB_STEP_SUMMARY"
+          echo "Requested Docker CI for PR #$PR_NUMBER at ${head_sha:0:7}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -1,0 +1,73 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Run Docker CI Command
+run-name: Run Docker CI for PR #${{ github.event.issue.number }}
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: run-docker-ci-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  request-docker-ci:
+    name: Request Docker CI
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/run-docker-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Authorize the request
+        env:
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          read -r pr_author pr_state < <(
+            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '[.user.login, .state] | @tsv'
+          )
+          if [ "$pr_state" != "open" ]; then
+            echo "::error::PR #$PR_NUMBER is not open."
+            exit 1
+          fi
+          if [ "${COMMENT_AUTHOR,,}" != "${pr_author,,}" ]; then
+            echo "::error::Only PR author @$pr_author can request Docker CI."
+            exit 1
+          fi
+
+      - name: Create isaaclab-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Trigger Docker CI
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          LABEL: ci:run-docker
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          endpoint="repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+          gh api --method DELETE "$endpoint/$LABEL" --silent >/dev/null 2>&1 || true
+          gh api --method POST "$endpoint" -f "labels[]=$LABEL" --silent
+          gh api --method DELETE "$endpoint/$LABEL" --silent
+
+          echo "Requested Docker CI for PR #$PR_NUMBER." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Request Docker CI
     if: >-
       github.event.issue.pull_request &&
-      github.event.comment.body == '/run-docker-ci'
+      github.event.comment.body == 'run-ci'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

- allow PR authors and repository users with write access to request Docker CI with `run-ci`
- use the existing `isaaclab-bot` App token to trigger the normal pull request workflow
- stop the base and cuRobo Docker builds from running on ordinary PR opens and pushes
- preserve changed-path detection, downstream test dependencies, and maintainer dispatches

## Why

The two self-hosted GPU Docker builds currently start automatically whenever relevant files change. PR authors need a self-service way to defer that expensive CI path without requiring a protected environment, a webhook service, or write access to launch `workflow_dispatch`.

## Impact

Commenting `run-ci` on an open pull request starts Docker CI when the commenter is the PR author or has write access to the repository. The trusted command workflow never checks out PR code; it briefly applies `ci:run-docker` with `isaaclab-bot`, which triggers `Docker + Tests` as a normal `pull_request` workflow on the current merge ref. The label is removed immediately so the command can be used again after later pushes.

GitHub cannot filter `pull_request` label names at workflow-trigger time. Any label applied manually therefore starts the same path-gated Docker workflow; the repository's automatic labeler uses `GITHUB_TOKEN`, whose label events do not create recursive workflow runs. Keeping the workflow unfiltered ensures that a manually labeled run cannot satisfy required checks by skipping them. Maintainers can also use the existing manual workflow dispatch.

The upstream `ci:run-docker` label has been created with the description "Trigger the on-demand Docker and GPU CI workflow."

## Validation

- `uv run isaaclab -f` before commit
- `uv run isaaclab -f` after commit and before push
- verified PR-author bypass plus write/admin and read-only permission handling
- verified the release ruleset's required Docker/test contexts remain produced only by a real labeled or dispatched run
