### PR TITLE
[Warp] Read parity fixture poses through the warp accessor

### DIFF
--- a/source/isaaclab_experimental/test/envs/mdp/parity_helpers.py
+++ b/source/isaaclab_experimental/test/envs/mdp/parity_helpers.py
@@ -19,6 +19,8 @@ import numpy as np
 import torch
 import warp as wp
 
+from isaaclab.envs.mdp.commands.commands_cfg import UniformPoseCommandCfg
+from isaaclab.envs.mdp.commands.pose_command import UniformPoseCommand
 from isaaclab.utils.warp import ProxyArray
 
 # ---------------------------------------------------------------------------
@@ -594,15 +596,12 @@ def make_pose_command_term(
     Returns:
         The command term, whose ``pose_command_b`` is the (num_envs, 7) command buffer.
     """
-    from isaaclab.envs.mdp.commands.commands_cfg import UniformPoseCommandCfg
-    from isaaclab.envs.mdp.commands.pose_command import UniformPoseCommand
-
     rng = np.random.RandomState(seed)
     data = articulation.data
-    root_pos = data.root_pos_w.torch.cpu().numpy()
-    root_quat = data.root_quat_w.torch.cpu().numpy()
-    body_pos = data.body_pos_w.torch.cpu().numpy()[:, body_idx]
-    body_quat = data.body_quat_w.torch.cpu().numpy()[:, body_idx]
+    root_pos = data.root_pos_w.warp.numpy()
+    root_quat = data.root_quat_w.warp.numpy()
+    body_pos = data.body_pos_w.warp.numpy()[:, body_idx]
+    body_quat = data.body_quat_w.warp.numpy()[:, body_idx]
 
     # position: place the target a known distance off the body, then express it in the root frame
     offset_dir = rng.randn(num_envs, 3).astype(np.float32)

--- a/source/isaaclab_experimental/test/envs/test_frontend_cfg_conversion.py
+++ b/source/isaaclab_experimental/test/envs/test_frontend_cfg_conversion.py
@@ -43,6 +43,10 @@ _STABLE_MANAGER_ENTRY_POINT = "isaaclab.envs:ManagerBasedRLEnv"
 # Stable task ids that adapt cleanly under ``--frontend warp``, as produced by
 # :func:`_sweep_warp_support`. Do not curate this by hand: when the test fails it prints the
 # exact set to paste back.
+#
+# The sweep reports what adapts today; this set records what must keep adapting. Without it a
+# task losing warp support only shrinks the computed answer, with nothing to compare against —
+# which is how Reach lost support unnoticed.
 _WARP_SUPPORTED_TASKS = frozenset(
     {
         "Isaac-Ant",


### PR DESCRIPTION
Addresses review comments on #6900.

- The pose-command parity fixture reached numpy via `.torch.cpu().numpy()`, routing warp buffers through a torch view and a host copy to get data warp hands back directly. Now uses `.warp.numpy()`.
- `UniformPoseCommand` imports moved to the top of the file; they were local without a cycle to justify it.

`ProxyArray.numpy()` is not equivalent and was tried first: unknown attributes forward to the torch view, so it inherits torch's CPU-only restriction and raises on the cuda tensors these fixtures use.

Not included, raised on #6900 and better handled separately:

- Dropping the `_wp` suffix. `term_dones_wp` belongs to a family of six (`time_outs_wp`, `dones_wp`, `terminated_wp`, `_truncated_wp`, `_terminated_wp`, `_scratch_term_mask_wp`); renaming one leaves the package less consistent than it is now. A rename of the family, with deprecations, is its own change.
- `wp.static` for the resolved threshold flags, and 2D/tiled rewrites of the reward kernels. Both are optimizations that change how the kernels are defined and warrant their own benchmarking.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

Test plan:

- [x] `pytest source/isaaclab_experimental/test/` — 205 passed, 1 skipped
- [x] `uv run isaaclab -f` clean
