### PR TITLE
Drop the dead importers token from the kit-less image

### DIFF
--- a/docker/Dockerfile.kitless
+++ b/docker/Dockerfile.kitless
@@ -46,13 +46,12 @@ COPY source/ source/
 COPY isaaclab.sh ./
 
 # Same entry point as Dockerfile.base. The selectors are explicit because a bare
-# --install excludes `ov` and `visualizer`; both take `[all]` here. `importers` carries
-# the standalone URDF/MJCF importers that replace the Isaac Sim ones. The venv pins
+# --install excludes `ov` and `visualizer`; both take `[all]` here. The venv pins
 # python3.12 to match the runtime stage's libpython3.12, and isaaclab.sh resolves
 # VIRTUAL_ENV first.
 RUN uv venv --python /usr/bin/python3.12 --seed --no-managed-python "${VIRTUAL_ENV}" \
  && chmod +x "${ISAACLAB_PATH}/isaaclab.sh" \
- && "${ISAACLAB_PATH}/isaaclab.sh" --install newton,rl[all],ov[all],visualizer[all],importers \
+ && "${ISAACLAB_PATH}/isaaclab.sh" --install newton,rl[all],ov[all],visualizer[all] \
  && python -c "import importlib.metadata as m; \
       names = {d.metadata['Name'].lower() for d in m.distributions()}; \
       assert 'isaacsim' not in names; \


### PR DESCRIPTION
## 1. Summary

- `docker/Dockerfile.kitless` passes `--install ... ,importers`, but the install CLI defines no `importers` token, so every kit-less image build logs `Unknown install token 'importers'. Valid values: ... Skipping` and carries on.
- Cosmetic today — the token is skipped and nothing is missing — but the selector reads as if it installs something, and the comment above it described packages the line does not install.
- Nothing else references the token: `grep -rn importers docker/ .github/` returns only prose.

## 2. Verification

| Check | Result |
|---|---|
| `importers` in `[project.optional-dependencies]` | absent |
| `importers` in `VALID_EXTRA_FEATURES` (`install.py`) | absent |
| Remaining tokens `newton`, `rl`, `ov`, `visualizer` | all present in `VALID_EXTRA_FEATURES` |
| Other references to the token | none |

## 3. Notes

Spotted by @StafaH while reviewing #6935 ("I don't see importers anywhere in the PR for isaaclab.sh -i, is this correct?"). The condition predates that PR, so it is split out to stay independent of it.
