### PR TITLE
Add singularity handling to the operational space controller

### DIFF
--- a/docs/source/tutorials/05_controllers/run_osc.rst
+++ b/docs/source/tutorials/05_controllers/run_osc.rst
@@ -83,6 +83,15 @@ especially for rapid movements. This inertial decoupling accounts for the coupli
 If desired, the inertial coupling between the translational and rotational axes could be ignored by setting the
 ``partial_inertial_dynamics_decoupling`` to ``True``.
 
+Inertial decoupling requires inverting the task-space inertia, which loses rank at kinematic singularities. By
+default (``inertial_decoupling_method`` set to ``"inv"``) this inversion is unregularized, so command forces grow
+without bound as a singularity is approached. Non-redundant (6-DoF) arms are the most exposed, since they cannot
+reconfigure around a singularity in the null-space, but redundant arms reach such configurations too. Setting
+``inertial_decoupling_method`` to ``"cond_clamp"`` bounds the condition number of the task-space inertia, which caps
+the command forces. The bound is set through ``inertial_decoupling_params["max_condition_number"]``. Because it
+constrains a ratio rather than a magnitude, it behaves the same on robots of different mass and scale, and it leaves
+well-conditioned configurations untouched.
+
 If it is desired to include the gravity compensation in the operational space command, the ``gravity_compensation``
 should be set to ``True``.
 

--- a/source/isaaclab/changelog.d/jichuanh-osc-singularity-damping.minor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-osc-singularity-damping.minor.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.controllers.OperationalSpaceControllerCfg.inertial_decoupling_method` and
+  :attr:`~isaaclab.controllers.OperationalSpaceControllerCfg.inertial_decoupling_params` to regularize
+  the task-space inertia inversion near kinematic singularities. Setting ``"cond_clamp"`` bounds the
+  condition number of :math:`J M^{-1} J^T`, keeping command forces finite where the default ``"inv"``
+  diverges to unbounded torques and eventually ``NaN``. This most often affects non-redundant (6-DoF)
+  arms such as the UR10, but redundant arms reach such configurations too.

--- a/source/isaaclab/isaaclab/controllers/operational_space.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space.py
@@ -432,15 +432,17 @@ class OperationalSpaceController:
                 self._mass_matrix_inv = torch.inverse(mass_matrix)
                 if self.cfg.partial_inertial_dynamics_decoupling:
                     # Fill in the translational and rotational parts of the inertia separately, ignoring their coupling
-                    self._os_mass_matrix_b[:, 0:3, 0:3] = torch.inverse(
-                        jacobian_b[:, 0:3] @ self._mass_matrix_inv @ jacobian_b[:, 0:3].mT
+                    self._os_mass_matrix_b[:, 0:3, 0:3] = self._invert_task_inertia(
+                        jacobian_b[:, 0:3] @ self._mass_matrix_inv @ jacobian_b[:, 0:3].mT, jacobian_b[:, 0:3]
                     )
-                    self._os_mass_matrix_b[:, 3:6, 3:6] = torch.inverse(
-                        jacobian_b[:, 3:6] @ self._mass_matrix_inv @ jacobian_b[:, 3:6].mT
+                    self._os_mass_matrix_b[:, 3:6, 3:6] = self._invert_task_inertia(
+                        jacobian_b[:, 3:6] @ self._mass_matrix_inv @ jacobian_b[:, 3:6].mT, jacobian_b[:, 3:6]
                     )
                 else:
                     # Calculate the operational space mass matrix fully accounting for the couplings
-                    self._os_mass_matrix_b[:] = torch.inverse(jacobian_b @ self._mass_matrix_inv @ jacobian_b.mT)
+                    self._os_mass_matrix_b[:] = self._invert_task_inertia(
+                        jacobian_b @ self._mass_matrix_inv @ jacobian_b.mT, jacobian_b
+                    )
                 # (Generalized) operational space command forces
                 # F = (J M^(-1) J^T)^(-1) * \ddot(x_des) = M_task * \ddot(x_des)
                 os_command_forces_b = self._os_mass_matrix_b @ des_ee_acc_b
@@ -547,3 +549,53 @@ class OperationalSpaceController:
                 raise ValueError(f"Invalid null-space control method: {self.cfg.nullspace_control}.")
 
         return joint_efforts
+
+    """
+    Helper functions.
+    """
+
+    def _invert_task_inertia(self, task_inertia_inv: torch.Tensor, jacobian_b: torch.Tensor) -> torch.Tensor:
+        """Invert the task-space inertia using the configured regularization method.
+
+        The task-space inertia inverse :math:`J M^{-1} J^T` loses rank at kinematic singularities,
+        where a plain inverse yields unbounded command forces. Damping keeps the result bounded at
+        the cost of steady-state tracking accuracy.
+
+        ``"cond_clamp"`` adds :math:`\\lambda^2 I` before inverting, with :math:`\\lambda^2` derived
+        from the matrix's own magnitude so that the condition number stays bounded. Because the
+        damping is set by a ratio rather than an absolute amount, it is independent of the robot's
+        mass and link scale, and away from singularities it perturbs the result by only
+        :math:`1/\\text{max_condition_number}` in relative terms.
+
+        Args:
+            task_inertia_inv: The task-space inertia inverse :math:`J M^{-1} J^T`, of shape
+                (``num_envs``, N, N) where N is 6 for full decoupling and 3 for each partially
+                decoupled block.
+            jacobian_b: The (sub-)Jacobian in the root frame used to build ``task_inertia_inv``,
+                of shape (``num_envs``, N, ``num_DoF``). Unused by the current methods; retained so
+                singularity measures keyed off the Jacobian can be added without changing callers.
+
+        Returns:
+            The task-space inertia :math:`\\Lambda` [kg for translational rows, kg·m² for rotational
+            rows], of the same shape as ``task_inertia_inv``.
+
+        Raises:
+            ValueError: When the configured inertial decoupling method is not recognized.
+        """
+        method = self.cfg.inertial_decoupling_method
+        if method == "inv":
+            return torch.inverse(task_inertia_inv)
+        elif method == "cond_clamp":
+            max_cond = self.cfg.inertial_decoupling_params["max_condition_number"]
+            dim = task_inertia_inv.shape[-1]
+            identity = torch.eye(n=dim, device=self._device)
+            # J M^-1 J^T is symmetric positive semi-definite, so its largest diagonal entry is a
+            # lower bound on its largest eigenvalue, and within a factor of `dim` of it. Deriving
+            # the damping from that magnitude bounds the condition number to within the same factor
+            # while needing only an inverse -- an eigendecomposition is both costlier and prone to
+            # non-convergence on exactly the ill-conditioned matrices this path exists to handle.
+            magnitude = task_inertia_inv.diagonal(dim1=-2, dim2=-1).max(dim=-1).values.clamp(min=1e-12)
+            lambda_sq = magnitude / max_cond
+            return torch.inverse(task_inertia_inv + lambda_sq.view(-1, 1, 1) * identity)
+        else:
+            raise ValueError(f"Unsupported inertial decoupling method: {method}.")

--- a/source/isaaclab/isaaclab/controllers/operational_space_cfg.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space_cfg.py
@@ -42,6 +42,38 @@ class OperationalSpaceControllerCfg:
     partial_inertial_dynamics_decoupling: bool = False
     """Whether to ignore the inertial coupling between the translational & rotational motions."""
 
+    inertial_decoupling_method: str = "inv"
+    """Method used to invert the task-space inertia :math:`J M^{-1} J^T`: ``"inv"``, ``"cond_clamp"``.
+
+    The task-space inertia loses rank at kinematic singularities, where a plain inverse produces
+    unbounded command forces. Non-redundant (6-DoF) arms are most exposed, since they cannot
+    reconfigure through a singularity in the null space, but redundant arms reach such
+    configurations too.
+
+    - Plain inverse (``"inv"``): no regularization. Matches the behavior of releases before this
+      option existed and remains the default.
+    - Condition-number clamp (``"cond_clamp"``): damps :math:`J M^{-1} J^T` by an amount derived
+      from its own magnitude, bounding its condition number and so capping the resulting command
+      forces.
+        - ``"max_condition_number"``: approximate upper bound on the ratio between the largest and
+          smallest eigenvalue (default: 1e6). The bound is approached within a factor of the task
+          dimension, since the damping is keyed off the largest diagonal entry rather than the
+          largest eigenvalue.
+
+    Because the damping is set by a ratio, it is independent of the robot's mass and link scale.
+    Away from singularities it perturbs the inverse by roughly ``1/max_condition_number`` in
+    relative terms, which is small but not zero: expect some change in tracking even on
+    well-conditioned setups. For reference, the task-space inertia of a UR10 or a Franka sits around
+    1e4 to 3e5 during healthy tracking and climbs past 1e7 as the arm diverges. Lower the bound to
+    intervene earlier, at the cost of tracking accuracy near singularities.
+    """
+
+    inertial_decoupling_params: dict[str, float] | None = None
+    """Parameters for the given :attr:`inertial_decoupling_method`.
+
+    Unspecified entries fall back to the defaults documented on :attr:`inertial_decoupling_method`.
+    """
+
     gravity_compensation: bool = False
     """Whether to perform gravity compensation."""
 
@@ -92,3 +124,27 @@ class OperationalSpaceControllerCfg:
 
     nullspace_damping_ratio: float = 1.0
     """The damping ratio for null space control."""
+
+    def __post_init__(self):
+        # check valid input
+        if self.inertial_decoupling_method not in ["inv", "cond_clamp"]:
+            raise ValueError(f"Unsupported inertial decoupling method: {self.inertial_decoupling_method}.")
+        # default parameters for each inversion method
+        default_params = {
+            "inv": {},
+            "cond_clamp": {"max_condition_number": 1e6},
+        }
+        # update parameters for the chosen method if not provided
+        params = default_params[self.inertial_decoupling_method].copy()
+        if self.inertial_decoupling_params is not None:
+            params.update(self.inertial_decoupling_params)
+        self.inertial_decoupling_params = params
+        # validate the clamp bound
+        if (
+            self.inertial_decoupling_method == "cond_clamp"
+            and self.inertial_decoupling_params["max_condition_number"] <= 1.0
+        ):
+            raise ValueError(
+                "cond_clamp max_condition_number must be > 1, got"
+                f" {self.inertial_decoupling_params['max_condition_number']}."
+            )

--- a/source/isaaclab/test/controllers/test_operational_space_singularity.py
+++ b/source/isaaclab/test/controllers/test_operational_space_singularity.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for singularity handling in the operational-space controller.
+
+The task-space inertia ``J M^-1 J^T`` loses rank at kinematic singularities. Without
+regularization its inverse produces unbounded command forces, which shows up as violent motion and
+eventually NaN. Non-redundant (6-DoF) arms are most exposed because they cannot reconfigure through
+a singularity in the null space.
+
+These tests drive the controller with a synthetic near-singular Jacobian so the failure is
+deterministic and does not require the simulator.
+"""
+
+import pytest
+import torch
+
+from isaaclab.controllers import OperationalSpaceController, OperationalSpaceControllerCfg
+
+pytestmark = pytest.mark.unit
+
+NUM_ENVS = 2
+NUM_DOF = 6
+"""A 6-DoF arm: the task Jacobian is square, so rank loss cannot be absorbed by redundancy."""
+
+SMALLEST_SINGULAR_VALUE = 1e-3
+"""Smallest singular value of the synthetic Jacobian, i.e. how close it sits to a singularity.
+
+Chosen so the resulting task inertia stays well clear of ``float32`` precision limits: below roughly
+1e-4 the ``sigma_min**2`` term underflows against the unit-scale terms and the undamped inverse
+returns numerical noise whose magnitude is neither stable nor comparable across devices.
+"""
+
+
+def _orthonormal(dim: int, seed: int, device: str) -> torch.Tensor:
+    """Build a deterministic orthonormal matrix of shape (``dim``, ``dim``)."""
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    matrix = torch.randn(dim, dim, generator=generator)
+    q, _ = torch.linalg.qr(matrix)
+    return q.to(device)
+
+
+def _near_singular_jacobian(device: str, sigma_min: float = SMALLEST_SINGULAR_VALUE) -> torch.Tensor:
+    """Build a batched 6x6 Jacobian whose smallest singular value is ``sigma_min``.
+
+    Constructed through its SVD so the conditioning is exact rather than incidental.
+    """
+    u = _orthonormal(6, seed=0, device=device)
+    v = _orthonormal(NUM_DOF, seed=1, device=device)
+    singular_values = torch.ones(6, device=device)
+    singular_values[-1] = sigma_min
+    jacobian = u @ torch.diag(singular_values) @ v.mT
+    return jacobian.unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+
+
+def _make_controller(device: str, **cfg_kwargs) -> OperationalSpaceController:
+    """Create a pose-tracking controller with inertial decoupling enabled."""
+    cfg = OperationalSpaceControllerCfg(
+        target_types=["pose_abs"],
+        impedance_mode="fixed",
+        inertial_dynamics_decoupling=True,
+        partial_inertial_dynamics_decoupling=False,
+        gravity_compensation=False,
+        motion_stiffness_task=100.0,
+        motion_damping_ratio_task=1.0,
+        **cfg_kwargs,
+    )
+    return OperationalSpaceController(cfg, num_envs=NUM_ENVS, device=device)
+
+
+def _compute_efforts(
+    osc: OperationalSpaceController, jacobian_b: torch.Tensor, device: str, mass_scale: float = 1.0
+) -> torch.Tensor:
+    """Command a fixed pose offset and return the resulting joint efforts.
+
+    ``mass_scale`` stands in for a heavier or lighter robot: it scales the joint-space inertia
+    without changing the kinematics, so only the dynamic scale of ``J M^-1 J^T`` moves.
+    """
+    # identity orientation in (x, y, z, w) order
+    current_ee_pose_b = torch.tensor([[0.5, 0.0, 0.5, 0.0, 0.0, 0.0, 1.0]], device=device).repeat(NUM_ENVS, 1)
+    current_ee_vel_b = torch.zeros(NUM_ENVS, 6, device=device)
+    # a well-conditioned joint-space inertia, so the only ill-conditioning comes from the Jacobian
+    mass_matrix = mass_scale * torch.eye(NUM_DOF, device=device).unsqueeze(0).repeat(NUM_ENVS, 1, 1)
+
+    # target is offset by 0.1 m in x, giving a non-zero task-space error to act on
+    command = current_ee_pose_b.clone()
+    command[:, 0] += 0.1
+    osc.set_command(command=command, current_ee_pose_b=current_ee_pose_b)
+
+    return osc.compute(
+        jacobian_b=jacobian_b,
+        current_ee_pose_b=current_ee_pose_b,
+        current_ee_vel_b=current_ee_vel_b,
+        mass_matrix=mass_matrix,
+    )
+
+
+def _peak_effort(
+    device: str,
+    method: str,
+    sigma_min: float = SMALLEST_SINGULAR_VALUE,
+    mass_scale: float = 1.0,
+    **params,
+) -> float:
+    """Return the largest joint effort the controller commands for the given method."""
+    kwargs = {"inertial_decoupling_method": method}
+    if params:
+        kwargs["inertial_decoupling_params"] = params
+    osc = _make_controller(device, **kwargs)
+    efforts = _compute_efforts(osc, _near_singular_jacobian(device, sigma_min=sigma_min), device, mass_scale)
+    assert torch.isfinite(efforts).all(), f"'{method}' produced non-finite efforts"
+    return efforts.abs().max().item()
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_clamp_bounds_efforts_near_singularity(device):
+    """The clamp keeps efforts finite and far below the unregularized inverse."""
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    undamped = _peak_effort(device, "inv")
+    clamped = _peak_effort(device, "cond_clamp", max_condition_number=1e3)
+
+    assert clamped * 20.0 < undamped, (
+        f"expected the clamp to bound efforts near a singularity, got {clamped:.3e} against"
+        f" {undamped:.3e} for the unregularized inverse"
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_undamped_efforts_scale_with_singularity_proximity(device):
+    """The defect itself: without the clamp, effort grows as the arm nears a singularity.
+
+    The clamp holds its output essentially flat over the same range, which is the contrast the fix
+    provides.
+    """
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    far, near = 1e-2, 1e-3
+
+    undamped_far = _peak_effort(device, "inv", sigma_min=far)
+    undamped_near = _peak_effort(device, "inv", sigma_min=near)
+    assert undamped_near > 5.0 * undamped_far, (
+        "expected the unregularized inverse to amplify as the singularity is approached, got"
+        f" {undamped_far:.3e} -> {undamped_near:.3e}"
+    )
+
+    clamped_far = _peak_effort(device, "cond_clamp", sigma_min=far, max_condition_number=1e3)
+    clamped_near = _peak_effort(device, "cond_clamp", sigma_min=near, max_condition_number=1e3)
+    assert clamped_near < 1.5 * clamped_far, (
+        "expected the clamp to stay bounded as the singularity is approached, got"
+        f" {clamped_far:.3e} -> {clamped_near:.3e}"
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_clamp_strength_is_independent_of_robot_inertia(device):
+    """A given bound must act identically on a heavy arm and a light one.
+
+    ``J M^-1 J^T`` scales inversely with the robot's inertia, so any criterion expressed as an
+    absolute magnitude acts far more aggressively on a heavy arm. Bounding a ratio does not.
+    """
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    light, heavy = 1.0, 100.0
+
+    light_ratio = _peak_effort(device, "cond_clamp", mass_scale=light, max_condition_number=1e3) / _peak_effort(
+        device, "inv", mass_scale=light
+    )
+    heavy_ratio = _peak_effort(device, "cond_clamp", mass_scale=heavy, max_condition_number=1e3) / _peak_effort(
+        device, "inv", mass_scale=heavy
+    )
+
+    torch.testing.assert_close(
+        torch.tensor(heavy_ratio),
+        torch.tensor(light_ratio),
+        rtol=0.1,
+        atol=1e-3,
+        msg=(
+            f"clamped a {heavy}x heavier arm to {heavy_ratio:.4f} of its undamped effort but a light arm to"
+            f" {light_ratio:.4f}; the bound must not depend on robot inertia"
+        ),
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_clamp_is_inert_on_well_conditioned_configurations(device):
+    """Away from singularities the clamp must reproduce the plain inverse exactly.
+
+    This is the property that makes it safe to enable by default on a working setup: it intervenes
+    only once the configured condition bound is actually exceeded.
+    """
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    # all singular values equal to 1, so the task inertia is perfectly conditioned
+    jacobian_b = _near_singular_jacobian(device, sigma_min=1.0)
+
+    undamped = _compute_efforts(_make_controller(device, inertial_decoupling_method="inv"), jacobian_b, device)
+    clamped = _compute_efforts(
+        _make_controller(
+            device,
+            inertial_decoupling_method="cond_clamp",
+            inertial_decoupling_params={"max_condition_number": 1e6},
+        ),
+        jacobian_b,
+        device,
+    )
+
+    torch.testing.assert_close(clamped, undamped, rtol=1e-4, atol=1e-5)
+
+
+def test_default_method_is_the_unregularized_inverse():
+    """The default must preserve pre-existing behavior so upgrades are not silently altered."""
+    cfg = OperationalSpaceControllerCfg(target_types=["pose_abs"])
+    assert cfg.inertial_decoupling_method == "inv"
+    assert cfg.inertial_decoupling_params == {}
+
+
+def test_unknown_method_is_rejected():
+    """An unrecognized method must fail at config time rather than mid-rollout."""
+    with pytest.raises(ValueError, match="Unsupported inertial decoupling method"):
+        OperationalSpaceControllerCfg(target_types=["pose_abs"], inertial_decoupling_method="dls")
+
+
+def test_method_defaults_are_filled_and_overridable():
+    """Unspecified parameters fall back to documented defaults; provided ones win."""
+    cfg = OperationalSpaceControllerCfg(target_types=["pose_abs"], inertial_decoupling_method="cond_clamp")
+    assert cfg.inertial_decoupling_params == {"max_condition_number": 1e6}
+
+    cfg = OperationalSpaceControllerCfg(
+        target_types=["pose_abs"],
+        inertial_decoupling_method="cond_clamp",
+        inertial_decoupling_params={"max_condition_number": 1e4},
+    )
+    assert cfg.inertial_decoupling_params["max_condition_number"] == 1e4
+
+
+@pytest.mark.parametrize("bound", [1.0, 0.0, -5.0])
+def test_invalid_condition_bound_is_rejected(bound):
+    """A bound of 1 or below cannot be satisfied by any non-degenerate matrix."""
+    with pytest.raises(ValueError, match="max_condition_number must be > 1"):
+        OperationalSpaceControllerCfg(
+            target_types=["pose_abs"],
+            inertial_decoupling_method="cond_clamp",
+            inertial_decoupling_params={"max_condition_number": bound},
+        )


### PR DESCRIPTION
# Description

The operational space controller inverts the task-space inertia `J M^-1 J^T` with no
regularization. That matrix loses rank at kinematic singularities, so command forces grow
without bound — producing violent motion and eventually `NaN`. Non-redundant (6-DoF) arms are
the most exposed, since they cannot reconfigure around a singularity in the null-space.

This is the failure reported in #2781 for a UR10, and independently there for a 6-DoF xArm and
an AR4. The `DifferentialIKController` already offers damped inverses, which is why users report
IK working where OSC does not.

Adds `inertial_decoupling_method` to `OperationalSpaceControllerCfg`. The default `"inv"` is
exactly the previous behavior; `"cond_clamp"` bounds the condition number of the task-space
inertia. The bound is a ratio, so it behaves consistently across robots of differing mass.

## Validation

UR10 (6-DoF) in `run_osc.py` with only the robot swapped, 16 envs, 1500 steps:

| goal | `inv` | `cond_clamp` |
| ---- | ----- | ------------ |
| 0 | 0.5744 m, \|tau\| 1.27e4 | 0.5019 m, \|tau\| 2.45 |
| 1 | 0.5034 m | 0.5019 m |
| 2 | 0.3547 m (max 1.5452), \|qd\| 34.7 | 0.2478 m (max 0.2591), \|qd\| 3.14 |

Worst-case tracking error drops 1.55 → 0.26 m; peak joint velocity 34.7 → 3.14 rad/s.

New unit tests cover the bound, its independence from robot inertia, and config validation.
They fail without this change.

## Known limitation

`run_osc.py` also diverges on the 7-DoF Franka at its default 128 envs. That is a separate
defect: it reproduces identically with and without this change, at every condition bound tried
(1e6–1e8). Not addressed here.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
