### PR TITLE
Resolve the RL agent entry point from task registry metadata

### DIFF
--- a/source/isaaclab/changelog.d/octi-preset-agent-auto-select.rst
+++ b/source/isaaclab/changelog.d/octi-preset-agent-auto-select.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed ``isaaclab benchmark training`` and ``isaaclab benchmark play`` for skrl
+  not resolving the agent entry point from the task's registry metadata. Both
+  ``_parse_args`` functions now pass ``agent_library="skrl"`` to
+  :func:`~isaaclab_tasks.utils.setup_preset_cli`, so a benchmark run picks the
+  same agent config that ``isaaclab train`` does for the active preset.
+* Fixed ``isaaclab benchmark play`` reporting the raw ``--algorithm`` flag in its
+  KPI metadata while writing the resolved algorithm to the run manifest. Both now
+  report the resolved value, matching ``isaaclab benchmark training``.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -102,7 +102,7 @@ def _parse_args(argv: list[str]):
     )
     add_launcher_args(parser)
 
-    args_cli, remaining_args = setup_preset_cli(parser, argv)
+    args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="skrl")
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -138,12 +138,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     # Resolve agent entry point (mirrors isaaclab_rl.entrypoints.backends.play_skrl).
-    if args_cli.agent is None:
-        algorithm = args_cli.algorithm.lower()
-        agent_cfg_entry_point = "skrl_cfg_entry_point" if algorithm == "ppo" else f"skrl_{algorithm}_cfg_entry_point"
-    else:
-        agent_cfg_entry_point = args_cli.agent
-        algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
+    agent_cfg_entry_point, algorithm = _common.resolve_skrl_agent_entry_point(args_cli.agent, args_cli.algorithm)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, agent_cfg_entry_point)
 
@@ -199,7 +194,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                         {"name": "task", "data": args_cli.task},
                         {"name": "num_envs", "data": args_cli.num_envs},
                         {"name": "num_steps", "data": args_cli.num_steps},
-                        {"name": "algorithm", "data": args_cli.algorithm},
+                        {"name": "algorithm", "data": algorithm.upper()},
                         {
                             "name": "environment_step_measurement_mode",
                             "data": ("serialized_synchronized" if args_cli.measure_sync_step else "host_return"),

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
@@ -201,7 +201,7 @@ def _parse_args(argv: list[str]):
     add_success_cli_args(parser, include_check_success=False)
     add_launcher_args(parser)
 
-    args_cli, remaining_args = setup_preset_cli(parser, argv)
+    args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="skrl")
     validate_distributed_args(parser, args_cli)
     enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
@@ -260,12 +260,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
     distributed = DistributedContext.from_env(args_cli.distributed)
 
     # Derive the default agent entry point from the selected algorithm.
-    if args_cli.agent is None:
-        algorithm = args_cli.algorithm.lower()
-        agent_cfg_entry_point = "skrl_cfg_entry_point" if algorithm == "ppo" else f"skrl_{algorithm}_cfg_entry_point"
-    else:
-        agent_cfg_entry_point = args_cli.agent
-        algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
+    agent_cfg_entry_point, algorithm = _common.resolve_skrl_agent_entry_point(args_cli.agent, args_cli.algorithm)
 
     config_t0 = time.perf_counter_ns()
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, agent_cfg_entry_point)

--- a/source/isaaclab_rl/changelog.d/octi-preset-agent-auto-select.rst
+++ b/source/isaaclab_rl/changelog.d/octi-preset-agent-auto-select.rst
@@ -1,0 +1,18 @@
+Fixed
+^^^^^
+
+* Fixed the skrl entrypoints reporting an observation/action space name as the
+  training algorithm. ``--agent`` keys do not all encode an algorithm: the
+  Cartpole showcase tasks key theirs by space combination, so
+  ``skrl_box_discrete_cfg_entry_point`` was decoded as the algorithm
+  ``box_discrete``. That value reached run manifests, benchmark KPI metadata, and
+  log directory names, and switched off the MARL-to-single-agent conversion that
+  PPO requires. Only ``amp``, ``ppo``, ``ippo``, and ``mappo`` are now read as
+  algorithms; any other key keeps the algorithm from ``--algorithm``.
+
+Changed
+^^^^^^^
+
+* Added :func:`~isaaclab_rl.entrypoints.common.resolve_skrl_agent_entry_point`,
+  replacing the four copies of the skrl agent/algorithm resolution in the train,
+  play, and benchmark entrypoints.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -34,6 +34,7 @@ from isaaclab_rl.entrypoints.common import (
     preserve_attribute,
     resolve_checkpoint_selector,
     resolve_play_task_name,
+    resolve_skrl_agent_entry_point,
     show_run_summary,
     startup_screen,
 )
@@ -122,12 +123,7 @@ if version.parse(skrl.__version__) < version.parse(SKRL_VERSION):
     )
     exit()
 
-if args_cli.agent is None:
-    algorithm = args_cli.algorithm.lower()
-    agent_cfg_entry_point = "skrl_cfg_entry_point" if algorithm in ["ppo"] else f"skrl_{algorithm}_cfg_entry_point"
-else:
-    agent_cfg_entry_point = args_cli.agent
-    algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
+agent_cfg_entry_point, algorithm = resolve_skrl_agent_entry_point(args_cli.agent, args_cli.algorithm)
 
 
 def main():

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -31,6 +31,7 @@ from isaaclab_rl.entrypoints.common import (
     pre_launch_video_config,
     preserve_attribute,
     resolve_checkpoint_selector,
+    resolve_skrl_agent_entry_point,
     set_hydra_args,
     show_run_summary,
     startup_screen,
@@ -87,13 +88,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def _resolve_agent_entry_point(args_cli: argparse.Namespace) -> tuple[str, str]:
     """Resolve the skrl agent entry point and algorithm from CLI arguments."""
-    if args_cli.agent is None:
-        algorithm = args_cli.algorithm.lower()
-        agent_cfg_entry_point = "skrl_cfg_entry_point" if algorithm in ["ppo"] else f"skrl_{algorithm}_cfg_entry_point"
-    else:
-        agent_cfg_entry_point = args_cli.agent
-        algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
-    return agent_cfg_entry_point, algorithm
+    return resolve_skrl_agent_entry_point(args_cli.agent, args_cli.algorithm)
 
 
 def _get_distributed_rank(args_cli: argparse.Namespace) -> int:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -43,6 +43,9 @@ _RENDERER_PRESET_NAMES = {"isaac_rtx": "isaacsim_rtx", "newton_warp": "newton_re
 RUN_MANIFEST_FILENAME = "run.json"
 RUN_MANIFEST_VERSION = 1
 CHECKPOINT_SELECTORS = frozenset({"latest", "best"})
+#: Algorithm names that may legitimately appear in a ``skrl_<name>_cfg_entry_point`` key.
+#: Union of the ``--algorithm`` choices across the skrl train, play, and benchmark entrypoints.
+SKRL_ALGORITHM_NAMES = frozenset({"amp", "ppo", "ippo", "mappo"})
 logger = logging.getLogger(__name__)
 _MISSING = object()
 
@@ -428,6 +431,35 @@ def add_common_train_args(
         default="tensorboard",
         help="Format used to save the captured sensor frames.",
     )
+
+
+def resolve_skrl_agent_entry_point(agent: str | None, algorithm: str) -> tuple[str, str]:
+    """Resolve the skrl agent config entry point and the algorithm it runs.
+
+    skrl is the only library whose entry point keys encode an algorithm
+    (``skrl_amp_cfg_entry_point``), so it is the only one that has to recover
+    the algorithm from a caller-supplied ``--agent``. Not every key encodes one:
+    the Cartpole showcase tasks key theirs by observation/action space
+    (``skrl_box_discrete_cfg_entry_point``), and
+    :func:`~isaaclab_tasks.utils.setup_preset_cli` selects those automatically
+    from the active preset. Decoding blindly yields ``"box_discrete"``, which
+    then reaches run manifests, benchmark KPI metadata, and log directory names,
+    and disables the MARL-to-single-agent conversion that PPO needs. Only names
+    in :data:`SKRL_ALGORITHM_NAMES` are trusted; anything else keeps the
+    algorithm the caller asked for.
+
+    Args:
+        agent: Value of ``--agent``, or ``None`` when the flag is unset.
+        algorithm: Value of ``--algorithm``, case-insensitive.
+
+    Returns:
+        ``(agent_cfg_entry_point, algorithm)`` with the algorithm lower-cased.
+    """
+    algorithm = algorithm.lower()
+    if agent is None:
+        return ("skrl_cfg_entry_point" if algorithm == "ppo" else f"skrl_{algorithm}_cfg_entry_point"), algorithm
+    encoded = agent.split("_cfg")[0].split("skrl_")[-1].lower()
+    return agent, encoded if encoded in SKRL_ALGORITHM_NAMES else algorithm
 
 
 def enable_cameras_for_video(args_cli: argparse.Namespace) -> None:

--- a/source/isaaclab_rl/test/test_entrypoints_common.py
+++ b/source/isaaclab_rl/test/test_entrypoints_common.py
@@ -24,6 +24,7 @@ from isaaclab_rl.entrypoints.common import (
     dispatch_library_entrypoint,
     enable_cameras_for_video,
     resolve_play_task_name,
+    resolve_skrl_agent_entry_point,
     wrap_sensor_capture,
 )
 
@@ -204,6 +205,29 @@ def test_enable_cameras_for_video_enables_cameras_for_sensor_capture() -> None:
     enable_cameras_for_video(args_cli)
 
     assert args_cli.enable_cameras
+
+
+@pytest.mark.parametrize(
+    "agent,algorithm,expected",
+    [
+        # Unset --agent: the entry point follows --algorithm, PPO being the unsuffixed default.
+        (None, "PPO", ("skrl_cfg_entry_point", "ppo")),
+        (None, "AMP", ("skrl_amp_cfg_entry_point", "amp")),
+        # An --agent whose key encodes a real algorithm reports that algorithm.
+        ("skrl_amp_cfg_entry_point", "PPO", ("skrl_amp_cfg_entry_point", "amp")),
+        ("skrl_ippo_cfg_entry_point", "PPO", ("skrl_ippo_cfg_entry_point", "ippo")),
+        # Showcase keys encode an observation/action space, not an algorithm. Reading
+        # one as the algorithm would put "box_discrete" in run manifests and benchmark
+        # KPI metadata and would switch off the PPO MARL conversion.
+        ("skrl_box_discrete_cfg_entry_point", "PPO", ("skrl_box_discrete_cfg_entry_point", "ppo")),
+        ("skrl_tuple_multidiscrete_cfg_entry_point", "AMP", ("skrl_tuple_multidiscrete_cfg_entry_point", "amp")),
+        # The canonical default decodes to the bare library name, which is not an algorithm.
+        ("skrl_cfg_entry_point", "PPO", ("skrl_cfg_entry_point", "ppo")),
+    ],
+)
+def test_resolve_skrl_agent_entry_point(agent: str | None, algorithm: str, expected: tuple[str, str]) -> None:
+    """The reported algorithm only comes from an entry point key that actually names one."""
+    assert resolve_skrl_agent_entry_point(agent, algorithm) == expected
 
 
 def test_common_train_args_register_frontend_with_torch_default() -> None:

--- a/source/isaaclab_tasks/changelog.d/octi-preset-agent-auto-select.rst
+++ b/source/isaaclab_tasks/changelog.d/octi-preset-agent-auto-select.rst
@@ -1,0 +1,21 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab_tasks.utils.setup_preset_cli` ignoring the agent metadata
+  tasks already declare in the Gym registry. When ``--agent`` is left at its
+  default, the entry point is now resolved from ``agent_preset_compatibility``
+  for the active ``presets=`` token, and from the sole registered entry point
+  when a task does not register ``<library>_cfg_entry_point`` at all. Previously
+  ``presets=box_discrete`` on ``IsaacContrib-Cartpole-Showcase-Direct`` loaded the
+  Gaussian-policy default and crashed on a shape mismatch, and the
+  ``IsaacContrib-Humanoid-AMP-*`` tasks crashed on the unregistered
+  ``skrl_cfg_entry_point``. Selection is skipped whenever the metadata is
+  ambiguous or ``--agent`` was passed explicitly, so no existing command line
+  changes meaning.
+* Fixed the default-absent rule being unreachable whenever any ``presets=`` token
+  was present. Benchmark sweeps broadcast the physics backend through that same
+  token, so ``presets=newton_mjwarp`` left the AMP tasks crashing as before.
+* Fixed agent auto-selection being unreachable for ``rsl_rl``, ``rl_games``, and
+  ``sb3``, whose ``--agent`` defaults to ``<library>_cfg_entry_point`` rather than
+  to ``None``. ``Isaac-Cartpole-Camera`` now honors the feature-extractor configs
+  it declares for ``presets=resnet18`` and ``presets=theia_tiny``.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
@@ -92,12 +92,15 @@ def setup_preset_cli(
             triggers ``--help`` rendering.
         agent_library: Optional RL-library prefix. When provided, task-specific
             help lists registered ``--agent`` values and declared preset
-            compatibility.
+            compatibility, and a defaulted ``--agent`` is resolved from the
+            task's registry metadata by :func:`_auto_select_agent`.
 
     Returns:
         ``(args, remaining)`` where ``remaining`` is the verbatim output of
         ``parser.parse_known_args(argv)``, ready to hand to Hydra via
-        ``sys.argv``.
+        ``sys.argv``. ``args.agent`` may have been filled in from the task's
+        registry metadata; the preset tokens that drove that choice stay in
+        ``remaining`` for hydra.
 
     Raises:
         SystemExit: If ``argv`` requests help, after printing it.
@@ -133,7 +136,13 @@ def setup_preset_cli(
         parser.print_help()
         raise SystemExit(0)
 
-    return parser.parse_known_args(args_to_parse)
+    args, remaining = parser.parse_known_args(args_to_parse)
+
+    task_name = getattr(args, "task", None) or argv_helper.task_name
+    if agent_library and task_name:
+        _auto_select_agent(args, parser, task_name, agent_library, _ArgvHelper.from_tokens(args_to_parse))
+
+    return args, remaining
 
 
 # ============================================================================
@@ -303,25 +312,32 @@ class _AgentDescriptionBuilder:
 
 
 # ============================================================================
-# argv inspection (pre-argparse peek for help-text rendering)
+# argv inspection (single-pass peek for tokens argparse cannot supply)
 # ============================================================================
 
 
 class _ArgvHelper:
-    """Single-pass argv scan that exposes ``task_name`` and ``help_requested``.
+    """Single-pass argv scan for tokens the parsed Namespace cannot provide.
 
-    Needed because argparse's ``--help`` short-circuits parsing, so help text
-    that depends on ``--task`` has to find it before argparse runs.
+    Needed on two counts: argparse's ``--help`` short-circuits parsing, so help
+    text that depends on ``--task`` has to find it before argparse runs; and no
+    argparse argument is registered for the Hydra-style selectors (see the
+    module docstring), so ``presets=`` never reaches the Namespace at all.
 
     Attributes:
         task_name: Last ``--task`` value (matching argparse's last-wins
             semantics), or ``None`` if absent.
         help_requested: ``True`` if ``--help`` or ``-h`` is present.
+        presets: Union of the names in every ``presets=NAME[,NAME,...]``
+            broadcast token, empty when none is present.
+        agent_explicit: ``True`` if ``--agent`` was passed in either form.
     """
 
     def __init__(self, argv: list[str]):
         self.task_name: str | None = None
         self.help_requested: bool = False
+        self.presets: set[str] = set()
+        self.agent_explicit: bool = False
         for i in range(1, len(argv)):
             token = argv[i]
             if token in ("--help", "-h"):
@@ -330,6 +346,95 @@ class _ArgvHelper:
                 self.task_name = argv[i + 1]
             elif token.startswith("--task="):
                 self.task_name = token[len("--task=") :]
+            elif token == "--agent" or token.startswith("--agent="):
+                self.agent_explicit = True
+            elif token.startswith("presets="):
+                self.presets.update(name.strip() for name in token[len("presets=") :].split(",") if name.strip())
+
+    @classmethod
+    def from_tokens(cls, tokens: list[str]) -> _ArgvHelper:
+        """Scan an argv slice whose leading program name has already been stripped."""
+        return cls(["", *tokens])
+
+
+# ============================================================================
+# Agent auto-selection (post-argparse, from task registry metadata)
+# ============================================================================
+
+
+def _auto_select_agent(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    task_name: str,
+    agent_library: str,
+    selection: _ArgvHelper,
+) -> None:
+    """Set ``args.agent`` when the task's metadata implies exactly one entry point.
+
+    Tasks declare the agent configs they register, and optionally which presets
+    each config is valid for (``agent_preset_compatibility``). Two rules turn
+    that metadata into a selection; the second is a fallback for when the first
+    does not fire:
+
+    1. **Preset-based**: when a ``presets=`` token names a preset the task
+       declares as an agent constraint, and exactly one registered entry point
+       is compatible with every such preset, that entry point is used. This is
+       what makes ``presets=box_discrete`` load a categorical-policy config
+       instead of the Gaussian default on the Cartpole showcase tasks.
+
+    2. **Default-absent**: when the canonical default entry point
+       (``<library>_cfg_entry_point``) is not registered but exactly one other
+       entry point is, that sole entry point is used. Handles tasks such as
+       ``IsaacContrib-Humanoid-AMP-*`` that support only a non-default
+       algorithm and so never register the PPO default.
+
+    Does nothing when the match is absent or ambiguous, leaving the caller's own
+    default resolution in charge.
+
+    Args:
+        args: Parsed namespace to update in-place.
+        parser: Parser that produced *args*, used to tell a defaulted
+            ``--agent`` from one the user typed.
+        task_name: Gymnasium task ID used to look up the registry spec.
+        agent_library: RL-library prefix (e.g. ``"skrl"``).
+        selection: Scan of the argv that was actually parsed, supplying the
+            ``presets=`` tokens and whether ``--agent`` was explicit.
+    """
+    import gymnasium as gym
+
+    if not hasattr(args, "agent"):
+        return
+    # An explicit --agent always wins. Compare against the parser's default
+    # rather than testing ``is None``: only skrl defaults --agent to None, while
+    # rsl_rl, rl_games and sb3 default it to ``<library>_cfg_entry_point``, so an
+    # ``is None`` guard would leave auto-selection unreachable for them.
+    if selection.agent_explicit or args.agent != parser.get_default("agent"):
+        return
+
+    try:
+        agents, compatibility = _enumerate_agents(task_name, agent_library)
+    except gym.error.Error:
+        # Unregistered or misspelled task ID: stay silent and let the caller's
+        # own task lookup raise the real error instead of reporting it here.
+        return
+
+    # Rule 1. Only presets the task declares as agent constraints participate:
+    # physics and renderer selections arrive through the same ``presets=``
+    # broadcast, and including them would fail the subset test for every entry
+    # point and silently leave the wrong default in place.
+    declared = {preset for presets in compatibility.values() for preset in presets}
+    constraining = selection.presets & declared
+    if constraining:
+        matches = [agent for agent, presets in compatibility.items() if constraining.issubset(set(presets))]
+        if len(matches) == 1:
+            args.agent = matches[0]
+            return
+
+    # Rule 2, reached whether or not a preset is active. Benchmark sweeps
+    # broadcast the physics backend through the same token (``presets=newton_mjwarp``),
+    # and an algorithm-only task still needs its sole entry point picked there.
+    if f"{agent_library}_cfg_entry_point" not in agents and len(agents) == 1:
+        args.agent = agents[0]
 
 
 # ============================================================================

--- a/source/isaaclab_tasks/test/core/test_preset_cli.py
+++ b/source/isaaclab_tasks/test/core/test_preset_cli.py
@@ -29,6 +29,13 @@ def _make_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _make_agent_parser(agent_default: str | None) -> argparse.ArgumentParser:
+    """Parser shaped like an RL entrypoint's, whose ``--agent`` default varies by library."""
+    parser = _make_parser()
+    parser.add_argument("--agent", type=str, default=agent_default)
+    return parser
+
+
 # ---------------------------------------------------------------------------
 # PresetTarget: per-target metadata on the enum
 # ---------------------------------------------------------------------------
@@ -227,6 +234,27 @@ def test_argv_helper_detects_help_flag():
     assert _ArgvHelper(["train.py", "-h"]).help_requested is True
     assert _ArgvHelper(["train.py", "--task=Foo", "--help"]).help_requested is True
     assert _ArgvHelper(["train.py", "env.sim.dt=0.001"]).help_requested is False
+
+
+def test_argv_helper_collects_selection_tokens():
+    """``presets=`` never reaches the Namespace, so the scanner is its only source."""
+    from isaaclab_tasks.utils.preset_cli import _ArgvHelper
+
+    argv = _ArgvHelper(["train.py", "presets=rgb,box_discrete", "presets=newton_mjwarp", "--agent=foo"])
+    assert argv.presets == {"rgb", "box_discrete", "newton_mjwarp"}
+    assert argv.agent_explicit is True
+    assert _ArgvHelper(["train.py", "--agent", "foo"]).agent_explicit is True
+    assert _ArgvHelper(["train.py", "presets="]).presets == set()
+    assert _ArgvHelper(["train.py"]).agent_explicit is False
+
+
+def test_argv_helper_from_tokens_skips_no_leading_entry():
+    """``from_tokens`` scans an argv slice that has no program name to skip."""
+    from isaaclab_tasks.utils.preset_cli import _ArgvHelper
+
+    argv = _ArgvHelper.from_tokens(["--task", "Foo-v0", "presets=rgb"])
+    assert argv.task_name == "Foo-v0"
+    assert argv.presets == {"rgb"}
 
 
 def test_argv_helper_task_returns_last_value():
@@ -483,3 +511,100 @@ def test_agent_preset_pairings_reference_registered_agents_and_presets(task_name
     assert compatibility
     assert set(compatibility) <= set(agents)
     assert {preset for presets in compatibility.values() for preset in presets} <= domain_presets
+
+
+# ---------------------------------------------------------------------------
+# Agent auto-selection from task registry metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_argv(monkeypatch):
+    """Isolate the pre-argparse ``sys.argv`` peek from pytest's own command line."""
+    monkeypatch.setattr(sys, "argv", ["train.py"])
+
+
+@pytest.mark.parametrize(
+    "task_name,agent_library,agent_default,argv_tail,expected",
+    [
+        # Rule 1: the active preset names exactly one compatible entry point.
+        (
+            "IsaacContrib-Cartpole-Showcase-Direct",
+            "skrl",
+            None,
+            ["presets=box_discrete"],
+            "skrl_box_discrete_cfg_entry_point",
+        ),
+        # Rule 1 is reachable for libraries that default --agent to a name rather
+        # than to None; an ``is None`` guard would skip rsl_rl, rl_games and sb3.
+        (
+            "Isaac-Cartpole-Camera",
+            "rsl_rl",
+            "rsl_rl_cfg_entry_point",
+            ["presets=resnet18"],
+            "rsl_rl_feature_cfg_entry_point",
+        ),
+        (
+            "Isaac-Cartpole-Camera",
+            "rl_games",
+            "rl_games_cfg_entry_point",
+            ["presets=theia_tiny"],
+            "rl_games_feature_cfg_entry_point",
+        ),
+        # Rule 2: the task never registers the canonical default, so its sole
+        # entry point is the only possible answer.
+        ("IsaacContrib-Humanoid-AMP-Walk-Direct", "skrl", None, [], "skrl_amp_cfg_entry_point"),
+        # Rule 2 still applies when a preset is active but constrains nothing:
+        # benchmark sweeps broadcast the physics backend through ``presets=``.
+        (
+            "IsaacContrib-Humanoid-AMP-Walk-Direct",
+            "skrl",
+            None,
+            ["presets=newton_mjwarp"],
+            "skrl_amp_cfg_entry_point",
+        ),
+    ],
+)
+def test_setup_preset_cli_auto_selects_agent(clean_argv, task_name, agent_library, agent_default, argv_tail, expected):
+    """A defaulted ``--agent`` is resolved from the task's registered metadata."""
+    import isaaclab_tasks  # noqa: F401
+    from isaaclab_tasks.utils.preset_cli import setup_preset_cli
+
+    parser = _make_agent_parser(agent_default)
+    args, _ = setup_preset_cli(parser, ["--task", task_name, *argv_tail], agent_library=agent_library)
+    assert args.agent == expected
+
+
+@pytest.mark.parametrize(
+    "argv_tail,expected",
+    [
+        # ``box_box`` is declared by both the canonical default and the explicit
+        # box_box entry point, so no single entry point is implied.
+        (["presets=box_box"], None),
+        # Two presets that no single entry point covers.
+        (["presets=box_discrete,dict_box"], None),
+        # A preset the task does not declare as an agent constraint.
+        (["presets=newton_mjwarp"], None),
+        # An explicit --agent is never overridden.
+        (["presets=box_discrete", "--agent", "skrl_dict_box_cfg_entry_point"], "skrl_dict_box_cfg_entry_point"),
+    ],
+)
+def test_setup_preset_cli_leaves_agent_alone_when_not_implied(clean_argv, argv_tail, expected):
+    """Ambiguous, unconstraining, and user-supplied cases all defer to the caller."""
+    import isaaclab_tasks  # noqa: F401
+    from isaaclab_tasks.utils.preset_cli import setup_preset_cli
+
+    parser = _make_agent_parser(None)
+    argv = ["--task", "IsaacContrib-Cartpole-Showcase-Direct", *argv_tail]
+    args, _ = setup_preset_cli(parser, argv, agent_library="skrl")
+    assert args.agent == expected
+
+
+def test_setup_preset_cli_auto_select_ignores_unregistered_task(clean_argv):
+    """A bad ``--task`` stays silent here so the caller's own lookup reports it."""
+    import isaaclab_tasks  # noqa: F401
+    from isaaclab_tasks.utils.preset_cli import setup_preset_cli
+
+    parser = _make_agent_parser(None)
+    args, _ = setup_preset_cli(parser, ["--task", "Isaac-Not-A-Task"], agent_library="skrl")
+    assert args.agent is None


### PR DESCRIPTION
## Description

Supersedes #7045. Same two bugs, same diagnosis — credit to @AntoineRichard for
root-causing both from the skrl benchmark sweep — but the fix in that PR leaves
half of the second bug live, misreports the algorithm in benchmark output, and
cannot reach three of the four RL libraries. This PR reimplements it on current
`develop`.

Tasks already declare which agent configs they register, and which presets each
config is valid for (`agent_preset_compatibility`). `setup_preset_cli` never read
that metadata, so `--agent` fell back to `<library>_cfg_entry_point`
unconditionally:

- **Non-box action/observation spaces.** `presets=box_discrete` on
  `IsaacContrib-Cartpole-Showcase-Direct` configured a `Discrete(3)` action space
  but loaded the `GaussianMixin` default, so the policy emitted a
  `(num_envs, 3)` continuous tensor where the env expected `(num_envs,)` →
  shape mismatch in `_apply_action`.
- **AMP-only tasks.** `IsaacContrib-Humanoid-AMP-{Dance,Run,Walk}-Direct`
  register `skrl_amp_cfg_entry_point` and no PPO default, so the default
  `--algorithm PPO` resolved a key that does not exist.

## What this does differently from #7045

**1. The default-absent rule now runs even when a preset is active.** #7045
`return`s out of the preset branch unconditionally, so the rule that fixes the
AMP tasks is skipped whenever any `presets=` token is present. The benchmark
dispatcher broadcasts the physics backend through exactly that token
(`dispatch.py:174` → `presets=newton_mjwarp`), so under #7045 the AMP crash
survives in the sweep configuration that motivated the PR. Verified: the new
regression case fails on #7045's implementation and passes here.

**2. The reported algorithm no longer comes from a space name.** skrl recovers
the algorithm by splitting the entry point key
(`agent.split("_cfg")[0].split("skrl_")[-1]`), which only holds for keys that
name an algorithm. Showcase keys name an observation/action space, so an
auto-selected `skrl_box_discrete_cfg_entry_point` decodes to the "algorithm"
`box_discrete`. Under #7045 that reaches the benchmark KPI payload
(`{"name": "algorithm", "data": "BOX_DISCRETE"}`), the run manifest, and the log
directory name, and flips `convert_marl_to_single_agent` off. 14 of the 15
showcase presets are affected — `box_box` escapes only because it ties between
two entry points and selects neither.

Decoding now accepts only `amp`, `ppo`, `ippo`, `mappo`; anything else keeps
`--algorithm`. This also fixes the pre-existing case where an explicitly passed
`--agent skrl_cfg_entry_point` was decoded as the algorithm `skrl`.

**3. Selection reaches every library, not just skrl.** #7045 guards on
`args.agent is None`, but only skrl defaults `--agent` to `None`; `rsl_rl`,
`rl_games`, and `sb3` default it to `<library>_cfg_entry_point`. So auto-select
was structurally unreachable for them, and `Isaac-Cartpole-Camera`'s
`agent_preset_compatibility` — declared *only* for `rl_games_*` and `rsl_rl_*` —
stayed dead metadata. The guard is now "unchanged from the parser default, and
`--agent` not present in argv".

Also folded in: the `presets=` scan moved into the existing `_ArgvHelper`
single-pass scan rather than a second ad-hoc parse; `except Exception` narrowed
to `gym.error.Error`, matching the convention `_enumerate_variants` documents in
the same module; the four copies of skrl's agent/algorithm resolution replaced
by `resolve_skrl_agent_entry_point`; `benchmark_play_skrl` KPI metadata switched
from the raw `--algorithm` flag to the resolved value, matching
`benchmark_train_skrl`.

## Blast radius

Enumerated over all 201 registered tasks — auto-selection changes `--agent` for
exactly these:

| task | library | selected |
|---|---|---|
| `IsaacContrib-Humanoid-AMP-{Dance,Run,Walk}-Direct` | skrl | `skrl_amp_cfg_entry_point` |
| `Isaac-Cartpole-Camera` (`presets=resnet18` / `theia_tiny`) | rsl_rl | `rsl_rl_feature_cfg_entry_point` |
| `Isaac-Cartpole-Camera` (`presets=resnet18` / `theia_tiny`) | rl_games | `rl_games_feature_cfg_entry_point` |
| `IsaacContrib-Cartpole-{Showcase,Camera-Showcase}-Direct` | skrl | per-preset space config |

Nothing else. An explicit `--agent` is never overridden, and ambiguous metadata
falls through to the caller's existing default, so no working command line
changes meaning.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `uv run --extra test --extra skrl --extra sb3 --extra rl-games --extra rsl-rl python -m pytest source/isaaclab_tasks/test/core/test_preset_cli.py source/isaaclab_rl/test/test_entrypoints_common.py source/isaaclab_rl/test/test_typed_preset_cli_train_play.py source/isaaclab/test/cli/test_benchmark_entrypoint.py` — 84 passed
- [x] `source/isaaclab_rl/test` — 145 passed; the 5 failures and 14 errors are
      `AppLauncher requires the full Isaac Sim runtime` in `test/export`, present
      on `develop` too
- [x] The three new regression cases fail against #7045's implementation
      (rsl_rl reachability, rl_games reachability, AMP under `presets=`) and
      pass here
- [x] End-to-end check over all 15 showcase presets: each selects its matching
      entry point and reports `algorithm=ppo`
- [x] `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
