### PR TITLE
[FIX] Defer asset imports until Kit startup

### DIFF
--- a/docs/source/overview/core-concepts/physical-backends/newton/using-cables.rst
+++ b/docs/source/overview/core-concepts/physical-backends/newton/using-cables.rst
@@ -30,7 +30,7 @@ in your environment:
 .. code-block:: bash
 
     # Default Newton VBD physics with the Kit visualizer.
-    uv run python scripts/demos/cables.py
+    uv run --extra isaacsim python scripts/demos/cables.py
 
     # Explicit Newton VBD physics with the Newton visualizer.
     uv run python scripts/demos/cables.py --physics newton_vbd --visualizer newton

--- a/docs/source/overview/showroom.rst
+++ b/docs/source/overview/showroom.rst
@@ -113,7 +113,7 @@ A few quick showroom scripts to run and checkout:
 
                .. code:: bash
 
-                  uv run python scripts/demos/cables.py
+                  uv run --extra isaacsim python scripts/demos/cables.py
 
             .. tab-item:: isaaclab.sh / isaaclab.bat
 

--- a/docs/source/tutorials/01_assets/run_deformable_object.rst
+++ b/docs/source/tutorials/01_assets/run_deformable_object.rst
@@ -49,7 +49,7 @@ The tutorial corresponds to the ``run_deformable_object.py`` script in the ``scr
 
    .. literalinclude:: ../../../../scripts/tutorials/01_assets/run_deformable_object.py
       :language: python
-      :emphasize-lines: 65-102, 123-128, 130-139, 144-152, 154-162
+      :emphasize-lines: 71-117, 146-151, 153-162, 167-175, 177-178, 184-189
       :linenos:
 
 

--- a/docs/source/tutorials/01_assets/run_deformable_object.rst
+++ b/docs/source/tutorials/01_assets/run_deformable_object.rst
@@ -25,12 +25,12 @@ commands to the mesh nodes to move the soft body.
 
 .. note::
 
-   This tutorial automatically tetrahedralizes volume deformables. Run it with the
-   ``tetrahedralization`` extra:
+   This tutorial automatically tetrahedralizes volume deformables, and its default
+   visualizer is Kit. Run it with the ``isaacsim`` and ``tetrahedralization`` extras:
 
    .. code-block:: bash
 
-      uv run --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py --visualizer kit
+      uv run --extra isaacsim --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py --visualizer kit
 
    With the legacy installer, install the optional dependencies first:
 
@@ -184,7 +184,7 @@ Now that we have gone through the code, let's run the script and see the result:
 
       .. code-block:: bash
 
-         uv run python scripts/tutorials/01_assets/run_deformable_object.py --visualizer kit
+         uv run --extra isaacsim --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py --visualizer kit
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
@@ -200,7 +200,7 @@ To run the same tutorial with the experimental Newton deformable backend:
 
       .. code-block:: bash
 
-         uv run python scripts/tutorials/01_assets/run_deformable_object.py --backend newton_vbd --visualizer kit
+         uv run --extra isaacsim --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py --backend newton_vbd --visualizer kit
 
 
    .. tab-item:: isaaclab.sh / isaaclab.bat

--- a/scripts/demos/cables.py
+++ b/scripts/demos/cables.py
@@ -8,7 +8,7 @@
 .. code-block:: bash
 
     # Usage with default Newton VBD physics and Kit visualizer.
-    uv run python scripts/demos/cables.py
+    uv run --extra isaacsim python scripts/demos/cables.py
 
     # Usage with explicit Newton VBD physics and Newton visualizer.
     uv run python scripts/demos/cables.py --physics newton_vbd --visualizer newton
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import math
 import random
+from typing import TYPE_CHECKING
 
 from isaaclab.app import add_launcher_args, launch_simulation
 
@@ -41,8 +42,10 @@ if args_cli.num_segments < 2:
     parser.error("--num_segments must be at least 2.")
 
 import isaaclab.sim as sim_utils
-from isaaclab.assets import CableObject, CableObjectCfg
 from isaaclab.physics import PhysicsCfg
+
+if TYPE_CHECKING:
+    from isaaclab.assets import CableObject
 
 
 def design_scene(num_cables: int, num_segments: int, colorize: bool) -> dict[str, CableObject]:
@@ -53,6 +56,8 @@ def design_scene(num_cables: int, num_segments: int, colorize: bool) -> dict[str
         num_segments: Number of segments per cable.
         colorize: Whether to give each cable a random visual material.
     """
+    from isaaclab.assets import CableObject, CableObjectCfg
+
     ground_cfg = sim_utils.GroundPlaneCfg()
     ground_cfg.func("/World/defaultGroundPlane", ground_cfg)
     light_cfg = sim_utils.DomeLightCfg(intensity=3000.0, color=(0.75, 0.75, 0.75))

--- a/scripts/tutorials/01_assets/run_deformable_object.py
+++ b/scripts/tutorials/01_assets/run_deformable_object.py
@@ -22,6 +22,7 @@ This script demonstrates how to work with the deformable object and interact wit
 """Parse CLI first so we can decide whether to launch Isaac Sim Kit."""
 
 import argparse
+from typing import TYPE_CHECKING
 
 from isaaclab.app import add_launcher_args, launch_simulation
 
@@ -45,12 +46,16 @@ import torch
 
 import isaaclab.sim as sim_utils
 import isaaclab.utils.math as math_utils
-from isaaclab.assets import DeformableObject, DeformableObjectCfg
 from isaaclab.physics import PhysicsCfg
+
+if TYPE_CHECKING:
+    from isaaclab.assets import DeformableObject
 
 
 def design_scene():
     """Designs the scene."""
+    from isaaclab.assets import DeformableObject, DeformableObjectCfg
+
     # Ground-plane
     cfg = sim_utils.GroundPlaneCfg()
     cfg.func("/World/defaultGroundPlane", cfg)

--- a/scripts/tutorials/01_assets/run_deformable_object.py
+++ b/scripts/tutorials/01_assets/run_deformable_object.py
@@ -9,13 +9,15 @@ This script demonstrates how to work with the deformable object and interact wit
 .. code-block:: bash
 
     # Usage with default PhysX physics and default kit visualizer.
-    uv run python scripts/tutorials/01_assets/run_deformable_object.py
+    uv run --extra isaacsim --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py
 
     # Usage with Newton VBD physics and default kit visualizer.
-    uv run python scripts/tutorials/01_assets/run_deformable_object.py --backend newton_vbd
+    uv run --extra isaacsim --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py \
+        --backend newton_vbd
 
     # Usage with OvPhysX physics without a visualizer.
-    uv run python scripts/tutorials/01_assets/run_deformable_object.py --backend ovphysx
+    uv run --extra ovphysx --extra tetrahedralization python scripts/tutorials/01_assets/run_deformable_object.py \
+        --backend ovphysx
 
 """
 


### PR DESCRIPTION
# Description

Defer the cable and deformable runtime asset imports until after `launch_simulation()` starts Kit. This prevents the standalone USD runtime from loading before Kit initializes its bundled USD runtime. The type annotations are kept via `TYPE_CHECKING` imports, matching the existing pattern in `scripts/demos/multi_asset.py` and `scripts/demos/procedural_terrain.py`.

Correct the documented commands for both demos so they install the extras their default configuration actually needs. The cable demo defaults to the Kit visualizer, so it needs `--extra isaacsim`. The deformable tutorial defaults to Kit and always tetrahedralizes its volume deformables, so it needs `--extra isaacsim --extra tetrahedralization`; its OvPhysX example stays Kitless but needs `--extra ovphysx --extra tetrahedralization`. The cable examples that pass `--visualizer newton` or `--visualizer none` are intentionally left Kitless.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Screenshots

Not applicable.

## Validation

- `uv run --frozen isaaclab -f`
- Cable demo completed two steps with the Kit visualizer.
- Deformable-object tutorial started Kit and simulated with each of the three backends, using the documented commands.
- Confirmed each documented extra is genuinely required: with the tetrahedralization dependencies unavailable, all three backends fail in `define_deformable_body_properties`.
- Documentation build completed successfully.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] No source-package changelog fragment is required
- [x] My name already exists in `CONTRIBUTORS.md`
