### PR TITLE
[Fix] Resolve package:// meshes when merging fixed joints in URDF conversion

### DIFF
--- a/docker/Dockerfile.kitless
+++ b/docker/Dockerfile.kitless
@@ -46,13 +46,12 @@ COPY source/ source/
 COPY isaaclab.sh ./
 
 # Same entry point as Dockerfile.base. The selectors are explicit because a bare
-# --install excludes `ov` and `visualizer`; both take `[all]` here. `importers` carries
-# the standalone URDF/MJCF importers that replace the Isaac Sim ones. The venv pins
+# --install excludes `ov` and `visualizer`; both take `[all]` here. The venv pins
 # python3.12 to match the runtime stage's libpython3.12, and isaaclab.sh resolves
 # VIRTUAL_ENV first.
 RUN uv venv --python /usr/bin/python3.12 --seed --no-managed-python "${VIRTUAL_ENV}" \
  && chmod +x "${ISAACLAB_PATH}/isaaclab.sh" \
- && "${ISAACLAB_PATH}/isaaclab.sh" --install newton,rl[all],ov[all],visualizer[all],importers \
+ && "${ISAACLAB_PATH}/isaaclab.sh" --install newton,rl[all],ov[all],visualizer[all] \
  && python -c "import importlib.metadata as m; \
       names = {d.metadata['Name'].lower() for d in m.distributions()}; \
       assert 'isaacsim' not in names; \

--- a/source/isaaclab/changelog.d/jichuanh-urdf-ros-package-root.rst
+++ b/source/isaaclab/changelog.d/jichuanh-urdf-ros-package-root.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed URDF conversion producing an asset with no geometry when the URDF referenced its meshes
+  through ``package://`` URLs and fixed joints were merged. The ROS package is now derived from the
+  URDF's own location, so ``UrdfConverterCfg.ros_package_paths`` only has to be set for packages
+  laid out unconventionally.

--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
@@ -9,6 +9,7 @@ import logging
 import os
 import pathlib
 import warnings
+import xml.etree.ElementTree as ElementTree
 
 from isaaclab.utils.version import has_kit
 
@@ -16,6 +17,31 @@ from .asset_converter_base import AssetConverterBase
 from .urdf_converter_cfg import UrdfConverterCfg
 
 logger = logging.getLogger(__name__)
+
+
+def _find_ros_package(urdf_path: str) -> dict[str, str] | None:
+    """Find the ROS package a URDF belongs to, as a name/path mapping.
+
+    A ROS package is rooted at the directory holding its ``package.xml``, and ``package://<name>/``
+    URIs inside the URDF address that directory.
+
+    Args:
+        urdf_path: Path of the URDF file.
+
+    Returns:
+        The ``{"name": ..., "path": ...}`` mapping, or None when the URDF is not inside a package.
+    """
+    for directory in pathlib.Path(urdf_path).resolve().parents:
+        manifest = directory / "package.xml"
+        if not manifest.is_file():
+            continue
+        try:
+            name = ElementTree.parse(manifest).getroot().findtext("name")
+        except ElementTree.ParseError:
+            logger.warning(f"UrdfConverter: could not parse '{manifest}' to resolve 'package://' URLs.")
+            return None
+        return {"name": name.strip(), "path": str(directory)} if name and name.strip() else None
+    return None
 
 
 class UrdfConverter(AssetConverterBase):
@@ -92,6 +118,12 @@ class UrdfConverter(AssetConverterBase):
 
         # translate nested `JointDriveCfg` into flat importer fields
         drive_type, target_type, stiffness, damping = self._unpack_joint_drive(cfg.joint_drive)
+        # Merging fixed joints rewrites the URDF into a scratch directory, and the importer then
+        # resolves ``package://`` against that copy, where no meshes exist. Naming the source
+        # package keeps the URLs anchored to it.
+        ros_package_paths = list(cfg.ros_package_paths)
+        if not ros_package_paths and (package := _find_ros_package(cfg.asset_path)):
+            ros_package_paths = [package]
 
         import_config = URDFImporterConfig(
             urdf_path=os.path.normpath(cfg.asset_path),
@@ -101,7 +133,7 @@ class UrdfConverter(AssetConverterBase):
             collision_from_visuals=cfg.collision_from_visuals,
             collision_type=cfg.collision_type,
             allow_self_collision=cfg.self_collision,
-            ros_package_paths=list(cfg.ros_package_paths),
+            ros_package_paths=ros_package_paths,
             robot_type=cfg.robot_type,
             fix_base=cfg.fix_base,
             link_density=cfg.link_density if cfg.link_density > 0.0 else None,

--- a/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/urdf_converter.py
@@ -37,8 +37,8 @@ def _find_ros_package(urdf_path: str) -> dict[str, str] | None:
             continue
         try:
             name = ElementTree.parse(manifest).getroot().findtext("name")
-        except ElementTree.ParseError:
-            logger.warning(f"UrdfConverter: could not parse '{manifest}' to resolve 'package://' URLs.")
+        except (ElementTree.ParseError, OSError):
+            logger.warning(f"UrdfConverter: could not read '{manifest}' to resolve 'package://' URLs.")
             return None
         return {"name": name.strip(), "path": str(directory)} if name and name.strip() else None
     return None

--- a/source/isaaclab/test/sim/test_urdf_converter.py
+++ b/source/isaaclab/test/sim/test_urdf_converter.py
@@ -844,3 +844,52 @@ def test_ros_package_derived_from_urdf_location(tmp_path):
     loose = tmp_path / "loose.urdf"
     loose.write_text("<robot name='robot'/>")
     assert _find_ros_package(str(loose)) is None
+
+
+@pytest.mark.isaacsim_ci
+def test_package_url_meshes_survive_fixed_joint_merge(sim_config, tmp_path):
+    """A ``package://`` mesh survives fixed-joint merging without an explicit package mapping.
+
+    Merging rewrites the URDF into a scratch directory, so an unanchored ``package://`` URL
+    resolves against a copy holding no meshes and every mesh silently drops out.
+    """
+    _, config = sim_config
+
+    package = tmp_path / "test_mesh_description"
+    (package / "meshes").mkdir(parents=True)
+    (package / "package.xml").write_text("<package><name>test_mesh_description</name></package>")
+    (package / "meshes" / "tetra.obj").write_text(
+        "v 0 0 0\nv 0.1 0 0\nv 0 0.1 0\nv 0 0 0.1\nf 1 3 2\nf 1 2 4\nf 1 4 3\nf 2 3 4\n"
+    )
+    # the mesh is the only geometry, so any Mesh prim in the output proves the URL resolved
+    urdf = package / "robot.urdf"
+    urdf.write_text(
+        "<robot name='test_package_url'>"
+        "<link name='root_link'/>"
+        "<joint name='root_to_base' type='fixed'>"
+        "<parent link='root_link'/><child link='base_link'/></joint>"
+        "<link name='base_link'><visual><geometry>"
+        "<mesh filename='package://test_mesh_description/meshes/tetra.obj'/>"
+        "</geometry></visual><inertial><mass value='1'/>"
+        "<inertia ixx='1.0' ixy='0.0' ixz='0.0' iyy='1.0' iyz='0.0' izz='1.0'/></inertial></link>"
+        "<joint name='base_to_link1' type='continuous'>"
+        "<parent link='base_link'/><child link='link_1'/>"
+        "<axis xyz='0 0 1'/><origin xyz='0 0 0.2'/></joint>"
+        "<link name='link_1'><inertial><mass value='1'/>"
+        "<inertia ixx='1.0' ixy='0.0' ixz='0.0' iyy='1.0' iyz='0.0' izz='1.0'/></inertial></link>"
+        "</robot>"
+    )
+
+    output_dir = os.path.join(str(tmp_path), "urdf_package_url")
+    os.makedirs(output_dir, exist_ok=True)
+    config.asset_path = str(urdf)
+    config.merge_fixed_joints = True
+    config.force_usd_conversion = True
+    config.usd_dir = output_dir
+
+    from pxr import Usd, UsdGeom
+
+    stage = Usd.Stage.Open(UrdfConverter(config).usd_path)
+    # the geometry is behind an instanceable reference, which a plain Traverse() does not descend into
+    meshes = [p for p in Usd.PrimRange.Stage(stage, Usd.TraverseInstanceProxies()) if p.IsA(UsdGeom.Mesh)]
+    assert len(meshes) > 0, "the 'package://' visual mesh was dropped by the merged conversion"

--- a/source/isaaclab/test/sim/test_urdf_converter.py
+++ b/source/isaaclab/test/sim/test_urdf_converter.py
@@ -823,3 +823,24 @@ def test_physics_variant_raises_again_on_retry(tmp_path):
     for _ in range(2):
         with pytest.raises(ValueError, match="no 'physx' physics variant"):
             UrdfConverter(config)
+
+
+def test_ros_package_derived_from_urdf_location(tmp_path):
+    """The ROS package holding a URDF is derived from its path, so ``package://`` URLs resolve.
+
+    Merging fixed joints relocates the URDF to a scratch directory, and the importer resolves
+    ``package://`` against that copy, so the mapping has to name the source package.
+    """
+    from isaaclab.sim.converters.urdf_converter import _find_ros_package
+
+    package = tmp_path / "my_robot_description"
+    (package / "urdf").mkdir(parents=True)
+    (package / "package.xml").write_text("<package><name>my_robot_description</name></package>")
+    urdf = package / "urdf" / "robot.urdf"
+    urdf.write_text("<robot name='robot'/>")
+
+    assert _find_ros_package(str(urdf)) == {"name": "my_robot_description", "path": str(package)}
+    # a URDF outside any package has no mapping to derive
+    loose = tmp_path / "loose.urdf"
+    loose.write_text("<robot name='robot'/>")
+    assert _find_ros_package(str(loose)) is None


### PR DESCRIPTION
# Description

Two independent changes to URDF conversion and the kit-less image.

## 1. `package://` meshes are dropped when fixed joints are merged

Merging fixed joints rewrites the URDF into a scratch directory
(`/tmp/urdf_import_<robot>_*/`), and the importer resolves `package://<pkg>/...`
relative to that copy. No meshes live there, so every visual and collision mesh
resolves to a missing file. Conversion still succeeds: the resulting asset has the
full joint and rigid-body hierarchy but no geometry at all, and nothing renders.

This affects any ROS-style description converted with the default
`UrdfConverterCfg(merge_fixed_joints=True)`, unless the user already knew to set
`ros_package_paths` by hand.

`UrdfConverter` now derives the mapping from the URDF's own location: it walks up to
the nearest `package.xml`, reads its `<name>`, and passes the resulting
`{"name", "path"}` entry to the importer. An explicitly configured
`ros_package_paths` still takes precedence, so unconventional layouts are unaffected.

Measured on `anymal_d_simple_description`, `merge_fixed_joints=True`, no explicit
`ros_package_paths`:

| | `payloads/geometries.usd` |
| --- | --- |
| before | 0 B |
| after | 376,081 B |

Tracked against the Isaac Sim URDF importer as nvbug 6583703; this works around it
from the Isaac Lab side.

## 2. Kit-less image passes an install token that no longer exists

`docker/Dockerfile.kitless` still passes `importers` to `isaaclab.sh --install`. That
extra was removed in #6935, when the standalone URDF/MJCF importers became base
dependencies. An unknown token is warned about and skipped (`install.py:1195`), so the
image is correct today — this only drops the dead token and its stale comment, so
kit-less builds stop logging `Unknown install token 'importers'`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
