### PR TITLE
[CI] Run the isaaclab_ppisp tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -573,6 +573,27 @@ jobs:
         filter-pattern: "isaaclab_experimental"
         container-name: isaac-lab-experimental-test
 
+  test-isaaclab-ppisp:
+    name: isaaclab_ppisp
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 180
+    needs: [build, config]
+    if: >-
+      github.event_name != 'push' &&
+      needs.build.result == 'success'
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        lfs: true
+    - uses: ./.github/actions/run-package-tests
+      with:
+        image-tag: ${{ needs.config.outputs.ci_image_tag }}
+        isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
+        isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
+        filter-pattern: "isaaclab_ppisp"
+        container-name: isaac-lab-ppisp-test
+
   test-isaaclab-newton:
     name: isaaclab_newton
     runs-on: [self-hosted, gpu]


### PR DESCRIPTION
`source/isaaclab_ppisp/` had no CI job. All four of its test files were collected by nothing and had never run.

Every job either names a package with a positive `filter-pattern`, or — for the core jobs — passes `not isaaclab_`, which `run_tests.sh` converts into an *exclude* on `isaaclab_`. A package matching neither form runs nowhere, silently: no job errors, no "0 tests collected" warning, because other jobs still collect plenty.

- Replaying the filter logic over the tree, test files matched by no job goes **4 → 0**. Every file under `source/` is now claimed by a job.
- The suite is green as it stands: **26 passed, 1 skipped, 4.6 s**.

Same gap and same fix as `isaaclab_experimental` in #6900; this was called out there as out of scope.

Test plan:

- [x] `pytest source/isaaclab_ppisp/test/` — 26 passed, 1 skipped
- [x] Filter-logic replay — uncollected test files 4 → 0
- [x] `uv run isaaclab -f` clean
