### PR TITLE
Use clone-plan positions for OVRTX roots

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-clone-plan-position.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-clone-plan-position.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX environment placement by authoring root translations from the clone plan after
+  cloning instead of capturing transforms from the USD stage.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -24,7 +24,6 @@ import logging
 import math
 import os
 import re
-from itertools import compress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
@@ -251,49 +250,6 @@ def _write_file(output_dir: Path, file_name: str, content: str) -> None:
         logger.info("Wrote USD file: %s", output_path)
 
 
-def _create_homogeneous_clone_plan(num_envs: int) -> ClonePlan:
-    """Create a homogeneous fallback plan that replicates ``env_0`` to every environment."""
-    return ClonePlan(
-        sources=("/World/envs/env_0",),
-        destinations=("/World/envs/env_{}",),
-        clone_mask=torch.ones((1, num_envs), dtype=torch.bool, device="cpu"),
-    )
-
-
-def _resolve_clone_plan(num_envs: int) -> ClonePlan:
-    """Resolve clone plan for local use.
-
-    If no clone plan is published by the scene or it has no active rows, returns a homogeneous clone plan.
-    If the clone plan has some inactive rows, returns a copy of the published clone plan with only the active rows.
-    If the clone plan has all active rows, returns the published clone plan (shallow copy).
-    """
-    published_clone_plan = SimulationContext.instance().get_clone_plan()
-
-    if published_clone_plan is None:
-        logger.warning("No clone plan is published by the scene; returning homogeneous clone plan")
-        return _create_homogeneous_clone_plan(num_envs)
-
-    active_rows = published_clone_plan.clone_mask.any(dim=1)
-
-    # If no rows are active, return a homogeneous clone plan.
-    if not active_rows.any():
-        logger.warning("Clone plan has no active rows, returning homogeneous clone plan")
-        return _create_homogeneous_clone_plan(num_envs)
-
-    # If some rows are inactive, return a copy of the published clone plan with only the active rows.
-    if not active_rows.all():
-        logger.warning("Clone plan has some inactive rows; returning a copy with only active rows")
-        active = active_rows.tolist()
-        return ClonePlan(
-            sources=tuple(compress(published_clone_plan.sources, active)),
-            destinations=tuple(compress(published_clone_plan.destinations, active)),
-            clone_mask=published_clone_plan.clone_mask[active_rows],
-        )
-
-    # If all rows are active, return the published clone plan (shallow copy).
-    return published_clone_plan
-
-
 class OVRTXRenderData:
     """OVRTX-specific RenderData. Holds warp output buffers sized from :class:`CameraRenderSpec`."""
 
@@ -435,6 +391,10 @@ class OVRTXRenderer(BaseRenderer):
         if stage is None:
             return
 
+        self._clone_plan = SimulationContext.instance().get_clone_plan()
+        if self._clone_plan is None or self._clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when preparing OVRTX stage")
+
         # If temp_usd_dir is set, write the pre-ovrtx stage to a temporary file.
         if self.cfg.temp_usd_dir is not None:
             _write_file(Path(self.cfg.temp_usd_dir), "pre_ovrtx_renderer_stage.usda", stage.ExportToString())
@@ -442,20 +402,9 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("Preparing stage (%d envs)...", num_envs)
         create_scene_partition_attributes(stage, num_envs)
 
-        # Resolve the clone plan for local use.
-        self._clone_plan = _resolve_clone_plan(num_envs)
-        if self._clone_plan is None:
-            raise RuntimeError("Clone plan is required when preparing OVRTX stage")
-
-        # The ovstage path cannot read env-root transforms back after load (see
-        # _clone_sources_ovstage), so snapshot them here while the full USD stage is still live.
-        if self._use_ovstage:
-            self._capture_env_root_xforms_ovstage(stage, num_envs)
-
         # keep_env_roots is False on the ovstage path: ovstage's ``Stage.clone`` requires each target
         # path to not already exist, so the non-source env roots must be trimmed from the exported
-        # stage for it to recreate them. Their xforms were captured just above, since trimming them
-        # is what makes them unreadable afterwards.
+        # stage for it to recreate them.
         self._exported_usd_string = export_stage_to_string(
             stage,
             num_envs,
@@ -563,35 +512,11 @@ class OVRTXRenderer(BaseRenderer):
     def _clone_sources_in_ovrtx(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan`."""
         clone_plan = self._clone_plan
-        if clone_plan is None:
-            raise RuntimeError("Clone plan is required when using OVRTX cloning")
+        if clone_plan is None or clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        xform_attr_name = "omni:xform"
-
-        # Snapshot per-env root transforms before clone_usd overwrites them with the source env root.
-        #
-        # We only create xform bindings for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no binding, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovrtx data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        self._renderer.read_attribute(
-            xform_attr_name,
-            env_prim_paths,
-            prim_mode=PrimMode.MUST_EXIST,
-            dest=env_root_xforms,
-        )
-        logger.info("Captured per-env root transforms before cloning")
-
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
 
@@ -618,15 +543,15 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
         self._renderer.write_attribute(
             prim_paths=env_prim_paths,
-            attribute_name=xform_attr_name,
+            attribute_name="omni:xform",
             tensor=env_root_xforms,
             semantic=Semantic.XFORM_MAT4x4,
             prim_mode=PrimMode.MUST_EXIST,
         )
-        logger.info("Restored per-env root transforms after cloning")
 
     def _update_scene_partitions_after_clone(self, num_envs: int):
         """Update scene partition attributes on cloned environments and cameras in OvRTX."""
@@ -1567,7 +1492,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_paths_list = None
         self._particle_points_query = None
         self._particle_paths_list = None
-        self._env_root_xforms: np.ndarray | None = None
 
     def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec) -> None:
         """Initialize the OVRTX renderer with internal environment cloning (ovstage path).
@@ -1678,54 +1602,14 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("OVRTX loaded USD from string successfully via ovstage")
         self._current_ordinal += 1
 
-    def _capture_env_root_xforms_ovstage(self, stage: Any, num_envs: int) -> None:
-        """Capture per-env root transforms from the live USD stage before export.
-
-        Must be called before :func:`export_stage_to_string`, which trims non-source
-        env geometry so those transforms cannot be read back reliably from ovstage after load.
-        The captured array is consumed by :meth:`_clone_sources_ovstage` and cleared after use.
-        """
-        from pxr import UsdGeom
-
-        xform_cache = UsdGeom.XformCache()
-        self._env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        for i in range(num_envs):
-            prim = stage.GetPrimAtPath(f"/World/envs/env_{i}")
-            self._env_root_xforms[i] = np.array(xform_cache.GetLocalToWorldTransform(prim), dtype=np.float64).reshape(
-                4, 4
-            )
-
     def _clone_sources_ovstage(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan` (ovstage path)."""
         clone_plan = self._clone_plan
-        if clone_plan is None:
-            raise RuntimeError("Clone plan is required when using OVRTX cloning")
+        if clone_plan is None or clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-
-        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
-        env_query = self._stage.query_from_path_list(env_paths_list)
-
-        # Snapshot per-env root transforms before clone overwrites them with the source env root.
-        #
-        # We only create xform queries for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no query, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovstage data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        # Transforms were captured from the live USD stage in prepare_stage before export
-        # stripped non-source envs — they are not readable from ovstage at this point.
-        env_root_xforms = self._env_root_xforms
-        if env_root_xforms is None:
-            raise RuntimeError("env_root_xforms not captured; ensure prepare_stage was called first")
-        logger.info("Using pre-captured per-env root transforms for post-clone restore")
 
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
@@ -1752,7 +1636,10 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
+        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
+        env_query = self._stage.query_from_path_list(env_paths_list)
         self._stage.write_attribute(
             env_query,
             "omni:xform",
@@ -1761,8 +1648,6 @@ class OVRTXRenderer(BaseRenderer):
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
-        self._env_root_xforms = None
-        logger.info("Restored per-env root transforms after cloning")
 
         self._stage.release_query(env_query).wait()
         self._stage_paths.destroy_path_list(env_paths_list)
@@ -2220,7 +2105,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_particle_counts = []
         self._particle_visual_offsets = []
         self._particle_visual_counts = []
-        self._env_root_xforms = None
 
         # Detach before closing ExitStack: the renderer holds a live reference into the stage,
         # so detaching first avoids a use-after-free when ExitStack destroys Stage and PathDictionary.

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Unit tests for OVRTX clone-plan resolution and OVRTX-side cloning."""
+"""Unit tests for OVRTX clone-plan consumption and OVRTX-side cloning."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -32,12 +33,7 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
-    from isaaclab_ov.renderers.ovrtx_renderer import (  # noqa: E402
-        OVRTXRenderer,
-        _create_homogeneous_clone_plan,
-        _resolve_clone_plan,
-        _write_file,
-    )
+    from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer, _write_file  # noqa: E402
 
     from pxr import Usd, UsdGeom  # noqa: E402
 else:
@@ -45,8 +41,6 @@ else:
     OVRTXRendererCfg = None
     Usd = None
     UsdGeom = None
-    _create_homogeneous_clone_plan = None
-    _resolve_clone_plan = None
     _write_file = None
 
 
@@ -100,7 +94,6 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     renderer.cfg = OVRTXRendererCfg()
     renderer._renderer = SimpleNamespace(
         clone_usd=lambda *args, **kwargs: None,
-        read_attribute=lambda *args, **kwargs: None,
         write_array_attribute=lambda *args, **kwargs: None,
         write_attribute=lambda *args, **kwargs: None,
     )
@@ -138,117 +131,21 @@ def _make_camera_render_spec(num_envs: int = 1) -> CameraRenderSpec:
     )
 
 
-def test_resolve_clone_plan_returns_homogeneous_when_unpublished(monkeypatch: pytest.MonkeyPatch):
-    """Missing published plan falls back to env_0 replication."""
-    _patch_simulation_context(monkeypatch, None)
-
-    num_envs = 4
-    resolved = _resolve_clone_plan(num_envs)
-    expected = _create_homogeneous_clone_plan(num_envs)
-
-    assert resolved.sources == expected.sources
-    assert resolved.destinations == expected.destinations
-    assert torch.equal(resolved.clone_mask, expected.clone_mask)
-
-
-def test_resolve_clone_plan_returns_homogeneous_when_no_active_rows(monkeypatch: pytest.MonkeyPatch):
-    """Plan with no active rows falls back to homogeneous replication."""
-    published = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
-        clone_mask=torch.zeros((2, 4), dtype=torch.bool),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    num_envs = 4
-    resolved = _resolve_clone_plan(num_envs)
-    expected = _create_homogeneous_clone_plan(num_envs)
-
-    assert resolved.sources == expected.sources
-    assert resolved.destinations == expected.destinations
-    assert torch.equal(resolved.clone_mask, expected.clone_mask)
-
-
-def test_resolve_clone_plan_filters_inactive_rows(monkeypatch: pytest.MonkeyPatch):
-    """Inactive clone-plan rows are removed before OVRTX uses the plan."""
-    published = ClonePlan(
-        sources=(
-            "/World/envs/env_0/Robot",
-            "/World/envs/env_1/Object",
-            "/World/envs/env_0/table",
-        ),
-        destinations=(
-            "/World/envs/env_{}/Robot",
-            "/World/envs/env_{}/Object",
-            "/World/envs/env_{}/table",
-        ),
-        clone_mask=torch.tensor(
-            [
-                [True, True, True, True],
-                [False, False, False, False],
-                [True, True, True, True],
-            ],
-            dtype=torch.bool,
-        ),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    resolved = _resolve_clone_plan(4)
-
-    assert resolved.sources == (published.sources[0], published.sources[2])
-    assert resolved.destinations == (published.destinations[0], published.destinations[2])
-    assert torch.equal(resolved.clone_mask, published.clone_mask[[0, 2]])
-
-
-def test_resolve_clone_plan_returns_published_plan_when_all_active(monkeypatch: pytest.MonkeyPatch):
-    """Fully active published plans are reused without copying."""
-    published = ClonePlan(
-        sources=("/World/envs/env_0/Robot",),
-        destinations=("/World/envs/env_{}/Robot",),
-        clone_mask=torch.ones((1, 3), dtype=torch.bool),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    resolved = _resolve_clone_plan(3)
-
-    assert resolved is published
-
-
-def test_clone_sources_in_ovrtx_homogeneous_row():
-    """Homogeneous env_0 row clones only env_1..env_{N-1} (env_0 is the source)."""
-    renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = _create_homogeneous_clone_plan(4)
-
-    clone_calls: list[tuple[str, list[str]]] = []
-
-    def _clone_usd(source: str, target_paths: list[str]) -> None:
-        clone_calls.append((source, target_paths))
-
-    renderer._renderer.clone_usd = _clone_usd
-
-    renderer._clone_sources_in_ovrtx()
-
-    assert clone_calls == [
-        (
-            "/World/envs/env_0",
-            ["/World/envs/env_1", "/World/envs/env_2", "/World/envs/env_3"],
-        )
-    ]
-
-
 def test_clone_sources_in_ovrtx_heterogeneous_rows():
-    """Each active clone-plan row issues its own clone_usd call."""
+    """Each active row clones its targets while an inactive row is skipped."""
     renderer = _make_ovrtx_renderer_without_backend()
     renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
+        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object", "/World/envs/env_0/Light"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object", "/World/envs/env_{}/Light"),
         clone_mask=torch.tensor(
             [
                 [True, True, True, True],
                 [False, False, True, True],
+                [False, False, False, False],
             ],
             dtype=torch.bool,
         ),
+        positions=torch.zeros((4, 3)),
     )
 
     clone_calls: list[tuple[str, list[str]]] = []
@@ -276,37 +173,15 @@ def test_clone_sources_in_ovrtx_heterogeneous_rows():
     ]
 
 
-def test_clone_sources_in_ovrtx_skips_empty_target_rows():
-    """Rows with no clone targets do not call clone_usd."""
-    renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_7/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
-        clone_mask=torch.tensor(
-            [
-                [False, False, False, False],
-                [False, False, False, False],
-            ],
-            dtype=torch.bool,
-        ),
-    )
-
-    clone_calls: list[tuple[str, list[str]]] = []
-
-    def _clone_usd(source: str, target_paths: list[str]) -> None:
-        clone_calls.append((source, target_paths))
-
-    renderer._renderer.clone_usd = _clone_usd
-
-    renderer._clone_sources_in_ovrtx()
-
-    assert clone_calls == []
-
-
 def test_clone_sources_in_ovrtx_raises_on_clone_failure():
     """clone_usd failures surface as RuntimeError with the row index."""
     renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = _create_homogeneous_clone_plan(2)
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        positions=torch.zeros((2, 3)),
+    )
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
         raise OSError("clone failed")
@@ -317,42 +192,103 @@ def test_clone_sources_in_ovrtx_raises_on_clone_failure():
         renderer._clone_sources_in_ovrtx()
 
 
-def test_clone_sources_in_ovrtx_restores_env_root_transforms():
-    """Pre-clone omni:xform snapshots are written back after cloning."""
-    import numpy as np
-
+def test_clone_sources_in_ovrtx_writes_plan_positions_after_cloning():
+    """Legacy OVRTX cloning writes translated identity root transforms from the plan."""
     renderer = _make_ovrtx_renderer_without_backend()
-    num_envs = 4
-    renderer._clone_plan = _create_homogeneous_clone_plan(num_envs)
-    captured_transforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
-    captured_transforms[:, 3, :3] = np.array([[i * 2.0, 0.0, 0.0] for i in range(num_envs)])
-
+    positions = torch.tensor([[0.0, 0.0, 0.0], [2.0, -1.0, 0.5], [-3.0, 4.0, 1.5]])
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        positions=positions,
+    )
     call_order: list[str] = []
-
-    def _read_attribute(attribute_name: str, prim_paths: list[str], **kwargs):
-        call_order.append("read")
-        assert attribute_name == "omni:xform"
-        kwargs["dest"][:] = captured_transforms[: len(prim_paths)]
+    clone_calls: list[tuple[str, list[str]]] = []
+    write_calls: list[dict] = []
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
         call_order.append("clone")
+        clone_calls.append((source, target_paths))
 
-    write_calls: list[dict] = []
+    renderer._renderer.clone_usd = _clone_usd
 
     def _write_attribute(**kwargs):
         call_order.append("write")
         write_calls.append(kwargs)
 
-    renderer._renderer.read_attribute = _read_attribute
-    renderer._renderer.clone_usd = _clone_usd
     renderer._renderer.write_attribute = _write_attribute
 
     renderer._clone_sources_in_ovrtx()
 
-    assert call_order == ["read", "clone", "write"]
+    expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
+    expected[:, 3, :3] = positions.numpy()
+    assert call_order == ["clone", "write"]
+    assert clone_calls == [("/World/envs/env_0", ["/World/envs/env_1", "/World/envs/env_2"])]
     assert len(write_calls) == 1
     assert write_calls[0]["attribute_name"] == "omni:xform"
-    np.testing.assert_array_equal(write_calls[0]["tensor"], captured_transforms)
+    np.testing.assert_array_equal(write_calls[0]["tensor"], expected)
+
+
+@pytest.mark.skipif(importlib.util.find_spec("ovstage") is None, reason="requires optional module: ovstage")
+def test_clone_sources_ovstage_writes_plan_positions_after_cloning(monkeypatch: pytest.MonkeyPatch):
+    """Ovstage skips inactive rows and writes translated identity root transforms from the plan."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    positions = torch.tensor([[0.0, 0.0, 0.0], [1.5, -2.0, 0.25], [3.0, 4.0, 0.5]])
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
+        clone_mask=torch.tensor([[False, False, False], [False, True, True]]),
+        positions=positions,
+    )
+    events: list[tuple[str, str, object]] = []
+    xforms: list[np.ndarray] = []
+    completion = SimpleNamespace(wait=lambda: None)
+
+    def _clone(source: str, target_paths: list[str], **_kwargs):
+        events.append(("clone", source, target_paths))
+
+    def _query(path_list: str) -> str:
+        events.append(("query", "envs", path_list))
+        return "env_query"
+
+    def _write(_query, attribute_name: str, **kwargs):
+        events.append(("write", attribute_name, kwargs["tensors"]))
+        return completion
+
+    def _create_paths(paths: list[str]) -> str:
+        events.append(("paths", "envs", paths))
+        return "env_paths"
+
+    renderer._stage = SimpleNamespace(
+        query_from_path_list=_query,
+        clone=_clone,
+        write_attribute=_write,
+        release_query=lambda _query: completion,
+    )
+    renderer._stage_paths = SimpleNamespace(
+        create_path_list_from_strings=_create_paths,
+        destroy_path_list=lambda _paths: None,
+    )
+    renderer._current_ordinal = 3
+
+    def _record_xforms(value: np.ndarray) -> str:
+        xforms.append(value.copy())
+        return "root_xforms"
+
+    monkeypatch.setattr("isaaclab_ov.renderers.ovrtx_renderer._xform_tensor_from_numpy", _record_xforms)
+
+    renderer._clone_sources_ovstage()
+
+    expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
+    expected[:, 3, :3] = positions.numpy()
+    assert events == [
+        ("clone", "/World/envs/env_1/Object", ["/World/envs/env_2/Object"]),
+        ("paths", "envs", ["/World/envs/env_0", "/World/envs/env_1", "/World/envs/env_2"]),
+        ("query", "envs", "env_paths"),
+        ("write", "omni:xform", "root_xforms"),
+    ]
+    assert len(xforms) == 1
+    np.testing.assert_array_equal(xforms[0], expected)
 
 
 def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):
@@ -366,9 +302,36 @@ def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):
     assert output_path.read_text(encoding="utf-8") == "#usda 1.0\n"
 
 
+@pytest.mark.parametrize(
+    "clone_plan",
+    [
+        None,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        ),
+    ],
+)
+def test_prepare_stage_requires_published_plan_positions(monkeypatch: pytest.MonkeyPatch, clone_plan: ClonePlan | None):
+    """OVRTX stage preparation rejects an absent plan and a plan without positions."""
+    _patch_simulation_context(monkeypatch, clone_plan)
+
+    with pytest.raises(RuntimeError, match="Clone plan with environment positions is required"):
+        _make_ovrtx_renderer_without_backend().prepare_stage(_make_multi_env_stage(2), 2)
+
+
 def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """prepare_stage writes the raw stage before OVRTX-specific preparation."""
-    _patch_simulation_context(monkeypatch, None)
+    _patch_simulation_context(
+        monkeypatch,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            positions=torch.zeros((2, 3)),
+        ),
+    )
 
     stage = _make_multi_env_stage(2)
     renderer = _make_ovrtx_renderer_without_backend()
@@ -386,7 +349,15 @@ def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: 
 
 def test_prepare_stage_skips_temp_usd_write_when_temp_usd_dir_unset(monkeypatch: pytest.MonkeyPatch):
     """prepare_stage does not write debug dumps when temp_usd_dir is None."""
-    _patch_simulation_context(monkeypatch, None)
+    _patch_simulation_context(
+        monkeypatch,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            positions=torch.zeros((2, 3)),
+        ),
+    )
     write_calls: list[tuple[Path, str, str]] = []
 
     def _record_write(output_dir: Path, file_name: str, content: str) -> None:
@@ -461,10 +432,15 @@ def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():
 
 
 def test_prepare_stage_stores_clone_plan_and_exports(monkeypatch: pytest.MonkeyPatch):
-    """prepare_stage resolves the clone plan and exports a trimmed prototype stage."""
+    """prepare_stage stores the published clone plan and exports a trimmed prototype stage."""
     num_envs = 4
 
-    published = _create_homogeneous_clone_plan(num_envs)
+    published = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, num_envs), dtype=torch.bool),
+        positions=torch.zeros((num_envs, 3)),
+    )
     _patch_simulation_context(monkeypatch, published)
 
     stage = _make_multi_env_stage(num_envs)
@@ -472,8 +448,7 @@ def test_prepare_stage_stores_clone_plan_and_exports(monkeypatch: pytest.MonkeyP
 
     renderer.prepare_stage(stage, 4)
 
-    assert renderer._clone_plan is not None
-    assert renderer._clone_plan.sources == published.sources
+    assert renderer._clone_plan is published
 
     # Only the env_0 prototype subtree is exported.
     _assert_export_contains_env_roots_and_children(renderer._exported_usd_string, [0])

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -478,7 +478,6 @@ def _make_ovstage_renderer_with_backend(events: list[str]) -> OVRTXRenderer:
     renderer._deformable_particle_counts = [1]
     renderer._particle_visual_offsets = [0]
     renderer._particle_visual_counts = [1]
-    renderer._env_root_xforms = object()
     renderer._renderer = Backend()
     renderer._ovstage_exit_stack = ExitStack()
     renderer._render_product_paths = ["/Render/RenderProduct_camera"]
@@ -541,7 +540,6 @@ def test_ovrtx_close_releases_ovstage_renderer_state():
     assert renderer._camera_xform_query is None
     assert renderer._particle_paths_list is None
     assert renderer._object_newton_indices is None
-    assert renderer._env_root_xforms is None
     assert renderer._renderer is None
     assert renderer._ovstage_exit_stack is None
     assert renderer._stage is None


### PR DESCRIPTION
# Description

Make the published `ClonePlan` authoritative for OVRTX environment-root placement.

- Require the renderer to consume a published plan with positions.
- Clone prototype rows before creating destination queries.
- Author identity root transforms with translations from `ClonePlan.positions` after cloning.
- Remove homogeneous fallback-plan resolution and USD-stage transform capture/cache machinery.

This keeps placement ownership in the clone plan and allows OVRTX destinations to be absent until the renderer clones them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Validation

- [x] OVRTX clone-plan and renderer contract tests: 34 passed
- [x] New regression slice against unfixed `develop`: 4 failed as expected
- [x] `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] Documentation changes are not required for this internal behavior fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for `isaaclab_ov`
- [x] My name already exists in `CONTRIBUTORS.md`