### PR TITLE
Add missing omni.kit.scene_view dependency for XR camera PiP

### DIFF
--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -34,10 +34,6 @@ cameras_enabled = true
 [dependencies]
 "isaaclab.python.xr.openxr" = {}
 
-# Required for XR camera picture-in-picture (Kit SceneUI)
-"omni.kit.scene_view.xr" = {}
-"omni.kit.scene_view.xr_utils" = {}
-
 # NOTE: xr.profile.ar.enabled is intentionally NOT set here.
 # Setting it in the .kit file causes Kit's XR system to create the OpenXR
 # instance before the teleop bridge extension loads, so the BridgeComponent

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -34,6 +34,10 @@ cameras_enabled = true
 [dependencies]
 "isaaclab.python.xr.openxr" = {}
 
+# Required for XR camera picture-in-picture (Kit SceneUI)
+"omni.kit.scene_view.xr" = {}
+"omni.kit.scene_view.xr_utils" = {}
+
 # NOTE: xr.profile.ar.enabled is intentionally NOT set here.
 # Setting it in the .kit file causes Kit's XR system to create the OpenXR
 # instance before the teleop bridge extension loads, so the BridgeComponent

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -54,6 +54,10 @@ xr.skipInputDeviceUSDWrites = true
 "omni.kit.xr.system.openxr" = {}
 "omni.kit.xr.ui.window.profile" = {}
 
+# Required for XR camera picture-in-picture (Kit SceneUI)
+"omni.kit.scene_view.xr" = {}
+"omni.kit.scene_view.xr_utils" = {}
+
 [settings.isaaclab]
 # This is used to check that this experience file is loaded when using cameras
 cameras_enabled = true


### PR DESCRIPTION
# Description

XR camera picture-in-picture silently disables itself with ModuleNotFoundError: No module named 'omni.kit.scene_view' because the isaaclab.python.xr.openxr app profiles never declare the
omni.kit.scene_view.xr / omni.kit.scene_view.xr_utils extensions. Those extensions ship on disk with Isaac Sim but aren't pulled in by any currently-declared dependency, so Kit's extension manager never
adds them to sys.path, and camera_feed.py's lazy import of the SceneUI presenter fails and PiP degrades silently.

This adds both extensions to [dependencies] in apps/isaaclab.python.xr.openxr.kit and apps/isaaclab.python.xr.openxr.headless.kit so PiP loads correctly.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there