### PR TITLE
Fix Factory collision prim resolution

### DIFF
--- a/source/isaaclab_tasks/changelog.d/zhengyuz-factory-env-regex.rst
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-factory-env-regex.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``IsaacContrib-Factory-Franka`` startup with segment-safe environment prim-path expressions.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/nist/utils/collision_analyzer.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/nist/utils/collision_analyzer.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 import warp as wp
 
-from isaaclab.sim.utils import get_first_matching_child_prim
+from isaaclab.sim.utils import resolve_matching_prims_from_source
 
 from isaaclab_tasks.contrib.nist.utils import mesh_ops as _mesh_ops
 from isaaclab_tasks.contrib.nist.utils.rigid_object_hasher import RigidObjectHasher
@@ -52,14 +52,15 @@ class CollisionAnalyzer:
         self.body_ids = []
         self.local_pts = []
         for body_name in body_names:
-            prim = get_first_matching_child_prim(
-                self.asset.cfg.prim_path.replace(".*", "0", 1),
+            _, prim_path_pattern = resolve_matching_prims_from_source(
+                self.asset.cfg.prim_path,
                 predicate=lambda p: p.GetName() == body_name and p.HasAPI(UsdPhysics.RigidBodyAPI),
-            )
+                expected_num_matches=1,
+            )[0]
             local_pts = _mesh_ops.sample_object_point_cloud(
                 num_envs=env.num_envs,
                 num_points=cfg.num_points,
-                prim_path_pattern=str(prim.GetPath()).replace("env_0", "env_.*", 1),
+                prim_path_pattern=prim_path_pattern,
                 device=device,
             )
             if local_pts is not None:


### PR DESCRIPTION
# Description

Fixes `IsaacContrib-Factory-Franka` startup after segment-safe prim-path expressions were introduced in #6841.

The Factory collision analyzer assumed cloned environment expressions contained `.*`. It rewrote that spelling to `0` to find a source prim, then rebuilt an `env_.*` expression. The current `{ENV_REGEX_NS}` expansion is `/World/envs/env_[^/]+`, so the rewrite no longer produced a concrete USD path and startup failed with:

```text
ValueError: Prim at path /World/envs/env_[^/]+/Robot is not valid.
```

This change resolves each collision body through `resolve_matching_prims_from_source`, the clone-plan-owned resolver. Its returned destination path expression is passed directly to point-cloud sampling, removing both wildcard-spelling rewrites and keeping ownership of clone-path resolution in the cloning subsystem.

No new dependencies or test files are introduced.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this is an environment-startup fix.

## Validation

- Reproduced the exact failure on unmodified latest `develop` with the existing consolidated Factory smoke case.
- Existing `IsaacContrib-Factory-Franka` smoke case: **1 passed in 39.33s**, including two environments and 20 random-action steps.
- Full `uv run isaaclab -f` equivalent repository hook suite: passed.
- `git diff --check upstream/develop...HEAD`: passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `isaaclab -f`
- [x] Documentation changes are not required; the changelog fragment documents the fix
- [x] My changes generate no new warnings
- [x] The existing consolidated Factory smoke test proves the fix; no new test file is required
- [x] I have added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
