### PR TITLE
[DOC] Clarify specialized extras excluded from all

### DIFF
--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -224,7 +224,9 @@ option resolves an optional integration only when that command needs it. Place i
 before ``isaaclab``; for example, ``--extra ov`` installs both ovphysx and ovrtx
 backends. Pass a comma-separated list or repeat ``--extra``. No extras conflict, so
 any combination resolves into one environment, and ``--extra all`` installs every
-backend, RL library, and visualizer at once:
+backend, RL library, and visualizer at once (the specialized extras ``rlinf``, ``mimic``,
+``teleop``, ``tetrahedralization``, ``video``, and ``leapp`` are not included; request
+them by name):
 
 .. code-block:: bash
 
@@ -232,6 +234,9 @@ backend, RL library, and visualizer at once:
       --task Isaac-Cartpole-Direct physics=isaacsim_physx
 
 See :ref:`installation-optional-extras` for the available extras.
+
+Use ``uv run --extra <name> <command>`` for one invocation, or
+``uv sync --inexact --extra <name>`` to prepare the project environment for multiple commands.
 
 Head over to the :doc:`/source/setup/quickstart`, which starts with your first task and
 introduces the available commands, RL libraries, backends, and visualizers.

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -220,13 +220,13 @@ Install ``uv``, clone Isaac Lab, and start a workflow:
          uv run isaaclab play --rl_library rsl_rl --task Isaac-Cartpole-Direct --viz newton
 
 ``uv run`` installs the core dependencies automatically. The ``--extra <name>``
-option resolves an optional integration only when that command needs it. Place it
+option includes the selected optional integration in the command's environment. Place it
 before ``isaaclab``; for example, ``--extra ov`` installs both ovphysx and ovrtx
 backends. Pass a comma-separated list or repeat ``--extra``. No extras conflict, so
-any combination resolves into one environment, and ``--extra all`` installs every
-backend, RL library, and visualizer at once (the specialized extras ``rlinf``, ``mimic``,
-``teleop``, ``tetrahedralization``, ``video``, and ``leapp`` are not included; request
-them by name):
+any combination resolves into one environment. The ``--extra all`` shortcut installs a
+curated set of backends, RL libraries, and visualizers. It does not include the specialized
+extras ``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, and ``leapp``;
+request them by name:
 
 .. code-block:: bash
 
@@ -235,8 +235,8 @@ them by name):
 
 See :ref:`installation-optional-extras` for the available extras.
 
-Pass ``--extra <name>`` to ``uv run`` when running a command that needs the extra.
-To install the extra in the project environment first, use
+``uv run --extra <name> <command>`` syncs the selected extra into the project environment
+and then runs the command. To sync it without running a command, use
 ``uv sync --inexact --extra <name>``.
 
 Head over to the :doc:`/source/setup/quickstart`, which starts with your first task and
@@ -600,17 +600,17 @@ use ``uv pip install "isaaclab[<extra>]"``; for a uv project, use
    * - ``leapp``
      - LEAP model export support.
    * - ``all``
-     - Every backend, RL library, and visualizer: ``isaacsim``, ``ov``, ``rl-games``,
+     - A curated set of backends, RL libraries, and visualizers: ``isaacsim``, ``ov``, ``rl-games``,
        ``sb3``, ``skrl``, ``rsl-rl``, ``rerun``, and ``viser``.
    * - ``test``
      - Developer test and documentation tooling.
 
 Extras can be combined freely: none of them conflict, so any set of extras -- including
 the Isaac Sim and OV backend stacks together -- resolves into a single environment.
-Use ``all`` to get every backend, RL library, and visualizer in one flag. The
-specialized extras (``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``,
-``leapp``) and the developer ``test`` tooling are not part of ``all``;
-request them by name.
+Use ``all`` to install the curated set of backends, RL libraries, and visualizers listed
+above with one flag. The specialized extras (``rlinf``, ``mimic``, ``teleop``,
+``tetrahedralization``, ``video``, ``leapp``) and the developer ``test`` tooling are not
+part of ``all``; request them by name.
 
 .. isaaclab-uv-wheel-install::
 

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -235,8 +235,9 @@ them by name):
 
 See :ref:`installation-optional-extras` for the available extras.
 
-Use ``uv run --extra <name> <command>`` for one invocation, or
-``uv sync --inexact --extra <name>`` to prepare the project environment for multiple commands.
+Pass ``--extra <name>`` to ``uv run`` when running a command that needs the extra.
+To install the extra in the project environment first, use
+``uv sync --inexact --extra <name>``.
 
 Head over to the :doc:`/source/setup/quickstart`, which starts with your first task and
 introduces the available commands, RL libraries, backends, and visualizers.

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -49,11 +49,11 @@ Training outputs, including checkpoints, are written under ``logs/``. Use
 
    Extras install capabilities; task selectors choose how to use them. For example,
    ``--extra ovphysx`` makes the OV PhysX integration available, while
-   ``physics=ovphysx`` selects it for the task. Extras can be combined freely, and
-   ``--extra all`` installs every backend, RL library, and visualizer at once (the specialized
-   extras ``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, and ``leapp``
-   are not included; request them by name). See :ref:`installation-optional-extras` for the
-   complete list.
+   ``physics=ovphysx`` selects it for the task. Extras can be combined freely. The
+   ``--extra all`` shortcut installs a curated set of backends, RL libraries, and visualizers.
+   It does not include the specialized extras ``rlinf``, ``mimic``, ``teleop``,
+   ``tetrahedralization``, ``video``, and ``leapp``; request them by name. See
+   :ref:`installation-optional-extras` for the complete list.
 
 
 Choose an RL library

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -50,8 +50,10 @@ Training outputs, including checkpoints, are written under ``logs/``. Use
    Extras install capabilities; task selectors choose how to use them. For example,
    ``--extra ovphysx`` makes the OV PhysX integration available, while
    ``physics=ovphysx`` selects it for the task. Extras can be combined freely, and
-   ``--extra all`` installs every backend, RL library, and visualizer at once. See
-   :ref:`installation-optional-extras` for the complete list.
+   ``--extra all`` installs every backend, RL library, and visualizer at once (the specialized
+   extras ``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, and ``leapp``
+   are not included; request them by name). See :ref:`installation-optional-extras` for the
+   complete list.
 
 
 Choose an RL library


### PR DESCRIPTION
# Description

Clarify where `--extra all` is first introduced that specialized extras, including `tetrahedralization`, are excluded and must be requested by name. This prevents users following the installation or quickstart flow from encountering a missing `pytetwild` dependency when they first run a volume-deformable task. This resolves [NVBug 6605861](https://nvbugspro.nvidia.com/bug/6605861).

Also explain that `uv run --extra <name> <command>` syncs the selected extra into the project environment and runs the command, while `uv sync --inexact --extra <name>` syncs it without running a command.

No additional dependencies are required.

## Type of change

- Documentation update

## Screenshots

Not applicable. This is a text-only documentation change.

## Validation

- `uv run --isolated --extra test -- sphinx-build -W --keep-going -j auto docs tmp/tetra-docs-build` completed successfully for all 241 documentation sources.
- `uv run --isolated isaaclab -f` passed all repository pre-commit hooks.
- `git diff --check` passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the repository pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Automated tests are not applicable to this documentation-only wording change
- [x] No source-package changelog fragment is required
- [x] My name already exists in `CONTRIBUTORS.md`
