### PR TITLE
docs: note that gripper must be fully open for SO-101 joint-teleop st…

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -556,6 +556,12 @@ time. To record demonstrations from this task, run ``scripts/tools/record_demos.
 ``--task`` and the plugin running in its second terminal -- see `Data Collection in Sim`_ for the
 full recording workflow and runtime troubleshooting.
 
+.. note::
+
+   After stacking the cube, open the gripper **all the way** before ending the episode. The task's
+   success check requires the gripper to be fully open -- a partially open gripper holding position
+   on top of the stack will not register as success, even if the cube is correctly placed.
+
 
 .. _isaac-teleop-retargeting:
 


### PR DESCRIPTION
# Description

  Adds a note to the SO-101 leader-arm joint-teleoperation example clarifying that the gripper must be opened all the way after stacking the cube — the task's success check requires a fully open gripper,
  and a partially open one holding position on the stack won't register as success even if the cube is correctly placed.

Fixes # (issue)

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there