### PR TITLE
Fix USD camera tutorial startup

### DIFF
--- a/scripts/tutorials/04_sensors/run_usd_camera.py
+++ b/scripts/tutorials/04_sensors/run_usd_camera.py
@@ -53,6 +53,8 @@ parser.add_argument(
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
 args_cli = parser.parse_args()
+# Camera sensors require the rendering extensions in headless and viewport-free launches.
+args_cli.enable_cameras = True
 
 # launch omniverse app
 app_launcher = AppLauncher(args_cli)
@@ -86,7 +88,7 @@ def define_sensor() -> Camera:
     sim_utils.create_prim("/World/Origin_00", "Xform")
     sim_utils.create_prim("/World/Origin_01", "Xform")
     camera_cfg = CameraCfg(
-        prim_path="/World/Origin_.*/CameraSensor",
+        prim_path="/World/Origin_[^/]+/CameraSensor",
         update_period=0,
         height=480,
         width=640,

--- a/source/isaaclab/changelog.d/agent-fix-usd-camera-tutorial.rst
+++ b/source/isaaclab/changelog.d/agent-fix-usd-camera-tutorial.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the USD camera tutorial after camera launcher flags were removed and prim paths adopted full regular-expression matching.

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -268,9 +268,7 @@ OVERRIDES = {
     "scripts/tutorials/04_sensors/run_ray_caster_camera.py": ScriptOverride(
         args=("--enable_cameras",), visualizers=("none", "kit")
     ),
-    "scripts/tutorials/04_sensors/run_usd_camera.py": ScriptOverride(
-        args=("--enable_cameras",), visualizers=("none", "kit")
-    ),
+    "scripts/tutorials/04_sensors/run_usd_camera.py": ScriptOverride(visualizers=("none", "kit")),
     "scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py": ScriptOverride(
         readiness_pattern=r"Gym action space",
         visualizers=("kit", "newton_gl"),

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -234,6 +234,13 @@ def test_commands_respect_script_launcher_capabilities():
     )
     assert "--enable_cameras" in ray_camera_case.command()
 
+    usd_camera_case = next(
+        case
+        for case in build_cases(SPECS)
+        if case.spec.relative_path == "scripts/tutorials/04_sensors/run_usd_camera.py" and case.visualizer == "none"
+    )
+    assert "--enable_cameras" not in usd_camera_case.command()
+
 
 @pytest.mark.parametrize(
     "relative_path",


### PR DESCRIPTION
# Description

Fix the USD camera tutorial for the current launcher and prim-path matching behavior.

The tutorial previously depended on the removed `--enable_cameras` launcher flag, so its smoke-test invocation started a lean Kit app and failed to import `omni.replicator.core`. It also used a prim-path pattern whose `.*` component could cross path separators under full regular-expression matching. This change:

- enables camera extensions from the tutorial before launching the app;
- restricts the environment-name pattern to a single path component;
- removes the stale launcher flag from the standalone-script override and adds a focused regression assertion.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this fixes headless tutorial startup and camera output generation.

## Validation

- `uv run --frozen python -m pytest source/isaaclab/test/app/test_standalone_scripts.py::test_commands_respect_script_launcher_capabilities -q` (`1 passed`)
- `ISAACLAB_CHANGELOG_BASE_REF=codex-validation-base uv run --frozen isaaclab -f` (all checks passed against the upstream base)
- Ran `run_usd_camera.py` to setup completion and verified two-camera RGB, depth, normals, and segmentation output shapes.
- Ran a bounded `run_usd_camera.py --save` check and verified PNG/JSON output was written.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the repository formatting and pre-commit checks
- [x] Documentation changes are not required for this behavior fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
