### PR TITLE
Defer replicated environment roots

### DIFF
--- a/docs/source/overview/core-concepts/multi_backend_architecture.rst
+++ b/docs/source/overview/core-concepts/multi_backend_architecture.rst
@@ -287,8 +287,9 @@ The physics manager also provides a **callback system** via
         name="my_callback",
     )
 
-Available events: ``MODEL_INIT`` (during scene building), ``PHYSICS_READY`` (after physics
-initialization), and ``STOP`` (on simulation shutdown).
+Available events: ``MODEL_INIT`` (after scene prototypes are authored and immediately before the
+backend attaches, loads, or constructs its model), ``PHYSICS_READY`` (after physics initialization),
+and ``STOP`` (on simulation shutdown).
 
 Asset and Sensor Interfaces
 ---------------------------

--- a/scripts/benchmarks/nsys_trace.json
+++ b/scripts/benchmarks/nsys_trace.json
@@ -259,16 +259,17 @@
             "OVRTXRenderer._clone_sources_ovstage",
             "OVRTXRenderer._update_scene_partitions_after_clone",
             "OVRTXRenderer._update_scene_partitions_after_clone_ovstage",
-            "OVRTXRenderer._setup_xform_bindings",
-            "OVRTXRenderer._setup_deformable_bindings",
-            "OVRTXRenderer._setup_particle_bindings",
+            "OVRTXRenderer._setup_xform_bindings_legacy",
+            "OVRTXRenderer._setup_xform_bindings_ovstage",
+            "OVRTXRenderer._setup_deformable_bindings_legacy",
+            "OVRTXRenderer._setup_deformable_bindings_ovstage",
+            "OVRTXRenderer._setup_particle_bindings_legacy",
+            "OVRTXRenderer._setup_particle_bindings_ovstage",
             "OVRTXRenderer.update_transforms",
             "OVRTXRenderer.update_geometries",
             "OVRTXRenderer.update_camera",
             "OVRTXRenderer.render",
-            "OVRTXRenderer.read_output",
-            {"module": "isaaclab_ov.renderers.ovrtx_usd", "function": "create_scene_partition_attributes"},
-            {"module": "isaaclab_ov.renderers.ovrtx_usd", "function": "export_stage_to_string"}
+            "OVRTXRenderer.read_output"
         ]
     },
     {

--- a/source/isaaclab/changelog.d/ovrtx-defer-env-roots.rst
+++ b/source/isaaclab/changelog.d/ovrtx-defer-env-roots.rst
@@ -1,0 +1,15 @@
+Changed
+^^^^^^^
+
+* Changed replicated stage preparation to retain only clone-plan prototypes until
+  :attr:`~isaaclab.physics.PhysicsEvent.MODEL_INIT`. Custom :class:`~isaaclab.cloner.ClonePlan`
+  instances that expect a backend to materialize environment roots must set
+  :attr:`~isaaclab.cloner.ClonePlan.env_template`; the provided constructors set it automatically.
+  Renderer implementations that require destination environments must expand the clone plan in a
+  private stage or defer that work until replication completes.
+
+Fixed
+^^^^^
+
+* Fixed replicated-scene startup scaling by deferring destination environment roots until backend
+  initialization, so asset spawners author each prototype only once.

--- a/source/isaaclab/isaaclab/cloner/clone_plan.py
+++ b/source/isaaclab/isaaclab/cloner/clone_plan.py
@@ -32,7 +32,7 @@ import isaaclab.sim as sim_utils
 
 from .cloner_cfg import DEFAULT_ENV_TEMPLATE, InclusionSet
 from .cloner_strategies import sequential
-from .path import match
+from .path import match, split
 
 
 @dataclass(frozen=True, eq=False)
@@ -60,6 +60,9 @@ class ClonePlan:
 
     cfg_rows: dict[int, tuple[int, ...]] = field(default_factory=dict)
     """``id(cfg)`` to the row indices the cfg owns."""
+
+    env_template: str | None = None
+    """Environment-root path template, or ``None`` when the plan does not own root materialization."""
 
 
 def grid_transforms(N: int, spacing: float = 1.0, up_axis: str = "z", device="cpu"):
@@ -292,6 +295,7 @@ def make_clone_plan(
             clone_mask=empty_mask,
             env_ids=env_ids,
             positions=positions,
+            env_template=env_template,
             cfg_rows={},
         )
 
@@ -306,6 +310,7 @@ def make_clone_plan(
             clone_mask=torch.ones((1, num_clones), dtype=torch.bool, device=device),
             env_ids=env_ids,
             positions=positions,
+            env_template=env_template,
             cfg_rows=cfg_rows,
         )
 
@@ -374,6 +379,7 @@ def make_clone_plan(
         clone_mask=clone_mask,
         env_ids=env_ids,
         positions=positions,
+        env_template=env_template,
         cfg_rows=cfg_rows,
     )
 
@@ -414,5 +420,6 @@ def clone_plan_from_env_0(
         clone_mask=torch.ones((1, num_clones), dtype=torch.bool, device=device),
         env_ids=torch.arange(num_clones, dtype=torch.long, device=device),
         positions=positions,
+        env_template=f"{split(destination)[0]}{{}}",
         cfg_rows=cfg_rows,
     )

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -15,6 +15,7 @@ from isaaclab.utils.backend_utils import FactoryBase
 from isaaclab.utils.string import string_to_callable
 from isaaclab.utils.version import has_kit
 
+from . import path
 from .clone_plan import make_clone_plan
 from .cloner_cfg import DEFAULT_ENV_TEMPLATE
 from .cloner_strategies import sequential
@@ -51,12 +52,13 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
 
     Physics contexts come from :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` when
     set, otherwise from the backend's ``PHYSICS_CONTEXT`` class.
-    :class:`~isaaclab.cloner.UsdReplicateContext` is added automatically when the cfg has a
-    spawner and Kit is available. Explicit contexts are honored regardless of Kit availability.
-    With ``replicate_physics=False`` physics contexts are dropped; USD replication still fires
-    when the spawner+Kit condition is met or the cfg explicitly requests it.
+    :class:`~isaaclab.cloner.UsdReplicateContext` is added automatically when the cfg has a spawner
+    and Kit is available. With physics replication enabled, this implicit context runs at
+    :attr:`~isaaclab.physics.PhysicsEvent.MODEL_INIT`; explicit contexts remain synchronous.
+    With ``replicate_physics=False`` physics contexts are dropped and USD replication remains
+    synchronous, whether implicit or explicit.
 
-    Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
+    Cfgs absent from ``plan.cfg_rows`` are silently skipped. Synchronous backend contexts run
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
     failure cannot leak stale entries into the next call.
 
@@ -66,6 +68,7 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
         replicate_physics: Whether physics replication clones each environment. If False,
             cloning is USD-only; an asset whose contexts are all physics-based is not cloned.
     """
+    from isaaclab.physics import PhysicsEvent  # noqa: PLC0415
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
     queued = REPLICATION_QUEUE.copy()
@@ -79,7 +82,7 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
     # calls (e.g. one per body type in RigidObjectCollection) all contribute {0} and the set
     # union keeps it as a single row — no redundant copy specs are authored.
     kit_available = has_kit()
-    backend_rows: dict[type, set[int]] = {}
+    backend_rows: dict[tuple[type, bool], set[int]] = {}
     for cfg in queued:
         rows = plan.cfg_rows.get(id(cfg))
         if rows is None:
@@ -91,15 +94,24 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
         if not replicate_physics:
             contexts = [c for c in contexts if c is UsdReplicateContext]
         ctx_set = dict.fromkeys(contexts)
-        if getattr(cfg, "spawn", None) is not None and kit_available:
-            ctx_set.setdefault(UsdReplicateContext, None)
         for BackendCtxCls in ctx_set:
-            backend_rows.setdefault(BackendCtxCls, set()).update(rows)
+            backend_rows.setdefault((BackendCtxCls, False), set()).update(rows)
+        if getattr(cfg, "spawn", None) is not None and kit_available and UsdReplicateContext not in ctx_set:
+            backend_rows.setdefault((UsdReplicateContext, replicate_physics), set()).update(rows)
 
-    backend_ctxs: dict[type, Any] = {}
-    for BackendCtxCls, row_set in backend_rows.items():
+    # One synchronous USD row already covers every cfg mapped to that row (notably the
+    # homogeneous env-root row), so do not enqueue the same row again for MODEL_INIT.
+    synchronous_usd_rows = backend_rows.get((UsdReplicateContext, False), set())
+    deferred_usd_rows = backend_rows.get((UsdReplicateContext, True))
+    if deferred_usd_rows is not None:
+        deferred_usd_rows.difference_update(synchronous_usd_rows)
+        if not deferred_usd_rows:
+            del backend_rows[(UsdReplicateContext, True)]
+
+    backend_ctxs: list[tuple[Any, bool]] = []
+    for (BackendCtxCls, defer_to_model_init), row_set in backend_rows.items():
         ctx = BackendCtxCls(stage)
-        backend_ctxs[BackendCtxCls] = ctx
+        backend_ctxs.append((ctx, defer_to_model_init))
         row_list = sorted(row_set)
         ctx.queue_mapping(
             [plan.sources[i] for i in row_list],
@@ -109,17 +121,21 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
             positions=plan.positions,
         )
 
-    for ctx in sorted(backend_ctxs.values(), key=lambda c: getattr(c, "replicate_priority", 0)):
-        ctx.replicate()
+    sim = SimulationContext.instance()
+    for ctx, defer_to_model_init in sorted(backend_ctxs, key=lambda item: getattr(item[0], "replicate_priority", 0)):
+        if defer_to_model_init:
+            sim.physics_manager.register_callback(ctx.replicate, PhysicsEvent.MODEL_INIT, order=2, wrap_weak_ref=False)
+        else:
+            ctx.replicate()
 
-    SimulationContext.instance().set_clone_plan(plan)
+    sim.set_clone_plan(plan)
 
 
 class ReplicateSession:
     """Folds :func:`make_clone_plan` and :func:`replicate` into a ``with`` block.
 
-    ``__enter__`` builds the plan (and mutates each cfg's ``spawn_path``); asset
-    constructors inside the block register their cfgs into
+    ``__enter__`` builds the plan, positions its prototype environment roots, and mutates
+    each cfg's ``spawn_path``. Asset constructors inside the block register their cfgs into
     :data:`REPLICATION_QUEUE`; ``__exit__`` drains and dispatches.
 
     Example:
@@ -173,7 +189,28 @@ class ReplicateSession:
         self._plan: ClonePlan | None = None
 
     def __enter__(self) -> ReplicateSession:
+        from pxr import Gf, UsdGeom  # noqa: PLC0415
+
         self._plan = make_clone_plan(self._cfgs, **self._kwargs)
+        assert self._plan.env_ids is not None and self._plan.positions is not None
+        assert self._plan.env_template is not None
+        env_template = self._plan.env_template
+        env_ids = self._plan.env_ids.cpu().tolist()
+        positions = self._plan.positions.cpu().tolist()
+        prototype_env_ids = {env_ids[0]}
+        active_rows = self._plan.clone_mask.any(dim=1).cpu().tolist()
+        for source, destination, is_active in zip(
+            self._plan.sources, self._plan.destinations, active_rows, strict=True
+        ):
+            if not is_active:
+                continue
+            source_match = path.match(source, destination)
+            assert source_match is not None and not source_match.suffix
+            prototype_env_ids.add(int(source_match.instance))
+        for env_id, position in zip(env_ids, positions, strict=True):
+            if env_id in prototype_env_ids:
+                root = UsdGeom.Xform.Define(self._stage, env_template.format(env_id))
+                UsdGeom.XformCommonAPI(root).SetTranslate(Gf.Vec3d(*position))
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:

--- a/source/isaaclab/isaaclab/cloner/usd.py
+++ b/source/isaaclab/isaaclab/cloner/usd.py
@@ -15,16 +15,6 @@ from ._fabric_notices import disabled_fabric_change_notifies
 from .path import split
 
 
-def _select_env_ids(env_ids: torch.Tensor, mask: torch.Tensor | None, row: int) -> torch.Tensor:
-    """Return the environment ids selected by a replication row."""
-    if mask is None:
-        return env_ids
-    row_mask = mask if mask.dim() == 1 else mask[row]
-    if row_mask.dtype != torch.bool:
-        row_mask = row_mask.to(dtype=torch.bool)
-    return env_ids[row_mask]
-
-
 class UsdReplicateContext:
     """Queue and apply USD replication work for one stage."""
 
@@ -54,11 +44,15 @@ class UsdReplicateContext:
             source: Source prim path.
             destination: Destination path template with ``"{}"`` for env id.
             env_ids: Environment ids selected for this source row.
-            positions: Optional per-environment world positions [m]. Authored only for
-                instance-root destination templates (for example, ``.../env_{}``).
-            quaternions: Optional per-environment orientations in xyzw order. Authored only
-                for instance-root destination templates (for example, ``.../env_{}``).
+            positions: Optional world positions [m], one row per env id. Authored on the instance
+                root identified by the destination template, including nested destinations.
+            quaternions: Optional xyzw orientations, one row per env id. Authored on the instance
+                root identified by the destination template, including nested destinations.
         """
+        if positions is not None and len(positions) != len(env_ids):
+            raise ValueError(f"positions must have {len(env_ids)} rows, got {len(positions)}.")
+        if quaternions is not None and len(quaternions) != len(env_ids):
+            raise ValueError(f"quaternions must have {len(env_ids)} rows, got {len(quaternions)}.")
         self._queue.append((source, destination, env_ids, positions, quaternions))
 
     def queue_mapping(
@@ -78,52 +72,61 @@ class UsdReplicateContext:
             destinations: Destination path templates with ``"{}"`` for env id.
             env_ids: Environment indices.
             mask: Optional per-source or shared mask.
-            positions: Optional per-environment world positions [m]. Authored only for
-                instance-root destination templates (for example, ``.../env_{}``).
-            quaternions: Optional per-environment orientations in xyzw order. Authored only
-                for instance-root destination templates (for example, ``.../env_{}``).
+            positions: Optional per-environment world positions [m], aligned with env-id columns.
+                Authored on the instance root identified by each destination template.
+            quaternions: Optional per-environment xyzw orientations, aligned with env-id columns.
+                Authored on the instance root identified by each destination template.
         """
         for i, source in enumerate(sources):
+            if mask is None:
+                row_mask = torch.ones_like(env_ids, dtype=torch.bool)
+            else:
+                row_mask = mask if mask.dim() == 1 else mask[i]
+                row_mask = row_mask.to(dtype=torch.bool)
             self.queue(
                 source,
                 destinations[i],
-                _select_env_ids(env_ids, mask, i),
-                positions=positions,
-                quaternions=quaternions,
+                env_ids[row_mask],
+                positions=positions[row_mask] if positions is not None else None,
+                quaternions=quaternions[row_mask] if quaternions is not None else None,
             )
 
-    def replicate(self) -> None:
-        """Apply all queued USD copy specs in parent-before-child order."""
-        if not self._queue:
+    def replicate(self, payload: object | None = None) -> None:
+        """Drain queued USD copy specs in parent-before-child order.
+
+        Args:
+            payload: Optional lifecycle event payload. Ignored.
+        """
+        del payload
+        queue, self._queue = self._queue, []
+        if not queue:
             return
 
         # Suspend Fabric's per-Sdf.CopySpec notice listener for the duration of the copy work;
         # no-op outside a live Kit application.
         with disabled_fabric_change_notifies(self.stage):
-            self._apply_queue()
+            self._apply_queue(queue)
 
-    def _apply_queue(self) -> None:
+    def _apply_queue(
+        self, queue: Sequence[tuple[str, str, torch.Tensor, torch.Tensor | None, torch.Tensor | None]]
+    ) -> None:
         """Author the queued copy specs into the stage's root layer."""
         rl = self.stage.GetRootLayer()
 
-        def dp_depth(template: str) -> int:
-            """Return destination prim path depth for stable parent-first replication."""
-            dp = template.format(0)
-            return Sdf.Path(dp).pathElementCount
-
         depth_to_items: dict[int, list[tuple[str, str, torch.Tensor, torch.Tensor | None, torch.Tensor | None]]] = {}
-        for item in self._queue:
-            depth_to_items.setdefault(dp_depth(item[1]), []).append(item)
+        for item in queue:
+            depth_to_items.setdefault(Sdf.Path(item[1].format(0)).pathElementCount, []).append(item)
 
         for depth in sorted(depth_to_items.keys()):
             with Sdf.ChangeBlock():
                 for src, tmpl, target_envs, positions, quaternions in depth_to_items[depth]:
-                    _, clone_suffix = split(tmpl)
+                    clone_prefix, clone_suffix = split(tmpl)
                     is_instance_root = clone_suffix == ""
 
-                    for wid in target_envs.tolist():
+                    for pose_row, wid in enumerate(target_envs.tolist()):
                         wid = int(wid)
                         dp = tmpl.format(wid)
+                        instance_root_path = f"{clone_prefix}{wid}"
                         Sdf.CreatePrimInLayer(rl, dp)
                         # ``CreatePrimInLayer`` authors missing intermediate ancestors (e.g. the
                         # ``Groceries`` scope in ``env_{}/Groceries/Object``) as ``over`` specs. A
@@ -137,32 +140,37 @@ class UsdReplicateContext:
                                 break
                             ancestor_spec.specifier = Sdf.SpecifierDef
                             ancestor = ancestor.GetParentPath()
-                        if src != dp:
+                        # A root copy must precede its transform overrides; a child copy follows
+                        # root setup so the missing instance root is positioned before CopySpec.
+                        if is_instance_root and src != dp:
                             Sdf.CopySpec(rl, Sdf.Path(src), rl, Sdf.Path(dp))
 
-                        # Author positions/quaternions for instance roots only.
-                        if is_instance_root and (positions is not None or quaternions is not None):
-                            ps = rl.GetPrimAtPath(dp)
+                        if positions is not None or quaternions is not None:
+                            ps = rl.GetPrimAtPath(instance_root_path)
+                            ps.specifier = Sdf.SpecifierDef
+                            ps.typeName = "Xform"
                             op_names = []
                             if positions is not None:
-                                p = positions[wid]
-                                t_attr = ps.GetAttributeAtPath(dp + ".xformOp:translate")
+                                p = positions[pose_row]
+                                t_attr = ps.GetAttributeAtPath(instance_root_path + ".xformOp:translate")
                                 if t_attr is None:
                                     t_attr = Sdf.AttributeSpec(ps, "xformOp:translate", Sdf.ValueTypeNames.Double3)
                                 t_attr.default = Gf.Vec3d(float(p[0]), float(p[1]), float(p[2]))
                                 op_names.append("xformOp:translate")
                             if quaternions is not None:
-                                q = quaternions[wid]
-                                o_attr = ps.GetAttributeAtPath(dp + ".xformOp:orient")
+                                q = quaternions[pose_row]
+                                o_attr = ps.GetAttributeAtPath(instance_root_path + ".xformOp:orient")
                                 if o_attr is None:
                                     o_attr = Sdf.AttributeSpec(ps, "xformOp:orient", Sdf.ValueTypeNames.Quatd)
                                 o_attr.default = Gf.Quatd(float(q[3]), Gf.Vec3d(float(q[0]), float(q[1]), float(q[2])))
                                 op_names.append("xformOp:orient")
-                            if op_names:
-                                op_order = ps.GetAttributeAtPath(dp + ".xformOpOrder") or Sdf.AttributeSpec(
-                                    ps, UsdGeom.Tokens.xformOpOrder, Sdf.ValueTypeNames.TokenArray
-                                )
-                                op_order.default = Vt.TokenArray(op_names)
+                            op_order = ps.GetAttributeAtPath(instance_root_path + ".xformOpOrder") or Sdf.AttributeSpec(
+                                ps, UsdGeom.Tokens.xformOpOrder, Sdf.ValueTypeNames.TokenArray
+                            )
+                            op_order.default = Vt.TokenArray(op_names)
+
+                        if not is_instance_root and src != dp:
+                            Sdf.CopySpec(rl, Sdf.Path(src), rl, Sdf.Path(dp))
 
 
 def usd_replicate(
@@ -186,10 +194,10 @@ def usd_replicate(
         destinations: Destination formattable templates with ``"{}"`` for env index.
         env_ids: Environment indices.
         mask: Optional per-source or shared mask. ``None`` selects all.
-        positions: Optional positions [m], shape ``[E, 3]``. Authored as ``xformOp:translate`` only
-            for env-instance root destinations (``.../env_{}``).
+        positions: Optional positions [m], shape ``[E, 3]``. Authored as ``xformOp:translate`` on
+            the instance root identified by each destination template.
         quaternions: Optional orientations in xyzw order, shape ``[E, 4]``. Authored as
-            ``xformOp:orient`` only for env-instance root destinations (``.../env_{}``).
+            ``xformOp:orient`` on the instance root identified by each destination template.
     """
     ctx = UsdReplicateContext(stage)
     ctx.queue_mapping(sources, destinations, env_ids, mask, positions=positions, quaternions=quaternions)

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -35,9 +35,10 @@ class PhysicsEvent(Enum):
     """
 
     MODEL_INIT = "model_init"
-    """Physics model is being constructed.
-    Fired during scene building, before simulation can run. Use this to register
-    physics representations (rigid bodies, joints, constraints) with the solver.
+    """The backend physics model is about to be attached, loaded, or constructed.
+
+    Fired after scene prototypes are authored and immediately before the backend consumes the
+    stage. Ordered callbacks may finish backend-specific stage preparation at this boundary.
     """
 
     PHYSICS_READY = "physics_ready"

--- a/source/isaaclab/isaaclab/renderers/base_renderer.py
+++ b/source/isaaclab/isaaclab/renderers/base_renderer.py
@@ -55,9 +55,11 @@ class BaseRenderer(ABC):
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Prepare the stage for rendering before :meth:`create_render_data` is called.
 
-        Some renderers need to export or preprocess the USD stage before
-        creating render data. This method is called after the renderer is
-        instantiated and before :meth:`create_render_data`.
+        Some renderers need to export or preprocess the USD stage before creating render data.
+        This method runs at :attr:`~isaaclab.physics.PhysicsEvent.MODEL_INIT`, after camera
+        overrides and before backend replication. In replicated scenes, ``stage`` contains the
+        authored clone-plan prototypes; renderers that need destination environments must expand
+        the clone plan in their private stage or defer that work until replication completes.
 
         Args:
             stage: USD stage to prepare, or None if not applicable.

--- a/source/isaaclab/isaaclab/renderers/camera_render_spec.py
+++ b/source/isaaclab/isaaclab/renderers/camera_render_spec.py
@@ -8,8 +8,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from isaaclab.sensors.camera.camera_cfg import CameraCfg
+if TYPE_CHECKING:
+    from isaaclab.cloner import ClonePlan
+    from isaaclab.sensors.camera.camera_cfg import CameraCfg
 
 
 @dataclass(frozen=True)
@@ -23,10 +26,12 @@ class CameraRenderSpec:
         cfg: Camera configuration (data types, resolution, filters, etc.).
         device: Torch device string (e.g. ``"cuda:0"``) used by GPU annotators and Warp.
         num_instances: Number of tiled camera instances (environments).
-        camera_prim_paths: Absolute USD paths for each environment's camera prim.
-        view_count: Number of camera prims (must match ``len(camera_prim_paths)``).
-        camera_path_relative_to_env_0: Camera prim path with ``/World/envs/env_0/`` prefix
-            stripped; required by OVRTX. Empty string if the first camera is not under env 0.
+        camera_prim_paths: Absolute USD paths for camera prims authored on the source stage. For
+            prototype-only stages, this contains only the source or prototype paths.
+        view_count: Number of logical camera views in the renderer output. This may exceed
+            ``len(camera_prim_paths)`` when a backend expands a source or prototype camera internally.
+        camera_path_relative_to_env_0: Legacy camera path relative to env 0. Current renderers resolve
+            prototype paths from the clone plan.
     """
 
     cfg: CameraCfg
@@ -34,4 +39,43 @@ class CameraRenderSpec:
     num_instances: int
     camera_prim_paths: tuple[str, ...]
     view_count: int
-    camera_path_relative_to_env_0: str
+    camera_path_relative_to_env_0: str = ""
+
+    def resolve_camera_prim_paths(self, clone_plan: ClonePlan | None) -> list[str]:
+        """Resolve authored prototype cameras to logical camera paths in clone-plan order.
+
+        Args:
+            clone_plan: Replication layout, or None when camera paths are already concrete.
+
+        Returns:
+            One camera prim path per logical view.
+
+        Raises:
+            RuntimeError: If a planned prototype is missing, an environment has no camera source,
+                or the resolved count differs from the logical view count.
+        """
+        from isaaclab import cloner  # noqa: PLC0415
+
+        paths_by_env: dict[int, str] = {}
+        plan_env_ids: list[int] | None = None
+        if clone_plan is not None and clone_plan.env_ids is not None:
+            plan_env_ids = [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+            for source_root, destination, source_path, env_ids in cloner.query.iter_sources(
+                clone_plan, self.cfg.prim_path
+            ):
+                if source_path not in self.camera_prim_paths:
+                    raise RuntimeError(f"Camera prototype '{source_path}' is not authored on the source stage.")
+                for env_id in env_ids:
+                    paths_by_env[env_id] = cloner.path.rebase(source_path, source_root, destination.format(env_id))
+
+        if paths_by_env:
+            assert plan_env_ids is not None
+            missing = [env_id for env_id in plan_env_ids if env_id not in paths_by_env]
+            if missing:
+                raise RuntimeError(f"Clone plan has no camera source for environments {missing}.")
+            camera_paths = [paths_by_env[env_id] for env_id in plan_env_ids]
+        else:
+            camera_paths = list(self.camera_prim_paths)
+        if len(camera_paths) != self.view_count:
+            raise RuntimeError(f"Resolved {len(camera_paths)} camera prim paths, expected {self.view_count}.")
+        return camera_paths

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -168,20 +168,8 @@ class InteractiveScene:
         self._scene_asset_names: list[str] = []
         self._clone_valid_set: torch.Tensor | None = None
 
-        # create source prim
-        self.stage.DefinePrim(self.env_prim_paths[0], "Xform")
         # allocate env indices
         self._ALL_INDICES = torch.arange(self.cfg.num_envs, dtype=torch.long, device=self.device)
-        # clone env_0 xform to env_1..env_{N-1} at grid origins
-        env_origins, _ = cloner.grid_transforms(self.num_envs, self.cfg.env_spacing, device=self.device)
-        with cloner.disabled_fabric_change_notifies(self.stage, restore=False):
-            cloner.usd_replicate(
-                self.stage,
-                [self.env_prim_paths[0]],
-                [self._env_fmt],
-                self._ALL_INDICES,
-                positions=env_origins,
-            )
 
         # Always enter so a ClonePlan is published even when the scene cfg has no entities.
         self._global_prim_paths = list()
@@ -281,12 +269,8 @@ class InteractiveScene:
         calling this method is idempotent and safe to invoke before
         :meth:`~isaaclab.sim.SimulationContext.reset`.
 
-        Pre-creating backends here makes the order of renderer construction
-        deterministic (matches sensor registration order) and front-loads logging
-        instead of trickling out during the first :meth:`Camera._initialize_impl`.
-        :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.prepare_stage` is
-        intentionally not invoked here; it runs on first camera initialization
-        with the correct ``num_envs`` and final stage.
+        Pre-creating backends here makes construction deterministic in sensor registration order
+        and front-loads logging. Each camera owns its renderer's model-initialization callbacks.
 
         Returns:
             The list of unique renderer backends now registered on the

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import torch
@@ -18,7 +18,9 @@ from pxr import Usd, UsdGeom, UsdPhysics
 import isaaclab.sim as sim_utils
 import isaaclab.utils.sensors as sensor_utils
 from isaaclab.app.logging_utils import force_log_level
+from isaaclab.cloner import path as clone_path
 from isaaclab.cloner import queue_replication
+from isaaclab.physics import PhysicsEvent
 from isaaclab.renderers import BaseRenderer, CameraRenderSpec
 from isaaclab.sim.views import FrameView
 from isaaclab.utils import to_camel_case
@@ -213,11 +215,19 @@ class Camera(SensorBase):
         self._sensor_prims: list[UsdGeom.Camera] = list()
         # Allocated in :meth:`_create_buffers` once the renderer's output contract is known.
         self._data: CameraData | None = None
-        # Renderer and render data — assigned in _initialize_impl.
+        # Renderer inputs are prepared before the stage; render data is created in _initialize_impl.
         self._renderer: BaseRenderer | None = None
+        self._render_spec: CameraRenderSpec | None = None
         self._render_data = None
         # Frame view — assigned in _initialize_impl.
         self._view: FrameView | None = None
+        assert sim_ctx is not None
+        self._renderer_prepare_handle = sim_ctx.physics_manager.register_callback(
+            self._prepare_renderer, PhysicsEvent.MODEL_INIT, order=-1
+        )
+        self._renderer_stage_prepare_handle = sim_ctx.physics_manager.register_callback(
+            self._prepare_renderer_stage, PhysicsEvent.MODEL_INIT, order=0
+        )
 
     def __del__(self):
         """Unsubscribes from callbacks and cleans up renderer resources."""
@@ -515,40 +525,9 @@ class Camera(SensorBase):
         # Initialize parent class
         super()._initialize_impl()
 
-        sim_ctx = sim_utils.SimulationContext.instance()
-        if sim_ctx is None:
-            raise RuntimeError("SimulationContext is not initialized.")
-        self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
-        with force_log_level(logging.INFO):
-            logger.info("Using renderer: %s", type(self._renderer).__name__)
-
-        # Build the render spec early — both the wrapper ISP (which delegates
-        # any renderer-side per-camera setup) and ``create_render_data`` consume
-        # it, and the prims are already authored at this point.
-        cam_paths = tuple(str(p.GetPath()) for p in sim_utils.find_matching_prims(self.cfg.prim_path, self.stage))
-        env_0_prefix = "/World/envs/env_0/"
-        rel_under_env0 = (
-            cam_paths[0].removeprefix(env_0_prefix) if cam_paths and cam_paths[0].startswith(env_0_prefix) else ""
-        )
-        device_str = self._device if isinstance(self._device, str) else str(self._device)
-        render_spec = CameraRenderSpec(
-            cfg=self.cfg,
-            device=device_str,
-            num_instances=self._num_envs,
-            camera_prim_paths=cam_paths,
-            view_count=self._num_envs,
-            camera_path_relative_to_env_0=rel_under_env0,
-        )
-
-        # Delegate per-camera USD setup to the renderer — must run **before**
-        # ``ensure_prepare_stage`` so renderers that snapshot the stage
-        # (ovrtx's ``stage.Export``) capture the resulting overrides in their
-        # exported USD.
-        self._renderer.prepare_cameras(self.stage, render_spec)
-
-        # Stage preprocessing must happen before creating the view because the view keeps
-        # references to prims located in the stage.
-        sim_ctx.render_context.ensure_prepare_stage(self.stage, self._num_envs)
+        assert self._renderer is not None
+        assert self._render_spec is not None
+        cam_paths = self._render_spec.camera_prim_paths
 
         self._view = FrameView(self.cfg.prim_path, device=self._device, stage=self.stage)
         # Check that sizes are correct
@@ -577,10 +556,51 @@ class Camera(SensorBase):
             # Add to list
             self._sensor_prims.append(UsdGeom.Camera(cam_prim))
 
-        self._render_data = self._renderer.create_render_data(render_spec)
+        self._render_data = self._renderer.create_render_data(self._render_spec)
 
         # Create internal buffers (includes intrinsic matrix and pose init)
         self._create_buffers()
+
+    def _prepare_renderer(self, _payload: Any = None) -> None:
+        """Prepare this camera's renderer inputs before the renderer snapshots the stage."""
+        if self._render_spec is not None:
+            return
+        sim_ctx = sim_utils.SimulationContext.instance()
+        if sim_ctx is None:
+            raise RuntimeError("SimulationContext is not initialized.")
+        self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
+        with force_log_level(logging.INFO):
+            logger.info("Using renderer: %s", type(self._renderer).__name__)
+
+        cam_paths = tuple(str(p.GetPath()) for p in sim_utils.find_matching_prims(self.cfg.prim_path, self.stage))
+        clone_plan = sim_ctx.get_clone_plan()
+        num_envs = len(cam_paths) if clone_plan is None or clone_plan.env_ids is None else len(clone_plan.env_ids)
+        relative_to_env_0 = ""
+        if clone_plan is not None and clone_plan.env_template is not None:
+            env_0_path = clone_plan.env_template.format(0)
+            for camera_path in cam_paths:
+                relative_path = clone_path.relative_to(camera_path, env_0_path)
+                if relative_path is not None:
+                    relative_to_env_0 = relative_path.removeprefix("/")
+                    break
+        render_spec = CameraRenderSpec(
+            cfg=self.cfg,
+            device=str(sim_ctx.device),
+            num_instances=num_envs,
+            camera_prim_paths=cam_paths,
+            view_count=num_envs,
+            camera_path_relative_to_env_0=relative_to_env_0,
+        )
+        self._renderer.prepare_cameras(self.stage, render_spec)
+        self._render_spec = render_spec
+
+    def _prepare_renderer_stage(self, _payload: Any = None) -> None:
+        """Prepare every registered renderer after all cameras have applied their USD overrides."""
+        assert self._render_spec is not None
+        sim_ctx = sim_utils.SimulationContext.instance()
+        if sim_ctx is None:
+            raise RuntimeError("SimulationContext is not initialized.")
+        sim_ctx.render_context.ensure_prepare_stage(self.stage, self._render_spec.num_instances)
 
     def _update_buffers_impl(self, env_mask: wp.array):
         if not self._env_mask_has_any(env_mask):
@@ -899,12 +919,22 @@ class Camera(SensorBase):
     Internal simulation callbacks.
     """
 
+    def _clear_callbacks(self) -> None:
+        """Clear renderer preparation callbacks before the base sensor callbacks."""
+        for attribute in ("_renderer_prepare_handle", "_renderer_stage_prepare_handle"):
+            handle = getattr(self, attribute, None)
+            if handle is not None:
+                handle.deregister()
+                setattr(self, attribute, None)
+        super()._clear_callbacks()
+
     def _invalidate_initialize_callback(self, event):
         """Invalidates the scene elements."""
         if self._renderer is not None and self._render_data is not None:
             self._renderer.cleanup(self._render_data)
         self._render_data = None
         self._renderer = None
+        self._render_spec = None
         # call parent
         super()._invalidate_initialize_callback(event)
         # release backend state deterministically, then invalidate the view

--- a/source/isaaclab/test/cloner/test_replicate_session.py
+++ b/source/isaaclab/test/cloner/test_replicate_session.py
@@ -12,6 +12,7 @@ import torch
 
 import isaaclab.cloner.replicate_session as replicate_session
 from isaaclab.cloner import ClonePlan
+from isaaclab.physics import PhysicsEvent
 from isaaclab.sensors import SensorBaseCfg
 from isaaclab.sim import SimulationContext
 
@@ -23,28 +24,103 @@ def test_sensor_default_does_not_request_a_cloning_context():
 
 
 @pytest.mark.parametrize(
-    ("kit_available", "explicit_request", "expected_instances"),
-    [(False, False, 0), (False, True, 1), (True, False, 1)],
+    ("clone_mask", "source_ids", "expected_prototypes"),
+    [
+        (torch.zeros((0, 4), dtype=torch.bool), (), {0}),
+        (
+            torch.tensor(
+                [
+                    [False, True, False, False],
+                    [False, False, False, True],
+                ]
+            ),
+            (1, 3),
+            {0, 1, 3},
+        ),
+        (
+            torch.tensor(
+                [
+                    [False, True, False, False],
+                    [False, False, False, False],
+                ]
+            ),
+            (1, 7),
+            {0, 1},
+        ),
+    ],
+)
+def test_replicate_session_positions_only_prototype_roots(monkeypatch, clone_mask, source_ids, expected_prototypes):
+    """The session authors active prototype roots without pre-authoring destinations."""
+    from pxr import Usd, UsdGeom  # noqa: PLC0415
+
+    positions = torch.tensor(
+        [
+            [-1.0, -1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+    plan = ClonePlan(
+        sources=tuple(f"/World/envs/env_{env_id}/Object" for env_id in source_ids),
+        destinations=tuple("/World/envs/env_{}/Object" for _ in source_ids),
+        clone_mask=clone_mask,
+        env_ids=torch.arange(4),
+        positions=positions,
+        env_template="/World/envs/env_{}",
+    )
+    stage = Usd.Stage.CreateInMemory()
+    monkeypatch.setattr(replicate_session, "make_clone_plan", lambda *_args, **_kwargs: plan)
+    monkeypatch.setattr(replicate_session, "replicate", lambda *_args, **_kwargs: None)
+
+    with replicate_session.ReplicateSession([], 4, 2.0, "cpu", stage=stage):
+        for env_id in range(4):
+            prim = stage.GetPrimAtPath(f"/World/envs/env_{env_id}")
+            assert prim.IsValid() is (env_id in expected_prototypes)
+            if prim.IsValid():
+                xform = UsdGeom.Xformable(prim).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+                assert tuple(xform.ExtractTranslation()) == pytest.approx(positions[env_id].tolist())
+
+
+@pytest.mark.parametrize(
+    ("kit_available", "explicit_request", "replicate_physics", "expected_sync", "expected_deferred"),
+    [
+        (False, False, True, 0, False),
+        (False, True, True, 1, False),
+        (True, False, True, 0, True),
+        (True, True, True, 1, False),
+        (True, False, False, 1, False),
+    ],
 )
 def test_replicate_distinguishes_automatic_and_explicit_usd_contexts(
-    monkeypatch, kit_available, explicit_request, expected_instances
+    monkeypatch, kit_available, explicit_request, replicate_physics, expected_sync, expected_deferred
 ):
-    """Kit gates automatic USD cloning without overriding an explicit cfg request."""
+    """Only implicit Kit USD cloning with physics waits for MODEL_INIT."""
 
     class FakeUsdContext:
         replicate_priority = 100
         instances: list["FakeUsdContext"] = []
 
         def __init__(self, stage):
+            self.replicate_calls = 0
             FakeUsdContext.instances.append(self)
 
         def queue_mapping(self, sources, destinations, env_ids, mask, *, positions=None):
             pass
 
-        def replicate(self):
-            pass
+        def replicate(self, payload=None):
+            self.replicate_calls += 1
 
-    published = SimpleNamespace(plan=None)
+    class FakePhysicsManager:
+        def __init__(self):
+            self.registrations = []
+
+        def register_callback(self, callback, event, order=0, wrap_weak_ref=True):
+            self.registrations.append((callback, event, order, wrap_weak_ref))
+            return object()
+
+    physics_manager = FakePhysicsManager()
+    published = SimpleNamespace(plan=None, physics_manager=physics_manager)
     published.set_clone_plan = lambda plan: setattr(published, "plan", plan)
     monkeypatch.setattr(replicate_session, "UsdReplicateContext", FakeUsdContext)
     monkeypatch.setattr(replicate_session, "has_kit", lambda: kit_available)
@@ -66,7 +142,69 @@ def test_replicate_distinguishes_automatic_and_explicit_usd_contexts(
         cfg_rows={id(cfg): (0,)},
     )
 
+    replicate_session.replicate(plan, stage=object(), replicate_physics=replicate_physics)
+
+    assert len(FakeUsdContext.instances) == int(expected_sync > 0 or expected_deferred)
+    assert published.plan is plan
+    if not FakeUsdContext.instances:
+        assert physics_manager.registrations == []
+        return
+
+    ctx = FakeUsdContext.instances[0]
+    assert ctx.replicate_calls == expected_sync
+    if expected_deferred:
+        callback, event, order, wrap_weak_ref = physics_manager.registrations[0]
+        assert event is PhysicsEvent.MODEL_INIT and order == 2 and wrap_weak_ref is False
+        callback(None)
+        assert ctx.replicate_calls == 1
+    else:
+        assert physics_manager.registrations == []
+
+
+def test_explicit_usd_context_owns_a_shared_implicit_row(monkeypatch):
+    """A synchronous explicit root row is not copied again by an implicit deferred context."""
+
+    class FakeUsdContext:
+        replicate_priority = 100
+        instances = []
+
+        def __init__(self, stage):
+            self.replicate_calls = 0
+            FakeUsdContext.instances.append(self)
+
+        def queue_mapping(self, sources, destinations, env_ids, mask, *, positions=None):
+            pass
+
+        def replicate(self, payload=None):
+            self.replicate_calls += 1
+
+    registrations = []
+    physics_manager = SimpleNamespace(
+        register_callback=lambda callback, event, order=0, wrap_weak_ref=True: registrations.append(
+            (callback, event, order, wrap_weak_ref)
+        )
+    )
+    published = SimpleNamespace(plan=None, physics_manager=physics_manager)
+    published.set_clone_plan = lambda plan: setattr(published, "plan", plan)
+    monkeypatch.setattr(replicate_session, "UsdReplicateContext", FakeUsdContext)
+    monkeypatch.setattr(replicate_session, "has_kit", lambda: True)
+    monkeypatch.setattr(replicate_session.FactoryBase, "_get_backend", lambda: "newton")
+    monkeypatch.setattr(SimulationContext, "instance", lambda: published)
+
+    explicit_cfg = SimpleNamespace(cloning_contexts=(FakeUsdContext,), spawn=object())
+    implicit_cfg = SimpleNamespace(cloning_contexts=(), spawn=object())
+    replicate_session.REPLICATION_QUEUE.extend((explicit_cfg, implicit_cfg))
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        env_ids=torch.arange(2),
+        positions=torch.zeros((2, 3)),
+        cfg_rows={id(explicit_cfg): (0,), id(implicit_cfg): (0,)},
+    )
+
     replicate_session.replicate(plan, stage=object())
 
-    assert len(FakeUsdContext.instances) == expected_instances
-    assert published.plan is plan
+    assert len(FakeUsdContext.instances) == 1
+    assert FakeUsdContext.instances[0].replicate_calls == 1
+    assert registrations == []

--- a/source/isaaclab/test/cloner/test_usd_replicate_ancestors.py
+++ b/source/isaaclab/test/cloner/test_usd_replicate_ancestors.py
@@ -5,11 +5,12 @@
 
 """Tests for ancestor authoring in :func:`~isaaclab.cloner.usd_replicate`."""
 
+import pytest
 import torch
 
-from pxr import Sdf, Usd
+from pxr import Gf, Sdf, Usd, UsdGeom
 
-from isaaclab.cloner import usd_replicate
+from isaaclab.cloner import UsdReplicateContext, usd_replicate
 
 
 def _make_stage_with_source(source_path: str) -> Usd.Stage:
@@ -54,3 +55,96 @@ def test_usd_replicate_keeps_existing_ancestor_specs():
     assert scope.IsDefined()
     assert scope.GetTypeName() == "Xform"
     assert stage.GetPrimAtPath("/World/envs/env_1/Groceries/Object").IsDefined()
+
+
+def test_usd_replicate_context_drains_after_model_init_callback(monkeypatch):
+    """A deferred context applies its queue once even when MODEL_INIT repeats."""
+    stage = _make_stage_with_source("/World/envs/env_0/Robot")
+    context = UsdReplicateContext(stage)
+    context.queue(
+        "/World/envs/env_0/Robot",
+        "/World/envs/env_{}/Robot",
+        torch.tensor([1]),
+    )
+
+    copied_paths = []
+    copy_spec = Sdf.CopySpec
+
+    def capture_copy(source_layer, source_path, destination_layer, destination_path):
+        copied_paths.append(str(destination_path))
+        return copy_spec(source_layer, source_path, destination_layer, destination_path)
+
+    monkeypatch.setattr(Sdf, "CopySpec", capture_copy)
+    context.replicate(None)
+    context.replicate(None)
+
+    assert copied_paths == ["/World/envs/env_1/Robot"]
+
+
+def test_leaf_destination_positions_missing_instance_root_before_copy(monkeypatch):
+    """A leaf-only row positions and orients its missing instance root before copying the child."""
+    stage = _make_stage_with_source("/World/envs/env_0/Camera")
+    camera_offset = Gf.Vec3d(0.57, -0.8, 0.5)
+    UsdGeom.Xformable(stage.GetPrimAtPath("/World/envs/env_0/Camera")).AddTranslateOp().Set(camera_offset)
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0]])
+    quaternions = torch.tensor([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.70710678, 0.70710678]])
+    root_before_child_copy = []
+    copy_spec = Sdf.CopySpec
+
+    def capture_copy(source_layer, source_path, destination_layer, destination_path):
+        if str(destination_path) == "/World/envs/env_1/Camera":
+            root_path = "/World/envs/env_1"
+            root = destination_layer.GetPrimAtPath(root_path)
+            translation = root.GetAttributeAtPath(root_path + ".xformOp:translate").default
+            orientation = root.GetAttributeAtPath(root_path + ".xformOp:orient").default
+            root_before_child_copy.append((root.specifier, root.typeName, translation, orientation))
+        return copy_spec(source_layer, source_path, destination_layer, destination_path)
+
+    monkeypatch.setattr(Sdf, "CopySpec", capture_copy)
+    usd_replicate(
+        stage,
+        sources=["/World/envs/env_0/Camera"],
+        destinations=["/World/envs/env_{}/Camera"],
+        env_ids=torch.arange(2),
+        positions=positions,
+        quaternions=quaternions,
+    )
+
+    assert len(root_before_child_copy) == 1
+    specifier, type_name, translation, orientation = root_before_child_copy[0]
+    assert specifier == Sdf.SpecifierDef and type_name == "Xform"
+    assert tuple(translation) == pytest.approx(positions[1].tolist())
+    assert orientation.GetReal() == pytest.approx(quaternions[1, 3].item())
+    assert tuple(orientation.GetImaginary()) == pytest.approx(quaternions[1, :3].tolist())
+
+    root = stage.GetPrimAtPath("/World/envs/env_1")
+    assert root.IsDefined() and root.GetTypeName() == "Xform"
+    camera = stage.GetPrimAtPath("/World/envs/env_1/Camera")
+    assert camera.IsDefined()
+    assert tuple(camera.GetAttribute("xformOp:translate").Get()) == pytest.approx(tuple(camera_offset))
+
+
+def test_sparse_environment_ids_use_column_aligned_poses():
+    """Sparse environment ids use their clone-plan columns to select root poses."""
+    stage = _make_stage_with_source("/World/scenes/scene_2/Camera")
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0], [7.0, -8.0, 9.0]])
+    quaternions = torch.tensor(
+        [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.70710678, 0.70710678], [0.0, 0.70710678, 0.0, 0.70710678]]
+    )
+
+    usd_replicate(
+        stage,
+        sources=["/World/scenes/scene_2/Camera"],
+        destinations=["/World/scenes/scene_{}/Camera"],
+        env_ids=torch.tensor([2, 7, 11]),
+        mask=torch.tensor([[True, False, True]]),
+        positions=positions,
+        quaternions=quaternions,
+    )
+
+    assert not stage.GetPrimAtPath("/World/scenes/scene_7").IsValid()
+    root = stage.GetPrimAtPath("/World/scenes/scene_11")
+    assert tuple(root.GetAttribute("xformOp:translate").Get()) == pytest.approx(positions[2].tolist())
+    orientation = root.GetAttribute("xformOp:orient").Get()
+    assert orientation.GetReal() == pytest.approx(quaternions[2, 3].item())
+    assert tuple(orientation.GetImaginary()) == pytest.approx(quaternions[2, :3].tolist())

--- a/source/isaaclab/test/scene/test_interactive_scene.py
+++ b/source/isaaclab/test/scene/test_interactive_scene.py
@@ -194,7 +194,7 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
     captured: list = []
 
     def fake_replicate(plan, *, stage, replicate_physics=True):
-        captured.append((plan, stage, replicate_physics))
+        captured.append((plan, stage, replicate_physics, stage.ExportToString()))
 
     monkeypatch.setattr(replicate_session_module, "replicate", fake_replicate)
 
@@ -203,12 +203,35 @@ def test_scene_publishes_plan_via_replicate(monkeypatch: pytest.MonkeyPatch):
         scene = InteractiveScene(MySceneCfg(num_envs=4, env_spacing=1.0))
 
     assert len(captured) == 1
-    plan, stage, replicate_physics = captured[0]
+    plan, stage, replicate_physics, stage_usda = captured[0]
     assert plan.sources == ("/World/envs/env_0",)
     assert plan.destinations == ("/World/envs/env_{}",)
     assert plan.clone_mask.shape == (1, 4)
     assert stage is scene.stage
     assert replicate_physics is True
+    assert 'def Xform "env_0"' in stage_usda
+    assert '"Robot"' in stage_usda
+    assert '"RigidObj"' in stage_usda
+    for env_idx in range(1, 4):
+        assert f'def Xform "env_{env_idx}"' not in stage_usda
+
+
+def test_initialize_renderers_precreates_unique_backends():
+    """Renderer backends are pre-created once per unique camera configuration."""
+    renderer = object()
+    renderer_cfg = object()
+
+    class FakeCamera:
+        cfg = SimpleNamespace(renderer_cfg=renderer_cfg)
+
+    render_context = SimpleNamespace(get_renderer=lambda _cfg: renderer)
+    scene = SimpleNamespace(
+        _sensors={"first": FakeCamera(), "second": FakeCamera()},
+        sim=SimpleNamespace(render_context=render_context),
+    )
+
+    assert InteractiveScene.initialize_renderers(scene) == [renderer]
+    assert InteractiveScene.initialize_renderers(scene) == [renderer]
 
 
 @pytest.mark.parametrize("device", ["cuda:0"])

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -17,6 +17,7 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 
 import copy
 import random
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -82,6 +83,61 @@ def setup() -> tuple[sim_utils.SimulationContext, CameraCfg, float]:
     # load stage
     sim_utils.update_stage()
     return sim, camera_cfg, dt
+
+
+def test_camera_owns_model_init_renderer_callbacks(setup_sim_camera):
+    """Camera prepares its renderer before one shared stage snapshot at MODEL_INIT."""
+    from isaaclab.physics import PhysicsEvent
+
+    sim, camera_cfg, _ = setup_sim_camera
+    camera = Camera(camera_cfg)
+
+    prepare_registration = sim.physics_manager._callbacks[camera._renderer_prepare_handle.id]
+    stage_registration = sim.physics_manager._callbacks[camera._renderer_stage_prepare_handle.id]
+    assert prepare_registration[0] is PhysicsEvent.MODEL_INIT
+    assert prepare_registration[2] == -1
+    assert stage_registration[0] is PhysicsEvent.MODEL_INIT
+    assert stage_registration[2] == 0
+
+    del camera
+
+
+def test_prepare_renderer_retries_after_failure(monkeypatch):
+    """A failed renderer preparation leaves the camera ready for a later retry."""
+    attempts = []
+
+    class FailingOnceRenderer:
+        def prepare_cameras(self, stage, spec):
+            attempts.append((stage, spec))
+            if len(attempts) == 1:
+                raise RuntimeError("renderer preparation failed")
+
+    renderer = FailingOnceRenderer()
+    sim = SimpleNamespace(
+        device="cpu",
+        render_context=SimpleNamespace(get_renderer=lambda _cfg: renderer),
+        get_clone_plan=lambda: SimpleNamespace(env_ids=torch.arange(4), env_template="/World/envs/env_{}"),
+    )
+    camera = SimpleNamespace(
+        _renderer=None,
+        _render_spec=None,
+        cfg=SimpleNamespace(renderer_cfg=object(), prim_path="/World/envs/env_.*/Camera"),
+        stage=object(),
+    )
+    camera_prim = SimpleNamespace(GetPath=lambda: "/World/envs/env_0/Camera")
+    monkeypatch.setattr(sim_utils.SimulationContext, "instance", staticmethod(lambda: sim))
+    monkeypatch.setattr(sim_utils, "find_matching_prims", lambda _prim_path, _stage: [camera_prim])
+
+    with pytest.raises(RuntimeError, match="renderer preparation failed"):
+        Camera._prepare_renderer(camera)
+
+    assert camera._render_spec is None
+
+    Camera._prepare_renderer(camera)
+
+    assert len(attempts) == 2
+    assert camera._render_spec is attempts[-1][1]
+    assert camera._render_spec.camera_path_relative_to_env_0 == "Camera"
 
 
 def teardown(sim: sim_utils.SimulationContext):

--- a/source/isaaclab/test/sim/test_cloner.py
+++ b/source/isaaclab/test/sim/test_cloner.py
@@ -428,23 +428,26 @@ def test_make_clone_plan_heterogeneous_mutates_spawn_paths(sim):
 
 
 def test_make_clone_plan_skips_global_cfgs(sim):
-    """Cfgs whose prim_path is not under /World/envs/ are excluded from the plan."""
+    """Global cfgs are excluded while an empty plan retains its environment template."""
     global_cfg = SimpleNamespace(
         prim_path="/World/global/Robot",
         spawn=sim_utils.CuboidCfg(size=(0.1, 0.1, 0.1)),
     )
 
+    env_template = "/World/scenes/scene_{}"
     plan = make_clone_plan(
         cfgs=[global_cfg],
         num_clones=3,
         env_spacing=1.0,
         device=sim.cfg.device,
+        env_template=env_template,
     )
 
     assert plan.sources == ()
     assert plan.destinations == ()
     assert plan.clone_mask.shape == (0, 3)
     assert plan.cfg_rows == {}
+    assert plan.env_template == env_template
 
 
 def test_clone_plan_from_env_0_populates_cfg_rows(sim):
@@ -468,8 +471,17 @@ def test_clone_plan_from_env_0_populates_cfg_rows(sim):
     assert plan.sources == ("/World/envs/env_0",)
     assert plan.destinations == ("/World/envs/env_{}",)
     assert plan.cfg_rows == {id(env_cfg_a): (0,), id(env_cfg_b): (0,)}
+    assert plan.env_template == "/World/envs/env_{}"
     assert plan.clone_mask.all() and plan.clone_mask.shape == (1, 4)
     assert torch.equal(plan.env_ids, torch.arange(4, dtype=torch.long, device=sim.cfg.device))
+
+    nested_plan = cloner.clone_plan_from_env_0(
+        source="/World/envs/env_0/Robot",
+        destination="/World/envs/env_{}/Robot",
+        num_clones=4,
+        device=sim.cfg.device,
+    )
+    assert nested_plan.env_template == "/World/envs/env_{}"
 
 
 def test_replicate_physics_false_keeps_usd_only(sim):

--- a/source/isaaclab_ov/changelog.d/ovrtx-clone-plan-position.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-clone-plan-position.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX environment placement by authoring root translations from the clone plan after
+  cloning instead of capturing transforms from the USD stage.

--- a/source/isaaclab_ov/changelog.d/ovrtx-defer-env-roots.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-defer-env-roots.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed OvPhysX and OVRTX initialization to consume prototype-only stages and clone destination
+  environments in their private backend stages, including heterogeneous clone-plan prototypes.

--- a/source/isaaclab_ov/isaaclab_ov/cloner/replicate.py
+++ b/source/isaaclab_ov/isaaclab_ov/cloner/replicate.py
@@ -12,7 +12,7 @@ this point in the scene setup — it is created lazily on the first
 
 This function records an active clone recipe on :class:`OvPhysxManager`.  When
 :meth:`~isaaclab_ov.physics.OvPhysxManager._warmup_and_load` eventually
-creates the ``PhysX`` instance, env-0-only loads replay each recipe via
+creates the ``PhysX`` instance, prototype-only loads replay each recipe via
 ``physx.clone(source, targets, transforms)`` after loading. Full-stage loads instead
 materialize or overlay every recipe in serialized USDA before attaching OVStage.
 Recipes remain active for the current simulation context so a forced re-warmup
@@ -32,14 +32,6 @@ from isaaclab import cloner
 from isaaclab_ov._clone import CloneTransform, clone_transforms_from_positions
 
 
-def _select_env_ids(env_ids: torch.Tensor, mapping: torch.Tensor, row: int) -> torch.Tensor:
-    """Return the environment ids selected by a replication row."""
-    row_mask = mapping[row]
-    if row_mask.dtype != torch.bool:
-        row_mask = row_mask.to(dtype=torch.bool)
-    return env_ids[row_mask]
-
-
 def _matrix_to_clone_transform(matrix: Gf.Matrix4d) -> CloneTransform:
     """Convert a USD pose matrix to an OvPhysX xyzw clone transform."""
     matrix = matrix.RemoveScaleShear()
@@ -57,22 +49,15 @@ def _matrix_to_clone_transform(matrix: Gf.Matrix4d) -> CloneTransform:
     )
 
 
-def _pose_tensor_rows(tensor: torch.Tensor | None, name: str, component_count: int) -> list[list[float]] | None:
+def _pose_tensor_rows(
+    tensor: torch.Tensor | None, name: str, num_envs: int, component_count: int
+) -> list[list[float]] | None:
     """Validate and copy an optional per-environment pose tensor to CPU rows."""
     if tensor is None:
         return None
-    if tensor.ndim != 2 or tensor.shape[1] != component_count:
-        raise ValueError(f"{name} must have shape [num_envs, {component_count}], got {list(tensor.shape)}.")
+    if tensor.ndim != 2 or tuple(tensor.shape) != (num_envs, component_count):
+        raise ValueError(f"{name} must have shape [{num_envs}, {component_count}], got {list(tensor.shape)}.")
     return tensor.detach().cpu().tolist()
-
-
-def _validate_pose_rows(name: str, rows: list[list[float]] | None, env_ids: Sequence[int]) -> None:
-    """Validate that optional pose rows contain every selected environment."""
-    if rows is None:
-        return
-    for env_id in env_ids:
-        if env_id < 0 or env_id >= len(rows):
-            raise ValueError(f"{name} does not contain selected environment id {env_id}; it has {len(rows)} rows.")
 
 
 class OvPhysxReplicateContext:
@@ -128,24 +113,24 @@ class OvPhysxReplicateContext:
             env_ids: Environment indices.
             mapping: Bool/int mask selecting envs per source.
             positions: Optional per-environment world positions [m], shape
-                ``[num_envs, 3]``.
+                ``[num_envs, 3]``, aligned with env-id columns.
             quaternions: Optional per-environment orientations in xyzw order,
-                shape ``[num_envs, 4]``.
+                shape ``[num_envs, 4]``, aligned with env-id columns.
 
         Raises:
             ValueError: If a provided pose tensor is malformed or lacks a selected
                 environment, or if an active source or source anchor prim is invalid.
         """
-        positions_list = _pose_tensor_rows(positions, "positions", 3)
-        quaternions_list = _pose_tensor_rows(quaternions, "quaternions", 4)
+        positions_list = _pose_tensor_rows(positions, "positions", len(env_ids), 3)
+        quaternions_list = _pose_tensor_rows(quaternions, "quaternions", len(env_ids), 4)
         xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
 
         for i, src in enumerate(sources):
-            active_env_ids = [int(env_id) for env_id in _select_env_ids(env_ids, mapping, i).tolist()]
+            row_mask = mapping[i].to(dtype=torch.bool)
+            active_columns = row_mask.nonzero().flatten().tolist()
+            active_env_ids = [int(env_id) for env_id in env_ids[row_mask].tolist()]
             if not active_env_ids:
                 continue
-            _validate_pose_rows("positions", positions_list, active_env_ids)
-            _validate_pose_rows("quaternions", quaternions_list, active_env_ids)
 
             self_env_id: int | None = None
             matched = cloner.path.match(src, destinations[i])
@@ -171,17 +156,17 @@ class OvPhysxReplicateContext:
 
             targets: list[str] = []
             target_transforms: list[CloneTransform] = []
-            for env_id in active_env_ids:
+            for column, env_id in zip(active_columns, active_env_ids, strict=True):
                 if env_id == self_env_id:
                     continue
                 targets.append(destinations[i].format(env_id))
 
                 target_env_world = Gf.Matrix4d(1.0)
                 if positions_list is not None:
-                    pos = positions_list[env_id]
+                    pos = positions_list[column]
                     target_env_world.SetTranslateOnly(Gf.Vec3d(float(pos[0]), float(pos[1]), float(pos[2])))
                 if quaternions_list is not None:
-                    quat = quaternions_list[env_id]
+                    quat = quaternions_list[column]
                     target_env_world.SetRotateOnly(
                         Gf.Quatd(
                             float(quat[3]),
@@ -203,10 +188,7 @@ class OvPhysxReplicateContext:
 
 
 PHYSICS_CONTEXT = OvPhysxReplicateContext
-"""Physics replication context for OvPhysX assets.  OvPhysxReplicateContext authors USD
-internally, so USD replication is not separately added.
-TODO: decompose into UsdReplicateContext + a pure-physics OvPhysxReplicateContext to match
-the physx/newton split."""
+"""Pure-physics replication context that registers clone recipes for OvPhysX model initialization."""
 
 
 def ovphysx_replicate(

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 
 import atexit
 import logging
-import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import warp as wp
 
 from pxr import UsdPhysics
 
+from isaaclab.cloner import path as clone_path
+from isaaclab.cloner.cloner_cfg import DEFAULT_ENV_TEMPLATE
 from isaaclab.physics import PhysicsEvent, PhysicsManager
 from isaaclab.scene_data import SceneDataBackend, SceneDataFormat
 from isaaclab.scene_data.deformable_discovery import (
@@ -100,13 +101,14 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
             paths.extend(list(entry["pose"].prim_paths))
         return paths
 
-    def setup(self, physx, stage, device: str) -> None:
+    def setup(self, physx, stage, device: str, env_template: str = DEFAULT_ENV_TEMPLATE) -> None:
         """Discover RigidBodyAPI prims, dedup by env-wildcard form, create one binding per pattern.
 
         Args:
             physx: Live ``ovphysx.PhysX`` instance (the wheel handle).
             stage: USD stage to traverse for RigidBodyAPI prims.
             device: Warp device string used to allocate the staging and merged buffers.
+            env_template: Clone-plan environment-root template used to deduplicate rigid paths.
         """
         from isaaclab_ov import tensor_types as TT  # local: keep heavy ovphysx out of module load
         from isaaclab_ov.sim.views.ovphysx_view import OvPhysxView
@@ -126,7 +128,9 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
         patterns: set[str] = set()
         for prim in stage.Traverse():
             if prim.HasAPI(UsdPhysics.RigidBodyAPI):
-                patterns.add(re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", prim.GetPath().pathString))
+                prim_path = prim.GetPath().pathString
+                matched = clone_path.match(prim_path, env_template)
+                patterns.add(prim_path if matched is None else env_template.format("*") + matched.suffix)
 
         # Rigid discovery may be empty for deformable-only scenes; still set up
         # deformable nodal bindings so SceneData geometry export stays available.
@@ -372,7 +376,7 @@ class OvPhysxManager(PhysicsManager):
     # re-warmup can rebuild serialized-stage or runtime-only clones.
     _active_clone_recipes: ClassVar[list[tuple[str, list[str], list[CloneTransform]]]] = []
     # Consumable snapshot of the active recipes. Full-stage warmup materializes
-    # these into serialized USDA; env-0-only warmup replays them with physx.clone().
+    # these into serialized USDA; prototype-only warmup replays them with physx.clone().
     _pending_clones: ClassVar[list[tuple[str, list[str], list[CloneTransform]]]] = []
     _atexit_registered: ClassVar[bool] = False
     _scene_data_backend: ClassVar[OvPhysxSceneDataBackend | None] = None
@@ -486,6 +490,13 @@ class OvPhysxManager(PhysicsManager):
         cls._stage_usda = None
         cls._pending_clones = []
         cls._active_clone_recipes = []
+        cls.register_callback(
+            cls._capture_stage_usda,
+            PhysicsEvent.MODEL_INIT,
+            order=1,
+            name="ovphysx_capture_stage_usda",
+            wrap_weak_ref=False,
+        )
         # Construct the SceneDataBackend eagerly so :class:`SimulationContext`
         # captures a real instance (not ``None``) when it builds the central
         # :class:`~isaaclab.scene.scene_data_provider.SceneDataProvider` in
@@ -701,7 +712,6 @@ class OvPhysxManager(PhysicsManager):
         if exported_stage is None:
             raise RuntimeError("OvPhysxManager: failed to open the flattened full-stage layer.")
 
-        envs_path = Sdf.Path("/World/envs")
         operations: list[tuple[Sdf.Path, Sdf.Path, bool]] = []
         processed_targets: set[Sdf.Path] = set()
         for source, targets, _ in pending_clones:
@@ -712,13 +722,6 @@ class OvPhysxManager(PhysicsManager):
                 target_path = Sdf.Path(target)
                 if target_path in processed_targets:
                     continue
-                boundary_path = target_path.GetParentPath()
-                for prefix in target_path.GetPrefixes():
-                    if prefix.GetParentPath() == envs_path:
-                        boundary_path = prefix
-                        break
-                if layer.GetPrimAtPath(boundary_path) is None:
-                    raise RuntimeError(f"OvPhysxManager: clone target parent is absent for {target!r}.")
                 operations.append((source_path, target_path, layer.GetPrimAtPath(target_path) is not None))
                 processed_targets.add(target_path)
 
@@ -754,40 +757,37 @@ class OvPhysxManager(PhysicsManager):
             logger.info("OvPhysxManager: materialized %d clone targets in the full-stage layer", len(operations))
         return len(operations)
 
-    @staticmethod
-    def _strip_nonzero_environments(layer: Any) -> int:
-        """Strip authored ``env_<i>`` prims other than ``env_0`` from a stage layer."""
-        envs_spec = layer.GetPrimAtPath("/World/envs")
-        if envs_spec is None or not envs_spec:
-            return 0
-
-        env_name_re = re.compile(r"^env_(\d+)$")
-        names_to_remove = [
-            child_name
-            for child_name in list(envs_spec.nameChildren.keys())
-            if (match := env_name_re.match(child_name)) and match.group(1) != "0"
-        ]
-        for child_name in names_to_remove:
-            del envs_spec.nameChildren[child_name]
-        return len(names_to_remove)
-
     @classmethod
     def _serialize_selected_stage(cls, sim_stage: Any) -> str:
-        """Serialize the selected stage representation for OVStage population."""
+        """Serialize prototypes, expanding roots and targets only for full-stage consumers."""
         layer = sim_stage.Flatten()
         if cls._requires_full_stage:
+            from pxr import Gf, Usd, UsdGeom  # noqa: PLC0415
+
+            sim = PhysicsManager._sim
+            clone_plan = sim.get_clone_plan() if sim is not None else None
+            if clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None:
+                env_ids = clone_plan.env_ids.detach().cpu().tolist()
+                positions = clone_plan.positions.detach().cpu().tolist() if clone_plan.positions is not None else None
+                private_stage = Usd.Stage.Open(layer)
+                for env_index, env_id in enumerate(env_ids):
+                    root = UsdGeom.Xform.Define(private_stage, clone_plan.env_template.format(env_id))
+                    if positions is not None:
+                        UsdGeom.XformCommonAPI(root).SetTranslate(Gf.Vec3d(*positions[env_index]))
+
             cls._materialize_pending_clones_in_layer(layer)
             logger.info("OvPhysxManager: serialized the full USD stage in memory")
-        else:
-            removed_count = cls._strip_nonzero_environments(layer)
-            if removed_count:
-                logger.info(
-                    "OvPhysxManager: stripped %d env_<i!=0> subtrees from in-memory USD (kept env_0 + globals)",
-                    removed_count,
-                )
-            else:
-                logger.debug("OvPhysxManager: no cloned environments to strip — serialized stage as-is.")
         return layer.ExportToString()
+
+    @classmethod
+    def _capture_stage_usda(cls, _event: Any) -> None:
+        """Capture the prototype stage before common-stage USD replication."""
+        if cls._stage_usda is not None:
+            return
+        sim = PhysicsManager._sim
+        if sim is None:
+            raise RuntimeError("OvPhysxManager: SimulationContext is not set.")
+        cls._stage_usda = cls._serialize_selected_stage(sim.stage)
 
     @classmethod
     def _replay_pending_clones(cls, physx: Any, requires_full_stage: bool) -> None:
@@ -854,29 +854,13 @@ class OvPhysxManager(PhysicsManager):
         if scene_prim.IsValid():
             cls._configure_physx_scene_prim(scene_prim, PhysicsManager._cfg, ovphysx_device)
 
-        # Flatten the current USD stage to USDA text so OVStage can populate it
-        # without an intermediate file.
-        #
-        # When ``InteractiveScene`` runs with ``clone_usd=True``, the live USD
-        # stage carries env_0..N's full asset subtrees as authored copies.
-        # Handing that whole stage to OVStage would make the wheel ingest
-        # all 4096 envs as independent USD-defined bodies, defeating the
-        # ``physx.clone()`` fast path and turning every subsequent
-        # ``create_tensor_binding`` call into an O(N) USD enumeration -- the
-        # hang you'd see at large env counts.
-        #
-        # By default, strip ``/World/envs/env_<i>`` for i != 0 from the
-        # flattened layer before handing it to the wheel. Sensors that read
-        # USD directly (RayCaster, Camera, ContactSensor discovery) still see
-        # the full N-env stage; only the wheel-side physics ingestion is
-        # scoped to env_0, and ``physx.clone()`` re-populates env_1..N in
-        # the physics runtime with proper clone lineage (which is what the
-        # binding fast path expects). Features that need distinct authored
-        # physics in every environment request the full stage; missing
-        # heterogeneous clone targets are materialized in its flattened layer.
+        # The live stage contains only clone-plan prototypes. Full-stage consumers materialize
+        # targets in the flattened copy; the default path replays them through ``physx.clone``.
         cls._rearm_pending_clones()
-        stage_usda = cls._serialize_selected_stage(sim.stage)
-        cls._stage_usda = stage_usda
+        cls.dispatch_event(PhysicsEvent.MODEL_INIT, payload={})
+        stage_usda = cls._stage_usda
+        if stage_usda is None:
+            raise RuntimeError("OvPhysxManager: MODEL_INIT did not capture the prototype stage.")
 
         if cls._physx is None:
             cls._construct_physx(ovphysx_device, gpu_index)
@@ -903,9 +887,14 @@ class OvPhysxManager(PhysicsManager):
         # via :meth:`get_scene_data_backend`.
         if cls._scene_data_backend is None:
             cls._scene_data_backend = OvPhysxSceneDataBackend()
-        cls._scene_data_backend.setup(cls._physx, sim.stage, PhysicsManager._device)
+        clone_plan = sim.get_clone_plan()
+        env_template = (
+            clone_plan.env_template
+            if clone_plan is not None and clone_plan.env_template is not None
+            else DEFAULT_ENV_TEMPLATE
+        )
+        cls._scene_data_backend.setup(cls._physx, sim.stage, PhysicsManager._device, env_template=env_template)
 
-        cls.dispatch_event(PhysicsEvent.MODEL_INIT, payload={})
         cls._warmup_done = True
 
     @classmethod

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -23,7 +23,6 @@ import contextlib
 import logging
 import math
 import os
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
@@ -73,6 +72,7 @@ except ModuleNotFoundError as exc:
         "'ovrtx>=0.4.0,<0.5.0')."
     ) from exc
 
+from isaaclab import cloner
 from isaaclab.cloner.clone_plan import ClonePlan
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
@@ -92,11 +92,7 @@ from .ovrtx_renderer_kernels import (
     generate_random_colors_from_ids_kernel,
     sync_newton_transforms_kernel,
 )
-from .ovrtx_usd import (
-    build_render_product_as_string,
-    create_scene_partition_attributes,
-    export_stage_to_string,
-)
+from .ovrtx_usd import build_render_product_as_string
 
 if TYPE_CHECKING:
     from isaaclab_ppisp import PpispPipeline
@@ -325,9 +321,7 @@ class OVRTXRenderer(BaseRenderer):
         self.cfg = cfg
         self._device = "cuda:0"  # default; overridden by create_render_data(spec)
         self._render_product_paths = []
-        # Shared by both paths. The legacy-only binding handles that pair with these live in
-        # _init_fields_legacy instead; the ovstage path drives the same offsets and counts
-        # through its stage queries.
+        # Shared by the legacy and OVStage paths.
         self._object_newton_indices: wp.array | None = None
         self._deformable_particle_offsets: list[int] = []
         self._deformable_particle_counts: list[int] = []
@@ -335,14 +329,31 @@ class OVRTXRenderer(BaseRenderer):
         self._particle_visual_counts: list[int] = []
         self._initialized_scene = False
         self._exported_usd_string: str | None = None
-        self._camera_rel_path: str | None = None
         self._output_id_color_buffers: dict[str, wp.array] = {}
         self._clone_plan: ClonePlan | None = None
 
         # Selected once at construction so every dispatch method below sees a stable path for the
         # lifetime of the renderer, even if the environment variable changes mid-process.
         self._use_ovstage = ovrtx_use_ovstage_enabled()
-        self._init_fields()
+        if self._use_ovstage:
+            self._stage = None
+            self._stage_paths = None
+            self._ovstage_exit_stack: contextlib.ExitStack | None = None
+            self._current_ordinal: int = 0
+            self._camera_xform_query = None
+            self._camera_paths_list = None
+            self._object_xform_query = None
+            self._object_paths_list = None
+            self._deformable_points_query = None
+            self._deformable_paths_list = None
+            self._particle_points_query = None
+            self._particle_paths_list = None
+        else:
+            self._camera_xform_binding = None
+            self._object_xform_binding = None
+            self._deformable_points_binding = None
+            self._particle_points_binding = None
+            self._particle_workaround_applied = False
 
         logger.info("Creating OVRTX renderer...")
         OVRTX_CONFIG = RendererConfig(
@@ -385,52 +396,65 @@ class OVRTXRenderer(BaseRenderer):
     def prepare_stage(self, stage: Any, num_envs: int) -> None:
         """Prepare the USD stage for OVRTX before :meth:`create_render_data`.
 
-        Adds scene partition attributes and exports the stage to a string held on the renderer until
-        :meth:`create_render_data` is called.
+        OVStage consumes the prototype stage directly. The legacy path adds private destination roots and scene
+        partitions because its renderer discovers that structure while loading USD, then clones prototype assets
+        when :meth:`create_render_data` initializes the scene.
         """
         if stage is None:
             return
 
         self._clone_plan = SimulationContext.instance().get_clone_plan()
-        if self._clone_plan is None or self._clone_plan.positions is None:
-            raise RuntimeError("Clone plan with environment positions is required when preparing OVRTX stage")
+        if (
+            self._clone_plan is None
+            or self._clone_plan.env_ids is None
+            or self._clone_plan.positions is None
+            or self._clone_plan.env_template is None
+        ):
+            raise RuntimeError(
+                "Clone plan with environment ids, positions, and an environment template is required when preparing"
+                " OVRTX stage"
+            )
+        env_ids = [int(env_id) for env_id in self._clone_plan.env_ids.detach().cpu().tolist()]
+        if len(env_ids) != num_envs:
+            raise RuntimeError(f"Clone plan contains {len(env_ids)} environments, expected {num_envs}.")
 
-        # If temp_usd_dir is set, write the pre-ovrtx stage to a temporary file.
+        stage_usda = stage.ExportToString()
         if self.cfg.temp_usd_dir is not None:
-            _write_file(Path(self.cfg.temp_usd_dir), "pre_ovrtx_renderer_stage.usda", stage.ExportToString())
+            _write_file(Path(self.cfg.temp_usd_dir), "pre_ovrtx_renderer_stage.usda", stage_usda)
 
         logger.info("Preparing stage (%d envs)...", num_envs)
-        create_scene_partition_attributes(stage, num_envs)
+        if self._use_ovstage:
+            self._exported_usd_string = stage_usda
+            return
 
-        # keep_env_roots is False on the ovstage path: ovstage's ``Stage.clone`` requires each target
-        # path to not already exist, so the non-source env roots must be trimmed from the exported
-        # stage for it to recreate them.
-        self._exported_usd_string = export_stage_to_string(
-            stage,
-            num_envs,
-            source_paths=self._clone_plan.sources,
-            keep_env_roots=not self._use_ovstage,
-        )
+        # Import after ovrtx so its native library does not load pxr's potentially incompatible USD libraries.
+        from pxr import Sdf, Usd, UsdGeom  # noqa: PLC0415
 
-    def _init_fields_legacy(self) -> None:
-        """Initialize the legacy-path instance fields.
+        private_stage = Usd.Stage.CreateInMemory("ovrtx-private.usda")
+        private_layer = private_stage.GetRootLayer()
+        if not private_layer.ImportFromString(stage_usda):
+            raise RuntimeError("Failed to create the legacy OVRTX stage from the prototype USD")
 
-        Counterpart to :meth:`_init_fields_ovstage`. Only fields the ovstage path never touches live
-        here: the four ``bind_attribute``/``bind_array_attribute`` handles and the
-        ``UsdGeom.Points`` seeding flag. State shared by both paths (``_object_newton_indices``, the
-        particle offset/count lists) stays in :meth:`__init__`.
-        """
-        self._camera_xform_binding = None
-        self._object_xform_binding = None
-        self._deformable_points_binding = None
-        self._particle_points_binding = None
-        self._particle_workaround_applied = False
+        for env_id in env_ids:
+            env_name = f"env_{env_id}"
+            env_prim = UsdGeom.Xform.Define(private_stage, self._clone_plan.env_template.format(env_id)).GetPrim()
+            env_prim.CreateAttribute(
+                "primvars:omni:scenePartition", Sdf.ValueTypeNames.Token, True, Sdf.VariabilityUniform
+            ).Set(env_name)
+            for prim in Usd.PrimRange(env_prim):
+                if prim.IsA(UsdGeom.Camera):
+                    prim.CreateAttribute(
+                        "omni:scenePartition", Sdf.ValueTypeNames.Token, True, Sdf.VariabilityUniform
+                    ).Set(env_name)
 
-    def _initialize_from_spec_legacy(self, spec: CameraRenderSpec):
+        self._exported_usd_string = private_layer.ExportToString()
+
+    def _initialize_from_spec_legacy(self, spec: CameraRenderSpec, camera_paths: list[str]):
         """Initialize the OVRTX renderer with internal environment cloning.
 
         Args:
             spec: Tiled camera description (resolution, paths, data types).
+            camera_paths: Resolved camera paths in clone-plan environment order.
         """
         width = spec.cfg.width
         height = spec.cfg.height
@@ -438,12 +462,6 @@ class OVRTXRenderer(BaseRenderer):
         data_types = spec.cfg.data_types if spec.cfg.data_types else ["rgb"]
         if spec.cfg.isp_cfg is not None and "rgb_hdr" not in data_types:
             data_types = [*data_types, "rgb_hdr"]
-
-        env_0_prefix = "/World/envs/env_0/"
-        first_cam_path = spec.camera_prim_paths[0]
-        if not first_cam_path.startswith(env_0_prefix):
-            raise RuntimeError(f"Expected camera prim under '{env_0_prefix}', got '{first_cam_path}'")
-        self._camera_rel_path = spec.camera_path_relative_to_env_0
 
         logger.info("Injecting camera definitions...")
 
@@ -456,7 +474,7 @@ class OVRTXRenderer(BaseRenderer):
             num_envs=num_envs,
             data_types=data_types,
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
-            camera_rel_path=self._camera_rel_path,
+            camera_path=spec.camera_prim_paths[0],
             background_color=getattr(spec.cfg, "background_color", None),
         )
         self._render_product_paths.append(render_product_path)
@@ -472,17 +490,15 @@ class OVRTXRenderer(BaseRenderer):
         self._renderer.open_usd_from_string(combined_usd_string)
         logger.info("OVRTX loaded USD from string successfully")
 
-        camera_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
-        if num_envs > 1:
-            self._clone_sources_in_ovrtx()
-            self._update_scene_partitions_after_clone(num_envs)
-            # OVRTX 0.4 keeps the initial Fabric camera relationship after clone_usd creates the remaining
-            # cameras. Rewrite it so the RenderProduct includes every camera in its tiled output.
-            self._renderer.write_array_attribute(
-                prim_paths=[render_product_path],
-                attribute_name="camera",
-                tensors=[camera_paths],
-            )
+        self._clone_sources_in_ovrtx()
+        self._update_scene_partitions_after_clone(camera_paths)
+        # OVRTX 0.4 keeps the initial Fabric camera relationship after clone_usd creates the remaining
+        # cameras. Rewrite it so the RenderProduct includes every camera in its tiled output.
+        self._renderer.write_array_attribute(
+            prim_paths=[render_product_path],
+            attribute_name="camera",
+            tensors=[camera_paths],
+        )
 
         self._initialized_scene = True
 
@@ -505,25 +521,25 @@ class OVRTXRenderer(BaseRenderer):
         else:
             raise RuntimeError("Camera binding is None — cannot render without a valid camera binding")
 
-        self._setup_xform_bindings()
-        self._setup_deformable_bindings(num_envs)
-        self._setup_particle_bindings()
+        self._setup_xform_bindings_legacy(camera_paths)
+        self._setup_deformable_bindings_legacy(num_envs)
+        self._setup_particle_bindings_legacy()
 
     def _clone_sources_in_ovrtx(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan`."""
         clone_plan = self._clone_plan
-        if clone_plan is None or clone_plan.positions is None:
-            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
+        assert clone_plan is not None and clone_plan.env_ids is not None
+        assert clone_plan.positions is not None and clone_plan.env_template is not None
 
-        num_envs = clone_plan.clone_mask.shape[1]
-        env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
+        env_ids = clone_plan.env_ids.to(device=clone_plan.clone_mask.device)
+        env_id_values = [int(env_id) for env_id in env_ids.detach().cpu().tolist()]
+        env_prim_paths = [clone_plan.env_template.format(env_id) for env_id in env_id_values]
         logger.info("Cloning sources in OVRTX...")
-        env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
 
         num_cloned_sources = 0
 
         for row_idx, (source, destination) in enumerate(zip(clone_plan.sources, clone_plan.destinations, strict=True)):
-            target_env_ids = env_ids[clone_plan.clone_mask[row_idx]].tolist()
+            target_env_ids = env_ids[clone_plan.clone_mask[row_idx]].detach().cpu().tolist()
 
             target_paths = []
             for env_id in target_env_ids:
@@ -543,7 +559,7 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (len(env_ids), 1, 1))
         env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
         self._renderer.write_attribute(
             prim_paths=env_prim_paths,
@@ -553,12 +569,14 @@ class OVRTXRenderer(BaseRenderer):
             prim_mode=PrimMode.MUST_EXIST,
         )
 
-    def _update_scene_partitions_after_clone(self, num_envs: int):
+    def _update_scene_partitions_after_clone(self, camera_paths: list[str]):
         """Update scene partition attributes on cloned environments and cameras in OvRTX."""
-        logger.info("Writing scene partitions for %d environments...", num_envs)
-        partition_tokens = [f"env_{i}" for i in range(num_envs)]
-        env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        camera_prim_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None
+        env_ids = [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+        partition_tokens = [f"env_{env_id}" for env_id in env_ids]
+        env_prim_paths = [clone_plan.env_template.format(env_id) for env_id in env_ids]
+        logger.info("Writing scene partitions for %d environments...", len(env_ids))
 
         self._renderer.write_attribute(
             env_prim_paths,
@@ -566,17 +584,17 @@ class OVRTXRenderer(BaseRenderer):
             partition_tokens,
             semantic=Semantic.TOKEN_STRING,
         )
-        logger.info("Written primvars:omni:scenePartition to %d environments", num_envs)
+        logger.info("Written primvars:omni:scenePartition to %d environments", len(env_ids))
 
         self._renderer.write_attribute(
-            camera_prim_paths,
+            camera_paths,
             "omni:scenePartition",
             partition_tokens,
             semantic=Semantic.TOKEN_STRING,
         )
-        logger.info("Written omni:scenePartition to %d cameras", num_envs)
+        logger.info("Written omni:scenePartition to %d cameras", len(camera_paths))
 
-    def _setup_xform_bindings_legacy(self):
+    def _setup_xform_bindings_legacy(self, camera_paths: list[str]):
         """Setup OVRTX bindings for scene objects to sync with Newton physics."""
         try:
             from isaaclab_newton.physics import NewtonManager
@@ -598,10 +616,17 @@ class OVRTXRenderer(BaseRenderer):
             logger.info("Newton model has no body_label, skipping object bindings")
             return
 
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_template is not None
+        camera_path_set = set(camera_paths)
         object_paths = []
         newton_indices = []
         for idx, path in enumerate(all_body_paths):
-            if "/World/envs/" in path and self._camera_rel_path not in path and "GroundPlane" not in path:
+            if (
+                cloner.path.match(path, clone_plan.env_template) is not None
+                and path not in camera_path_set
+                and "GroundPlane" not in path
+            ):
                 object_paths.append(path)
                 newton_indices.append(idx)
 
@@ -645,6 +670,10 @@ class OVRTXRenderer(BaseRenderer):
             logger.debug("Deformable registry is empty, skipping deformable body bindings")
             return
 
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None
+        env_ids = [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+
         # Validate the number of particle offsets for each deformable entry upfront.
         bad_entries = [entry for entry in deformable_registry if len(entry.particle_offsets) != num_envs]
         if bad_entries:
@@ -661,27 +690,17 @@ class OVRTXRenderer(BaseRenderer):
 
         vis_mesh_prim_paths: list[str] = []
 
-        # Each registry entry is one deformable asset registered at spawn time. Its
-        # ``vis_mesh_prim_path`` uses a regex env wildcard (e.g. ``env_.*``) to denote one
-        # homogeneous visual mesh replicated into every environment, not a subset of envs.
-        # During replication, Newton appends one particle block per env in contiguous env order
-        # and records the start index in ``entry.particle_offsets``; ``particles_per_body`` is
-        # the block size. The inner loop therefore emits one OVRTX mesh binding per env,
-        # resolving the env wildcard with ``env_idx`` and pairing it with that env's slice in
-        # the flat ``particle_q`` array.
-        #
-        # This mapping is valid only while deformable registry entries remain homogeneous across
-        # all envs with dense, contiguous env ids. If deformables later support env subsets or
-        # non-contiguous env ids, OVRTX must consume explicit per-instance env metadata instead
-        # of deriving env ids from ``enumerate(entry.particle_offsets)``.
         for entry in deformable_registry:
-            for idx, particle_offset in enumerate(entry.particle_offsets):
+            matched = cloner.path.match(entry.vis_mesh_prim_path, clone_plan.env_template)
+            if matched is None:
+                raise RuntimeError(
+                    f"Deformable visual path '{entry.vis_mesh_prim_path}' is outside the environment template"
+                    f" '{clone_plan.env_template}'."
+                )
+            for env_id, particle_offset in zip(env_ids, entry.particle_offsets, strict=True):
                 self._deformable_particle_offsets.append(particle_offset)
                 self._deformable_particle_counts.append(entry.particles_per_body)
-
-                vis_mesh_prim_paths.append(
-                    re.sub(r"(?<=[Ee]nv_)(?:\[\^/\][*+]|\.\*)", str(idx), entry.vis_mesh_prim_path)
-                )
+                vis_mesh_prim_paths.append(clone_plan.env_template.format(env_id) + matched.suffix)
 
         prim_count = len(vis_mesh_prim_paths)
         if prim_count == 0:
@@ -775,7 +794,13 @@ class OVRTXRenderer(BaseRenderer):
         """
         self._device = spec.device
         if not self._initialized_scene:
-            self._initialize_from_spec(spec)
+            clone_plan = self._clone_plan
+            assert clone_plan is not None and clone_plan.env_ids is not None
+            camera_paths = spec.resolve_camera_prim_paths(clone_plan)
+            if self._use_ovstage:
+                self._initialize_from_spec_ovstage(spec, camera_paths)
+            else:
+                self._initialize_from_spec_legacy(spec, camera_paths)
         return OVRTXRenderData(spec, self._device)
 
     def set_outputs(self, render_data: OVRTXRenderData, output_data: dict[str, ProxyArray]) -> None:
@@ -1382,36 +1407,6 @@ class OVRTXRenderer(BaseRenderer):
     # Dispatch methods — route to ovstage or legacy implementation
     # ---------------------------------------------------------------------------
 
-    def _init_fields(self) -> None:
-        if self._use_ovstage:
-            self._init_fields_ovstage()
-        else:
-            self._init_fields_legacy()
-
-    def _initialize_from_spec(self, spec: CameraRenderSpec) -> None:
-        if self._use_ovstage:
-            self._initialize_from_spec_ovstage(spec)
-        else:
-            self._initialize_from_spec_legacy(spec)
-
-    def _setup_xform_bindings(self) -> None:
-        if self._use_ovstage:
-            self._setup_xform_bindings_ovstage()
-        else:
-            self._setup_xform_bindings_legacy()
-
-    def _setup_deformable_bindings(self, num_envs: int) -> None:
-        if self._use_ovstage:
-            self._setup_deformable_bindings_ovstage(num_envs)
-        else:
-            self._setup_deformable_bindings_legacy(num_envs)
-
-    def _setup_particle_bindings(self) -> None:
-        if self._use_ovstage:
-            self._setup_particle_bindings_ovstage()
-        else:
-            self._setup_particle_bindings_legacy()
-
     def update_transforms(self) -> None:
         """Sync transforms to OVRTX."""
         if self._use_ovstage:
@@ -1479,25 +1474,12 @@ class OVRTXRenderer(BaseRenderer):
     #   ovstage 0.1.1 will address this.
     # ---------------------------------------------------------------------------
 
-    def _init_fields_ovstage(self) -> None:
-        self._stage = None
-        self._stage_paths = None
-        self._ovstage_exit_stack: contextlib.ExitStack | None = None
-        self._current_ordinal: int = 0
-        self._camera_xform_query = None
-        self._camera_paths_list = None
-        self._object_xform_query = None
-        self._object_paths_list = None
-        self._deformable_points_query = None
-        self._deformable_paths_list = None
-        self._particle_points_query = None
-        self._particle_paths_list = None
-
-    def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec) -> None:
+    def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec, camera_paths: list[str]) -> None:
         """Initialize the OVRTX renderer with internal environment cloning (ovstage path).
 
         Args:
             spec: Tiled camera description (resolution, paths, data types).
+            camera_paths: Resolved camera paths in clone-plan environment order.
         """
         width = spec.cfg.width
         height = spec.cfg.height
@@ -1505,12 +1487,6 @@ class OVRTXRenderer(BaseRenderer):
         data_types = spec.cfg.data_types if spec.cfg.data_types else ["rgb"]
         if spec.cfg.isp_cfg is not None and "rgb_hdr" not in data_types:
             data_types = [*data_types, "rgb_hdr"]
-
-        env_0_prefix = "/World/envs/env_0/"
-        first_cam_path = spec.camera_prim_paths[0]
-        if not first_cam_path.startswith(env_0_prefix):
-            raise RuntimeError(f"Expected camera prim under '{env_0_prefix}', got '{first_cam_path}'")
-        self._camera_rel_path = spec.camera_path_relative_to_env_0
 
         logger.info("Injecting camera definitions...")
 
@@ -1523,7 +1499,7 @@ class OVRTXRenderer(BaseRenderer):
             num_envs=num_envs,
             data_types=data_types,
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
-            camera_rel_path=self._camera_rel_path,
+            camera_path=spec.camera_prim_paths[0],
         )
         self._render_product_paths.append(render_product_path)
 
@@ -1547,13 +1523,10 @@ class OVRTXRenderer(BaseRenderer):
             domains=ovstage.PopulationDomain.RENDERING,
         )
 
-        if num_envs > 1:
-            self._clone_sources_ovstage()
-            self._update_scene_partitions_after_clone_ovstage(num_envs)
+        self._clone_sources_ovstage()
+        self._update_scene_partitions_after_clone_ovstage(camera_paths)
 
         self._initialized_scene = True
-
-        camera_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
 
         # Re-author the RenderProduct's camera relationship after clone. ``stage.clone`` recreates the per-env
         # cameras, so the RenderProduct must be pointed at the freshly-interned camera path ids to discover every
@@ -1591,7 +1564,7 @@ class OVRTXRenderer(BaseRenderer):
             is_array=False,
         ).wait()
 
-        self._setup_xform_bindings_ovstage()
+        self._setup_xform_bindings_ovstage(camera_paths)
         self._setup_deformable_bindings_ovstage(num_envs)
         self._setup_particle_bindings_ovstage()
 
@@ -1605,18 +1578,18 @@ class OVRTXRenderer(BaseRenderer):
     def _clone_sources_ovstage(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan` (ovstage path)."""
         clone_plan = self._clone_plan
-        if clone_plan is None or clone_plan.positions is None:
-            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
+        assert clone_plan is not None and clone_plan.env_ids is not None
+        assert clone_plan.positions is not None and clone_plan.env_template is not None
 
-        num_envs = clone_plan.clone_mask.shape[1]
-        env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
+        env_ids = clone_plan.env_ids.to(device=clone_plan.clone_mask.device)
+        env_id_values = [int(env_id) for env_id in env_ids.detach().cpu().tolist()]
+        env_prim_paths = [clone_plan.env_template.format(env_id) for env_id in env_id_values]
 
         logger.info("Cloning sources in OVRTX...")
-        env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
 
         num_cloned_sources = 0
         for row_idx, (source, destination) in enumerate(zip(clone_plan.sources, clone_plan.destinations, strict=True)):
-            target_env_ids = env_ids[clone_plan.clone_mask[row_idx]].tolist()
+            target_env_ids = env_ids[clone_plan.clone_mask[row_idx]].detach().cpu().tolist()
 
             target_paths = []
             for env_id in target_env_ids:
@@ -1636,7 +1609,7 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (len(env_ids), 1, 1))
         env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
         env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
         env_query = self._stage.query_from_path_list(env_paths_list)
@@ -1652,14 +1625,16 @@ class OVRTXRenderer(BaseRenderer):
         self._stage.release_query(env_query).wait()
         self._stage_paths.destroy_path_list(env_paths_list)
 
-    def _update_scene_partitions_after_clone_ovstage(self, num_envs: int):
+    def _update_scene_partitions_after_clone_ovstage(self, camera_paths: list[str]):
         """Update scene partition attributes on cloned environments and cameras (ovstage path)."""
-        logger.info("Writing scene partitions for %d environments...", num_envs)
-        env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        camera_prim_paths = [f"/World/envs/env_{i}/{self._camera_rel_path}" for i in range(num_envs)]
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None
+        env_ids = [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+        env_prim_paths = [clone_plan.env_template.format(env_id) for env_id in env_ids]
+        logger.info("Writing scene partitions for %d environments...", len(env_ids))
         # TOKEN_ID semantic tells ovstage the uint64 values are interned string tokens, not raw integers;
         # the renderer resolves them back to the original "env_N" strings for scene-partition lookup.
-        token_ids = np.array([self._stage_paths.intern_token(f"env_{i}") for i in range(num_envs)], dtype=np.uint64)
+        token_ids = np.array([self._stage_paths.intern_token(f"env_{env_id}") for env_id in env_ids], dtype=np.uint64)
 
         env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
         env_query = self._stage.query_from_path_list(env_paths_list)
@@ -1673,9 +1648,9 @@ class OVRTXRenderer(BaseRenderer):
         ).wait()
         self._stage.release_query(env_query).wait()
         self._stage_paths.destroy_path_list(env_paths_list)
-        logger.info("Written primvars:omni:scenePartition to %d environments", num_envs)
+        logger.info("Written primvars:omni:scenePartition to %d environments", len(env_ids))
 
-        cam_paths_list = self._stage_paths.create_path_list_from_strings(camera_prim_paths)
+        cam_paths_list = self._stage_paths.create_path_list_from_strings(camera_paths)
         cam_query = self._stage.query_from_path_list(cam_paths_list)
         self._stage.write_attribute(
             cam_query,
@@ -1687,9 +1662,9 @@ class OVRTXRenderer(BaseRenderer):
         ).wait()
         self._stage.release_query(cam_query).wait()
         self._stage_paths.destroy_path_list(cam_paths_list)
-        logger.info("Written omni:scenePartition to %d cameras", num_envs)
+        logger.info("Written omni:scenePartition to %d cameras", len(camera_paths))
 
-    def _setup_xform_bindings_ovstage(self) -> None:
+    def _setup_xform_bindings_ovstage(self, camera_paths: list[str]) -> None:
         """Setup OVRTX bindings for scene objects to sync with Newton physics (ovstage path)."""
         try:
             from isaaclab_newton.physics import NewtonManager
@@ -1711,10 +1686,17 @@ class OVRTXRenderer(BaseRenderer):
             logger.info("Newton model has no body_label, skipping object bindings")
             return
 
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_template is not None
+        camera_path_set = set(camera_paths)
         object_paths = []
         newton_indices = []
         for idx, path in enumerate(all_body_paths):
-            if "/World/envs/" in path and self._camera_rel_path not in path and "GroundPlane" not in path:
+            if (
+                cloner.path.match(path, clone_plan.env_template) is not None
+                and path not in camera_path_set
+                and "GroundPlane" not in path
+            ):
                 object_paths.append(path)
                 newton_indices.append(idx)
 
@@ -1756,6 +1738,10 @@ class OVRTXRenderer(BaseRenderer):
             logger.debug("Deformable registry is empty, skipping deformable body bindings")
             return
 
+        clone_plan = self._clone_plan
+        assert clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None
+        env_ids = [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+
         # Validate the number of particle offsets for each deformable entry upfront.
         bad_entries = [entry for entry in deformable_registry if len(entry.particle_offsets) != num_envs]
         if bad_entries:
@@ -1772,27 +1758,17 @@ class OVRTXRenderer(BaseRenderer):
 
         vis_mesh_prim_paths: list[str] = []
 
-        # Each registry entry is one deformable asset registered at spawn time. Its
-        # ``vis_mesh_prim_path`` uses a regex env wildcard (e.g. ``env_.*``) to denote one
-        # homogeneous visual mesh replicated into every environment, not a subset of envs.
-        # During replication, Newton appends one particle block per env in contiguous env order
-        # and records the start index in ``entry.particle_offsets``; ``particles_per_body`` is
-        # the block size. The inner loop therefore emits one OVRTX mesh binding per env,
-        # resolving the env wildcard with ``env_idx`` and pairing it with that env's slice in
-        # the flat ``particle_q`` array.
-        #
-        # This mapping is valid only while deformable registry entries remain homogeneous across
-        # all envs with dense, contiguous env ids. If deformables later support env subsets or
-        # non-contiguous env ids, OVRTX must consume explicit per-instance env metadata instead
-        # of deriving env ids from ``enumerate(entry.particle_offsets)``.
         for entry in deformable_registry:
-            for idx, particle_offset in enumerate(entry.particle_offsets):
+            matched = cloner.path.match(entry.vis_mesh_prim_path, clone_plan.env_template)
+            if matched is None:
+                raise RuntimeError(
+                    f"Deformable visual path '{entry.vis_mesh_prim_path}' is outside the environment template"
+                    f" '{clone_plan.env_template}'."
+                )
+            for env_id, particle_offset in zip(env_ids, entry.particle_offsets, strict=True):
                 self._deformable_particle_offsets.append(particle_offset)
                 self._deformable_particle_counts.append(entry.particles_per_body)
-
-                vis_mesh_prim_paths.append(
-                    re.sub(r"(?<=[Ee]nv_)(?:\[\^/\][*+]|\.\*)", str(idx), entry.vis_mesh_prim_path)
-                )
+                vis_mesh_prim_paths.append(clone_plan.env_template.format(env_id) + matched.suffix)
 
         prim_count = len(vis_mesh_prim_paths)
         if prim_count == 0:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -24,7 +24,6 @@ import logging
 import math
 import os
 import re
-from itertools import compress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
@@ -251,49 +250,6 @@ def _write_file(output_dir: Path, file_name: str, content: str) -> None:
         logger.info("Wrote USD file: %s", output_path)
 
 
-def _create_homogeneous_clone_plan(num_envs: int) -> ClonePlan:
-    """Create a homogeneous fallback plan that replicates ``env_0`` to every environment."""
-    return ClonePlan(
-        sources=("/World/envs/env_0",),
-        destinations=("/World/envs/env_{}",),
-        clone_mask=torch.ones((1, num_envs), dtype=torch.bool, device="cpu"),
-    )
-
-
-def _resolve_clone_plan(num_envs: int) -> ClonePlan:
-    """Resolve clone plan for local use.
-
-    If no clone plan is published by the scene or it has no active rows, returns a homogeneous clone plan.
-    If the clone plan has some inactive rows, returns a copy of the published clone plan with only the active rows.
-    If the clone plan has all active rows, returns the published clone plan (shallow copy).
-    """
-    published_clone_plan = SimulationContext.instance().get_clone_plan()
-
-    if published_clone_plan is None:
-        logger.warning("No clone plan is published by the scene; returning homogeneous clone plan")
-        return _create_homogeneous_clone_plan(num_envs)
-
-    active_rows = published_clone_plan.clone_mask.any(dim=1)
-
-    # If no rows are active, return a homogeneous clone plan.
-    if not active_rows.any():
-        logger.warning("Clone plan has no active rows, returning homogeneous clone plan")
-        return _create_homogeneous_clone_plan(num_envs)
-
-    # If some rows are inactive, return a copy of the published clone plan with only the active rows.
-    if not active_rows.all():
-        logger.warning("Clone plan has some inactive rows; returning a copy with only active rows")
-        active = active_rows.tolist()
-        return ClonePlan(
-            sources=tuple(compress(published_clone_plan.sources, active)),
-            destinations=tuple(compress(published_clone_plan.destinations, active)),
-            clone_mask=published_clone_plan.clone_mask[active_rows],
-        )
-
-    # If all rows are active, return the published clone plan (shallow copy).
-    return published_clone_plan
-
-
 class OVRTXRenderData:
     """OVRTX-specific RenderData. Holds warp output buffers sized from :class:`CameraRenderSpec`."""
 
@@ -435,6 +391,10 @@ class OVRTXRenderer(BaseRenderer):
         if stage is None:
             return
 
+        self._clone_plan = SimulationContext.instance().get_clone_plan()
+        if self._clone_plan is None or self._clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when preparing OVRTX stage")
+
         # If temp_usd_dir is set, write the pre-ovrtx stage to a temporary file.
         if self.cfg.temp_usd_dir is not None:
             _write_file(Path(self.cfg.temp_usd_dir), "pre_ovrtx_renderer_stage.usda", stage.ExportToString())
@@ -442,20 +402,9 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("Preparing stage (%d envs)...", num_envs)
         create_scene_partition_attributes(stage, num_envs)
 
-        # Resolve the clone plan for local use.
-        self._clone_plan = _resolve_clone_plan(num_envs)
-        if self._clone_plan is None:
-            raise RuntimeError("Clone plan is required when preparing OVRTX stage")
-
-        # The ovstage path cannot read env-root transforms back after load (see
-        # _clone_sources_ovstage), so snapshot them here while the full USD stage is still live.
-        if self._use_ovstage:
-            self._capture_env_root_xforms_ovstage(stage, num_envs)
-
         # keep_env_roots is False on the ovstage path: ovstage's ``Stage.clone`` requires each target
         # path to not already exist, so the non-source env roots must be trimmed from the exported
-        # stage for it to recreate them. Their xforms were captured just above, since trimming them
-        # is what makes them unreadable afterwards.
+        # stage for it to recreate them.
         self._exported_usd_string = export_stage_to_string(
             stage,
             num_envs,
@@ -563,35 +512,11 @@ class OVRTXRenderer(BaseRenderer):
     def _clone_sources_in_ovrtx(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan`."""
         clone_plan = self._clone_plan
-        if clone_plan is None:
-            raise RuntimeError("Clone plan is required when using OVRTX cloning")
+        if clone_plan is None or clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-        xform_attr_name = "omni:xform"
-
-        # Snapshot per-env root transforms before clone_usd overwrites them with the source env root.
-        #
-        # We only create xform bindings for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no binding, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovrtx data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        self._renderer.read_attribute(
-            xform_attr_name,
-            env_prim_paths,
-            prim_mode=PrimMode.MUST_EXIST,
-            dest=env_root_xforms,
-        )
-        logger.info("Captured per-env root transforms before cloning")
-
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
 
@@ -618,15 +543,15 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
         self._renderer.write_attribute(
             prim_paths=env_prim_paths,
-            attribute_name=xform_attr_name,
+            attribute_name="omni:xform",
             tensor=env_root_xforms,
             semantic=Semantic.XFORM_MAT4x4,
             prim_mode=PrimMode.MUST_EXIST,
         )
-        logger.info("Restored per-env root transforms after cloning")
 
     def _update_scene_partitions_after_clone(self, num_envs: int):
         """Update scene partition attributes on cloned environments and cameras in OvRTX."""
@@ -1567,7 +1492,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_paths_list = None
         self._particle_points_query = None
         self._particle_paths_list = None
-        self._env_root_xforms: np.ndarray | None = None
 
     def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec) -> None:
         """Initialize the OVRTX renderer with internal environment cloning (ovstage path).
@@ -1678,54 +1602,14 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("OVRTX loaded USD from string successfully via ovstage")
         self._current_ordinal += 1
 
-    def _capture_env_root_xforms_ovstage(self, stage: Any, num_envs: int) -> None:
-        """Capture per-env root transforms from the live USD stage before export.
-
-        Must be called before :func:`export_stage_to_string`, which trims non-source
-        env geometry so those transforms cannot be read back reliably from ovstage after load.
-        The captured array is consumed by :meth:`_clone_sources_ovstage` and cleared after use.
-        """
-        from pxr import UsdGeom
-
-        xform_cache = UsdGeom.XformCache()
-        self._env_root_xforms = np.empty((num_envs, 4, 4), dtype=np.float64)
-        for i in range(num_envs):
-            prim = stage.GetPrimAtPath(f"/World/envs/env_{i}")
-            self._env_root_xforms[i] = np.array(xform_cache.GetLocalToWorldTransform(prim), dtype=np.float64).reshape(
-                4, 4
-            )
-
     def _clone_sources_ovstage(self):
         """Clone sources in OVRTX using the scene :class:`~isaaclab.cloner.ClonePlan` (ovstage path)."""
         clone_plan = self._clone_plan
-        if clone_plan is None:
-            raise RuntimeError("Clone plan is required when using OVRTX cloning")
+        if clone_plan is None or clone_plan.positions is None:
+            raise RuntimeError("Clone plan with environment positions is required when using OVRTX cloning")
 
         num_envs = clone_plan.clone_mask.shape[1]
         env_prim_paths = [f"/World/envs/env_{i}" for i in range(num_envs)]
-
-        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
-        env_query = self._stage.query_from_path_list(env_paths_list)
-
-        # Snapshot per-env root transforms before clone overwrites them with the source env root.
-        #
-        # We only create xform queries for prims in the body_label list, so their transforms are
-        # driven each frame from simulation data. Prims not in that list (e.g. static rigid objects
-        # such as tables) get no query, and we never reset their xform stack. Their world placement
-        # therefore relies on every ancestor holding a correct xform in the ovstage data. In
-        # particular, if an env root has no valid xform, these prims collapse toward env_0 frame
-        # (e.g. tables ending up at env_0 and missing from the other tiles).
-        #
-        # Snapshotting the env-root xforms here and restoring them after clone (see below) keeps those
-        # hierarchy-positioned prims correctly placed per env. This is a cheap one-off operation,
-        # preferable to forcing every static object into the body_label list just to bind its xform.
-        #
-        # Transforms were captured from the live USD stage in prepare_stage before export
-        # stripped non-source envs — they are not readable from ovstage at this point.
-        env_root_xforms = self._env_root_xforms
-        if env_root_xforms is None:
-            raise RuntimeError("env_root_xforms not captured; ensure prepare_stage was called first")
-        logger.info("Using pre-captured per-env root transforms for post-clone restore")
 
         logger.info("Cloning sources in OVRTX...")
         env_ids = torch.arange(num_envs, dtype=torch.int32, device=clone_plan.clone_mask.device)
@@ -1752,7 +1636,10 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Cloned %d sources successfully in OVRTX", num_cloned_sources)
 
-        # Restore the pre-clone xforms.
+        env_root_xforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
+        env_root_xforms[:, 3, :3] = clone_plan.positions.cpu().numpy()
+        env_paths_list = self._stage_paths.create_path_list_from_strings(env_prim_paths)
+        env_query = self._stage.query_from_path_list(env_paths_list)
         self._stage.write_attribute(
             env_query,
             "omni:xform",
@@ -1761,8 +1648,6 @@ class OVRTXRenderer(BaseRenderer):
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
-        self._env_root_xforms = None
-        logger.info("Restored per-env root transforms after cloning")
 
         self._stage.release_query(env_query).wait()
         self._stage_paths.destroy_path_list(env_paths_list)
@@ -2220,7 +2105,6 @@ class OVRTXRenderer(BaseRenderer):
         self._deformable_particle_counts = []
         self._particle_visual_offsets = []
         self._particle_visual_counts = []
-        self._env_root_xforms = None
 
         # Detach before closing ExitStack: the renderer holds a live reference into the stage,
         # so detaching first avoids a use-after-free when ExitStack destroys Stage and PathDictionary.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -3,16 +3,11 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""USD manipulation for OVRTX: Render scope building, camera injection, and stage prim activation."""
+"""USD string construction for OVRTX render products."""
 
 from __future__ import annotations
 
-import logging
 import math
-
-from pxr import Sdf, Usd, UsdGeom
-
-logger = logging.getLogger(__name__)
 
 
 def get_render_var_config(data_types: list[str]) -> tuple[str, str, str]:
@@ -180,36 +175,29 @@ def Scope "Render"
 '''
 
 
-def _tiled_resolution(num_envs: int, width: int, height: int) -> tuple[int, int]:
-    """Compute tiled width and height from env count and per-env resolution (same as Camera)."""
-    num_cols = math.ceil(math.sqrt(num_envs))
-    num_rows = math.ceil(num_envs / num_cols)
-    return num_cols * width, num_rows * height
-
-
 def build_render_product_as_string(
     width: int,
     height: int,
     num_envs: int,
     data_types: list[str],
+    camera_path: str,
     minimal_mode: int | None = None,
-    camera_rel_path: str = "Camera",
     background_color: tuple[float, float, float] | None = None,
 ) -> tuple[str, str]:
     """Build the render product USD snippet as a string.
 
     This string is meant to be appended to an exported stage (ASCII) before loading into OVRTX.
-    The initial camera relationship targets only environment zero, whose camera is guaranteed to
-    exist in the trimmed stage. Multi-environment rendering rewrites the relationship with every
-    resolved camera path after runtime cloning.
+    The initial camera relationship targets one camera authored in the prototype stage.
+    Multi-environment rendering rewrites the relationship with every resolved camera path after
+    runtime cloning.
 
     Args:
         width: Tile width from sensor config [px].
         height: Tile height from sensor config [px].
         num_envs: Number of environments from scene.
         data_types: Data types from sensor config.
+        camera_path: Absolute path of a camera authored in the prototype stage.
         minimal_mode: RTX minimal mode. None if not requested. Valid values are 1, 2, 3.
-        camera_rel_path: Camera prim path relative to the env root (e.g. ``"Camera"`` or ``"Robot/head_cam"``).
         background_color: Solid background color as normalized RGB floats ``(r, g, b)`` in ``[0, 1]``.
             When set, the render product uses a solid color background instead of the dome light.
             When ``None``, the default dome-light background is used.
@@ -218,9 +206,10 @@ def build_render_product_as_string(
         Tuple of (render product USD snippet as a string, absolute render product prim path).
     """
     data_types = data_types if data_types else ["rgb"]
-    tiled_width, tiled_height = _tiled_resolution(num_envs, width, height)
+    num_cols = math.ceil(math.sqrt(num_envs))
+    tiled_width, tiled_height = num_cols * width, math.ceil(num_envs / num_cols) * height
 
-    camera_paths = [f"/World/envs/env_0/{camera_rel_path}"]
+    camera_paths = [camera_path]
     render_product_name = "RenderProduct"
     render_product_path = f"/Render/{render_product_name}"
 
@@ -240,164 +229,3 @@ def build_render_product_as_string(
         background_color,
     )
     return camera_content, render_product_path
-
-
-def create_scene_partition_attributes(
-    stage,
-    num_envs: int = 1,
-) -> None:
-    """Create scene partition attributes for env roots and cameras.
-
-    Camera prims are discovered by USD type (``UsdGeom.Camera``) rather than by name, so this works regardless of
-    where the camera is placed in the hierarchy.
-
-    Args:
-        stage: USD stage to modify.
-        num_envs: Number of environments.
-    """
-    # Collect the attribute paths and scene partition tokens to update.
-    attr_updates: list[tuple[Sdf.Path, str]] = []
-    for env_idx in range(num_envs):
-        env_path = f"/World/envs/env_{env_idx}"
-        env_prim = stage.GetPrimAtPath(env_path)
-        if not env_prim.IsValid():
-            logger.warning("Failed to get env root prim at '%s'", env_path)
-            continue
-
-        scene_partition = f"env_{env_idx}"
-
-        for prim in Usd.PrimRange(env_prim):
-            if prim.GetPath() == env_prim.GetPath():
-                attr_path = prim.GetPath().AppendProperty("primvars:omni:scenePartition")
-            elif prim.IsA(UsdGeom.Camera):
-                attr_path = prim.GetPath().AppendProperty("omni:scenePartition")
-            else:
-                continue
-            attr_updates.append((attr_path, scene_partition))
-
-    root_layer = stage.GetRootLayer()
-    type_name = Sdf.ValueTypeNames.Token
-    variability = Sdf.VariabilityUniform
-    is_custom = True
-
-    # Create the attributes and set the default values.
-    with Sdf.ChangeBlock():
-        for attr_path, scene_partition in attr_updates:
-            Sdf.JustCreatePrimAttributeInLayer(root_layer, attr_path, type_name, variability, is_custom)
-            root_layer.GetAttributeAtPath(attr_path).default = scene_partition
-            logger.debug("Set scene partition '%s' on '%s'", scene_partition, attr_path.GetPrimPath())
-
-
-def _collect_prims_to_deactivate(parent_prim: Usd.Prim, source_paths: frozenset[Sdf.Path]) -> list[Sdf.Path]:
-    """Collect child prims under ``parent_prim`` for deactivation.
-
-    For each child:
-
-    * If the child is a source, keep the full subtree and stop descending.
-    * If the child is an ancestor of some source, recurse to deactivate non-source siblings deeper in the tree.
-    * Otherwise, deactivate the child prim (including descendants).
-
-    Args:
-        parent_prim: Parent prim whose children are considered.
-        source_paths: The paths to the cloning sources.
-
-    Returns:
-        Paths of prims to deactivate on the root layer.
-    """
-    prim_paths: list[Sdf.Path] = []
-
-    for child in parent_prim.GetChildren():
-        child_path = child.GetPath()
-
-        # If the child is a source, keep it and stop walking down the tree.
-        if child_path in source_paths:
-            continue
-
-        # If the child is an ancestor of some source, recurse to deactivate non-source siblings deeper in the tree.
-        if any(source.HasPrefix(child_path) for source in source_paths):
-            prim_paths.extend(_collect_prims_to_deactivate(child, source_paths))
-            continue
-
-        # Otherwise, deactivate the child prim (including descendants).
-        if child.IsActive():
-            prim_paths.append(child_path)
-
-    return prim_paths
-
-
-def _set_prims_active_on_layer(layer: Sdf.Layer, prim_paths: list[Sdf.Path], active: bool) -> None:
-    """Activate or deactivate prims on the given layer.
-
-    Args:
-        layer: Layer to modify the prims on.
-        prim_paths: Paths of prims to activate or deactivate.
-        active: Whether to activate or deactivate the prims.
-    """
-    action_str = "Activated" if active else "Deactivated"
-
-    with Sdf.ChangeBlock():
-        for prim_path in prim_paths:
-            # If a prim already exists at the given path it will be returned unmodified.
-            prim_spec = Sdf.CreatePrimInLayer(layer, prim_path)
-            prim_spec.active = active
-            logger.debug("%s prim: %s", action_str, prim_path)
-
-    logger.info("%s %d prims in total", action_str, len(prim_paths))
-
-
-def export_stage_to_string(
-    stage: Usd.Stage, num_envs: int, source_paths: tuple[str, ...], keep_env_roots: bool = True
-) -> str:
-    """Export the USD stage as a USDA string for OVRTX loading.
-
-    When ``num_envs`` is 1, the full stage is exported unchanged. Otherwise the stage is trimmed so OVRTX receives
-    only the prototype geometry it replicates at clone time. Non-source env descendants are temporarily deactivated
-    on the root layer during export and restored afterwards; ``stage.ExportToString`` re-composes the stage, so
-    deactivated prims drop out of the exported text and their paths are absent when the clone path repopulates them.
-
-    When ``keep_env_roots`` is True (the legacy ``renderer.clone_usd`` path) the non-source env root prims stay
-    active so the exported stage retains a slot for every env. The ovstage ``stage.clone`` path passes False, which
-    additionally trims the non-source env roots themselves; ``stage.clone`` recreates them and the RenderProduct's
-    camera relationship is re-authored after clone.
-
-    Args:
-        stage: USD stage to export.
-        num_envs: Number of parallel environments on the stage.
-        source_paths: The paths to source prims to keep in the exported stage.
-        keep_env_roots: Whether to keep the non-source env root prims active in the exported stage. Pass False for
-            the ovstage clone path, which repopulates env roots itself.
-
-    Returns:
-        USDA text of the (possibly trimmed) stage.
-    """
-    if num_envs <= 1:
-        return stage.ExportToString()
-
-    envs_path = Sdf.Path("/World/envs")
-    envs_prim = stage.GetPrimAtPath(envs_path)
-    if not envs_prim.IsValid():
-        raise RuntimeError(f"Failed to get prim at path: {envs_path}")
-
-    source_path_set = frozenset(map(Sdf.Path, source_paths))
-    prim_paths: list[Sdf.Path] = []
-
-    if keep_env_roots:
-        for child in envs_prim.GetChildren():
-            # Legacy code path: keep env roots so we can query their xforms after opening stage
-            child_path = child.GetPath()
-            if child_path not in source_path_set:
-                prim_paths.extend(_collect_prims_to_deactivate(child, source_path_set))
-    else:
-        # Ovstage code path: strip env roots, their xforms are queried beforehand.
-        prim_paths = _collect_prims_to_deactivate(envs_prim, source_path_set)
-
-    root_layer = stage.GetRootLayer()
-
-    # Temporarily deactivate the prims so that the stage is exported without them.
-    _set_prims_active_on_layer(root_layer, prim_paths, active=False)
-
-    try:
-        return stage.ExportToString()
-    finally:
-        # Restore the active state of the prims.
-        _set_prims_active_on_layer(root_layer, prim_paths, active=True)

--- a/source/isaaclab_ov/isaaclab_ov/sim/views/ovphysx_frame_view.py
+++ b/source/isaaclab_ov/isaaclab_ov/sim/views/ovphysx_frame_view.py
@@ -17,6 +17,7 @@ from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
+from isaaclab.cloner.cloner_cfg import DEFAULT_ENV_TEMPLATE
 from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.views.base_frame_view import BaseFrameView
 from isaaclab.sim.views.usd_frame_view import UsdFrameView
@@ -315,6 +316,10 @@ class OvPhysxFrameView(BaseFrameView):
         self._stage = stage
         sim = sim_utils.SimulationContext.instance()
         plan = sim.get_clone_plan() if sim is not None else None
+        self._clone_plan = plan
+        self._env_template = (
+            plan.env_template if plan is not None and plan.env_template is not None else DEFAULT_ENV_TEMPLATE
+        )
         source_matches = tuple(cloner.query.iter_sources(plan, prim_path)) if plan is not None else ()
         self._source_records = []
         self._prims: list[Usd.Prim] = []
@@ -367,8 +372,8 @@ class OvPhysxFrameView(BaseFrameView):
         """Resolve prims to rigid-body ancestors and create a RIGID_BODY_POSE tensor binding.
 
         With a ClonePlan, site discovery reads only its authored source prims, whether or not
-        destination USD prims exist. The RIGID_BODY_POSE binding is the source of truth for the
-        site count, and per-env site paths are synthesized from the source prim paths.
+        destination USD prims exist. Authored sources provide site transforms; the
+        RIGID_BODY_POSE binding maps replicated ancestors to physics rows.
         """
         from isaaclab_ov import tensor_types as TT  # noqa: PLC0415
         from isaaclab_ov.sim.views.ovphysx_view import OvPhysxView  # noqa: PLC0415
@@ -411,7 +416,7 @@ class OvPhysxFrameView(BaseFrameView):
 
         # 3. Dedup discovered ancestor paths into env-wildcarded patterns (one binding per pattern).
         all_ancestors = [p for p in (per_prim_ancestor + parent_ancestor) if p is not None]
-        patterns = sorted({self._env_wildcardify(p) for p in all_ancestors})
+        patterns = sorted({self._retarget_environment(path, "*") for path in all_ancestors})
         if len(patterns) > 1:
             raise NotImplementedError(
                 f"OvPhysxFrameView v1 supports a single body-type pattern; resolved {len(patterns)}"
@@ -439,7 +444,7 @@ class OvPhysxFrameView(BaseFrameView):
             binding_paths = []
 
         world_sites = self._expand_world_sites_from_clone_plan(xform_cache) if not binding_paths else []
-        # 5. Expand source prim data to one entry per binding row.
+        # 5. Broadcast a single authored site across replicated physics binding rows.
         if binding_paths and len(binding_paths) > len(self._prims):
             template_ancestor = per_prim_ancestor[0]
             template_site_local = per_prim_site_local[0]
@@ -453,24 +458,24 @@ class OvPhysxFrameView(BaseFrameView):
             parent_site_local = []
             synthetic_prim_paths: list[str] = []
             for body_path in binding_paths:
-                env_match = re.search(r"/World/envs/env_(\d+)", body_path)
-                env_token = env_match.group(0) if env_match else None
-                # Re-target the template path's env segment to this row's env_id.
-                if env_token is not None:
-                    synthetic_path = re.sub(r"/World/envs/env_\d+", env_token, template_path)
-                    ap = re.sub(r"/World/envs/env_\d+", env_token, template_ancestor) if template_ancestor else None
-                    pap = (
-                        re.sub(r"/World/envs/env_\d+", env_token, template_parent_ancestor)
+                matched = cloner.path.match(body_path, self._env_template)
+                if matched is not None:
+                    synthetic_path = self._retarget_environment(template_path, matched.instance)
+                    ancestor = (
+                        self._retarget_environment(template_ancestor, matched.instance) if template_ancestor else None
+                    )
+                    parent = (
+                        self._retarget_environment(template_parent_ancestor, matched.instance)
                         if template_parent_ancestor
                         else None
                     )
                 else:
                     synthetic_path = template_path
-                    ap = template_ancestor
-                    pap = template_parent_ancestor
-                per_prim_ancestor.append(ap)
+                    ancestor = template_ancestor
+                    parent = template_parent_ancestor
+                per_prim_ancestor.append(ancestor)
                 per_prim_site_local.append(template_site_local)
-                parent_ancestor.append(pap)
+                parent_ancestor.append(parent)
                 parent_site_local.append(template_parent_site_local)
                 synthetic_prim_paths.append(synthetic_path)
             self._synthetic_prim_paths: list[str] | None = synthetic_prim_paths
@@ -486,13 +491,9 @@ class OvPhysxFrameView(BaseFrameView):
             self._synthetic_prim_paths = None
 
         # 6. Build site_body and parent_site_body indices into the binding's row order.
-        path_to_row = {p: i for i, p in enumerate(binding_paths)}
-        site_bodies = [
-            path_to_row.get(ap, WORLD_BODY_INDEX) if ap is not None else WORLD_BODY_INDEX for ap in per_prim_ancestor
-        ]
-        parent_bodies = [
-            path_to_row.get(pap, WORLD_BODY_INDEX) if pap is not None else WORLD_BODY_INDEX for pap in parent_ancestor
-        ]
+        path_to_row = {path: row for row, path in enumerate(binding_paths)}
+        site_bodies = [path_to_row[ap] if ap is not None else WORLD_BODY_INDEX for ap in per_prim_ancestor]
+        parent_bodies = [path_to_row[pap] if pap is not None else WORLD_BODY_INDEX for pap in parent_ancestor]
 
         # 7. Allocate Warp arrays.
         device = self._device
@@ -520,6 +521,16 @@ class OvPhysxFrameView(BaseFrameView):
         if sum(len(env_ids) for _, _, _, env_ids in self._source_records) <= len(self._prims):
             return []
 
+        clone_plan = self._clone_plan
+        assert clone_plan is not None
+        plan_env_ids = (
+            list(range(clone_plan.clone_mask.shape[1]))
+            if clone_plan.env_ids is None
+            else [int(env_id) for env_id in clone_plan.env_ids.detach().cpu().tolist()]
+        )
+        positions = clone_plan.positions.detach().cpu().tolist() if clone_plan.positions is not None else None
+        position_by_env = dict(zip(plan_env_ids, positions, strict=True)) if positions is not None else {}
+
         records: list[tuple[int, Usd.Prim, list[float], list[float], str]] = []
         for source_root, destination_template, source_prim, env_ids in self._source_records:
             source_prim_path = source_prim.GetPath().pathString
@@ -528,21 +539,20 @@ class OvPhysxFrameView(BaseFrameView):
                 raise RuntimeError(f"OvPhysxFrameView source prim {source_prim_path!r} is not under {source_root!r}.")
             source_world = xform_cache.GetLocalToWorldTransform(source_prim)
             source_parent_world = xform_cache.GetLocalToWorldTransform(source_prim.GetParent())
+            source_match = cloner.path.match(source_prim_path, self._env_template)
+            source_anchor_world = Gf.Matrix4d(1.0)
+            if source_match is not None:
+                source_anchor = self._stage.GetPrimAtPath(self._env_template.format(source_match.instance))
+                if not source_anchor.IsValid():
+                    raise RuntimeError(f"OvPhysxFrameView source root is absent for {source_prim_path!r}.")
+                source_anchor_world = xform_cache.GetLocalToWorldTransform(source_anchor)
+            source_inverse = source_anchor_world.GetInverse()
 
             for env_id in env_ids:
                 destination_root = destination_template.format(env_id)
-                source_anchor_path, destination_anchor_path = source_root, destination_root
-                destination_anchor = self._stage.GetPrimAtPath(destination_anchor_path)
-                while not destination_anchor.IsValid() and destination_anchor_path != "/":
-                    source_anchor_path = source_anchor_path.rsplit("/", 1)[0] or "/"
-                    destination_anchor_path = destination_anchor_path.rsplit("/", 1)[0] or "/"
-                    destination_anchor = self._stage.GetPrimAtPath(destination_anchor_path)
-
-                source_anchor = self._stage.GetPrimAtPath(source_anchor_path)
-                if not source_anchor.IsValid() or not destination_anchor.IsValid():
-                    raise RuntimeError(f"OvPhysxFrameView could not project {source_prim_path!r} into env {env_id}.")
-                source_inverse = xform_cache.GetLocalToWorldTransform(source_anchor).GetInverse()
-                destination_world = xform_cache.GetLocalToWorldTransform(destination_anchor)
+                destination_world = Gf.Matrix4d(1.0)
+                if env_id in position_by_env:
+                    destination_world.SetTranslateOnly(Gf.Vec3d(*position_by_env[env_id]))
                 site_world = _gf_matrix_to_xform7(source_world * source_inverse * destination_world)
                 parent_world = _gf_matrix_to_xform7(source_parent_world * source_inverse * destination_world)
                 records.append((env_id, source_prim, site_world, parent_world, destination_root + suffix))
@@ -557,12 +567,10 @@ class OvPhysxFrameView(BaseFrameView):
     ) -> tuple[str | None, list[float]]:
         """Walk USD ancestors to find the nearest prim with ``UsdPhysics.RigidBodyAPI``.
 
-        Under OVPhysX scenes built with ``clone_usd=False`` (the default for
-        :class:`~isaaclab.scene.InteractiveScene`), only ``env_0`` carries the
-        authored RigidBodyAPI -- ``env_1..N`` exist only as physics-layer clones
-        and the corresponding USD prims (when present) are untyped Xforms.
-        :meth:`_prim_or_template_has_rigid_body_api` handles this by checking
-        the prim's env_0 equivalent when the API is not directly applied.
+        Under OVPhysX scenes built from clone-plan prototypes, destination bodies exist only as
+        physics-layer clones. Source prims carry the authored physics schemas used for lookup.
+        :meth:`_prim_or_template_has_rigid_body_api` handles this by resolving
+        destination prims back to their clone-plan sources.
 
         Returns:
             ``(ancestor_path, [tx, ty, tz, qx, qy, qz, qw])``. ``ancestor_path`` is
@@ -571,7 +579,7 @@ class OvPhysxFrameView(BaseFrameView):
         """
         prim_world_tf = xform_cache.GetLocalToWorldTransform(prim)
         prim_world_tf.Orthonormalize()
-        # If the prim itself is a rigid body (directly or via env_0 template), the site offset is identity.
+        # If the prim itself is a rigid body, directly or through its plan source, the site offset is identity.
         if self._prim_or_template_has_rigid_body_api(prim):
             return prim.GetPath().pathString, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
         ancestor = prim.GetParent()
@@ -585,31 +593,29 @@ class OvPhysxFrameView(BaseFrameView):
         return None, _gf_matrix_to_xform7(prim_world_tf)
 
     def _prim_or_template_has_rigid_body_api(self, prim: Usd.Prim) -> bool:
-        """Return whether the prim (or its ``env_0`` equivalent) has ``RigidBodyAPI`` applied.
-
-        Falls back to the env_0 template lookup so that ``clone_usd=False`` envs
-        (whose USD prims lack physics schemas) still resolve to the right body.
-        """
+        """Return whether the prim or its clone-plan source has ``RigidBodyAPI`` applied."""
         if prim.HasAPI(UsdPhysics.RigidBodyAPI):
             return True
         path = prim.GetPath().pathString
-        env_zero_path = self._env_zero_equivalent(path)
-        if env_zero_path == path:
-            return False
-        template_prim = self._stage.GetPrimAtPath(env_zero_path) if self._stage is not None else None
+        if self._clone_plan is None:
+            source_path = self._retarget_environment(path, 0)
+            if source_path == path:
+                return False
+        else:
+            resolved = cloner.query.path_to_source(self._clone_plan, path)
+            if resolved is None:
+                return False
+            source_root, _, suffix = resolved
+            source_path = (source_root.rstrip("/") + suffix) or "/"
+        template_prim = self._stage.GetPrimAtPath(source_path) if self._stage is not None else None
         if template_prim is None or not template_prim.IsValid():
             return False
         return template_prim.HasAPI(UsdPhysics.RigidBodyAPI)
 
-    @staticmethod
-    def _env_zero_equivalent(path: str) -> str:
-        """Replace ``/World/envs/env_<digits>`` with ``/World/envs/env_0`` for template lookup."""
-        return re.sub(r"/World/envs/env_\d+", "/World/envs/env_0", path)
-
-    @staticmethod
-    def _env_wildcardify(path: str) -> str:
-        """Replace ``/World/envs/env_<digits>`` with ``/World/envs/env_*`` for binding patterns."""
-        return re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", path)
+    def _retarget_environment(self, path: str, instance: int | str) -> str:
+        """Retarget an environment-scoped path through the clone plan's root template."""
+        matched = cloner.path.match(path, self._env_template)
+        return path if matched is None else self._env_template.format(instance) + matched.suffix
 
     # ------------------------------------------------------------------
     # Properties
@@ -628,9 +634,9 @@ class OvPhysxFrameView(BaseFrameView):
     def prim_paths(self) -> list[str]:
         """List of one prim path per site.
 
-        For ``clone_usd=False`` scenes (where ``env_1..N`` have no USD prim)
-        the paths are synthesized by replacing ``env_0`` in the template prim's
-        path with each binding row's env_id.
+        For prototype-only scenes, paths are synthesized by retargeting the
+        authored source path through the plan's environment template for each
+        binding row.
         """
         if hasattr(self, "_synthetic_prim_paths") and self._synthetic_prim_paths is not None:
             return self._synthetic_prim_paths

--- a/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
@@ -7,11 +7,11 @@
 
 from __future__ import annotations
 
-import logging
 import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
+import torch
 
 # The OVPhysX runtime wheel is optional. Skip gracefully when it is not installed;
 # CI jobs that need OVPhysX coverage install it explicitly.
@@ -88,6 +88,46 @@ def test_manager_full_stage_requirement_preserves_authored_environments():
         OvPhysxManager._requires_full_stage = previous
 
 
+def test_manager_full_stage_materializes_empty_plan_roots(monkeypatch):
+    """A private full-stage copy positions custom roots even when the plan has no asset rows."""
+    from isaaclab_ov.physics import OvPhysxManager
+
+    from pxr import Sdf, Usd
+
+    from isaaclab.cloner import ClonePlan
+    from isaaclab.physics import PhysicsManager
+
+    env_template = "/World/scenes/scene_{}"
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0], [7.0, -8.0, 9.0]])
+    stage = Usd.Stage.CreateInMemory()
+    stage.DefinePrim(f"{env_template.format(0)}/Marker", "Xform")
+    plan = ClonePlan(
+        sources=(),
+        destinations=(),
+        clone_mask=torch.zeros((0, 3), dtype=torch.bool),
+        env_ids=torch.arange(3),
+        positions=positions,
+        env_template=env_template,
+    )
+    monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(get_clone_plan=lambda: plan))
+
+    previous = OvPhysxManager._pending_clones
+    try:
+        OvPhysxManager._pending_clones = []
+        layer = Sdf.Layer.CreateAnonymous("full.usda")
+        assert layer.ImportFromString(_serialize_full_stage_with_pending_clones(stage))
+        exported = Usd.Stage.Open(layer)
+        for env_id, expected_position in enumerate(positions):
+            root = exported.GetPrimAtPath(env_template.format(env_id))
+            assert root.IsValid() and root.GetTypeName() == "Xform"
+            assert tuple(root.GetAttribute("xformOp:translate").Get()) == pytest.approx(expected_position.tolist())
+            assert not root.HasAttribute("xformOp:orient")
+        assert exported.GetPrimAtPath(f"{env_template.format(0)}/Marker").IsValid()
+        assert not stage.GetPrimAtPath(env_template.format(1)).IsValid()
+    finally:
+        OvPhysxManager._pending_clones = previous
+
+
 def test_manager_full_stage_never_replays_runtime_clones():
     """A full-stage load never mutates the already loaded runtime through cloning."""
     from isaaclab_ov.physics import OvPhysxManager
@@ -102,20 +142,32 @@ def test_manager_full_stage_never_replays_runtime_clones():
         OvPhysxManager._pending_clones = previous
 
 
-def test_manager_full_stage_materializes_only_missing_heterogeneous_targets():
-    """A full-stage export copies missing heterogeneous targets without replacing authored ones."""
+def test_manager_full_stage_materializes_only_missing_heterogeneous_targets(monkeypatch):
+    """A full-stage copy creates and positions missing roots without replacing authored targets."""
     from isaaclab_ov.physics import OvPhysxManager
 
     from pxr import Sdf, Usd
 
+    from isaaclab.cloner import ClonePlan
+    from isaaclab.physics import PhysicsManager
+
     stage = Usd.Stage.CreateInMemory()
     stage.DefinePrim("/World/envs/env_0", "Xform")
     stage.DefinePrim("/World/envs/env_1", "Xform")
-    stage.DefinePrim("/World/envs/env_2", "Xform")
     source = stage.DefinePrim("/World/envs/env_0/Object", "Xform")
     source.CreateAttribute("test:variant", Sdf.ValueTypeNames.String).Set("source")
     existing = stage.DefinePrim("/World/envs/env_1/Object", "Xform")
     existing.CreateAttribute("test:variant", Sdf.ValueTypeNames.String).Set("authored")
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0], [7.0, -8.0, 9.0]])
+    plan = ClonePlan(
+        sources=("/World/envs/env_0/Object",),
+        destinations=("/World/envs/env_{}/Object",),
+        clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        env_ids=torch.arange(3),
+        positions=positions,
+        env_template="/World/envs/env_{}",
+    )
+    monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(get_clone_plan=lambda: plan))
     previous = OvPhysxManager._pending_clones
     try:
         OvPhysxManager._pending_clones = [
@@ -131,6 +183,11 @@ def test_manager_full_stage_materializes_only_missing_heterogeneous_targets():
         exported = Usd.Stage.Open(layer)
         assert exported.GetPrimAtPath("/World/envs/env_1/Object").GetAttribute("test:variant").Get() == "authored"
         assert exported.GetPrimAtPath("/World/envs/env_2/Object").GetAttribute("test:variant").Get() == "source"
+        for env_id, expected_position in enumerate(positions):
+            root = exported.GetPrimAtPath(f"/World/envs/env_{env_id}")
+            assert tuple(root.GetAttribute("xformOp:translate").Get()) == pytest.approx(expected_position.tolist())
+            assert not root.HasAttribute("xformOp:orient")
+        assert not stage.GetPrimAtPath("/World/envs/env_2").IsValid()
         assert OvPhysxManager._pending_clones == []
     finally:
         OvPhysxManager._pending_clones = previous
@@ -276,31 +333,36 @@ def test_manager_retains_clone_recipes_across_full_stage_serializations():
         OvPhysxManager._active_clone_recipes = previous_active
 
 
-def test_manager_full_stage_materialization_is_atomic_on_invalid_target():
-    """A validation failure clears the queue without partially modifying the export."""
+def test_manager_serializes_authored_prototype_poses_unchanged():
+    """The default copy retains every prototype pose without creating destinations."""
     from isaaclab_ov.physics import OvPhysxManager
 
-    from pxr import Usd
+    from pxr import Gf, Sdf, Usd, UsdGeom
 
     stage = Usd.Stage.CreateInMemory()
-    stage.DefinePrim("/World/envs/env_0", "Xform")
-    stage.DefinePrim("/World/envs/env_1", "Xform")
-    stage.DefinePrim("/World/envs/env_0/Object", "Xform")
-    previous = OvPhysxManager._pending_clones
+    root_0 = UsdGeom.Xform.Define(stage, "/World/envs/env_0")
+    stage.DefinePrim("/World/envs/env_0/Robot", "Xform")
+    root_2 = UsdGeom.Xform.Define(stage, "/World/envs/env_2")
+    stage.DefinePrim("/World/envs/env_2/Sphere", "Xform")
+    positions = {0: (1.0, 2.0, 3.0), 2: (7.0, -8.0, 9.0)}
+    UsdGeom.XformCommonAPI(root_0).SetTranslate(Gf.Vec3d(*positions[0]))
+    UsdGeom.XformCommonAPI(root_2).SetTranslate(Gf.Vec3d(*positions[2]))
+    root_2.AddRotateZOp().Set(15.0)
+    previous = OvPhysxManager._requires_full_stage
     try:
-        OvPhysxManager._pending_clones = [
-            (
-                "/World/envs/env_0/Object",
-                ["/World/envs/env_1/Object", "/World/envs/env_2/Object"],
-                [(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0), (2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)],
-            )
-        ]
-        with pytest.raises(RuntimeError, match="clone target parent is absent"):
-            _serialize_full_stage_with_pending_clones(stage)
-        assert OvPhysxManager._pending_clones == []
-        assert not stage.GetPrimAtPath("/World/envs/env_1/Object").IsValid()
+        OvPhysxManager._requires_full_stage = False
+        layer = Sdf.Layer.CreateAnonymous("prototypes.usda")
+        assert layer.ImportFromString(OvPhysxManager._serialize_selected_stage(stage))
+        exported = Usd.Stage.Open(layer)
+        assert exported.GetPrimAtPath("/World/envs/env_0/Robot").IsValid()
+        assert exported.GetPrimAtPath("/World/envs/env_2/Sphere").IsValid()
+        assert not exported.GetPrimAtPath("/World/envs/env_1").IsValid()
+        for env_id in (0, 2):
+            root = exported.GetPrimAtPath(f"/World/envs/env_{env_id}")
+            assert tuple(root.GetAttribute("xformOp:translate").Get()) == pytest.approx(positions[env_id])
+        assert exported.GetPrimAtPath("/World/envs/env_2").GetAttribute("xformOp:rotateZ").Get() == 15.0
     finally:
-        OvPhysxManager._pending_clones = previous
+        OvPhysxManager._requires_full_stage = previous
 
 
 def test_manager_replays_pending_runtime_clones_without_full_stage_requirement():
@@ -339,6 +401,102 @@ def test_manager_resets_full_stage_requirement_between_contexts():
     OvPhysxManager.require_full_stage()
     OvPhysxManager.close()
     assert OvPhysxManager._requires_full_stage is False
+
+
+def test_manager_captures_prototypes_before_live_replication_and_reuses_them(monkeypatch):
+    """OvPhysX snapshots after renderer prep and reuses that snapshot during re-warmup."""
+    from isaaclab_ov.physics import OvPhysxManager
+
+    from isaaclab.physics import PhysicsEvent, PhysicsManager
+
+    events = []
+    invalid_prim = SimpleNamespace(IsValid=lambda: False)
+    stage = SimpleNamespace(expanded=False, GetPrimAtPath=lambda _path: invalid_prim)
+    sim = SimpleNamespace(
+        stage=stage,
+        cfg=SimpleNamespace(physics=None, device="cpu", physics_prim_path="/physicsScene"),
+    )
+
+    for name, value in {
+        "_sim": None,
+        "_cfg": None,
+        "_device": "cpu",
+        "_sim_time": 0.0,
+    }.items():
+        monkeypatch.setattr(PhysicsManager, name, value)
+    for name, value in {
+        "_callbacks": {},
+        "_callback_id": 0,
+        "_physx": None,
+        "_stage_usda": None,
+        "_warmup_done": False,
+        "_requires_full_stage": False,
+        "_locked_device": None,
+        "_active_clone_recipes": [],
+        "_pending_clones": [],
+        "_scene_data_backend": None,
+    }.items():
+        monkeypatch.setattr(OvPhysxManager, name, value)
+    monkeypatch.setattr(OvPhysxManager, "_ensure_physx_schemas_registered", lambda: None)
+
+    def serialize_prototypes(sim_stage):
+        events.append(("capture", sim_stage.expanded))
+        return "prototype stage"
+
+    monkeypatch.setattr(OvPhysxManager, "_serialize_selected_stage", serialize_prototypes)
+    OvPhysxManager.initialize(sim)
+    OvPhysxManager.register_callback(
+        lambda _event: events.append("prepare_renderer"),
+        PhysicsEvent.MODEL_INIT,
+        order=0,
+        wrap_weak_ref=False,
+    )
+
+    def replicate_live_stage(_event):
+        if not stage.expanded:
+            events.append("replicate_live_stage")
+            stage.expanded = True
+
+    OvPhysxManager.register_callback(
+        replicate_live_stage,
+        PhysicsEvent.MODEL_INIT,
+        order=2,
+        wrap_weak_ref=False,
+    )
+    monkeypatch.setattr(OvPhysxManager, "_rearm_pending_clones", lambda: events.append("rearm"))
+
+    def construct_physx(_device, _gpu_index):
+        events.append("construct")
+        OvPhysxManager._physx = object()
+
+    monkeypatch.setattr(OvPhysxManager, "_construct_physx", construct_physx)
+    monkeypatch.setattr(OvPhysxManager, "_prepare_physx_for_stage_reuse", lambda: events.append("reuse"))
+
+    def stop_after_attach(stage_usda):
+        events.append(("attach", stage_usda))
+        raise RuntimeError("stop after attach")
+
+    monkeypatch.setattr(OvPhysxManager, "_attach_ovstage", stop_after_attach)
+
+    with pytest.raises(RuntimeError, match="stop after attach"):
+        OvPhysxManager._warmup_and_load()
+    with pytest.raises(RuntimeError, match="stop after attach"):
+        OvPhysxManager._warmup_and_load()
+
+    assert events == [
+        "rearm",
+        "prepare_renderer",
+        ("capture", False),
+        "replicate_live_stage",
+        "construct",
+        ("attach", "prototype stage"),
+        "rearm",
+        "prepare_renderer",
+        "reuse",
+        ("attach", "prototype stage"),
+    ]
+    assert stage.expanded
+    assert OvPhysxManager._stage_usda == "prototype stage"
 
 
 def test_manager_forced_rewarm_invalidates_bindings_before_loading(monkeypatch):
@@ -404,53 +562,6 @@ def test_manager_supports_pinned_runtime_api(device, gpu_index, expected_cpu_mod
     assert physx.constructor["active_cuda_gpus"] == expected_active_cuda_gpus
     assert physx.constructor["config"].num_threads == 8
     assert physx.calls == [("step_sync", 0.02), ("reset_stage",), ("wait_op", 23)]
-
-
-def test_manager_serializes_env0_only_stage_in_memory(caplog):
-    """The OVPhysX input keeps globals and env 0 without writing cloned envs."""
-    from isaaclab_ov.physics import OvPhysxManager
-
-    from pxr import Sdf, Usd, UsdGeom
-
-    stage = Usd.Stage.CreateInMemory()
-    for path in ("/World/Ground", "/World/envs/env_0/Cube", "/World/envs/env_1/Cube"):
-        UsdGeom.Xform.Define(stage, path)
-
-    previous = OvPhysxManager._requires_full_stage
-    try:
-        OvPhysxManager._requires_full_stage = False
-        with caplog.at_level(logging.INFO, logger=OvPhysxManager.__module__):
-            usda = OvPhysxManager._serialize_selected_stage(stage)
-    finally:
-        OvPhysxManager._requires_full_stage = previous
-    layer = Sdf.Layer.CreateAnonymous("filtered.usda")
-    assert layer.ImportFromString(usda)
-    filtered = Usd.Stage.Open(layer)
-
-    assert filtered.GetPrimAtPath("/World/Ground").IsValid()
-    assert filtered.GetPrimAtPath("/World/envs/env_0/Cube").IsValid()
-    assert not filtered.GetPrimAtPath("/World/envs/env_1").IsValid()
-    assert "stripped 1 env_<i!=0> subtrees from in-memory USD" in caplog.text
-
-
-def test_manager_logs_when_serialized_stage_has_no_envs(caplog):
-    """The in-memory serializer diagnoses stages without the standard env namespace."""
-    from isaaclab_ov.physics import OvPhysxManager
-
-    from pxr import Usd, UsdGeom
-
-    stage = Usd.Stage.CreateInMemory()
-    UsdGeom.Xform.Define(stage, "/World/Ground")
-
-    previous = OvPhysxManager._requires_full_stage
-    try:
-        OvPhysxManager._requires_full_stage = False
-        with caplog.at_level(logging.DEBUG, logger=OvPhysxManager.__module__):
-            OvPhysxManager._serialize_selected_stage(stage)
-    finally:
-        OvPhysxManager._requires_full_stage = previous
-
-    assert "no cloned environments to strip — serialized stage as-is" in caplog.text
 
 
 def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
@@ -750,7 +861,7 @@ def test_transform_paths_empty_when_no_bindings():
 
 
 def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
-    """``setup(physx, stage, device)`` buckets RigidBodyAPI prims by env-wildcard form.
+    """``setup`` buckets RigidBodyAPI prims through the clone plan's environment template.
 
     For cartpole-shaped scenes (``cart``, ``pole``), expect 2 bindings — one
     per distinct env-relative prim path.
@@ -761,10 +872,10 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
 
     # Stage stub: traversal yields four RigidBodyAPI prims (cart/pole across two envs).
     paths = [
-        "/World/envs/env_0/Robot/cart",
-        "/World/envs/env_0/Robot/pole",
-        "/World/envs/env_1/Robot/cart",
-        "/World/envs/env_1/Robot/pole",
+        "/World/scenes/scene_2/Robot/cart",
+        "/World/scenes/scene_2/Robot/pole",
+        "/World/scenes/scene_7/Robot/cart",
+        "/World/scenes/scene_7/Robot/pole",
     ]
 
     def fake_traverse():
@@ -797,13 +908,13 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
     # Rigid-body setup uses a SimpleNamespace stage stub; skip deformable discovery.
     monkeypatch.setattr(om_mod, "discover_deformables_on_stage", lambda stage: [])
 
-    b.setup(FakePhysX(), stage, "cpu")
+    b.setup(FakePhysX(), stage, "cpu", env_template="/World/scenes/scene_{}")
 
     # Cartpole = 2 distinct env-wildcard patterns -> 2 bindings.
     assert len(created) == 2
     assert {c.pattern for c in created} == {
-        "/World/envs/env_*/Robot/cart",
-        "/World/envs/env_*/Robot/pole",
+        "/World/scenes/scene_*/Robot/cart",
+        "/World/scenes/scene_*/Robot/pole",
     }
     # Per-binding row counts sum to 4.
     assert b.transform_count == 4

--- a/source/isaaclab_ov/test/sim/test_views_xform_prim_ovphysx.py
+++ b/source/isaaclab_ov/test/sim/test_views_xform_prim_ovphysx.py
@@ -66,21 +66,23 @@ def test_world_attached_source_prim_expands_from_clone_plan():
         device=device, sim_cfg=OVPHYSX_SIM_CFG, auto_add_lighting=False, add_ground_plane=False
     ) as sim:
         sim._app_control_on_stop_handle = None
-        scene = InteractiveScene(_OvPhysxFrameViewSceneCfg(num_envs=4, env_spacing=2.0))
+        scene_cfg = _OvPhysxFrameViewSceneCfg(num_envs=4, env_spacing=2.0)
+        scene_cfg.clone_cfg.clone_template = "/World/scenes/scene_{}"
+        scene = InteractiveScene(scene_cfg)
         sim.reset()
 
         stage = sim_utils.get_current_stage()
-        prim = stage.DefinePrim("/World/envs/env_0/WorldCamera", "Xform")
+        prim = stage.DefinePrim("/World/scenes/scene_0/WorldCamera", "Xform")
         sim_utils.standardize_xform_ops(prim)
         prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(0.25, -0.5, 1.0))
 
-        view = FrameView("/World/envs/env_[^/]+/WorldCamera", device=device)
+        view = FrameView("/World/scenes/scene_[^/]+/WorldCamera", device=device)
 
-        assert not stage.GetPrimAtPath("/World/envs/env_1/WorldCamera").IsValid()
+        assert not stage.GetPrimAtPath("/World/scenes/scene_1/WorldCamera").IsValid()
         assert view.count == scene.num_envs
         assert len(view.prims) == scene.num_envs
-        assert {prim.GetPath().pathString for prim in view.prims} == {"/World/envs/env_0/WorldCamera"}
-        assert view.prim_paths == [f"/World/envs/env_{i}/WorldCamera" for i in range(scene.num_envs)]
+        assert {prim.GetPath().pathString for prim in view.prims} == {"/World/scenes/scene_0/WorldCamera"}
+        assert view.prim_paths == [f"/World/scenes/scene_{i}/WorldCamera" for i in range(scene.num_envs)]
         positions, _ = view.get_world_poses()
     expected_positions = scene.env_origins + torch.tensor([0.25, -0.5, 1.0], device=device)
     torch.testing.assert_close(positions.torch, expected_positions)
@@ -182,17 +184,24 @@ def view_factory():
         sim._app_control_on_stop_handle = None
         contexts.append(ctx)
 
-        InteractiveScene(_OvPhysxFrameViewSceneCfg(num_envs=num_envs, env_spacing=2.0))
+        scene_cfg = _OvPhysxFrameViewSceneCfg(num_envs=num_envs, env_spacing=2.0)
+        scene_cfg.clone_cfg.clone_template = "/World/scenes/scene_{}"
+        scene = InteractiveScene(scene_cfg)
 
         stage = sim_utils.get_current_stage()
-        for i in range(num_envs):
-            prim = stage.DefinePrim(f"/World/envs/env_{i}/Cube/CameraMount", "Xform")
-            sim_utils.standardize_xform_ops(prim)
-            prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(*CHILD_OFFSET))
-            prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
+        prim = stage.DefinePrim(f"{scene.env_prim_paths[0]}/Cube/CameraMount", "Xform")
+        sim_utils.standardize_xform_ops(prim)
+        prim.GetAttribute("xformOp:translate").Set(Gf.Vec3d(*CHILD_OFFSET))
+        prim.GetAttribute("xformOp:orient").Set(Gf.Quatd(1.0, 0.0, 0.0, 0.0))
 
         sim.reset()
-        view = OvPhysxFrameView("/World/envs/env_[^/]+/Cube/CameraMount", device=device)
+        assert not stage.GetPrimAtPath(f"{scene.env_prim_paths[1]}/Cube/CameraMount").IsValid()
+        for env_path in scene.env_prim_paths[1:]:
+            destination = stage.DefinePrim(f"{env_path}/Cube/CameraMount", "Xform")
+            sim_utils.standardize_xform_ops(destination)
+            destination.GetAttribute("xformOp:translate").Set(Gf.Vec3d(*CHILD_OFFSET))
+        view = OvPhysxFrameView(f"{scene.env_regex_ns}/Cube/CameraMount", device=device)
+        assert view.prim_paths == [f"{env_path}/Cube/CameraMount" for env_path in scene.env_prim_paths]
 
         # Capture binding row order, populate _pose_buf once with the live spawn poses,
         # then detach the binding so subsequent reads do not overwrite the buffer.
@@ -201,7 +210,7 @@ def view_factory():
         path_to_row = {p: i for i, p in enumerate(view._pose_binding.prim_paths)}
         view._pose_binding = None
 
-        cube_rows = [path_to_row[f"/World/envs/env_{i}/Cube"] for i in range(num_envs)]
+        cube_rows = [path_to_row[f"{env_path}/Cube"] for env_path in scene.env_prim_paths]
         pose_buf_torch = wp.to_torch(view._pose_buf)  # shape [num_bodies, 7] float32
 
         def _get_parent_pos(n: int, dev: str) -> torch.Tensor:

--- a/source/isaaclab_ov/test/test_cloner.py
+++ b/source/isaaclab_ov/test/test_cloner.py
@@ -76,6 +76,35 @@ def test_nested_clone_uses_final_target_pose(monkeypatch):
     assert orientation.tolist() == pytest.approx(expected_orientation.tolist())
 
 
+def test_sparse_environment_ids_use_column_aligned_poses(monkeypatch):
+    """Sparse environment ids use their clone-plan columns to select target poses."""
+    monkeypatch.setattr(OvPhysxManager, "_active_clone_recipes", [])
+    monkeypatch.setattr(OvPhysxManager, "_pending_clones", [])
+    stage = Usd.Stage.CreateInMemory()
+    source_root = UsdGeom.Xform.Define(stage, "/World/scenes/scene_2")
+    UsdGeom.XformCommonAPI(source_root).SetTranslate(Gf.Vec3d(1.0, 2.0, 3.0))
+    UsdGeom.Xform.Define(stage, "/World/scenes/scene_2/Robot")
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0], [7.0, -8.0, 9.0]])
+
+    context = OvPhysxReplicateContext(stage)
+    context.queue_mapping(
+        sources=["/World/scenes/scene_2/Robot"],
+        destinations=["/World/scenes/scene_{}/Robot"],
+        env_ids=torch.tensor([2, 7, 11]),
+        mapping=torch.tensor([[True, False, True]]),
+        positions=positions,
+    )
+    context.replicate()
+
+    assert OvPhysxManager._pending_clones == [
+        (
+            "/World/scenes/scene_2/Robot",
+            ["/World/scenes/scene_11/Robot"],
+            [(7.0, -8.0, 9.0, 0.0, 0.0, 0.0, 1.0)],
+        )
+    ]
+
+
 def test_register_clone_preserves_translation_only_compatibility(monkeypatch):
     """World positions become target-root poses with identity rotations."""
     monkeypatch.setattr(OvPhysxManager, "_active_clone_recipes", [])

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Unit tests for OVRTX clone-plan resolution and OVRTX-side cloning."""
+"""Unit tests for OVRTX clone-plan consumption and OVRTX-side cloning."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -32,12 +33,7 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
-    from isaaclab_ov.renderers.ovrtx_renderer import (  # noqa: E402
-        OVRTXRenderer,
-        _create_homogeneous_clone_plan,
-        _resolve_clone_plan,
-        _write_file,
-    )
+    from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer, _write_file  # noqa: E402
 
     from pxr import Usd, UsdGeom  # noqa: E402
 else:
@@ -45,8 +41,6 @@ else:
     OVRTXRendererCfg = None
     Usd = None
     UsdGeom = None
-    _create_homogeneous_clone_plan = None
-    _resolve_clone_plan = None
     _write_file = None
 
 
@@ -100,7 +94,6 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     renderer.cfg = OVRTXRendererCfg()
     renderer._renderer = SimpleNamespace(
         clone_usd=lambda *args, **kwargs: None,
-        read_attribute=lambda *args, **kwargs: None,
         write_array_attribute=lambda *args, **kwargs: None,
         write_attribute=lambda *args, **kwargs: None,
     )
@@ -138,117 +131,21 @@ def _make_camera_render_spec(num_envs: int = 1) -> CameraRenderSpec:
     )
 
 
-def test_resolve_clone_plan_returns_homogeneous_when_unpublished(monkeypatch: pytest.MonkeyPatch):
-    """Missing published plan falls back to env_0 replication."""
-    _patch_simulation_context(monkeypatch, None)
-
-    num_envs = 4
-    resolved = _resolve_clone_plan(num_envs)
-    expected = _create_homogeneous_clone_plan(num_envs)
-
-    assert resolved.sources == expected.sources
-    assert resolved.destinations == expected.destinations
-    assert torch.equal(resolved.clone_mask, expected.clone_mask)
-
-
-def test_resolve_clone_plan_returns_homogeneous_when_no_active_rows(monkeypatch: pytest.MonkeyPatch):
-    """Plan with no active rows falls back to homogeneous replication."""
-    published = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
-        clone_mask=torch.zeros((2, 4), dtype=torch.bool),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    num_envs = 4
-    resolved = _resolve_clone_plan(num_envs)
-    expected = _create_homogeneous_clone_plan(num_envs)
-
-    assert resolved.sources == expected.sources
-    assert resolved.destinations == expected.destinations
-    assert torch.equal(resolved.clone_mask, expected.clone_mask)
-
-
-def test_resolve_clone_plan_filters_inactive_rows(monkeypatch: pytest.MonkeyPatch):
-    """Inactive clone-plan rows are removed before OVRTX uses the plan."""
-    published = ClonePlan(
-        sources=(
-            "/World/envs/env_0/Robot",
-            "/World/envs/env_1/Object",
-            "/World/envs/env_0/table",
-        ),
-        destinations=(
-            "/World/envs/env_{}/Robot",
-            "/World/envs/env_{}/Object",
-            "/World/envs/env_{}/table",
-        ),
-        clone_mask=torch.tensor(
-            [
-                [True, True, True, True],
-                [False, False, False, False],
-                [True, True, True, True],
-            ],
-            dtype=torch.bool,
-        ),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    resolved = _resolve_clone_plan(4)
-
-    assert resolved.sources == (published.sources[0], published.sources[2])
-    assert resolved.destinations == (published.destinations[0], published.destinations[2])
-    assert torch.equal(resolved.clone_mask, published.clone_mask[[0, 2]])
-
-
-def test_resolve_clone_plan_returns_published_plan_when_all_active(monkeypatch: pytest.MonkeyPatch):
-    """Fully active published plans are reused without copying."""
-    published = ClonePlan(
-        sources=("/World/envs/env_0/Robot",),
-        destinations=("/World/envs/env_{}/Robot",),
-        clone_mask=torch.ones((1, 3), dtype=torch.bool),
-    )
-    _patch_simulation_context(monkeypatch, published)
-
-    resolved = _resolve_clone_plan(3)
-
-    assert resolved is published
-
-
-def test_clone_sources_in_ovrtx_homogeneous_row():
-    """Homogeneous env_0 row clones only env_1..env_{N-1} (env_0 is the source)."""
-    renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = _create_homogeneous_clone_plan(4)
-
-    clone_calls: list[tuple[str, list[str]]] = []
-
-    def _clone_usd(source: str, target_paths: list[str]) -> None:
-        clone_calls.append((source, target_paths))
-
-    renderer._renderer.clone_usd = _clone_usd
-
-    renderer._clone_sources_in_ovrtx()
-
-    assert clone_calls == [
-        (
-            "/World/envs/env_0",
-            ["/World/envs/env_1", "/World/envs/env_2", "/World/envs/env_3"],
-        )
-    ]
-
-
 def test_clone_sources_in_ovrtx_heterogeneous_rows():
-    """Each active clone-plan row issues its own clone_usd call."""
+    """Each active row clones its targets while an inactive row is skipped."""
     renderer = _make_ovrtx_renderer_without_backend()
     renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
+        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object", "/World/envs/env_0/Light"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object", "/World/envs/env_{}/Light"),
         clone_mask=torch.tensor(
             [
                 [True, True, True, True],
                 [False, False, True, True],
+                [False, False, False, False],
             ],
             dtype=torch.bool,
         ),
+        positions=torch.zeros((4, 3)),
     )
 
     clone_calls: list[tuple[str, list[str]]] = []
@@ -276,37 +173,15 @@ def test_clone_sources_in_ovrtx_heterogeneous_rows():
     ]
 
 
-def test_clone_sources_in_ovrtx_skips_empty_target_rows():
-    """Rows with no clone targets do not call clone_usd."""
-    renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_7/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
-        clone_mask=torch.tensor(
-            [
-                [False, False, False, False],
-                [False, False, False, False],
-            ],
-            dtype=torch.bool,
-        ),
-    )
-
-    clone_calls: list[tuple[str, list[str]]] = []
-
-    def _clone_usd(source: str, target_paths: list[str]) -> None:
-        clone_calls.append((source, target_paths))
-
-    renderer._renderer.clone_usd = _clone_usd
-
-    renderer._clone_sources_in_ovrtx()
-
-    assert clone_calls == []
-
-
 def test_clone_sources_in_ovrtx_raises_on_clone_failure():
     """clone_usd failures surface as RuntimeError with the row index."""
     renderer = _make_ovrtx_renderer_without_backend()
-    renderer._clone_plan = _create_homogeneous_clone_plan(2)
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        positions=torch.zeros((2, 3)),
+    )
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
         raise OSError("clone failed")
@@ -317,42 +192,103 @@ def test_clone_sources_in_ovrtx_raises_on_clone_failure():
         renderer._clone_sources_in_ovrtx()
 
 
-def test_clone_sources_in_ovrtx_restores_env_root_transforms():
-    """Pre-clone omni:xform snapshots are written back after cloning."""
-    import numpy as np
-
+def test_clone_sources_in_ovrtx_writes_plan_positions_after_cloning():
+    """Legacy OVRTX cloning writes translated identity root transforms from the plan."""
     renderer = _make_ovrtx_renderer_without_backend()
-    num_envs = 4
-    renderer._clone_plan = _create_homogeneous_clone_plan(num_envs)
-    captured_transforms = np.tile(np.eye(4, dtype=np.float64), (num_envs, 1, 1))
-    captured_transforms[:, 3, :3] = np.array([[i * 2.0, 0.0, 0.0] for i in range(num_envs)])
-
+    positions = torch.tensor([[0.0, 0.0, 0.0], [2.0, -1.0, 0.5], [-3.0, 4.0, 1.5]])
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        positions=positions,
+    )
     call_order: list[str] = []
-
-    def _read_attribute(attribute_name: str, prim_paths: list[str], **kwargs):
-        call_order.append("read")
-        assert attribute_name == "omni:xform"
-        kwargs["dest"][:] = captured_transforms[: len(prim_paths)]
+    clone_calls: list[tuple[str, list[str]]] = []
+    write_calls: list[dict] = []
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
         call_order.append("clone")
+        clone_calls.append((source, target_paths))
 
-    write_calls: list[dict] = []
+    renderer._renderer.clone_usd = _clone_usd
 
     def _write_attribute(**kwargs):
         call_order.append("write")
         write_calls.append(kwargs)
 
-    renderer._renderer.read_attribute = _read_attribute
-    renderer._renderer.clone_usd = _clone_usd
     renderer._renderer.write_attribute = _write_attribute
 
     renderer._clone_sources_in_ovrtx()
 
-    assert call_order == ["read", "clone", "write"]
+    expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
+    expected[:, 3, :3] = positions.numpy()
+    assert call_order == ["clone", "write"]
+    assert clone_calls == [("/World/envs/env_0", ["/World/envs/env_1", "/World/envs/env_2"])]
     assert len(write_calls) == 1
     assert write_calls[0]["attribute_name"] == "omni:xform"
-    np.testing.assert_array_equal(write_calls[0]["tensor"], captured_transforms)
+    np.testing.assert_array_equal(write_calls[0]["tensor"], expected)
+
+
+@pytest.mark.skipif(importlib.util.find_spec("ovstage") is None, reason="requires optional module: ovstage")
+def test_clone_sources_ovstage_writes_plan_positions_after_cloning(monkeypatch: pytest.MonkeyPatch):
+    """Ovstage skips inactive rows and writes translated identity root transforms from the plan."""
+    renderer = _make_ovrtx_renderer_without_backend()
+    positions = torch.tensor([[0.0, 0.0, 0.0], [1.5, -2.0, 0.25], [3.0, 4.0, 0.5]])
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
+        clone_mask=torch.tensor([[False, False, False], [False, True, True]]),
+        positions=positions,
+    )
+    events: list[tuple[str, str, object]] = []
+    xforms: list[np.ndarray] = []
+    completion = SimpleNamespace(wait=lambda: None)
+
+    def _clone(source: str, target_paths: list[str], **_kwargs):
+        events.append(("clone", source, target_paths))
+
+    def _query(path_list: str) -> str:
+        events.append(("query", "envs", path_list))
+        return "env_query"
+
+    def _write(_query, attribute_name: str, **kwargs):
+        events.append(("write", attribute_name, kwargs["tensors"]))
+        return completion
+
+    def _create_paths(paths: list[str]) -> str:
+        events.append(("paths", "envs", paths))
+        return "env_paths"
+
+    renderer._stage = SimpleNamespace(
+        query_from_path_list=_query,
+        clone=_clone,
+        write_attribute=_write,
+        release_query=lambda _query: completion,
+    )
+    renderer._stage_paths = SimpleNamespace(
+        create_path_list_from_strings=_create_paths,
+        destroy_path_list=lambda _paths: None,
+    )
+    renderer._current_ordinal = 3
+
+    def _record_xforms(value: np.ndarray) -> str:
+        xforms.append(value.copy())
+        return "root_xforms"
+
+    monkeypatch.setattr("isaaclab_ov.renderers.ovrtx_renderer._xform_tensor_from_numpy", _record_xforms)
+
+    renderer._clone_sources_ovstage()
+
+    expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
+    expected[:, 3, :3] = positions.numpy()
+    assert events == [
+        ("clone", "/World/envs/env_1/Object", ["/World/envs/env_2/Object"]),
+        ("paths", "envs", ["/World/envs/env_0", "/World/envs/env_1", "/World/envs/env_2"]),
+        ("query", "envs", "env_paths"),
+        ("write", "omni:xform", "root_xforms"),
+    ]
+    assert len(xforms) == 1
+    np.testing.assert_array_equal(xforms[0], expected)
 
 
 def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):
@@ -366,9 +302,36 @@ def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):
     assert output_path.read_text(encoding="utf-8") == "#usda 1.0\n"
 
 
+@pytest.mark.parametrize(
+    "clone_plan",
+    [
+        None,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        ),
+    ],
+)
+def test_prepare_stage_requires_published_plan_positions(monkeypatch: pytest.MonkeyPatch, clone_plan: ClonePlan | None):
+    """OVRTX stage preparation rejects an absent plan and a plan without positions."""
+    _patch_simulation_context(monkeypatch, clone_plan)
+
+    with pytest.raises(RuntimeError, match="Clone plan with environment positions is required"):
+        _make_ovrtx_renderer_without_backend().prepare_stage(_make_multi_env_stage(2), 2)
+
+
 def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """prepare_stage writes the raw stage before OVRTX-specific preparation."""
-    _patch_simulation_context(monkeypatch, None)
+    _patch_simulation_context(
+        monkeypatch,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            positions=torch.zeros((2, 3)),
+        ),
+    )
 
     stage = _make_multi_env_stage(2)
     renderer = _make_ovrtx_renderer_without_backend()
@@ -386,7 +349,15 @@ def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: 
 
 def test_prepare_stage_skips_temp_usd_write_when_temp_usd_dir_unset(monkeypatch: pytest.MonkeyPatch):
     """prepare_stage does not write debug dumps when temp_usd_dir is None."""
-    _patch_simulation_context(monkeypatch, None)
+    _patch_simulation_context(
+        monkeypatch,
+        ClonePlan(
+            sources=("/World/envs/env_0",),
+            destinations=("/World/envs/env_{}",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            positions=torch.zeros((2, 3)),
+        ),
+    )
     write_calls: list[tuple[Path, str, str]] = []
 
     def _record_write(output_dir: Path, file_name: str, content: str) -> None:
@@ -461,10 +432,15 @@ def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():
 
 
 def test_prepare_stage_stores_clone_plan_and_exports(monkeypatch: pytest.MonkeyPatch):
-    """prepare_stage resolves the clone plan and exports a trimmed prototype stage."""
+    """prepare_stage stores the published clone plan and exports a trimmed prototype stage."""
     num_envs = 4
 
-    published = _create_homogeneous_clone_plan(num_envs)
+    published = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, num_envs), dtype=torch.bool),
+        positions=torch.zeros((num_envs, 3)),
+    )
     _patch_simulation_context(monkeypatch, published)
 
     stage = _make_multi_env_stage(num_envs)
@@ -472,8 +448,7 @@ def test_prepare_stage_stores_clone_plan_and_exports(monkeypatch: pytest.MonkeyP
 
     renderer.prepare_stage(stage, 4)
 
-    assert renderer._clone_plan is not None
-    assert renderer._clone_plan.sources == published.sources
+    assert renderer._clone_plan is published
 
     # Only the env_0 prototype subtree is exported.
     _assert_export_contains_env_roots_and_children(renderer._exported_usd_string, [0])

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -35,9 +35,11 @@ if not _MISSING_MODULES:
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer, _write_file  # noqa: E402
 
-    from pxr import Usd, UsdGeom  # noqa: E402
+    from pxr import Gf, Sdf, Usd, UsdGeom  # noqa: E402
 else:
     OVRTXRenderer = None
+    Gf = None
+    Sdf = None
     OVRTXRendererCfg = None
     Usd = None
     UsdGeom = None
@@ -48,37 +50,19 @@ _PRE_OVRTX_STAGE_FILE = "pre_ovrtx_renderer_stage.usda"
 _OVRTX_STAGE_FILE = "ovrtx_renderer_stage.usda"
 
 
-def _make_multi_env_stage(num_envs: int) -> Usd.Stage:
-    """Build an in-memory stage with distinguishable content per environment."""
+def _make_prototype_stage() -> Usd.Stage:
+    """Build an in-memory stage containing only the environment-zero prototype."""
     stage = Usd.Stage.CreateInMemory()
     UsdGeom.Xform.Define(stage, "/World")
     UsdGeom.Xform.Define(stage, "/World/envs")
 
-    for env_idx in range(num_envs):
-        env_path = f"/World/envs/env_{env_idx}"
-        UsdGeom.Xform.Define(stage, env_path)
-        UsdGeom.Xform.Define(stage, f"{env_path}/Robot")
-        UsdGeom.Xform.Define(stage, f"{env_path}/Object_env{env_idx}_only")
-        UsdGeom.Camera.Define(stage, f"{env_path}/Camera")
+    env_path = "/World/envs/env_0"
+    UsdGeom.Xform.Define(stage, env_path)
+    UsdGeom.Xform.Define(stage, f"{env_path}/Robot")
+    UsdGeom.Xform.Define(stage, f"{env_path}/Object_env0_only")
+    UsdGeom.Camera.Define(stage, f"{env_path}/Camera")
 
     return stage
-
-
-def _assert_export_contains_env_roots_and_children(exported: str, env_indices: range | list[int]) -> None:
-    """Listed environment roots appear in the stage export."""
-    for env_idx in env_indices:
-        assert f'def Xform "env_{env_idx}"' in exported
-        assert f'def Xform "Object_env{env_idx}_only"' in exported
-
-    assert exported.count('def Xform "Robot"') == len(env_indices)
-    assert exported.count('def Camera "Camera"') == len(env_indices)
-
-
-def _assert_export_contains_env_roots_but_omits_children(exported: str, env_indices: range | list[int]) -> None:
-    """Listed environments and their unique children are omitted from the stage export."""
-    for env_idx in env_indices:
-        assert f'def Xform "env_{env_idx}"' in exported
-        assert f'def Xform "Object_env{env_idx}_only"' not in exported
 
 
 def _patch_simulation_context(monkeypatch: pytest.MonkeyPatch, clone_plan: ClonePlan | None) -> None:
@@ -98,7 +82,6 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
         write_attribute=lambda *args, **kwargs: None,
     )
     renderer._clone_plan = None
-    renderer._camera_rel_path = "Camera"
     renderer._render_product_paths = []
     renderer._exported_usd_string = None
     renderer._initialized_scene = False
@@ -131,21 +114,68 @@ def _make_camera_render_spec(num_envs: int = 1) -> CameraRenderSpec:
     )
 
 
+def _make_env_plan(num_envs: int, positions: torch.Tensor | None = None) -> ClonePlan:
+    """Build a complete homogeneous plan for tests that do not exercise heterogeneous layouts."""
+    return ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, num_envs), dtype=torch.bool),
+        env_ids=torch.arange(num_envs),
+        positions=torch.zeros((num_envs, 3)) if positions is None else positions,
+        env_template="/World/envs/env_{}",
+    )
+
+
+def test_ovrtx_clone_layout_has_no_default_environment_namespace():
+    """OVRTX must consume ClonePlan paths without restoring the old stage-patching helpers."""
+    package = Path(__file__).parents[1] / "isaaclab_ov" / "renderers"
+    renderer_source = (package / "ovrtx_renderer.py").read_text(encoding="utf-8")
+    usd_source = (package / "ovrtx_usd.py").read_text(encoding="utf-8")
+    physics_source = (package.parent / "physics" / "ovphysx_manager.py").read_text(encoding="utf-8")
+
+    assert "/World/envs/" not in renderer_source
+    assert "/World/envs/" not in usd_source
+    assert "/World/envs/" not in physics_source
+    assert "camera_path_relative_to_env_0" not in renderer_source
+    combined_source = renderer_source + usd_source + physics_source
+    for helper in (
+        "def create_scene_partition_attributes(",
+        "def export_stage_to_string(",
+        "def _collect_prims_to_deactivate(",
+        "def _set_prims_active_on_layer(",
+        "def _strip_nonzero_environments(",
+        "def _init_fields_legacy(",
+        "def _init_fields_ovstage(",
+        "def _initialize_from_spec(",
+    ):
+        assert helper not in combined_source
+
+
 def test_clone_sources_in_ovrtx_heterogeneous_rows():
     """Each active row clones its targets while an inactive row is skipped."""
     renderer = _make_ovrtx_renderer_without_backend()
     renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object", "/World/envs/env_0/Light"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object", "/World/envs/env_{}/Light"),
+        sources=(
+            "/World/scenes/scene_2/Robot",
+            "/World/scenes/scene_7/Object",
+            "/World/scenes/scene_2/Light",
+        ),
+        destinations=(
+            "/World/scenes/scene_{}/Robot",
+            "/World/scenes/scene_{}/Object",
+            "/World/scenes/scene_{}/Light",
+        ),
         clone_mask=torch.tensor(
             [
-                [True, True, True, True],
-                [False, False, True, True],
+                [True, False, True, False],
+                [False, True, False, True],
                 [False, False, False, False],
             ],
             dtype=torch.bool,
         ),
+        env_ids=torch.tensor([2, 7, 11, 19]),
         positions=torch.zeros((4, 3)),
+        env_template="/World/scenes/scene_{}",
     )
 
     clone_calls: list[tuple[str, list[str]]] = []
@@ -159,16 +189,12 @@ def test_clone_sources_in_ovrtx_heterogeneous_rows():
 
     assert clone_calls == [
         (
-            "/World/envs/env_0/Robot",
-            [
-                "/World/envs/env_1/Robot",
-                "/World/envs/env_2/Robot",
-                "/World/envs/env_3/Robot",
-            ],
+            "/World/scenes/scene_2/Robot",
+            ["/World/scenes/scene_11/Robot"],
         ),
         (
-            "/World/envs/env_1/Object",
-            ["/World/envs/env_2/Object", "/World/envs/env_3/Object"],
+            "/World/scenes/scene_7/Object",
+            ["/World/scenes/scene_19/Object"],
         ),
     ]
 
@@ -180,7 +206,9 @@ def test_clone_sources_in_ovrtx_raises_on_clone_failure():
         sources=("/World/envs/env_0",),
         destinations=("/World/envs/env_{}",),
         clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        env_ids=torch.arange(2),
         positions=torch.zeros((2, 3)),
+        env_template="/World/envs/env_{}",
     )
 
     def _clone_usd(source: str, target_paths: list[str]) -> None:
@@ -197,10 +225,12 @@ def test_clone_sources_in_ovrtx_writes_plan_positions_after_cloning():
     renderer = _make_ovrtx_renderer_without_backend()
     positions = torch.tensor([[0.0, 0.0, 0.0], [2.0, -1.0, 0.5], [-3.0, 4.0, 1.5]])
     renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0",),
-        destinations=("/World/envs/env_{}",),
+        sources=("/World/scenes/scene_2",),
+        destinations=("/World/scenes/scene_{}",),
         clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        env_ids=torch.tensor([2, 7, 11]),
         positions=positions,
+        env_template="/World/scenes/scene_{}",
     )
     call_order: list[str] = []
     clone_calls: list[tuple[str, list[str]]] = []
@@ -223,8 +253,13 @@ def test_clone_sources_in_ovrtx_writes_plan_positions_after_cloning():
     expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
     expected[:, 3, :3] = positions.numpy()
     assert call_order == ["clone", "write"]
-    assert clone_calls == [("/World/envs/env_0", ["/World/envs/env_1", "/World/envs/env_2"])]
+    assert clone_calls == [("/World/scenes/scene_2", ["/World/scenes/scene_7", "/World/scenes/scene_11"])]
     assert len(write_calls) == 1
+    assert write_calls[0]["prim_paths"] == [
+        "/World/scenes/scene_2",
+        "/World/scenes/scene_7",
+        "/World/scenes/scene_11",
+    ]
     assert write_calls[0]["attribute_name"] == "omni:xform"
     np.testing.assert_array_equal(write_calls[0]["tensor"], expected)
 
@@ -235,10 +270,12 @@ def test_clone_sources_ovstage_writes_plan_positions_after_cloning(monkeypatch: 
     renderer = _make_ovrtx_renderer_without_backend()
     positions = torch.tensor([[0.0, 0.0, 0.0], [1.5, -2.0, 0.25], [3.0, 4.0, 0.5]])
     renderer._clone_plan = ClonePlan(
-        sources=("/World/envs/env_0/Robot", "/World/envs/env_1/Object"),
-        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Object"),
+        sources=("/World/scenes/scene_2/Robot", "/World/scenes/scene_7/Object"),
+        destinations=("/World/scenes/scene_{}/Robot", "/World/scenes/scene_{}/Object"),
         clone_mask=torch.tensor([[False, False, False], [False, True, True]]),
+        env_ids=torch.tensor([2, 7, 11]),
         positions=positions,
+        env_template="/World/scenes/scene_{}",
     )
     events: list[tuple[str, str, object]] = []
     xforms: list[np.ndarray] = []
@@ -282,8 +319,12 @@ def test_clone_sources_ovstage_writes_plan_positions_after_cloning(monkeypatch: 
     expected = np.tile(np.eye(4, dtype=np.float64), (3, 1, 1))
     expected[:, 3, :3] = positions.numpy()
     assert events == [
-        ("clone", "/World/envs/env_1/Object", ["/World/envs/env_2/Object"]),
-        ("paths", "envs", ["/World/envs/env_0", "/World/envs/env_1", "/World/envs/env_2"]),
+        ("clone", "/World/scenes/scene_7/Object", ["/World/scenes/scene_11/Object"]),
+        (
+            "paths",
+            "envs",
+            ["/World/scenes/scene_2", "/World/scenes/scene_7", "/World/scenes/scene_11"],
+        ),
         ("query", "envs", "env_paths"),
         ("write", "omni:xform", "root_xforms"),
     ]
@@ -310,6 +351,8 @@ def test_write_file_creates_parent_directory_and_writes_utf8(tmp_path: Path):
             sources=("/World/envs/env_0",),
             destinations=("/World/envs/env_{}",),
             clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            env_ids=torch.arange(2),
+            env_template="/World/envs/env_{}",
         ),
     ],
 )
@@ -317,23 +360,18 @@ def test_prepare_stage_requires_published_plan_positions(monkeypatch: pytest.Mon
     """OVRTX stage preparation rejects an absent plan and a plan without positions."""
     _patch_simulation_context(monkeypatch, clone_plan)
 
-    with pytest.raises(RuntimeError, match="Clone plan with environment positions is required"):
-        _make_ovrtx_renderer_without_backend().prepare_stage(_make_multi_env_stage(2), 2)
+    with pytest.raises(RuntimeError, match="Clone plan with environment ids, positions"):
+        _make_ovrtx_renderer_without_backend().prepare_stage(_make_prototype_stage(), 2)
 
 
 def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """prepare_stage writes the raw stage before OVRTX-specific preparation."""
     _patch_simulation_context(
         monkeypatch,
-        ClonePlan(
-            sources=("/World/envs/env_0",),
-            destinations=("/World/envs/env_{}",),
-            clone_mask=torch.ones((1, 2), dtype=torch.bool),
-            positions=torch.zeros((2, 3)),
-        ),
+        _make_env_plan(2),
     )
 
-    stage = _make_multi_env_stage(2)
+    stage = _make_prototype_stage()
     renderer = _make_ovrtx_renderer_without_backend()
     renderer.cfg.temp_usd_dir = str(tmp_path)
     expected_pre_export = stage.ExportToString()
@@ -343,7 +381,7 @@ def test_prepare_stage_writes_pre_ovrtx_stage_dump(tmp_path: Path, monkeypatch: 
     pre_stage_path = tmp_path / _PRE_OVRTX_STAGE_FILE
     assert pre_stage_path.is_file()
     assert pre_stage_path.read_text(encoding="utf-8") == expected_pre_export
-    assert pre_stage_path.read_text(encoding="utf-8") != stage.ExportToString()
+    assert stage.ExportToString() == expected_pre_export
     assert (tmp_path / _OVRTX_STAGE_FILE).exists() is False
 
 
@@ -351,12 +389,7 @@ def test_prepare_stage_skips_temp_usd_write_when_temp_usd_dir_unset(monkeypatch:
     """prepare_stage does not write debug dumps when temp_usd_dir is None."""
     _patch_simulation_context(
         monkeypatch,
-        ClonePlan(
-            sources=("/World/envs/env_0",),
-            destinations=("/World/envs/env_{}",),
-            clone_mask=torch.ones((1, 2), dtype=torch.bool),
-            positions=torch.zeros((2, 3)),
-        ),
+        _make_env_plan(2),
     )
     write_calls: list[tuple[Path, str, str]] = []
 
@@ -365,7 +398,7 @@ def test_prepare_stage_skips_temp_usd_write_when_temp_usd_dir_unset(monkeypatch:
 
     monkeypatch.setattr("isaaclab_ov.renderers.ovrtx_renderer._write_file", _record_write)
 
-    stage = _make_multi_env_stage(2)
+    stage = _make_prototype_stage()
     renderer = _make_ovrtx_renderer_without_backend()
     renderer.cfg.temp_usd_dir = None
 
@@ -374,18 +407,20 @@ def test_prepare_stage_skips_temp_usd_write_when_temp_usd_dir_unset(monkeypatch:
     assert write_calls == []
 
 
-def test_initialize_from_spec_writes_combined_stage_dump(tmp_path: Path):
-    """_initialize_from_spec writes the combined stage when temp_usd_dir is set."""
+def test_initialize_from_spec_legacy_writes_combined_stage_dump(tmp_path: Path):
+    """Legacy initialization writes the combined stage when temp_usd_dir is set."""
     renderer = _make_ovrtx_renderer_without_backend()
+    renderer._clone_plan = _make_env_plan(1)
     renderer.cfg.temp_usd_dir = str(tmp_path)
     renderer._exported_usd_string = "#usda 1.0\n"
 
     open_calls: list[str] = []
     renderer._renderer.open_usd_from_string = lambda usd_string: open_calls.append(usd_string)
     renderer._renderer.bind_attribute = lambda **kwargs: object()
-    renderer._renderer.write_attribute = lambda **kwargs: None
+    renderer._renderer.write_attribute = lambda *_args, **_kwargs: None
 
-    renderer._initialize_from_spec(_make_camera_render_spec(num_envs=1))
+    spec = _make_camera_render_spec(num_envs=1)
+    renderer._initialize_from_spec_legacy(spec, list(spec.camera_prim_paths))
 
     combined_path = tmp_path / _OVRTX_STAGE_FILE
     combined_text = combined_path.read_text(encoding="utf-8")
@@ -395,10 +430,21 @@ def test_initialize_from_spec_writes_combined_stage_dump(tmp_path: Path):
     assert renderer._exported_usd_string is None
 
 
-def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():
-    """Multi-environment initialization rewrites the RenderProduct cameras after cloning."""
-    num_envs = 4
+def test_initialize_from_spec_legacy_refreshes_camera_relationship_after_cloning():
+    """Initialization resolves sparse heterogeneous cameras in ClonePlan column order."""
+    env_ids = [2, 7, 11, 19]
     renderer = _make_ovrtx_renderer_without_backend()
+    renderer._clone_plan = ClonePlan(
+        sources=("/World/scenes/scene_2/Camera", "/World/scenes/scene_7/Camera"),
+        destinations=("/World/scenes/scene_{}/Camera", "/World/scenes/scene_{}/Camera"),
+        clone_mask=torch.tensor(
+            [[True, False, True, False], [False, True, False, True]],
+            dtype=torch.bool,
+        ),
+        env_ids=torch.tensor(env_ids),
+        positions=torch.zeros((len(env_ids), 3)),
+        env_template="/World/scenes/scene_{}",
+    )
     renderer._exported_usd_string = "#usda 1.0\n"
 
     call_order: list[str] = []
@@ -406,7 +452,7 @@ def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():
 
     renderer._renderer.open_usd_from_string = lambda _usd_string: call_order.append("open")
     renderer._clone_sources_in_ovrtx = lambda: call_order.append("clone")
-    renderer._update_scene_partitions_after_clone = lambda _num_envs: call_order.append("partitions")
+    renderer._update_scene_partitions_after_clone = lambda _camera_paths: call_order.append("partitions")
 
     def _write_array_attribute(prim_paths: list[str], attribute_name: str, tensors: list[list[str]]) -> None:
         call_order.append("rewrite_cameras")
@@ -415,41 +461,125 @@ def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():
     renderer._renderer.write_array_attribute = _write_array_attribute
     renderer._renderer.bind_attribute = lambda **_kwargs: object()
     renderer._renderer.write_attribute = lambda **_kwargs: None
-    renderer._setup_xform_bindings = lambda: None
-    renderer._setup_deformable_bindings = lambda _num_envs: None
+    renderer._setup_xform_bindings_legacy = lambda _camera_paths: None
+    renderer._setup_deformable_bindings_legacy = lambda _num_envs: None
+    renderer._setup_particle_bindings_legacy = lambda: None
 
-    spec = _make_camera_render_spec(num_envs=num_envs)
-    renderer._initialize_from_spec(spec)
+    spec = _make_camera_render_spec()
+    spec.cfg.prim_path = "/World/scenes/scene_[^/]+/Camera"
+    spec = CameraRenderSpec(
+        cfg=spec.cfg,
+        device=spec.device,
+        num_instances=len(env_ids),
+        camera_prim_paths=("/World/scenes/scene_2/Camera", "/World/scenes/scene_7/Camera"),
+        view_count=len(env_ids),
+        camera_path_relative_to_env_0="",
+    )
+    camera_paths = spec.resolve_camera_prim_paths(renderer._clone_plan)
+    renderer._initialize_from_spec_legacy(spec, camera_paths)
 
     assert call_order == ["open", "clone", "partitions", "rewrite_cameras"]
     assert write_array_calls == [
         (
             ["/Render/RenderProduct"],
             "camera",
-            [[f"/World/envs/env_{env_id}/Camera" for env_id in range(num_envs)]],
+            [[f"/World/scenes/scene_{env_id}/Camera" for env_id in env_ids]],
         )
     ]
 
 
-def test_prepare_stage_stores_clone_plan_and_exports(monkeypatch: pytest.MonkeyPatch):
-    """prepare_stage stores the published clone plan and exports a trimmed prototype stage."""
-    num_envs = 4
+def test_prepare_stage_builds_legacy_private_env_roots(monkeypatch: pytest.MonkeyPatch):
+    """Legacy preparation preserves sparse prototypes and adds only planned private roots."""
+    env_ids = [2, 7, 11, 19]
+    positions = torch.tensor([[1.0, -1.0, 0.0], [1.0, 1.0, 0.0], [-1.0, -1.0, 0.0], [-1.0, 1.0, 0.0]])
 
     published = ClonePlan(
-        sources=("/World/envs/env_0",),
-        destinations=("/World/envs/env_{}",),
-        clone_mask=torch.ones((1, num_envs), dtype=torch.bool),
-        positions=torch.zeros((num_envs, 3)),
+        sources=("/World/scenes/scene_2", "/World/scenes/scene_7"),
+        destinations=("/World/scenes/scene_{}", "/World/scenes/scene_{}"),
+        clone_mask=torch.tensor(
+            [[True, False, True, False], [False, True, False, True]],
+            dtype=torch.bool,
+        ),
+        env_ids=torch.tensor(env_ids),
+        positions=positions,
+        env_template="/World/scenes/scene_{}",
     )
     _patch_simulation_context(monkeypatch, published)
 
-    stage = _make_multi_env_stage(num_envs)
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.Xform.Define(stage, "/World")
+    UsdGeom.Xform.Define(stage, "/World/scenes")
+    for column, env_id in enumerate(env_ids[:2]):
+        root = UsdGeom.Xform.Define(stage, f"/World/scenes/scene_{env_id}")
+        UsdGeom.XformCommonAPI(root).SetTranslate(Gf.Vec3d(*positions[column].tolist()))
+        UsdGeom.Xform.Define(stage, f"/World/scenes/scene_{env_id}/Asset")
+        UsdGeom.Camera.Define(stage, f"/World/scenes/scene_{env_id}/Camera")
+    prototype_export = stage.ExportToString()
     renderer = _make_ovrtx_renderer_without_backend()
 
-    renderer.prepare_stage(stage, 4)
+    renderer.prepare_stage(stage, len(env_ids))
 
     assert renderer._clone_plan is published
+    assert stage.ExportToString() == prototype_export
 
-    # Only the env_0 prototype subtree is exported.
-    _assert_export_contains_env_roots_and_children(renderer._exported_usd_string, [0])
-    _assert_export_contains_env_roots_but_omits_children(renderer._exported_usd_string, [1, 2, 3])
+    layer = Sdf.Layer.CreateAnonymous("private.usda")
+    assert layer.ImportFromString(renderer._exported_usd_string)
+    private_stage = Usd.Stage.Open(layer)
+    for column, env_id in enumerate(env_ids):
+        env_prim = private_stage.GetPrimAtPath(f"/World/scenes/scene_{env_id}")
+        assert env_prim.IsA(UsdGeom.Xform)
+        assert env_prim.GetAttribute("primvars:omni:scenePartition").Get() == f"env_{env_id}"
+        translate_ops = [
+            op
+            for op in UsdGeom.Xformable(env_prim).GetOrderedXformOps()
+            if op.GetOpType() == UsdGeom.XformOp.TypeTranslate
+        ]
+        if column < 2:
+            assert len(translate_ops) == 1
+            assert Gf.IsClose(translate_ops[0].Get(), Gf.Vec3d(*map(float, positions[column])), 1.0e-8)
+        else:
+            assert translate_ops == []
+        assert private_stage.GetPrimAtPath(f"/World/scenes/scene_{env_id}/Asset").IsValid() == (column < 2)
+        assert private_stage.GetPrimAtPath(f"/World/scenes/scene_{env_id}/Camera").IsValid() == (column < 2)
+
+    for env_id in env_ids[:2]:
+        camera = private_stage.GetPrimAtPath(f"/World/scenes/scene_{env_id}/Camera")
+        assert camera.GetAttribute("omni:scenePartition").Get() == f"env_{env_id}"
+    assert private_stage.GetPrimAtPath("/World/envs").IsValid() is False
+
+
+def test_prepare_stage_selects_heterogeneous_prototypes_for_ovstage(monkeypatch: pytest.MonkeyPatch):
+    """OVStage consumes the heterogeneous prototype stage without another filtering pass."""
+    env_ids = [2, 7, 11, 19]
+    published = ClonePlan(
+        sources=("/World/scenes/scene_2/Robot", "/World/scenes/scene_7/Camera"),
+        destinations=("/World/scenes/scene_{}/Robot", "/World/scenes/scene_{}/Camera"),
+        clone_mask=torch.tensor(
+            [[True, True, False, False], [False, False, True, True]],
+            dtype=torch.bool,
+        ),
+        env_ids=torch.tensor(env_ids),
+        positions=torch.zeros((len(env_ids), 3)),
+        env_template="/World/scenes/scene_{}",
+    )
+    _patch_simulation_context(monkeypatch, published)
+
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.Xform.Define(stage, "/World")
+    UsdGeom.Xform.Define(stage, "/World/scenes")
+    UsdGeom.Xform.Define(stage, "/World/scenes/scene_2")
+    UsdGeom.Xform.Define(stage, "/World/scenes/scene_2/Robot")
+    UsdGeom.Xform.Define(stage, "/World/scenes/scene_7")
+    UsdGeom.Camera.Define(stage, "/World/scenes/scene_7/Camera")
+    UsdGeom.Xform.Define(stage, "/World/Ground")
+    live_export = stage.ExportToString()
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._use_ovstage = True
+
+    renderer.prepare_stage(stage, len(env_ids))
+
+    assert stage.ExportToString() == live_export
+    assert renderer._exported_usd_string == live_export
+    assert stage.GetPrimAtPath("/World/scenes/scene_11").IsValid() is False
+    assert stage.GetPrimAtPath("/World/scenes/scene_19").IsValid() is False
+    assert stage.GetPrimAtPath("/World/envs").IsValid() is False

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -12,7 +12,10 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 import warp as wp
+
+from isaaclab.cloner import ClonePlan
 
 _REQUIRED_MODULES = ("isaaclab_ov", "ovrtx", "pxr", "isaaclab_newton")
 _MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
@@ -90,11 +93,22 @@ class _FakeOVRTXBackend:
         self.writes.append(kwargs)
 
 
-def _make_renderer_without_backend(device: str = "cpu") -> tuple[OVRTXRenderer, _FakeOVRTXBackend]:
+def _make_renderer_without_backend(
+    device: str = "cpu",
+    env_ids: tuple[int, ...] = (0,),
+    env_template: str = "/World/envs/env_{}",
+) -> tuple[OVRTXRenderer, _FakeOVRTXBackend]:
     renderer = OVRTXRenderer.__new__(OVRTXRenderer)
     renderer.cfg = OVRTXRendererCfg()
     renderer._device = device
-    renderer._camera_rel_path = "Camera"
+    renderer._clone_plan = ClonePlan(
+        sources=(env_template.format(env_ids[0]),),
+        destinations=(env_template,),
+        clone_mask=torch.ones((1, len(env_ids)), dtype=torch.bool),
+        env_ids=torch.tensor(env_ids),
+        positions=torch.zeros((len(env_ids), 3)),
+        env_template=env_template,
+    )
     renderer._renderer = _FakeOVRTXBackend()
     renderer._deformable_points_binding = None
     renderer._deformable_particle_offsets = []
@@ -127,7 +141,7 @@ def test_setup_deformable_bindings_binds_surface_mesh_points(monkeypatch: pytest
 
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [entry])
 
-    renderer._setup_deformable_bindings(num_envs=1)
+    renderer._setup_deformable_bindings_legacy(num_envs=1)
 
     assert len(backend.calls) == 1
     assert backend.calls[0]["prim_paths"] == ["/World/envs/env_0/Deformable/mesh"]
@@ -158,7 +172,7 @@ def test_setup_deformable_bindings_binds_volume_mesh_points(monkeypatch: pytest.
 
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [entry])
 
-    renderer._setup_deformable_bindings(num_envs=1)
+    renderer._setup_deformable_bindings_legacy(num_envs=1)
 
     assert len(backend.calls) == 1
     assert backend.calls[0]["prim_paths"] == ["/World/envs/env_0/Deformable/mesh"]
@@ -169,7 +183,7 @@ def test_setup_deformable_bindings_binds_volume_mesh_points(monkeypatch: pytest.
 
 def test_setup_deformable_bindings_binds_mixed_surface_and_volume_entries(monkeypatch: pytest.MonkeyPatch):
     """Surface and volume deformable registry entries bind together with distinct offsets."""
-    renderer, backend = _make_renderer_without_backend()
+    renderer, backend = _make_renderer_without_backend(env_ids=(0, 1))
     surface_entry = SimpleNamespace(
         prim_path="/World/envs/env_[^/]+/DeformableSurface",
         vis_mesh_prim_path="/World/envs/env_[^/]+/DeformableSurface/mesh",
@@ -187,7 +201,7 @@ def test_setup_deformable_bindings_binds_mixed_surface_and_volume_entries(monkey
 
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [surface_entry, volume_entry])
 
-    renderer._setup_deformable_bindings(num_envs=2)
+    renderer._setup_deformable_bindings_legacy(num_envs=2)
 
     assert backend.calls[0]["prim_paths"] == [
         "/World/envs/env_0/DeformableSurface/mesh",
@@ -213,7 +227,7 @@ def test_setup_deformable_bindings_works_without_stage(monkeypatch: pytest.Monke
     monkeypatch.setattr("isaaclab.sim.utils.stage.get_current_stage", lambda: None)
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [entry])
 
-    renderer._setup_deformable_bindings(num_envs=1)
+    renderer._setup_deformable_bindings_legacy(num_envs=1)
 
     assert len(backend.calls) == 1
     assert backend.calls[0]["prim_paths"] == ["/World/envs/env_0/Deformable/mesh"]
@@ -221,11 +235,12 @@ def test_setup_deformable_bindings_works_without_stage(monkeypatch: pytest.Monke
 
 
 def test_setup_deformable_bindings_binds_all_surface_mesh_instances(monkeypatch: pytest.MonkeyPatch):
-    """Surface deformable registry entries bind every cloned visual mesh instance."""
-    renderer, backend = _make_renderer_without_backend()
+    """Surface deformable paths follow sparse ClonePlan IDs and its custom root template."""
+    env_ids = (2, 7, 11, 19)
+    renderer, backend = _make_renderer_without_backend(env_ids=env_ids, env_template="/World/scenes/scene_{}")
     entry = SimpleNamespace(
-        prim_path="/World/envs/env_[^/]+/Deformable",
-        vis_mesh_prim_path="/World/envs/env_[^/]+/Deformable/mesh",
+        prim_path="/World/scenes/scene_[^/]+/Deformable",
+        vis_mesh_prim_path="/World/scenes/scene_[^/]+/Deformable/mesh",
         deformable_type="surface",
         particle_offsets=[0, 3, 6, 9],
         particles_per_body=3,
@@ -233,9 +248,9 @@ def test_setup_deformable_bindings_binds_all_surface_mesh_instances(monkeypatch:
 
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [entry])
 
-    renderer._setup_deformable_bindings(num_envs=4)
+    renderer._setup_deformable_bindings_legacy(num_envs=4)
 
-    expected_paths = [f"/World/envs/env_{i}/Deformable/mesh" for i in range(4)]
+    expected_paths = [f"/World/scenes/scene_{env_id}/Deformable/mesh" for env_id in env_ids]
     assert backend.calls[0]["prim_paths"] == expected_paths
     assert renderer._deformable_particle_offsets == [0, 3, 6, 9]
     assert renderer._deformable_particle_counts == [3, 3, 3, 3]
@@ -282,7 +297,7 @@ def test_update_deformable_points_writes_world_particle_positions(monkeypatch: p
 
 def test_setup_deformable_bindings_rejects_offset_count_mismatch(monkeypatch: pytest.MonkeyPatch):
     """Registry entries must provide one particle offset per environment, listing every bad entry."""
-    renderer, _backend = _make_renderer_without_backend()
+    renderer, _backend = _make_renderer_without_backend(env_ids=(0, 1))
     bad_entry = SimpleNamespace(
         prim_path="/World/envs/env_[^/]+/Deformable",
         vis_mesh_prim_path="/World/envs/env_[^/]+/Deformable/mesh",
@@ -301,7 +316,7 @@ def test_setup_deformable_bindings_rejects_offset_count_mismatch(monkeypatch: py
     monkeypatch.setattr(NewtonManager, "_deformable_registry", [bad_entry, other_bad_entry])
 
     with pytest.raises(RuntimeError, match="one particle offset per environment") as excinfo:
-        renderer._setup_deformable_bindings(num_envs=2)
+        renderer._setup_deformable_bindings_legacy(num_envs=2)
 
     message = str(excinfo.value)
     assert bad_entry.prim_path in message
@@ -335,7 +350,7 @@ def test_setup_particle_points_bindings_binds_mpm_visual_prims(monkeypatch: pyte
 
     monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
 
-    renderer._setup_particle_bindings()
+    renderer._setup_particle_bindings_legacy()
 
     assert len(backend.calls) == 1
     assert backend.calls[0]["prim_paths"] == [
@@ -365,7 +380,7 @@ def test_setup_particle_points_bindings_binds_multiple_mpm_assets(monkeypatch: p
 
     monkeypatch.setattr(NewtonManager, "_particle_visual_prims", particle_visual_prims)
 
-    renderer._setup_particle_bindings()
+    renderer._setup_particle_bindings_legacy()
 
     # Binding order follows dict insertion order (no path sort).
     assert backend.calls[0]["prim_paths"] == [

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -478,7 +478,6 @@ def _make_ovstage_renderer_with_backend(events: list[str]) -> OVRTXRenderer:
     renderer._deformable_particle_counts = [1]
     renderer._particle_visual_offsets = [0]
     renderer._particle_visual_counts = [1]
-    renderer._env_root_xforms = object()
     renderer._renderer = Backend()
     renderer._ovstage_exit_stack = ExitStack()
     renderer._render_product_paths = ["/Render/RenderProduct_camera"]
@@ -541,7 +540,6 @@ def test_ovrtx_close_releases_ovstage_renderer_state():
     assert renderer._camera_xform_query is None
     assert renderer._particle_paths_list is None
     assert renderer._object_newton_indices is None
-    assert renderer._env_root_xforms is None
     assert renderer._renderer is None
     assert renderer._ovstage_exit_stack is None
     assert renderer._stage is None

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for OVRTX USD render product authoring and stage export."""
+"""Tests for OVRTX USD render product authoring."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ import importlib.util
 
 import pytest
 
-_REQUIRED_MODULES = ("isaaclab_ov", "pxr")
+_REQUIRED_MODULES = ("isaaclab_ov",)
 _MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
 
 pytestmark = [
@@ -26,56 +26,14 @@ if not _MISSING_MODULES:
     from isaaclab_ov.renderers.ovrtx_usd import (  # noqa: E402
         build_render_product_as_string,
         build_render_scope_usd,
-        create_scene_partition_attributes,
-        export_stage_to_string,
         get_render_var_config,
         get_render_var_configs,
     )
-
-    from pxr import Sdf, Usd, UsdGeom  # noqa: E402
 else:
-    Sdf = None
-    Usd = None
-    UsdGeom = None
     build_render_product_as_string = None
     build_render_scope_usd = None
-    create_scene_partition_attributes = None
-    export_stage_to_string = None
     get_render_var_config = None
     get_render_var_configs = None
-
-
-def _make_multi_env_stage(num_envs: int) -> Usd.Stage:
-    """Build an in-memory stage with distinguishable content per environment."""
-    stage = Usd.Stage.CreateInMemory()
-    UsdGeom.Xform.Define(stage, "/World")
-    UsdGeom.Xform.Define(stage, "/World/envs")
-
-    for env_idx in range(num_envs):
-        env_path = f"/World/envs/env_{env_idx}"
-        UsdGeom.Xform.Define(stage, env_path)
-        UsdGeom.Xform.Define(stage, f"{env_path}/Robot")
-        UsdGeom.Xform.Define(stage, f"{env_path}/Object_env{env_idx}_only")
-        UsdGeom.Camera.Define(stage, f"{env_path}/Camera")
-
-    return stage
-
-
-def _assert_export_contains_env_roots_and_children(exported: str, env_indices: range | list[int]) -> None:
-    """Listed environment roots appear in the stage export."""
-    for env_idx in env_indices:
-        assert f'def Xform "env_{env_idx}"' in exported
-        assert f'def Xform "Object_env{env_idx}_only"' in exported
-
-    assert exported.count('def Xform "Robot"') == len(env_indices)
-    assert exported.count('def Camera "Camera"') == len(env_indices)
-
-
-def _assert_export_omits_env_children(exported: str, env_indices: range | list[int]) -> None:
-    """Listed environments keep their roots but omit prototype children from the stage export."""
-    for env_idx in env_indices:
-        assert f'def Xform "env_{env_idx}"' in exported
-        assert f'def Xform "Object_env{env_idx}_only"' not in exported
 
 
 def test_build_render_scope_usd_default_background_is_dome_light():
@@ -139,18 +97,18 @@ def test_ovrtx_motion_vectors_with_rgb_falls_back_to_rgb():
 
 
 def test_render_product_initially_targets_only_the_resolvable_source_camera():
-    """Multi-environment RenderProducts initially target env zero while retaining tiled resolution."""
+    """Multi-environment RenderProducts initially target the authored prototype camera."""
     render_product, render_product_path = build_render_product_as_string(
         width=16,
         height=8,
         num_envs=4,
         data_types=["rgb"],
-        camera_rel_path="Robot/head_cam",
+        camera_path="/World/scenes/scene_7/Robot/head_cam",
     )
 
     assert render_product_path == "/Render/RenderProduct"
-    assert "rel camera = [</World/envs/env_0/Robot/head_cam>]" in render_product
-    assert "/World/envs/env_1/Robot/head_cam" not in render_product
+    assert "rel camera = [</World/scenes/scene_7/Robot/head_cam>]" in render_product
+    assert "/World/envs/" not in render_product
     assert "uniform int2 resolution = (32, 16)" in render_product
 
 
@@ -246,135 +204,3 @@ def test_ovrtx_semantic_and_instance_segmentation_share_a_single_semantic_id_map
     assert sources.count("SemanticIdMap") == 1
     # Both segmentations' map render vars are authored regardless of which AOV get_render_var_config resolves.
     assert {"SemanticIdMap", "StableIdSemanticIdMap", "StableIdMap"} <= set(sources)
-
-
-def test_export_stage_keeps_all_env_content_when_all_roots_are_sources():
-    """Listing every env root as a source preserves the full stage content."""
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    exported = export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=tuple(f"/World/envs/env_{env_idx}" for env_idx in range(num_envs)),
-    )
-
-    _assert_export_contains_env_roots_and_children(exported, range(num_envs))
-
-
-def test_export_stage_full_when_single_env():
-    """Single-environment stages are exported without trimming."""
-    num_envs = 1
-    stage = _make_multi_env_stage(num_envs)
-
-    exported = export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=("/World/envs/env_0",),
-    )
-
-    _assert_export_contains_env_roots_and_children(exported, range(num_envs))
-
-
-def test_export_stage_homogeneous_keeps_only_env0_prototype():
-    """Homogeneous cloning exports only the env_0 prototype subtree."""
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    exported = export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=("/World/envs/env_0",),
-    )
-
-    _assert_export_contains_env_roots_and_children(exported, [0])
-    _assert_export_omits_env_children(exported, range(1, num_envs))
-
-
-def test_export_stage_without_keep_env_roots_trims_non_source_env_roots():
-    """The ovstage clone path also trims the non-source env roots themselves.
-
-    ``ovstage.Stage.clone`` requires every target path to not already exist, so the exported stage
-    must not retain env roots that the clone will recreate. This is the only difference from the
-    legacy ``renderer.clone_usd`` path, which keeps the roots as placeholders.
-    """
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    exported = export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=("/World/envs/env_0",),
-        keep_env_roots=False,
-    )
-
-    _assert_export_contains_env_roots_and_children(exported, [0])
-    for env_idx in range(1, num_envs):
-        assert f'def Xform "env_{env_idx}"' not in exported
-        assert f'def Xform "Object_env{env_idx}_only"' not in exported
-
-
-def test_export_stage_heterogeneous_keeps_multiple_sources():
-    """Heterogeneous source paths export only prototype env subtrees."""
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    exported = export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=("/World/envs/env_0/Object_env0_only", "/World/envs/env_3/Object_env3_only"),
-    )
-
-    # Only the source subtrees are exported:
-    assert 'def Xform "env_0"' in exported
-    assert 'def Xform "Object_env0_only"' in exported
-    assert 'def Xform "env_3"' in exported
-    assert 'def Xform "Object_env3_only"' in exported
-
-    # Other env roots remain, but their prototype children are omitted.
-    _assert_export_omits_env_children(exported, [1, 2])
-    assert 'def Xform "Robot"' not in exported
-    assert 'def Camera "Camera"' not in exported
-
-
-def test_export_stage_restores_active_state():
-    """Export temporarily deactivates prims but restores them afterward."""
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    for env_idx in range(num_envs):
-        env_path = f"/World/envs/env_{env_idx}"
-        assert stage.GetPrimAtPath(env_path).IsActive()
-        assert stage.GetPrimAtPath(f"{env_path}/Object_env{env_idx}_only").IsActive()
-
-    export_stage_to_string(
-        stage,
-        num_envs,
-        source_paths=("/World/envs/env_0",),
-    )
-
-    for env_idx in range(num_envs):
-        env_path = f"/World/envs/env_{env_idx}"
-        assert stage.GetPrimAtPath(env_path).IsActive()
-        assert stage.GetPrimAtPath(f"{env_path}/Object_env{env_idx}_only").IsActive()
-
-
-def test_create_scene_partition_attributes_all_envs():
-    """Scene partition attributes are authored on every env root and camera."""
-    num_envs = 4
-    stage = _make_multi_env_stage(num_envs)
-
-    create_scene_partition_attributes(stage, num_envs)
-
-    root_layer = stage.GetRootLayer()
-    for env_idx in range(num_envs):
-        env_partition_attr = root_layer.GetAttributeAtPath(
-            Sdf.Path(f"/World/envs/env_{env_idx}").AppendProperty("primvars:omni:scenePartition")
-        )
-        camera_partition_attr = root_layer.GetAttributeAtPath(
-            Sdf.Path(f"/World/envs/env_{env_idx}/Camera").AppendProperty("omni:scenePartition")
-        )
-        assert env_partition_attr is not None
-        assert env_partition_attr.default == f"env_{env_idx}"
-        assert camera_partition_attr is not None
-        assert camera_partition_attr.default == f"env_{env_idx}"

--- a/source/isaaclab_physx/changelog.d/ovrtx-defer-env-roots.rst
+++ b/source/isaaclab_physx/changelog.d/ovrtx-defer-env-roots.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed PhysX replicated scenes to materialize positioned destination roots immediately before
+  model construction while preserving legacy warmup callback timing.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -30,7 +30,7 @@ import omni.physics.tensors
 import omni.physx
 import omni.timeline
 import omni.usd
-from pxr import Sdf, Usd, UsdPhysics, UsdUtils
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdUtils
 
 import isaaclab.sim as sim_utils
 from isaaclab.physics import CallbackHandle, PhysicsEvent, PhysicsManager
@@ -72,8 +72,8 @@ class IsaacEvents(Enum):
     TIMELINE_STOP = "isaac.timeline_stop"
 
 
+# MODEL_INIT is dispatched directly before model load; PHYSICS_WARMUP retains its legacy post-load timing.
 _PHYSICS_EVENT_TO_ISAAC_EVENT: dict[PhysicsEvent, IsaacEvents] = {
-    PhysicsEvent.MODEL_INIT: IsaacEvents.PHYSICS_WARMUP,
     PhysicsEvent.PHYSICS_READY: IsaacEvents.PHYSICS_READY,
     PhysicsEvent.STOP: IsaacEvents.TIMELINE_STOP,
 }
@@ -428,6 +428,13 @@ class PhysxManager(PhysicsManager):
         cls._stage_id = get_current_stage_id()
 
         cls._setup_subscriptions()
+        cls.register_callback(
+            cls._materialize_clone_plan_env_roots,
+            PhysicsEvent.MODEL_INIT,
+            order=3,
+            name="physx_materialize_clone_plan_env_roots",
+            wrap_weak_ref=False,
+        )
         cls._configure_physics()
         cls._load_fabric()
         cls._anim_recorder = AnimationRecorder(sim_context)
@@ -662,7 +669,7 @@ class PhysxManager(PhysicsManager):
     def _subscribe_to_event(
         cls, callback_id: int, callback: Callable, event: PhysicsEvent, order: int, name: str | None
     ) -> Any:
-        """Subscribe to PhysX events. Maps PhysicsEvent → IsaacEvents."""
+        """Subscribe cross-backend events that share a legacy PhysX event."""
         isaac_event = _PHYSICS_EVENT_TO_ISAAC_EVENT.get(event)
         if isaac_event is None:
             isaac_event = _PHYSICS_EVENT_VALUE_TO_ISAAC_EVENT.get(getattr(event, "value", event))
@@ -938,6 +945,9 @@ class PhysxManager(PhysicsManager):
         physx = omni.physx.get_physx_interface()
         physx_sim = omni.physx.get_physx_simulation_interface()
 
+        # MODEL_INIT listeners must finish authoring the stage before PhysX attaches or loads it.
+        cls.dispatch_event(PhysicsEvent.MODEL_INIT, payload={})
+
         # Attach stage to PhysX BEFORE loading/starting - only needed for GPU pipeline.
         # For CPU, the old SimulationManager never called attach_stage() explicitly.
         # Calling attach_stage() + force_load_physics_from_usd() together causes a
@@ -974,6 +984,21 @@ class PhysxManager(PhysicsManager):
         cls._event_bus.dispatch_event(IsaacEvents.SIMULATION_VIEW_CREATED.value, payload={})
         cls.dispatch_event(PhysicsEvent.PHYSICS_READY, payload={})
         cls._event_bus.dispatch_event(IsaacEvents.PHYSICS_READY.value, payload={})
+
+    @classmethod
+    def _materialize_clone_plan_env_roots(cls, _event: Any) -> None:
+        """Author clone-plan environment roots after common-stage USD replication."""
+        sim = PhysicsManager._sim
+        plan = sim.get_clone_plan() if sim is not None else None
+        if plan is None or plan.env_ids is None or plan.env_template is None:
+            return
+
+        env_ids = plan.env_ids.detach().cpu().tolist()
+        positions = plan.positions.detach().cpu().tolist() if plan.positions is not None else None
+        for env_idx, env_id in enumerate(env_ids):
+            root = UsdGeom.Xform.Define(sim.stage, plan.env_template.format(env_id))
+            if positions is not None:
+                UsdGeom.XformCommonAPI(root).SetTranslate(Gf.Vec3d(*positions[env_idx]))
 
     @classmethod
     def _invalidate_views(cls) -> None:

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -23,6 +23,7 @@ from pxr import Sdf, Usd, UsdGeom
 from isaaclab.app.settings_manager import get_settings_manager
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.renderers.camera_render_spec import CameraRenderSpec
+from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils import enable_extension
 from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled
 from isaaclab.utils.version import get_isaac_sim_version
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 
     from omni.replicator.core.scripts.utils.viewport_manager import HydraTexture
 
+    from isaaclab.cloner import ClonePlan
     from isaaclab.sensors.camera.camera_data import CameraData
     from isaaclab.utils.warp import ProxyArray
 
@@ -193,39 +195,34 @@ class IsaacRtxRenderer(BaseRenderer):
 
         return specs
 
-    def prepare_stage(self, stage: Usd.Stage, num_envs: int) -> None:
-        """Author per-env ``omni:scenePartition`` attributes for RTX cull-by-env rendering.
+    def prepare_stage(self, stage: Any, num_envs: int) -> None:
+        """Defer live-stage preparation until replicated environments exist."""
+        pass
 
-        Authoring is only performed when
-        ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` is set.
-        When the variable is absent the method is a no-op and no ``primvars:omni:scenePartition``
-        or ``omni:scenePartition`` attributes are written to the stage.
-
-        When enabled, for each ``/World/envs/env_{i}`` root, writes the inheriting primvar
-        ``primvars:omni:scenePartition`` (token ``env_{i}``) on the root and the matching
-        non-primvar ``omni:scenePartition`` token on every :class:`UsdGeom.Camera` descendant.
-        RTX honors primvar inheritance, so the env-root primvar propagates to all descendant
-        geometry and isolates each env's render tile.
-        See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.prepare_stage`."""
-
+    def _author_scene_partitions(self, stage: Usd.Stage, num_envs: int, clone_plan: ClonePlan | None) -> None:
+        """Author optional per-environment RTX scene partitions after USD replication."""
         if not isaac_rtx_per_env_scene_partition_enabled():
             return
-
+        if clone_plan is not None and clone_plan.env_ids is not None and clone_plan.env_template is not None:
+            env_roots = [
+                (int(env_id), clone_plan.env_template.format(int(env_id)))
+                for env_id in clone_plan.env_ids.detach().cpu().tolist()
+            ]
+        else:
+            env_roots = [(env_idx, f"/World/envs/env_{env_idx}") for env_idx in range(num_envs)]
         logger.debug(
             "Per-environment RTX scene partitioning is enabled"
             " (ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1)."
             " Authoring primvars:omni:scenePartition on %d env(s).",
-            num_envs,
+            len(env_roots),
         )
-
         root_layer = stage.GetRootLayer()
-        token_type = Sdf.ValueTypeNames.Token
         with Sdf.ChangeBlock():
-            for env_idx in range(num_envs):
-                env_prim = stage.GetPrimAtPath(f"/World/envs/env_{env_idx}")
+            for env_id, env_path in env_roots:
+                env_prim = stage.GetPrimAtPath(env_path)
                 if not env_prim.IsValid():
                     continue
-                token = f"env_{env_idx}"
+                token = f"env_{env_id}"
                 for prim in Usd.PrimRange(env_prim):
                     if prim == env_prim:
                         attr_path = prim.GetPath().AppendProperty("primvars:omni:scenePartition")
@@ -233,13 +230,10 @@ class IsaacRtxRenderer(BaseRenderer):
                         attr_path = prim.GetPath().AppendProperty("omni:scenePartition")
                     else:
                         continue
-                    # Idempotent: a different renderer backend sharing this stage may have already
-                    # authored this attribute. Re-creating an existing spec raises, so only create
-                    # it when absent, then (re)assign the per-env token either way.
                     attr_spec = root_layer.GetAttributeAtPath(attr_path)
                     if attr_spec is None:
                         Sdf.JustCreatePrimAttributeInLayer(
-                            root_layer, attr_path, token_type, Sdf.VariabilityUniform, True
+                            root_layer, attr_path, Sdf.ValueTypeNames.Token, Sdf.VariabilityUniform, True
                         )
                         attr_spec = root_layer.GetAttributeAtPath(attr_path)
                     attr_spec.default = token
@@ -249,7 +243,6 @@ class IsaacRtxRenderer(BaseRenderer):
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
         import omni.replicator.core as rep
         from omni.syntheticdata import SyntheticData
-        from pxr import UsdGeom
 
         from isaaclab.sim.utils.stage import get_current_stage
 
@@ -275,9 +268,14 @@ class IsaacRtxRenderer(BaseRenderer):
                     " The simple shading data types will be ignored."
                 )
 
+        stage = get_current_stage()
+        sim = SimulationContext.instance()
+        clone_plan = sim.get_clone_plan() if sim is not None else None
+        self._author_scene_partitions(stage, spec.num_instances, clone_plan)
+
         # HACK: Isaac Sim 4.5 has a bug in Camera that breaks segmentation
         # outputs for instanceable assets. Disable instancing as a workaround.
-        stage = get_current_stage()
+
         if isaac_sim_version == version.parse("4.5") and (
             "semantic_segmentation" in spec.cfg.data_types or "instance_segmentation" in spec.cfg.data_types
         ):
@@ -291,12 +289,11 @@ class IsaacRtxRenderer(BaseRenderer):
                 for prim in stage.Traverse():
                     prim.SetInstanceable(False)
 
-        # Get camera prim paths from sensor view
-        cam_prim_paths = list(spec.camera_prim_paths)
-        for cam_prim_path in cam_prim_paths:
-            cam_prim = stage.GetPrimAtPath(cam_prim_path)
-            if not cam_prim.IsA(UsdGeom.Camera):
-                raise RuntimeError(f"Prim at path '{cam_prim_path}' is not a Camera.")
+        # Expand source cameras only after deferred USD replication has populated the live stage.
+        cam_prim_paths = spec.resolve_camera_prim_paths(clone_plan)
+        for camera_path in cam_prim_paths:
+            if not stage.GetPrimAtPath(camera_path).IsA(UsdGeom.Camera):
+                raise RuntimeError(f"Prim at path '{camera_path}' is not a Camera.")
 
         # Unique UUID name so concurrent tiled cameras and sequential env create/destroy
         # cycles in one Kit process do not reuse a stale Replicator / SyntheticData activation.

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
@@ -16,7 +16,7 @@ import pytest
 import warp as wp
 from packaging import version
 
-from isaaclab.renderers import RenderBufferKind, RenderBufferSpec
+from isaaclab.renderers import CameraRenderSpec, RenderBufferKind, RenderBufferSpec
 
 pytestmark = pytest.mark.isaacsim_ci
 
@@ -93,10 +93,9 @@ def test_create_render_data_uses_unique_sdf_safe_render_product_name(monkeypatch
     replicator_core_module.AnnotatorRegistry = registry
 
     # Minimal CameraRenderSpec: one rgb tiled camera is enough to exercise naming.
-    spec = SimpleNamespace(
-        camera_prim_paths=["/World/envs/env_0/Camera"],
-        device="cpu",
+    spec = CameraRenderSpec(
         cfg=SimpleNamespace(
+            prim_path="/World/envs/env_[^/]+/Camera",
             data_types=["rgb"],
             width=64,
             height=64,
@@ -105,6 +104,10 @@ def test_create_render_data_uses_unique_sdf_safe_render_product_name(monkeypatch
             colorize_instance_segmentation=False,
             colorize_instance_id_segmentation=False,
         ),
+        device="cpu",
+        num_instances=1,
+        camera_prim_paths=("/World/envs/env_0/Camera",),
+        view_count=1,
     )
     renderer = rtx_renderer.IsaacRtxRenderer.__new__(rtx_renderer.IsaacRtxRenderer)
     renderer.cfg = IsaacRtxRendererCfg()
@@ -135,6 +138,73 @@ def test_create_render_data_uses_unique_sdf_safe_render_product_name(monkeypatch
         # Replicator builds a USD prim from this name; reject illegal identifiers.
         assert Sdf.Path.IsValidIdentifier(name)
         assert Sdf.Path.IsValidPathString(f"/Render/{name}")
+
+
+def test_create_render_data_expands_camera_paths_from_custom_clone_template(monkeypatch):
+    """Prototype cameras expand through the clone plan instead of a hardcoded environment namespace."""
+    replicator_core_module, syntheticdata_module = _install_omni_stubs(monkeypatch)
+    monkeypatch.setattr(syntheticdata_module, "SyntheticData", MagicMock(), raising=False)
+
+    import isaaclab_physx.renderers.isaac_rtx_renderer as rtx_renderer
+    import torch
+    from isaaclab_physx.renderers.isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+    from pxr import Usd, UsdGeom
+
+    import isaaclab.sim.utils.stage as stage_utils
+    from isaaclab.cloner import ClonePlan
+    from isaaclab.sim import SimulationContext
+
+    stage = Usd.Stage.CreateInMemory()
+    camera_paths = [
+        str(UsdGeom.Camera.Define(stage, f"/World/scenes/scene_{env_id}/Robot/Camera").GetPath())
+        for env_id in (2, 7, 11)
+    ]
+    plan = ClonePlan(
+        sources=(camera_paths[0], camera_paths[1]),
+        destinations=("/World/scenes/scene_{}/Robot/Camera", "/World/scenes/scene_{}/Robot/Camera"),
+        clone_mask=torch.tensor([[True, False, True], [False, True, False]]),
+        env_ids=torch.tensor([2, 7, 11]),
+        env_template="/World/scenes/scene_{}",
+    )
+    sim = SimpleNamespace(get_clone_plan=lambda: plan)
+    spec = CameraRenderSpec(
+        cfg=SimpleNamespace(
+            prim_path="/World/scenes/scene_[^/]+/Robot/Camera", data_types=["rgb"], width=8, height=8, isp_cfg=None
+        ),
+        device="cpu",
+        num_instances=3,
+        camera_prim_paths=tuple(camera_paths[:2]),
+        view_count=3,
+        camera_path_relative_to_env_0="Robot/Camera",
+    )
+    renderer = rtx_renderer.IsaacRtxRenderer.__new__(rtx_renderer.IsaacRtxRenderer)
+    renderer.cfg = IsaacRtxRendererCfg()
+    settings = MagicMock()
+    settings.get.return_value = False
+
+    class _PathsObserved(Exception):
+        pass
+
+    def _observe_paths(**kwargs):
+        assert kwargs["cameras"] == camera_paths
+        for env_id, camera_path in zip((2, 7, 11), camera_paths):
+            token = f"env_{env_id}"
+            env_prim = stage.GetPrimAtPath(f"/World/scenes/scene_{env_id}")
+            assert env_prim.GetAttribute("primvars:omni:scenePartition").Get() == token
+            assert stage.GetPrimAtPath(camera_path).GetAttribute("omni:scenePartition").Get() == token
+        raise _PathsObserved
+
+    replicator_core_module.create = SimpleNamespace(render_product_tiled=_observe_paths)
+    with (
+        patch.object(rtx_renderer, "get_settings_manager", return_value=settings),
+        patch.object(rtx_renderer, "get_isaac_sim_version", return_value=version.parse("6.0")),
+        patch.object(SimulationContext, "instance", return_value=sim),
+        patch.object(stage_utils, "get_current_stage", return_value=stage),
+        patch.object(rtx_renderer, "isaac_rtx_per_env_scene_partition_enabled", return_value=True),
+        pytest.raises(_PathsObserved),
+    ):
+        renderer.create_render_data(spec)
 
 
 def test_render_product_uuid_name_format_is_sdf_safe():
@@ -184,9 +254,12 @@ def test_depth_only_camera_color_render_setting(monkeypatch, has_gui, expected_d
     # color-render setting is selected, keeping this a lightweight unit test.
     stage = MagicMock()
     stage.GetPrimAtPath.return_value.IsA.return_value = False
-    spec = SimpleNamespace(
-        camera_prim_paths=["/World/NotACamera"],
-        cfg=SimpleNamespace(data_types=["depth"]),
+    spec = CameraRenderSpec(
+        cfg=SimpleNamespace(prim_path="/World/NotACamera", data_types=["depth"]),
+        device="cpu",
+        num_instances=1,
+        camera_prim_paths=("/World/NotACamera",),
+        view_count=1,
     )
     renderer = rtx_renderer.IsaacRtxRenderer.__new__(rtx_renderer.IsaacRtxRenderer)
     renderer.cfg = IsaacRtxRendererCfg()

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_scene_partitioning.py
@@ -34,6 +34,7 @@ simulation_app = AppLauncher(headless=True, enable_cameras=True).app
 """Rest everything follows."""
 
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -42,9 +43,11 @@ from isaaclab_physx.renderers.isaac_rtx_renderer import IsaacRtxRenderer, IsaacR
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.cloner import ClonePlan
+from isaaclab.renderers import CameraRenderSpec
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors.camera import CameraCfg
-from isaaclab.sim import build_simulation_context
+from isaaclab.sim import SimulationContext, build_simulation_context
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_assets.robots.kuka_allegro import KUKA_ALLEGRO_CFG
@@ -62,15 +65,9 @@ def enable_scene_partition(monkeypatch):
 
 
 @pytest.mark.isaacsim_ci
-def test_partitioning_disabled_by_default(monkeypatch):
-    """``primvars:omni:scenePartition`` must NOT be authored when the env var is absent.
-
-    The feature is off by default; this test confirms that :meth:`IsaacRtxRenderer.prepare_stage`
-    is a no-op without ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1``.
-    """
+def test_prepare_stage_defers_partitioning(enable_scene_partition):
+    """Stage preparation stays read-only before implicit USD replication."""
     from pxr import Usd
-
-    monkeypatch.delenv(_ENV_VAR, raising=False)
 
     stage = Usd.Stage.CreateInMemory()
     world = stage.DefinePrim("/World", "Xform")  # noqa: F841
@@ -81,9 +78,60 @@ def test_partitioning_disabled_by_default(monkeypatch):
     renderer.prepare_stage(stage, num_envs=1)
 
     prim = stage.GetPrimAtPath("/World/envs/env_0")
-    assert not prim.HasAttribute("primvars:omni:scenePartition"), (
-        "primvars:omni:scenePartition must not be authored when partitioning is disabled."
+    assert not prim.HasAttribute("primvars:omni:scenePartition")
+
+
+@pytest.mark.isaacsim_ci
+def test_create_render_data_partitions_replicated_environments(enable_scene_partition, monkeypatch):
+    """Render-data creation partitions every environment after implicit USD replication."""
+    import omni.replicator.core as rep
+    from pxr import Usd, UsdGeom
+
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.Xform.Define(stage, "/World")
+    UsdGeom.Xform.Define(stage, "/World/envs")
+    camera_paths = []
+    for env_idx in range(2):
+        env_path = f"/World/envs/env_{env_idx}"
+        UsdGeom.Xform.Define(stage, env_path)
+        camera_paths.append(str(UsdGeom.Camera.Define(stage, f"{env_path}/Camera").GetPath()))
+
+    renderer = object.__new__(IsaacRtxRenderer)
+    renderer.cfg = IsaacRtxRendererCfg()
+    spec = CameraRenderSpec(
+        cfg=SimpleNamespace(prim_path="/World/envs/env_[^/]+/Camera", data_types=["rgb"], height=8, width=8),
+        device="cpu",
+        num_instances=2,
+        camera_prim_paths=(camera_paths[0],),
+        view_count=2,
+        camera_path_relative_to_env_0="Camera",
     )
+    plan = ClonePlan(
+        sources=(camera_paths[0],),
+        destinations=("/World/envs/env_{}/Camera",),
+        clone_mask=torch.ones((1, 2), dtype=torch.bool),
+        env_ids=torch.tensor([0, 1]),
+        env_template="/World/envs/env_{}",
+    )
+    sim = SimpleNamespace(get_clone_plan=lambda: plan)
+    monkeypatch.setattr(SimulationContext, "instance", lambda: sim)
+    monkeypatch.setattr("isaaclab.sim.utils.stage.get_current_stage", lambda: stage)
+
+    class _PartitionsObserved(Exception):
+        pass
+
+    def _observe_partitions(**kwargs):
+        assert kwargs["cameras"] == camera_paths
+        for env_idx, camera_path in enumerate(camera_paths):
+            token = f"env_{env_idx}"
+            env_prim = stage.GetPrimAtPath(f"/World/envs/{token}")
+            assert env_prim.GetAttribute("primvars:omni:scenePartition").Get() == token
+            assert stage.GetPrimAtPath(camera_path).GetAttribute("omni:scenePartition").Get() == token
+        raise _PartitionsObserved
+
+    monkeypatch.setattr(rep.create, "render_product_tiled", _observe_partitions)
+    with pytest.raises(_PartitionsObserved):
+        renderer.create_render_data(spec)
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab_physx/test/sim/test_simulation_manager_ownership.py
+++ b/source/isaaclab_physx/test/sim/test_simulation_manager_ownership.py
@@ -6,6 +6,7 @@
 """Verify PhysX lifecycle ownership when its package is imported before Kit starts."""
 
 import sys
+from unittest.mock import MagicMock
 
 from isaaclab_physx.physics import PhysxCfg
 
@@ -16,10 +17,13 @@ from isaaclab.test.utils import resolve_test_sim_device
 simulation_app = AppLauncher(headless=True, device=resolve_test_sim_device()).app
 
 import pytest
-from isaaclab_physx.physics import PhysxManager
+import torch
+from isaaclab_physx.physics import IsaacEvents, PhysxManager
 
 import carb
 
+from isaaclab.cloner import ClonePlan
+from isaaclab.physics import PhysicsEvent
 from isaaclab.sim.utils import enable_extension
 
 enable_extension("isaacsim.core.simulation_manager")
@@ -57,3 +61,131 @@ def test_initialize_claims_simulation_manager_lifecycle():
         assert simulation_manager_module.SimulationManager is original_manager
     else:
         assert simulation_manager_module.SimulationManager is PhysxManager
+
+
+@pytest.mark.isaacsim_ci
+def test_model_init_precedes_physx_stage_attach_model_load_and_legacy_warmup(monkeypatch):
+    """MODEL_INIT finishes stage authoring before PhysX attaches or loads the model."""
+    SimulationContext(cfg=SimulationCfg(physics=PhysxCfg()))
+    calls: list[str] = []
+    subscriptions = {}
+    event_bus = MagicMock()
+
+    def observe_event(*, event_name, on_event, **_kwargs):
+        subscriptions.setdefault(event_name, []).append(on_event)
+        return MagicMock()
+
+    def dispatch_event(event_name, *, payload):
+        for callback in subscriptions.get(event_name, ()):
+            callback(payload)
+
+    event_bus.observe_event.side_effect = observe_event
+    event_bus.dispatch_event.side_effect = dispatch_event
+    physx = MagicMock()
+    physx.force_load_physics_from_usd.side_effect = lambda: calls.append("model_load")
+    physx.update_simulation.side_effect = lambda *_: calls.append("model_update")
+    physx_sim = MagicMock()
+    physx_sim.attach_stage.side_effect = lambda *_: calls.append("attach_stage")
+    physx_sim.fetch_results.side_effect = lambda: calls.append("fetch_results")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(PhysxManager, "_event_bus", event_bus)
+        PhysxManager.register_callback(
+            lambda _event: calls.append("model_init"),
+            PhysicsEvent.MODEL_INIT,
+            order=0,
+            wrap_weak_ref=False,
+        )
+        event_bus.dispatch_event(IsaacEvents.PHYSICS_WARMUP.value, payload={})
+        assert calls == []
+        PhysxManager.register_callback(
+            lambda _event: calls.append("legacy_warmup"),
+            IsaacEvents.PHYSICS_WARMUP,
+            order=0,
+            wrap_weak_ref=False,
+        )
+
+        patch.setattr("omni.physx.get_physx_interface", lambda: physx)
+        patch.setattr("omni.physx.get_physx_simulation_interface", lambda: physx_sim)
+        patch.setattr(PhysxManager, "_warmup_needed", True)
+        patch.setattr(PhysxManager, "_view_created", True)
+        PhysxManager._warmup_and_create_views()
+
+    assert calls == ["model_init", "attach_stage", "model_load", "model_update", "fetch_results", "legacy_warmup"]
+
+
+@pytest.mark.isaacsim_ci
+def test_model_init_failure_prevents_physx_model_load(monkeypatch):
+    """A pre-load lifecycle failure propagates before PhysX can consume an incomplete stage."""
+    SimulationContext(cfg=SimulationCfg(physics=PhysxCfg()))
+    physx = MagicMock()
+
+    def fail_model_init(_event):
+        raise RuntimeError("model init failed")
+
+    PhysxManager.register_callback(
+        fail_model_init,
+        PhysicsEvent.MODEL_INIT,
+        order=0,
+        wrap_weak_ref=False,
+    )
+
+    physx_sim = MagicMock()
+    with monkeypatch.context() as patch:
+        patch.setattr("omni.physx.get_physx_interface", lambda: physx)
+        patch.setattr("omni.physx.get_physx_simulation_interface", lambda: physx_sim)
+        patch.setattr(PhysxManager, "_warmup_needed", True)
+        patch.setattr(PhysxManager, "_view_created", True)
+        with pytest.raises(RuntimeError, match="model init failed"):
+            PhysxManager._warmup_and_create_views()
+
+    physx_sim.attach_stage.assert_not_called()
+    physx.force_load_physics_from_usd.assert_not_called()
+
+
+@pytest.mark.isaacsim_ci
+def test_model_init_materializes_empty_clone_plan_env_roots():
+    """PhysX reset authors every positioned root even when the plan has no asset rows."""
+    sim = SimulationContext(cfg=SimulationCfg(physics=PhysxCfg()))
+    stage = sim.stage
+    env_template = "/World/scenes/scene_{}"
+    stage.DefinePrim(env_template.format(0), "Xform")
+    stage.DefinePrim(f"{env_template.format(0)}/PrototypeMarker", "Xform")
+
+    positions = torch.tensor([[1.0, 2.0, 3.0], [-4.0, 5.0, 6.0], [7.0, -8.0, 9.0]])
+    sim.set_clone_plan(
+        ClonePlan(
+            sources=(),
+            destinations=(),
+            clone_mask=torch.zeros((0, 3), dtype=torch.bool),
+            env_ids=torch.arange(3),
+            positions=positions,
+            env_template=env_template,
+        )
+    )
+
+    root_states: list[bool] = []
+    PhysxManager.register_callback(
+        lambda _event: root_states.append(stage.GetPrimAtPath(env_template.format(1)).IsValid()),
+        PhysicsEvent.MODEL_INIT,
+        order=2,
+        wrap_weak_ref=False,
+    )
+    PhysxManager.register_callback(
+        lambda _event: root_states.append(stage.GetPrimAtPath(env_template.format(1)).IsValid()),
+        PhysicsEvent.MODEL_INIT,
+        order=4,
+        wrap_weak_ref=False,
+    )
+
+    assert not stage.GetPrimAtPath(env_template.format(1)).IsValid()
+    sim.reset()
+
+    assert root_states == [False, True]
+    for env_id, expected_position in enumerate(positions):
+        root = stage.GetPrimAtPath(env_template.format(env_id))
+        assert root.IsValid() and root.GetTypeName() == "Xform"
+        assert tuple(root.GetAttribute("xformOp:translate").Get()) == pytest.approx(expected_position.tolist())
+        assert not root.HasAttribute("xformOp:orient")
+        assert not stage.GetPrimAtPath(f"{env_template.format(env_id)}/Robot").IsValid()
+    assert stage.GetPrimAtPath(f"{env_template.format(0)}/PrototypeMarker").IsValid()


### PR DESCRIPTION
# Description

Depends on #7090 (Action 2).

This PR implements Action 3 of the clone-plan lifecycle cleanup. Replicated scenes are authored from prototype environments only, and destination environment roots are materialized at `PhysicsEvent.MODEL_INIT` by the backend that needs them.

The model-initialization order is:

1. Camera renderer inputs (`-1`)
2. Renderer prototype-stage preparation (`0`)
3. OvPhysX private-stage capture (`1`)
4. Common live-stage USD replication (`2`)
5. PhysX destination-root materialization (`3`)

`MODEL_INIT` remains a native physics event dispatched before PhysX attaches or loads the stage. It is intentionally not mapped to legacy `IsaacEvents.PHYSICS_WARMUP`, whose post-load timing remains unchanged.

The change also removes the legacy OVRTX destination deactivation and transform capture/restore path, and carries clone-plan environment templates through camera, renderer, OvPhysX, and frame-view resolution. Production Python is net 84 lines smaller.

## Performance

Measured on the same 4,096-environment Shadow Hand camera benchmark with seed 42 and `presets=newton_mjwarp,newton_renderer`:

| Metric | Action 2 | Action 3 | Improvement |
| --- | ---: | ---: | ---: |
| Scene creation | 50.60 s | 16.93 s | 33.67 s (66.5%) |
| Simulation start | 22.40 s | 15.07 s | 7.33 s (32.7%) |
| Environment creation | 75.08 s | 34.14 s | 40.94 s (54.5%) |
| Total startup | 78.03 s | 37.53 s | 40.50 s (51.9%) |

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Validation

- `./isaaclab.sh -f`
- `uv run --isolated --extra test -- make -C docs current-docs`
- Common clone/session/scene lifecycle tests: 21 passed
- OVRTX contract tests: 60 passed
- OvPhysX FrameView tests: 27 CPU and 24 CUDA passed
- PhysX MODEL_INIT lifecycle tests: 3 passed
- Camera MODEL_INIT tests: 2 passed
- Isaac RTX renderer contract tests: 11 passed
- Legacy and OVStage OVRTX RGB golden tests: 2 passed

The two local Isaac RTX RGB golden comparisons retain the same mismatch metrics on both Action 2 and Action 3, so they are baseline renderer/golden drift rather than a regression from this change.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
