### PR TITLE
Pin OVRTX below 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,9 @@ rerun = [
 
 isaacsim = ["isaacsim[all,extscache]==6.0.1.0"]
 
-ov = ["ovphysx==0.5.9", "ovrtx>=0.4.0,<0.5.0", "ovstage==0.1.0.346039"]
+ov = ["ovphysx==0.5.9", "ovrtx>0.4.0,<0.4.1", "ovstage==0.1.0.346039"]
 ovphysx = ["ovphysx==0.5.9", "ovstage==0.1.0.346039"]
-ovrtx = ["ovrtx>=0.4.0,<0.5.0", "ovstage==0.1.0.346039"]
+ovrtx = ["ovrtx>0.4.0,<0.4.1", "ovstage==0.1.0.346039"]
 
 mimic = [
     "isaaclab-mimic",
@@ -212,7 +212,7 @@ torch = "2.11.0"
 torchvision = "0.26.0"
 torchaudio = "2.11.0"
 ovphysx = "0.5.9"
-ovrtx = ">=0.4.0,<0.5.0"
+ovrtx = ">0.4.0,<0.4.1"
 ovstage = "0.1.0.346039"
 newton = "release-1.5"
 warp = "1.16.0"

--- a/source/isaaclab_ov/changelog.d/mh-pin-ovrtx-040.rst
+++ b/source/isaaclab_ov/changelog.d/mh-pin-ovrtx-040.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Constrained the optional OVRTX runtime to ``ovrtx>0.4.0,<0.4.1`` to retain the validated
+  OVRTX 0.4.0 rendering outputs. Users with OVRTX 0.4.1 should downgrade until its output
+  changes are adopted with updated rendering baselines.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -70,7 +70,7 @@ except ModuleNotFoundError as exc:
         "The OVRTX renderer requires the optional 'ovrtx' runtime wheel, which is not installed. "
         "Run your command with: uv run --extra ovrtx <command> "
         "(or, manually: python -m pip install --extra-index-url https://pypi.nvidia.com "
-        "'ovrtx>=0.4.0,<0.5.0')."
+        "'ovrtx>0.4.0,<0.4.1')."
     ) from exc
 
 from isaaclab.cloner.clone_plan import ClonePlan

--- a/uv.lock
+++ b/uv.lock
@@ -1764,12 +1764,12 @@ wheels = [
 
 [[package]]
 name = "isaaclab"
-version = "16.0.1"
+version = "16.2.1"
 source = { editable = "source/isaaclab" }
 
 [[package]]
 name = "isaaclab-assets"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "source/isaaclab_assets" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -1784,7 +1784,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-contrib"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "source/isaaclab_contrib" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2046,8 +2046,8 @@ requires-dist = [
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux')", specifier = ">=0.19.0" },
     { name = "ovphysx", marker = "extra == 'ov'", specifier = "==0.5.9", index = "https://pypi.org/simple" },
     { name = "ovphysx", marker = "extra == 'ovphysx'", specifier = "==0.5.9", index = "https://pypi.org/simple" },
-    { name = "ovrtx", marker = "extra == 'ov'", specifier = ">=0.4.0,<0.5.0" },
-    { name = "ovrtx", marker = "extra == 'ovrtx'", specifier = ">=0.4.0,<0.5.0" },
+    { name = "ovrtx", marker = "extra == 'ov'", specifier = ">0.4.0,<0.4.1" },
+    { name = "ovrtx", marker = "extra == 'ovrtx'", specifier = ">0.4.0,<0.4.1" },
     { name = "ovstage", marker = "extra == 'ov'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
     { name = "ovstage", marker = "extra == 'ovphysx'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
     { name = "ovstage", marker = "extra == 'ovrtx'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
@@ -2119,7 +2119,7 @@ provides-extras = ["tetrahedralization", "video", "test", "sb3", "skrl", "rl-gam
 
 [[package]]
 name = "isaaclab-experimental"
-version = "0.1.5"
+version = "0.2.1"
 source = { editable = "source/isaaclab_experimental" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2130,7 +2130,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-mimic"
-version = "2.0.4"
+version = "2.0.5"
 source = { editable = "source/isaaclab_mimic" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2147,7 +2147,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-newton"
-version = "4.0.0"
+version = "5.2.0"
 source = { editable = "source/isaaclab_newton" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2158,7 +2158,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-ov"
-version = "2.0.0"
+version = "2.0.2"
 source = { editable = "source/isaaclab_ov" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2173,7 +2173,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-physx"
-version = "5.0.0"
+version = "5.0.1"
 source = { editable = "source/isaaclab_physx" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2195,7 +2195,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-rl"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "source/isaaclab_rl" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2212,7 +2212,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-tasks"
-version = "16.0.0"
+version = "16.3.0"
 source = { editable = "source/isaaclab_tasks" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2253,7 +2253,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-visualizers"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "source/isaaclab_visualizers" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },


### PR DESCRIPTION
# Description

Constrain the optional OVRTX runtime from `>=0.4.0,<0.5.0` to `>0.4.0,<0.4.1`.

OVRTX 0.4.1 changed RTX Minimal motion output for static pixels. Because CI installs the newest wheel admitted by the range, existing pull requests began resolving `0.4.1.364340` and failing the Cartpole, Kuka Allegro, and Shadow Hand motion-vector golden comparisons even though their source changes were unrelated to rendering. The strict upper bound retains the validated `0.4.0.346409` runtime until the 0.4.1 output changes and rendering baselines are adopted together.

This also updates the renderer installation guidance, refreshes the lockfile, and records the temporary compatibility constraint in the `isaaclab_ov` changelog.

Related failure: #7092

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Dependency constraint update

## Validation

- `uv tree --package ovrtx` resolves `ovrtx v0.4.0.346409`
- `uv lock --check`
- `uv run python -m pytest source/isaaclab/test/cli/test_uv_run_pyproject.py -k "version_single_source or public_ov_packages"` (`2 passed`)
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks.
- [x] I have updated the user-facing installation guidance and changelog fragment.
- [x] My changes generate no new warnings.
- [x] Existing dependency-source-of-truth coverage validates the new constraint.
- [x] I have added a changelog fragment for the touched package.
- [x] My name already exists in `CONTRIBUTORS.md`.