### PR TITLE
Let Camera create its own renderer backend

### DIFF
--- a/docs/source/overview/core-concepts/visualization.rst
+++ b/docs/source/overview/core-concepts/visualization.rst
@@ -338,8 +338,7 @@ golden-ratio hue palette to assign each class ID a distinct color.
    **Auto-create streaming camera and Newton MJWarp (``replicate_physics=True``)**
 
    When ``streaming_sensor_prim_path`` is ``None`` (auto-create mode), the visualizer
-   spawns a new camera prim after ``scene.initialize_renderers()`` has already finalised
-   Newton's clone plan.  With ``replicate_physics=True`` — which Newton MJWarp requires for
+   spawns a new camera prim after scene construction has already finalised Newton's clone plan.  With ``replicate_physics=True`` — which Newton MJWarp requires for
    its high-performance sparse world replication — only ``env_0`` exists as a USD prim after
    physics init; ``env_1..N`` are handled internally by Newton without USD prims.  The
    spawned cameras at ``env_1..N`` are silently dropped, ``FrameView`` resolves only one

--- a/source/isaaclab/changelog.d/camera-owns-renderer.minor.rst
+++ b/source/isaaclab/changelog.d/camera-owns-renderer.minor.rst
@@ -1,0 +1,15 @@
+Changed
+^^^^^^^
+
+* Moved renderer backend creation into :meth:`~isaaclab.sensors.camera.Camera.__init__`, which runs
+  during scene construction. A backend's ``__init__`` is its pre-physics phase and must complete
+  before :meth:`~isaaclab.sim.SimulationContext.reset`, whereas sensor initialization only runs on
+  ``PhysicsEvent.PHYSICS_READY``. Backend construction order still follows sensor registration
+  order, and configs that compare equal still share one backend.
+
+Removed
+^^^^^^^
+
+* **Breaking:** Removed ``InteractiveScene.initialize_renderers``. It only pre-created the backends
+  that each camera now creates for itself, and its return value was unused. Delete the call; no
+  replacement is needed.

--- a/source/isaaclab/isaaclab/envs/direct_marl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_marl_env.py
@@ -148,7 +148,6 @@ class DirectMARLEnv(gym.Env):
             with use_stage(self.sim.stage):
                 self.scene = InteractiveScene(self.cfg.scene)
                 self._setup_scene()
-                self.scene.initialize_renderers()
             self.sim.register_interactive_scene(self.scene)
         print("[INFO]: Scene manager: ", self.scene)
 

--- a/source/isaaclab/isaaclab/envs/direct_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/direct_rl_env.py
@@ -154,7 +154,6 @@ class DirectRLEnv(gym.Env):
             with use_stage(self.sim.stage):
                 self.scene = InteractiveScene(self.cfg.scene)
                 self._setup_scene()
-                self.scene.initialize_renderers()
             self.sim.register_interactive_scene(self.scene)
         print("[INFO]: Scene manager: ", self.scene)
 

--- a/source/isaaclab/isaaclab/envs/leapp_deployment_env.py
+++ b/source/isaaclab/isaaclab/envs/leapp_deployment_env.py
@@ -182,7 +182,6 @@ class LeappDeploymentEnv:
 
         with use_stage(self.sim.stage):
             self.scene = InteractiveScene(cfg.scene)
-            self.scene.initialize_renderers()
         with use_stage(self.sim.stage):
             self.sim.reset()
         self.scene.update(dt=self.physics_dt)

--- a/source/isaaclab/isaaclab/envs/manager_based_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_env.py
@@ -176,7 +176,6 @@ class ManagerBasedEnv:
             # set the stage context for scene creation steps which use the stage
             with use_stage(self.sim.stage):
                 self.scene = InteractiveScene(self.cfg.scene)
-                self.scene.initialize_renderers()
             self.sim.register_interactive_scene(self.scene)
         print("[INFO]: Scene manager: ", self.scene)
 

--- a/source/isaaclab/isaaclab/scene/interactive_scene.py
+++ b/source/isaaclab/isaaclab/scene/interactive_scene.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from isaaclab_physx.assets import SurfaceGripper
 
-    from isaaclab.renderers.base_renderer import BaseRenderer
     from isaaclab.terrains.terrain_importer import TerrainImporter
 
 import torch
@@ -250,42 +249,6 @@ class InteractiveScene:
         else:
             self._clone_valid_set = None
         return cfgs
-
-    def initialize_renderers(self) -> list[BaseRenderer]:
-        """Pre-create renderer backends for all scene sensors with a ``renderer_cfg``.
-
-        Walks the constructed sensors and registers each unique
-        :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` with the
-        simulation-scoped :class:`~isaaclab.renderers.render_context.RenderContext`.
-        Configs that compare equal share a single backend (see
-        :meth:`~isaaclab.renderers.render_context.RenderContext.get_renderer`), so
-        calling this method is idempotent and safe to invoke before
-        :meth:`~isaaclab.sim.SimulationContext.reset`.
-
-        Pre-creating backends here makes the order of renderer construction
-        deterministic (matches sensor registration order) and front-loads logging
-        instead of trickling out during the first :meth:`Camera._initialize_impl`.
-        :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.prepare_stage` is
-        intentionally not invoked here; it runs on first camera initialization
-        with the correct ``num_envs`` and final stage.
-
-        Returns:
-            The list of unique renderer backends now registered on the
-            shared :class:`~isaaclab.renderers.render_context.RenderContext`,
-            in sensor registration order.
-        """
-        ctx = self.sim.render_context
-        backends: list[BaseRenderer] = []
-        seen: set[int] = set()
-        for sensor in self._sensors.values():
-            rcfg = getattr(getattr(sensor, "cfg", None), "renderer_cfg", None)
-            if rcfg is None:
-                continue
-            backend = ctx.get_renderer(rcfg)
-            if id(backend) not in seen:
-                seen.add(id(backend))
-                backends.append(backend)
-        return backends
 
     def filter_collisions(self, global_prim_paths: list[str] | None = None):
         """Filter environments collisions.

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -213,8 +213,15 @@ class Camera(SensorBase):
         self._sensor_prims: list[UsdGeom.Camera] = list()
         # Allocated in :meth:`_create_buffers` once the renderer's output contract is known.
         self._data: CameraData | None = None
-        # Renderer and render data — assigned in _initialize_impl.
+        # The backend's ``__init__`` is its pre-physics phase, so it has to exist before
+        # ``sim.reset()``; sensor initialization only runs on ``PhysicsEvent.PHYSICS_READY``, which is
+        # too late. Backends are shared per renderer config, so this stays cheap for many cameras.
         self._renderer: BaseRenderer | None = None
+        if sim_ctx is not None:
+            self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
+            with force_log_level(logging.INFO):
+                logger.info("Using renderer: %s", type(self._renderer).__name__)
+        # Render data — assigned in _initialize_impl.
         self._render_data = None
         # Frame view — assigned in _initialize_impl.
         self._view: FrameView | None = None
@@ -502,10 +509,9 @@ class Camera(SensorBase):
     def _initialize_impl(self):
         """Initializes the sensor handles and internal buffers.
 
-        This function obtains the simulation-scoped :class:`~isaaclab.renderers.base_renderer.BaseRenderer`
-        from :attr:`~isaaclab.sim.simulation_context.SimulationContext.render_context` using the configured
-        :attr:`~isaaclab.sensors.camera.CameraCfg.renderer_cfg` and delegates all render-product
-        and annotator management to it. It also initializes the internal buffers to store the data.
+        This function delegates all render-product and annotator management to the
+        :class:`~isaaclab.renderers.base_renderer.BaseRenderer` created in :meth:`__init__`. It also
+        initializes the internal buffers to store the data.
 
         Raises:
             RuntimeError: If the number of camera prims in the view does not match the number of environments.
@@ -518,9 +524,9 @@ class Camera(SensorBase):
         sim_ctx = sim_utils.SimulationContext.instance()
         if sim_ctx is None:
             raise RuntimeError("SimulationContext is not initialized.")
-        self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
-        with force_log_level(logging.INFO):
-            logger.info("Using renderer: %s", type(self._renderer).__name__)
+        # Normally created in ``__init__``; only missing when the camera was built without a simulation.
+        if self._renderer is None:
+            self._renderer = sim_ctx.render_context.get_renderer(self.cfg.renderer_cfg)
 
         # Build the render spec early — both the wrapper ISP (which delegates
         # any renderer-side per-camera setup) and ``create_render_data`` consume

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/direct_rl_env_warp.py
@@ -161,7 +161,6 @@ class DirectRLEnvWarp(DirectRLEnv):
             with use_stage(self.sim.stage):
                 self.scene = InteractiveSceneWarp(self.cfg.scene)
                 self._setup_scene()
-                self.scene.initialize_renderers()
                 # attach_stage_to_usd_context()
         print("[INFO]: Scene manager: ", self.scene)
 

--- a/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
+++ b/source/isaaclab_experimental/isaaclab_experimental/envs/manager_based_env_warp.py
@@ -140,7 +140,6 @@ class ManagerBasedEnvWarp:
             with use_stage(self.sim.stage):
                 self.scene = InteractiveScene(self.cfg.scene)
                 # attach_stage_to_usd_context()
-                self.scene.initialize_renderers()
         print("[INFO]: Scene manager: ", self.scene)
 
         # Shared per-env Warp RNG state (accessible to all managers/terms via `env`).


### PR DESCRIPTION
## Summary

**Stacked on #7112.** This branch is built on top of that one, so until #7112 merges the diff here also shows its commit. Please review and merge #7112 first.

`InteractiveScene.initialize_renderers()` existed purely as a timing device. A renderer backend's `__init__` is its pre-physics phase and must run before `sim.reset()` (OVRTX requires being built before ovphysx initialises, and `RenderContext` deliberately defers `initialize()` to `ensure_initialize()` post-physics), but sensor initialization runs on `PhysicsEvent.PHYSICS_READY`, which is too late. So the scene pre-created the backends that `Camera._initialize_impl` would otherwise create, and all six env classes had to remember to call it and then discard its return value.

`Camera.__init__` runs during scene construction, the same pre-reset window, and already hosts the equivalent pre-reset wiring (`require_visual_shapes()`, the RTX settings flip). Creating the backend there:

- keeps construction order equal to sensor registration order, and keeps logging front-loaded;
- leaves a one-line lazy fallback in `_initialize_impl` for cameras built without a `SimulationContext`;
- makes `initialize_renderers()` dead, removing it, its six call sites, and one sentence of `visualization.rst`.

### Breaking change

`InteractiveScene.initialize_renderers()` is removed. Delete the call; no replacement is needed. Nothing in the test suite referenced it.

## Test plan

- [x] `ruff check` clean over `source/` and `docs/`
- [x] `pytest source/isaaclab/test/sensors/test_camera.py` — 36 passed
- [x] `pytest source/isaaclab/test/scene/test_interactive_scene.py source/isaaclab/test/renderers/ source/isaaclab/test/scene_data/` — 68 passed
- [ ] CI