### PR TITLE
Fix NumPy to Warp dictionary conversion

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-numpy-warp-conversion.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-numpy-warp-conversion.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``convert_dict_to_backend(..., backend="warp")`` rejecting NumPy arrays because the
+  conversion registry used the ``np.array`` constructor instead of the ``np.ndarray`` type.

--- a/source/isaaclab/isaaclab/utils/array.py
+++ b/source/isaaclab/isaaclab/utils/array.py
@@ -34,7 +34,7 @@ The keys are the name of the backend ("numpy", "torch", "warp") and the values a
 TENSOR_TYPE_CONVERSIONS = {
     "numpy": {wp.array: lambda x: x.numpy(), torch.Tensor: lambda x: x.detach().cpu().numpy()},
     "torch": {wp.array: lambda x: wp.torch.to_torch(x), np.ndarray: lambda x: torch.from_numpy(x)},
-    "warp": {np.array: lambda x: wp.array(x), torch.Tensor: lambda x: wp.torch.from_torch(x)},
+    "warp": {np.ndarray: lambda x: wp.array(x), torch.Tensor: lambda x: wp.torch.from_torch(x)},
 }
 """A nested dictionary containing the conversion functions for each backend.
 

--- a/source/isaaclab/test/utils/test_array_conversion_registry.py
+++ b/source/isaaclab/test/utils/test_array_conversion_registry.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.utils.dict import convert_dict_to_backend
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_numpy_array_to_warp_backend():
+    data = {"values": np.array([1.0, 2.0, 3.0], dtype=np.float32)}
+
+    converted = convert_dict_to_backend(data, backend="warp", array_types=("numpy",))
+
+    assert isinstance(converted["values"], wp.array)
+    np.testing.assert_array_equal(converted["values"].numpy(), data["values"])


### PR DESCRIPTION
# Description

`convert_dict_to_backend(..., backend="warp")` identifies NumPy inputs as `np.ndarray`, but the Warp conversion registry was keyed by `np.array`, the constructor function. Valid NumPy arrays therefore failed the registry lookup.

This changes the key to `np.ndarray`, adds regression coverage, and includes a changelog fragment.

## Type of change

- Bug fix