### PR TITLE
Fix YAML dumps to the current working directory

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dump-yaml-current-directory.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dump-yaml-current-directory.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``dump_yaml`` failing when the output filename has no directory component, allowing YAML files to be
+  written directly into the current working directory.

--- a/source/isaaclab/isaaclab/utils/io/yaml.py
+++ b/source/isaaclab/isaaclab/utils/io/yaml.py
@@ -46,8 +46,9 @@ def dump_yaml(filename: str, data: dict | object, sort_keys: bool = False):
     if not filename.endswith("yaml"):
         filename += ".yaml"
     # create directory
-    if not os.path.exists(os.path.dirname(filename)):
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
+    directory = os.path.dirname(filename)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
     # convert data into dictionary
     if not isinstance(data, dict):
         data = class_to_dict(data)

--- a/source/isaaclab/test/utils/test_yaml_io.py
+++ b/source/isaaclab/test/utils/test_yaml_io.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from isaaclab.utils.io.yaml import dump_yaml, load_yaml
+
+pytestmark = pytest.mark.unit
+
+
+def test_dump_yaml_supports_current_working_directory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    dump_yaml("config.yaml", {"value": 42})
+
+    assert (tmp_path / "config.yaml").is_file()
+    assert load_yaml("config.yaml") == {"value": 42}
+
+
+def test_dump_yaml_adds_extension_in_current_working_directory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    dump_yaml("config", {"value": 42})
+
+    assert (tmp_path / "config.yaml").is_file()


### PR DESCRIPTION
# Description

`dump_yaml()` always attempted to create `os.path.dirname(filename)`. For a filename such as `config.yaml`, the directory component is an empty string, causing `os.makedirs("")` to fail before the file can be written.

This change only creates a parent directory when the output path actually contains one. Existing nested-path behavior is unchanged.

## Validation

Adds unit coverage for:
- writing `config.yaml` directly in the current working directory;
- automatic `.yaml` extension handling without a directory component.

## Type of change

- Bug fix