### PR TITLE
Fix dotted callable reference resolution

### DIFF
--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -81,6 +81,10 @@ for maintaining the documentation.
 Sending a pull request for the documentation is the same as sending a pull request for the codebase.
 Please follow the steps mentioned in the `Contributing Code`_ section.
 
+For documentation media, only small ``.jpg`` files should be committed directly to the Isaac Lab repository.
+Upload larger images, videos, animations, and other media to an external hosting location, then link to or embed
+the externally hosted file from the documentation.
+
 .. caution::
 
   Install `uv <https://docs.astral.sh/uv/getting-started/installation/>`__ before building
@@ -120,12 +124,8 @@ To do a clean build, run the following command in the terminal:
 Contributing assets
 -------------------
 
-Currently, we host the assets for the extensions on `NVIDIA Nucleus Server <https://docs.omniverse.nvidia.com/nucleus/latest/index.html>`__.
-Nucleus is a cloud-based storage service that allows users to store and share files. It is
-integrated with the `NVIDIA Omniverse Platform <https://developer.nvidia.com/omniverse>`__.
-
-Since all assets are hosted on Nucleus, we do not need to include them in the repository. However,
-we need to include the links to the assets in the documentation.
+Large asset files should not be added directly to the Isaac Lab repository. Instead, host them in a
+separate repository and link to them from the relevant documentation.
 
 Please checkout the `Isaac Sim Assets <https://docs.isaacsim.omniverse.nvidia.com/latest/assets/usd_assets_overview.html>`__
 for more information on what is presently available.
@@ -142,26 +142,22 @@ To host your own assets, the current solution is:
 3. Include images of the assets in the README file of the repository
 4. Send a pull request with a link to the repository
 
-We will then verify the assets, its licensing, and include the assets into the Nucleus server for hosting.
-In case you have any questions, please feel free to reach out to us through e-mail or by opening an issue
-in the repository.
+We will then verify the assets and their licensing and determine how to integrate them. If you have
+questions, please open an issue in the repository.
 
 
-Maintaining a changelog and extension.toml
-------------------------------------------
+Maintaining package changelogs and versions
+-------------------------------------------
 
-Each extension maintains a changelog in the ``CHANGELOG.rst`` file in the ``docs`` directory,
-as well as a ``extension.toml`` file in the ``config`` directory.
+Each release-managed package maintains a changelog in ``docs/CHANGELOG.rst`` and its version in
+``pyproject.toml``.
 
-The ``extension.toml`` file contains the metadata for the extension. It is used to describe the
-name, version, description, and other metadata of the extension.
-
-The ``CHANGELOG.rst`` is a file that contains the curated, chronologically ordered list of notable changes
-for each version of the extension.
+The changelog contains the curated, chronologically ordered list of notable changes for each
+package version.
 
 .. note::
 
-   ``CHANGELOG.rst`` and ``extension.toml`` are compiled by CI from per-PR **fragment
+   ``CHANGELOG.rst`` and the package version in ``pyproject.toml`` are compiled by CI from per-PR **fragment
    files** — contributors do not edit them directly. For every package your PR touches
    in ``source/<pkg>/`` (outside ``changelog.d/``), add one fragment under
    ``source/<pkg>/changelog.d/<slug>.<tier>.rst``:
@@ -173,12 +169,12 @@ for each version of the extension.
 
    ``<slug>`` is any short, unique name; your branch name with ``/`` replaced by ``-``
    is the recommended default. Within a batch the highest tier wins for the package.
-   The version on ``extension.toml`` is bumped by CI according to
+   The package version in ``pyproject.toml`` is bumped by CI according to
    `Semantic Versioning <https://semver.org/>`__.
 
 The changelog file is written in `reStructuredText <https://docutils.sourceforge.io/rst.html>`__ format.
 The goal of this changelog is to help users and contributors see precisely what notable changes have
-been made between each release (or version) of the extension. This is a *MUST* for every extension.
+been made between each release of a package. This is a *MUST* for every release-managed package.
 
 For each fragment, please follow the following guidelines:
 
@@ -799,4 +795,4 @@ following command in the terminal:
 
       .. code-block:: bash
 
-         isaaclab.bat --format  # or "isaaclab.bat -f"
+         isaaclab.bat --format  # or "./isaaclab.bat -f"

--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -121,7 +121,7 @@ Contributing assets
 -------------------
 
 Currently, we host the assets for the extensions on `NVIDIA Nucleus Server <https://docs.omniverse.nvidia.com/nucleus/latest/index.html>`__.
-Nucleus is a cloud-based storage service that allows users to store and share large files. It is
+Nucleus is a cloud-based storage service that allows users to store and share files. It is
 integrated with the `NVIDIA Omniverse Platform <https://developer.nvidia.com/omniverse>`__.
 
 Since all assets are hosted on Nucleus, we do not need to include them in the repository. However,
@@ -447,7 +447,8 @@ direct reference. This avoids eagerly importing heavyweight modules (``omni``, `
 etc.) at config construction time — the string is resolved to the actual callable only
 after ``SimulationApp`` has been initialized.
 
-You can use either the ``{DIR}`` shorthand or a fully-qualified module path:
+You can use either the ``{DIR}`` shorthand or a fully-qualified module path. Attribute paths
+after the colon may be dotted when the callable is nested under an exported class or object:
 
 .. code:: python
 
@@ -456,6 +457,9 @@ You can use either the ``{DIR}`` shorthand or a fully-qualified module path:
 
    # Good — fully-qualified path (useful for cross-package references)
    class_type: type[Sensor] | str = "isaaclab.sensors.my_sensor.sensor:Sensor"
+
+   # Good — dotted attribute path for a nested callable
+   updater: str = "collections:Counter.update"
 
    # Bad — eagerly imports the implementation module
    from .sensor import Sensor

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dotted-callable-resolution.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dotted-callable-resolution.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed callable string serialization and resolution for attributes nested under classes or other module objects,
+  so references such as ``pathlib:Path.cwd`` round-trip correctly through the callable utilities.
+  Nested attributes now use qualified names when safely resolvable, while local functions and instance-bound
+  methods retain the previous simple-name serialization to avoid unresolvable ``<locals>`` paths or silently
+  dropping instance bindings.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -17,8 +17,8 @@ from typing import Any, ClassVar
 from .dict import class_to_dict, update_class_from_dict
 from .string import ResolvableString
 
-_CALLABLE_STR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\\.]*:[A-Za-z_][A-Za-z0-9_]*$")
-_CALLABLE_STR_WITH_DIR_RE = re.compile(r"^\{DIR\}(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$")
+_CALLABLE_STR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_\\.]*:[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_CALLABLE_STR_WITH_DIR_RE = re.compile(r"^\{DIR\}(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
 
 _CONFIGCLASS_METHODS = ["to_dict", "from_dict", "replace", "copy", "validate"]
 """List of class methods added at runtime to dataclass."""

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -130,8 +130,8 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
 
     Returns:
         A string representation of the callable object. Nested attributes use
-        their qualified name when it can be resolved safely. Local functions
-        and instance-bound methods retain the legacy simple-name format.
+        their qualified name only when that exact path resolves back to the same
+        callable. Otherwise the legacy simple-name representation is retained.
     """
     # check if callable
     if not callable(value):
@@ -144,15 +144,25 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
         lambda_line = re.sub(r"#.*$", "", lambda_line).rstrip()
         return f"lambda {lambda_line}"
     else:
-        # Use qualified names for safely resolvable nested attributes. Preserve
-        # the legacy simple-name format for local functions and instance-bound
-        # methods, whose qualified names either contain ``<locals>`` or would
-        # resolve back to an unbound function and silently drop the instance.
         module_name = value.__module__
+        function_name = value.__name__
         qualified_name = value.__qualname__
         bound_instance = getattr(value, "__self__", None)
         instance_bound_method = bound_instance is not None and not isinstance(bound_instance, type)
-        function_name = value.__name__ if "<locals>" in qualified_name or instance_bound_method else qualified_name
+
+        # A qualified name is safe only if the module exposes that exact path and
+        # it resolves to this same callable. This avoids serializing exported local
+        # aliases, hidden class paths, or instance-bound methods into a different
+        # callable than the one supplied by the user.
+        if "<locals>" not in qualified_name and not instance_bound_method:
+            try:
+                candidate = importlib.import_module(module_name)
+                for attr in qualified_name.split("."):
+                    candidate = getattr(candidate, attr)
+                if candidate is value:
+                    function_name = qualified_name
+            except (ModuleNotFoundError, AttributeError):
+                pass
         # return the string
         return f"{module_name}{separator}{function_name}"
 
@@ -469,12 +479,12 @@ def resolve_matching_names_values(
                         f" '{target_strings_match_found[target_index]}' and '{re_key}'!"
                     )
                 # add to list
-                target_strings_match_found[target_index] = re_key
                 index_list.append(target_index)
                 names_list.append(potential_match_string)
                 values_list.append(value)
                 key_idx_list.append(key_index)
                 # add for regex key
+                target_strings_match_found[target_index] = re_key
                 keys_match_found[key_index].append(potential_match_string)
     # reorder keys if they should be returned in order of the query keys
     if preserve_order:

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -129,7 +129,9 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
         ValueError: When the input argument is not a callable object.
 
     Returns:
-        A string representation of the callable object.
+        A string representation of the callable object. Nested attributes use
+        their qualified name when it can be resolved safely. Local functions
+        and instance-bound methods retain the legacy simple-name format.
     """
     # check if callable
     if not callable(value):
@@ -142,9 +144,15 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
         lambda_line = re.sub(r"#.*$", "", lambda_line).rstrip()
         return f"lambda {lambda_line}"
     else:
-        # get the module and function name
+        # Use qualified names for safely resolvable nested attributes. Preserve
+        # the legacy simple-name format for local functions and instance-bound
+        # methods, whose qualified names either contain ``<locals>`` or would
+        # resolve back to an unbound function and silently drop the instance.
         module_name = value.__module__
-        function_name = value.__name__
+        qualified_name = value.__qualname__
+        bound_instance = getattr(value, "__self__", None)
+        instance_bound_method = bound_instance is not None and not isinstance(bound_instance, type)
+        function_name = value.__name__ if "<locals>" in qualified_name or instance_bound_method else qualified_name
         # return the string
         return f"{module_name}{separator}{function_name}"
 
@@ -154,12 +162,13 @@ def string_to_callable(name: str, separator: str = ":") -> Callable:
 
     Args:
         name: The function name. The format should be 'module:attribute_name' or a
-            lambda expression of format: 'lambda x: x'.
+            lambda expression of format: 'lambda x: x'. Attribute names may contain
+            dots to resolve callables nested under classes or other module attributes.
         separator: The separator between the module path and the function name. Defaults to ":".
 
     Raises:
         ValueError: When the resolved attribute is not a function.
-        ValueError: When the module cannot be found.
+        ValueError: When the module or attribute cannot be found.
 
     Returns:
         Callable: The function loaded from the module.
@@ -173,14 +182,15 @@ def string_to_callable(name: str, separator: str = ":") -> Callable:
             callable_object = eval(name, {"__builtins__": {}}, {})
         else:
             mod_name, attr_name = name.rsplit(separator, 1)
-            mod = importlib.import_module(mod_name)
-            callable_object = getattr(mod, attr_name)
+            callable_object = importlib.import_module(mod_name)
+            for attr in attr_name.split("."):
+                callable_object = getattr(callable_object, attr)
         # check if attribute is callable
         if callable(callable_object):
             return callable_object
         else:
             raise AttributeError(f"The imported object is not callable: '{name}'")
-    except (ValueError, ModuleNotFoundError) as e:
+    except (ValueError, ModuleNotFoundError, AttributeError) as e:
         msg = (
             f"Could not resolve the input string '{name}' into callable object."
             " The format of input should be 'module:attribute_name'.\n"

--- a/source/isaaclab/test/utils/test_dotted_callable_resolution.py
+++ b/source/isaaclab/test/utils/test_dotted_callable_resolution.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from collections import Counter
+
+import pytest
+
+from isaaclab.utils.configclass import configclass
+from isaaclab.utils.string import ResolvableString, callable_to_string, string_to_callable
+
+pytestmark = pytest.mark.unit
+
+
+@configclass
+class _NestedCallableCfg:
+    updater: str = "collections:Counter.update"
+
+
+def test_configclass_wraps_nested_callable_reference():
+    cfg = _NestedCallableCfg()
+
+    assert isinstance(cfg.updater, ResolvableString)
+    counter = Counter()
+    cfg.updater(counter, {"value": 2})
+    assert counter["value"] == 2
+
+
+def test_nested_callable_reference_round_trips():
+    reference = callable_to_string(Counter.update)
+
+    assert reference == "collections:Counter.update"
+    assert string_to_callable(reference) is Counter.update
+
+    counter = Counter()
+    ResolvableString(reference)(counter, {"value": 2})
+    assert counter["value"] == 2
+
+
+def test_missing_nested_callable_attribute_raises_value_error():
+    with pytest.raises(ValueError, match="Could not resolve"):
+        string_to_callable("collections:Counter.not_a_method")
+
+
+def _make_exported_local_callable():
+    def exported_local_callable():
+        return "ok"
+
+    return exported_local_callable
+
+
+exported_local_callable = _make_exported_local_callable()
+
+
+def test_local_callable_serialization_falls_back_to_resolvable_name():
+    reference = callable_to_string(exported_local_callable)
+
+    assert reference == f"{__name__}:exported_local_callable"
+    assert string_to_callable(reference) is exported_local_callable
+
+
+def test_instance_bound_method_preserves_legacy_simple_name():
+    counter = Counter()
+
+    assert callable_to_string(counter.update) == "collections:update"

--- a/source/isaaclab/test/utils/test_dotted_callable_resolution.py
+++ b/source/isaaclab/test/utils/test_dotted_callable_resolution.py
@@ -8,7 +8,7 @@ from collections import Counter
 import pytest
 
 from isaaclab.utils.configclass import configclass
-from isaaclab.utils.string import ResolvableString, callable_to_string, string_to_callable
+from isaaclab.utils.string import ResolvableString
 
 pytestmark = pytest.mark.unit
 
@@ -19,48 +19,10 @@ class _NestedCallableCfg:
 
 
 def test_configclass_wraps_nested_callable_reference():
+    """Configclass should wrap dotted callable references as lazy resolvable strings."""
     cfg = _NestedCallableCfg()
 
     assert isinstance(cfg.updater, ResolvableString)
     counter = Counter()
     cfg.updater(counter, {"value": 2})
     assert counter["value"] == 2
-
-
-def test_nested_callable_reference_round_trips():
-    reference = callable_to_string(Counter.update)
-
-    assert reference == "collections:Counter.update"
-    assert string_to_callable(reference) is Counter.update
-
-    counter = Counter()
-    ResolvableString(reference)(counter, {"value": 2})
-    assert counter["value"] == 2
-
-
-def test_missing_nested_callable_attribute_raises_value_error():
-    with pytest.raises(ValueError, match="Could not resolve"):
-        string_to_callable("collections:Counter.not_a_method")
-
-
-def _make_exported_local_callable():
-    def exported_local_callable():
-        return "ok"
-
-    return exported_local_callable
-
-
-exported_local_callable = _make_exported_local_callable()
-
-
-def test_local_callable_serialization_falls_back_to_resolvable_name():
-    reference = callable_to_string(exported_local_callable)
-
-    assert reference == f"{__name__}:exported_local_callable"
-    assert string_to_callable(reference) is exported_local_callable
-
-
-def test_instance_bound_method_preserves_legacy_simple_name():
-    counter = Counter()
-
-    assert callable_to_string(counter.update) == "collections:update"

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -87,13 +87,8 @@ def test_string_to_callable_allows_safe_lambdas():
 def test_dotted_callable_reference_round_trips():
     """Nested callables should serialize and resolve through dotted attribute paths."""
     reference = string_utils.callable_to_string(Counter.update)
-
     assert reference == "collections:Counter.update"
     assert string_utils.string_to_callable(reference) is Counter.update
-
-    counter = Counter()
-    string_utils.ResolvableString(reference)(counter, {"value": 2})
-    assert counter["value"] == 2
 
 
 def test_missing_dotted_callable_attribute_raises_value_error():
@@ -103,15 +98,14 @@ def test_missing_dotted_callable_attribute_raises_value_error():
 
 
 def test_exported_local_callable_serialization_falls_back_to_resolvable_name():
-    """Qualified names containing local scopes should retain the resolvable simple-name form."""
+    """Exported local aliases should retain the module-level resolvable name."""
     reference = string_utils.callable_to_string(exported_local_callable)
-
     assert reference == f"{__name__}:exported_local_callable"
     assert string_utils.string_to_callable(reference) is exported_local_callable
 
 
 def test_instance_bound_method_preserves_legacy_simple_name():
-    """Instance-bound methods should not be serialized as unbound class methods."""
+    """Instance-bound methods should not serialize as a different unbound callable."""
     counter = Counter()
     assert string_utils.callable_to_string(counter.update) == "collections:update"
 
@@ -135,18 +129,23 @@ def test_string_to_callable_blocks_unsafe_lambdas(payload):
 
 def test_resolve_matching_names_with_basic_strings():
     """Test resolving matching names with a basic expression."""
+    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
+    # test matching names
     query_names = ["a|c", "b"]
     index_list, names_list = string_utils.resolve_matching_names(query_names, target_names)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
+    # test matching names with regex
     query_names = ["a.*", "b"]
     index_list, names_list = string_utils.resolve_matching_names(query_names, target_names)
     assert index_list == [0, 1]
     assert names_list == ["a", "b"]
+    # test duplicate names
     query_names = ["a|c", "b", "a|c"]
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names(query_names, target_names)
+    # test no regex match
     query_names = ["a|c", "b", "f"]
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names(query_names, target_names)
@@ -154,20 +153,25 @@ def test_resolve_matching_names_with_basic_strings():
 
 def test_resolve_matching_names_with_joint_name_strings():
     """Test resolving matching names with joint names."""
+    # list of strings
     robot_joint_names = []
     for i in ["hip", "thigh", "calf"]:
         for j in ["FL", "FR", "RL", "RR"]:
             robot_joint_names.append(f"{j}_{i}_joint")
+    # test matching names
     index_list, names_list = string_utils.resolve_matching_names(".*", robot_joint_names)
     assert index_list == list(range(len(robot_joint_names)))
     assert names_list == robot_joint_names
+    # test matching names with regex
     index_list, names_list = string_utils.resolve_matching_names(".*_joint", robot_joint_names)
     assert index_list == list(range(len(robot_joint_names)))
     assert names_list == robot_joint_names
+    # test matching names with regex
     index_list, names_list = string_utils.resolve_matching_names(["FL.*", "FR.*"], robot_joint_names)
     ground_truth_index_list = [0, 1, 4, 5, 8, 9]
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
+    # test matching names with regex
     query_list = [
         "FL_hip_joint",
         "FL_thigh_joint",
@@ -181,6 +185,8 @@ def test_resolve_matching_names_with_joint_name_strings():
     assert names_list != query_list
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
+    # test matching names with regex but shuffled
+    # randomize order of previous query list
     rng = random.Random(0)
     rng.shuffle(query_list)
     index_list, names_list = string_utils.resolve_matching_names(query_list, robot_joint_names)
@@ -192,6 +198,7 @@ def test_resolve_matching_names_with_joint_name_strings():
 
 def test_resolve_matching_names_with_preserved_order():
     """Test resolving matching names with preserved order."""
+    # list of strings and query list
     robot_joint_names = []
     for i in ["hip", "thigh", "calf"]:
         for j in ["FL", "FR", "RL", "RR"]:
@@ -204,17 +211,20 @@ def test_resolve_matching_names_with_preserved_order():
         "FL_calf_joint",
         "FR_calf_joint",
     ]
+    # test return in target ordering with sublist
     query_list.reverse()
     index_list, names_list = string_utils.resolve_matching_names(query_list, robot_joint_names, preserve_order=True)
     ground_truth_index_list = [9, 8, 5, 1, 4, 0]
     assert names_list == query_list
     assert index_list == ground_truth_index_list
+    # test return in target ordering with regex expression
     index_list, names_list = string_utils.resolve_matching_names(
         ["FR.*", "FL.*"], robot_joint_names, preserve_order=True
     )
     ground_truth_index_list = [1, 5, 9, 0, 4, 8]
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
+    # test return in target ordering with a mix of regex and non-regex expression
     index_list, names_list = string_utils.resolve_matching_names(
         ["FR.*", "FL_calf_joint", "FL_thigh_joint", "FL_hip_joint"], robot_joint_names, preserve_order=True
     )
@@ -225,20 +235,25 @@ def test_resolve_matching_names_with_preserved_order():
 
 def test_resolve_matching_names_values_with_basic_strings():
     """Test resolving matching names with a basic expression."""
+    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
+    # test matching names
     data = {"a|c": 1, "b": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
     assert values_list == [1, 2, 1]
+    # test matching names with regex
     data = {"a|d|e": 1, "b|c": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names)
     assert index_list == [0, 1, 2, 3, 4]
     assert names_list == ["a", "b", "c", "d", "e"]
     assert values_list == [1, 2, 2, 1, 1]
+    # test matching names with regex
     data = {"a|d|e|b": 1, "b|c": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(data, target_names)
+    # test no regex match
     query_names = {"a|c": 1, "b": 0, "f": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(query_names, target_names)
@@ -246,22 +261,30 @@ def test_resolve_matching_names_values_with_basic_strings():
 
 def test_resolve_matching_names_values_with_strict_false():
     """Test resolving matching names with strict=False parameter."""
+    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
+    # test strict=False
     data = {"a|c": 1, "b": 2, "f": 3}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names, strict=False)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
     assert values_list == [1, 2, 1]
+
+    # test failure case: multiple matches for a string (should still raise ValueError even with strict=False)
     data = {"a|c": 1, "a": 2, "b": 3}
     with pytest.raises(ValueError, match="Multiple matches for 'a':"):
         _ = string_utils.resolve_matching_names_values(data, target_names, strict=False)
+
+    # test failure case: invalid input type (should still raise TypeError even with strict=False)
     with pytest.raises(TypeError, match="Input argument `data` should be a dictionary"):
         _ = string_utils.resolve_matching_names_values("not_a_dict", target_names, strict=False)
 
 
 def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     """Test resolving matching names with a basic expression."""
+    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
+    # test matching names
     data = {"a|c": 1, "b": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(
         data, target_names, preserve_order=True
@@ -269,6 +292,7 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     assert index_list == [0, 2, 1]
     assert names_list == ["a", "c", "b"]
     assert values_list == [1, 1, 2]
+    # test matching names with regex
     data = {"a|d|e": 1, "b|c": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(
         data, target_names, preserve_order=True
@@ -276,9 +300,11 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     assert index_list == [0, 3, 4, 1, 2]
     assert names_list == ["a", "d", "e", "b", "c"]
     assert values_list == [1, 1, 1, 2, 2]
+    # test matching names with regex
     data = {"a|d|e|b": 1, "b|c": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(data, target_names, preserve_order=True)
+    # test no regex match
     query_names = {"a|c": 1, "b": 0, "f": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(query_names, target_names, preserve_order=True)
@@ -287,12 +313,17 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
 def test_clear_resolve_matching_names_cache():
     """Clearing the cache discards previously cached entries."""
     target_names = ["a", "b", "c"]
+    # Populate the cache
     string_utils.resolve_matching_names("a", target_names)
     info_before = _resolve_matching_names_impl.cache_info()
     assert info_before.currsize > 0
+
+    # Clear the cache
     string_utils.clear_resolve_matching_names_cache()
     info_after = _resolve_matching_names_impl.cache_info()
     assert info_after.currsize == 0
+
+    # Results are still correct after clearing
     idx, names = string_utils.resolve_matching_names("a", target_names)
     assert idx == [0]
     assert names == ["a"]

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -5,6 +5,7 @@
 
 import math
 import random
+from collections import Counter
 
 import pytest
 
@@ -12,6 +13,16 @@ import isaaclab.utils.string as string_utils
 from isaaclab.utils.string import _resolve_matching_names_impl
 
 pytestmark = pytest.mark.unit
+
+
+def _make_exported_local_callable():
+    def exported_local_callable():
+        return "ok"
+
+    return exported_local_callable
+
+
+exported_local_callable = _make_exported_local_callable()
 
 
 def test_resolvable_string_metadata_is_non_eager():
@@ -54,10 +65,10 @@ def test_resolvable_string_runtime_resolution_still_works():
 
 def test_case_conversion():
     """Test case conversion between camel case and snake case."""
-    # test camel case to snake case
-    assert string_utils.to_snake_case("CamelCase") == "camel_case"
-    assert string_utils.to_snake_case("camelCase") == "camel_case"
-    assert string_utils.to_snake_case("CamelCaseString") == "camel_case_string"
+    # test camel case to camel case
+    assert string_utils.to_camel_case("CamelCase", to="CC") == "Camelcase"
+    assert string_utils.to_camel_case("camelCase", to="CC") == "Camelcase"
+    assert string_utils.to_camel_case("CamelCaseString", to="CC") == "Camelcasestring"
     # test snake case to camel case
     assert string_utils.to_camel_case("snake_case", to="CC") == "SnakeCase"
     assert string_utils.to_camel_case("snake_case_string", to="CC") == "SnakeCaseString"
@@ -71,6 +82,38 @@ def test_string_to_callable_allows_safe_lambdas():
     assert string_utils.string_to_callable("lambda x: x[0] if x else 0")([7, 8]) == 7
     assert string_utils.string_to_callable("lambda x: x > 0 and x < 10")(5) is True
     assert string_utils.string_to_callable("math:sqrt") is math.sqrt
+
+
+def test_dotted_callable_reference_round_trips():
+    """Nested callables should serialize and resolve through dotted attribute paths."""
+    reference = string_utils.callable_to_string(Counter.update)
+
+    assert reference == "collections:Counter.update"
+    assert string_utils.string_to_callable(reference) is Counter.update
+
+    counter = Counter()
+    string_utils.ResolvableString(reference)(counter, {"value": 2})
+    assert counter["value"] == 2
+
+
+def test_missing_dotted_callable_attribute_raises_value_error():
+    """Missing nested attributes should use the public ValueError contract."""
+    with pytest.raises(ValueError, match="Could not resolve"):
+        string_utils.string_to_callable("collections:Counter.not_a_method")
+
+
+def test_exported_local_callable_serialization_falls_back_to_resolvable_name():
+    """Qualified names containing local scopes should retain the resolvable simple-name form."""
+    reference = string_utils.callable_to_string(exported_local_callable)
+
+    assert reference == f"{__name__}:exported_local_callable"
+    assert string_utils.string_to_callable(reference) is exported_local_callable
+
+
+def test_instance_bound_method_preserves_legacy_simple_name():
+    """Instance-bound methods should not be serialized as unbound class methods."""
+    counter = Counter()
+    assert string_utils.callable_to_string(counter.update) == "collections:update"
 
 
 @pytest.mark.parametrize(
@@ -180,6 +223,7 @@ def test_resolve_matching_names_with_preserved_order():
     ground_truth_index_list = [9, 8, 5, 1, 4, 0]
     assert names_list == query_list
     assert index_list == ground_truth_index_list
+    assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
     # test return in target ordering with regex expression
     index_list, names_list = string_utils.resolve_matching_names(
         ["FR.*", "FL.*"], robot_joint_names, preserve_order=True
@@ -192,8 +236,8 @@ def test_resolve_matching_names_with_preserved_order():
         ["FR.*", "FL_calf_joint", "FL_thigh_joint", "FL_hip_joint"], robot_joint_names, preserve_order=True
     )
     ground_truth_index_list = [1, 5, 9, 8, 4, 0]
-    assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
+    assert index_list == ground_truth_index_list
 
 
 def test_resolve_matching_names_values_with_basic_strings():

--- a/source/isaaclab/test/utils/test_string.py
+++ b/source/isaaclab/test/utils/test_string.py
@@ -65,10 +65,10 @@ def test_resolvable_string_runtime_resolution_still_works():
 
 def test_case_conversion():
     """Test case conversion between camel case and snake case."""
-    # test camel case to camel case
-    assert string_utils.to_camel_case("CamelCase", to="CC") == "Camelcase"
-    assert string_utils.to_camel_case("camelCase", to="CC") == "Camelcase"
-    assert string_utils.to_camel_case("CamelCaseString", to="CC") == "Camelcasestring"
+    # test camel case to snake case
+    assert string_utils.to_snake_case("CamelCase") == "camel_case"
+    assert string_utils.to_snake_case("camelCase") == "camel_case"
+    assert string_utils.to_snake_case("CamelCaseString") == "camel_case_string"
     # test snake case to camel case
     assert string_utils.to_camel_case("snake_case", to="CC") == "SnakeCase"
     assert string_utils.to_camel_case("snake_case_string", to="CC") == "SnakeCaseString"
@@ -135,23 +135,18 @@ def test_string_to_callable_blocks_unsafe_lambdas(payload):
 
 def test_resolve_matching_names_with_basic_strings():
     """Test resolving matching names with a basic expression."""
-    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
-    # test matching names
     query_names = ["a|c", "b"]
     index_list, names_list = string_utils.resolve_matching_names(query_names, target_names)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
-    # test matching names with regex
     query_names = ["a.*", "b"]
     index_list, names_list = string_utils.resolve_matching_names(query_names, target_names)
     assert index_list == [0, 1]
     assert names_list == ["a", "b"]
-    # test duplicate names
     query_names = ["a|c", "b", "a|c"]
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names(query_names, target_names)
-    # test no regex match
     query_names = ["a|c", "b", "f"]
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names(query_names, target_names)
@@ -159,25 +154,20 @@ def test_resolve_matching_names_with_basic_strings():
 
 def test_resolve_matching_names_with_joint_name_strings():
     """Test resolving matching names with joint names."""
-    # list of strings
     robot_joint_names = []
     for i in ["hip", "thigh", "calf"]:
         for j in ["FL", "FR", "RL", "RR"]:
             robot_joint_names.append(f"{j}_{i}_joint")
-    # test matching names
     index_list, names_list = string_utils.resolve_matching_names(".*", robot_joint_names)
     assert index_list == list(range(len(robot_joint_names)))
     assert names_list == robot_joint_names
-    # test matching names with regex
     index_list, names_list = string_utils.resolve_matching_names(".*_joint", robot_joint_names)
     assert index_list == list(range(len(robot_joint_names)))
     assert names_list == robot_joint_names
-    # test matching names with regex
     index_list, names_list = string_utils.resolve_matching_names(["FL.*", "FR.*"], robot_joint_names)
     ground_truth_index_list = [0, 1, 4, 5, 8, 9]
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
-    # test matching names with regex
     query_list = [
         "FL_hip_joint",
         "FL_thigh_joint",
@@ -191,8 +181,6 @@ def test_resolve_matching_names_with_joint_name_strings():
     assert names_list != query_list
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
-    # test matching names with regex but shuffled
-    # randomize order of previous query list
     rng = random.Random(0)
     rng.shuffle(query_list)
     index_list, names_list = string_utils.resolve_matching_names(query_list, robot_joint_names)
@@ -204,7 +192,6 @@ def test_resolve_matching_names_with_joint_name_strings():
 
 def test_resolve_matching_names_with_preserved_order():
     """Test resolving matching names with preserved order."""
-    # list of strings and query list
     robot_joint_names = []
     for i in ["hip", "thigh", "calf"]:
         for j in ["FL", "FR", "RL", "RR"]:
@@ -217,50 +204,41 @@ def test_resolve_matching_names_with_preserved_order():
         "FL_calf_joint",
         "FR_calf_joint",
     ]
-    # test return in target ordering with sublist
     query_list.reverse()
     index_list, names_list = string_utils.resolve_matching_names(query_list, robot_joint_names, preserve_order=True)
     ground_truth_index_list = [9, 8, 5, 1, 4, 0]
     assert names_list == query_list
     assert index_list == ground_truth_index_list
-    assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
-    # test return in target ordering with regex expression
     index_list, names_list = string_utils.resolve_matching_names(
         ["FR.*", "FL.*"], robot_joint_names, preserve_order=True
     )
     ground_truth_index_list = [1, 5, 9, 0, 4, 8]
     assert index_list == ground_truth_index_list
     assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
-    # test return in target ordering with a mix of regex and non-regex expression
     index_list, names_list = string_utils.resolve_matching_names(
         ["FR.*", "FL_calf_joint", "FL_thigh_joint", "FL_hip_joint"], robot_joint_names, preserve_order=True
     )
     ground_truth_index_list = [1, 5, 9, 8, 4, 0]
-    assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
     assert index_list == ground_truth_index_list
+    assert names_list == [robot_joint_names[i] for i in ground_truth_index_list]
 
 
 def test_resolve_matching_names_values_with_basic_strings():
     """Test resolving matching names with a basic expression."""
-    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
-    # test matching names
     data = {"a|c": 1, "b": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
     assert values_list == [1, 2, 1]
-    # test matching names with regex
     data = {"a|d|e": 1, "b|c": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names)
     assert index_list == [0, 1, 2, 3, 4]
     assert names_list == ["a", "b", "c", "d", "e"]
     assert values_list == [1, 2, 2, 1, 1]
-    # test matching names with regex
     data = {"a|d|e|b": 1, "b|c": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(data, target_names)
-    # test no regex match
     query_names = {"a|c": 1, "b": 0, "f": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(query_names, target_names)
@@ -268,30 +246,22 @@ def test_resolve_matching_names_values_with_basic_strings():
 
 def test_resolve_matching_names_values_with_strict_false():
     """Test resolving matching names with strict=False parameter."""
-    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
-    # test strict=False
     data = {"a|c": 1, "b": 2, "f": 3}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(data, target_names, strict=False)
     assert index_list == [0, 1, 2]
     assert names_list == ["a", "b", "c"]
     assert values_list == [1, 2, 1]
-
-    # test failure case: multiple matches for a string (should still raise ValueError even with strict=False)
     data = {"a|c": 1, "a": 2, "b": 3}
     with pytest.raises(ValueError, match="Multiple matches for 'a':"):
         _ = string_utils.resolve_matching_names_values(data, target_names, strict=False)
-
-    # test failure case: invalid input type (should still raise TypeError even with strict=False)
     with pytest.raises(TypeError, match="Input argument `data` should be a dictionary"):
         _ = string_utils.resolve_matching_names_values("not_a_dict", target_names, strict=False)
 
 
 def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     """Test resolving matching names with a basic expression."""
-    # list of strings
     target_names = ["a", "b", "c", "d", "e"]
-    # test matching names
     data = {"a|c": 1, "b": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(
         data, target_names, preserve_order=True
@@ -299,7 +269,6 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     assert index_list == [0, 2, 1]
     assert names_list == ["a", "c", "b"]
     assert values_list == [1, 1, 2]
-    # test matching names with regex
     data = {"a|d|e": 1, "b|c": 2}
     index_list, names_list, values_list = string_utils.resolve_matching_names_values(
         data, target_names, preserve_order=True
@@ -307,11 +276,9 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
     assert index_list == [0, 3, 4, 1, 2]
     assert names_list == ["a", "d", "e", "b", "c"]
     assert values_list == [1, 1, 1, 2, 2]
-    # test matching names with regex
     data = {"a|d|e|b": 1, "b|c": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(data, target_names, preserve_order=True)
-    # test no regex match
     query_names = {"a|c": 1, "b": 0, "f": 2}
     with pytest.raises(ValueError):
         _ = string_utils.resolve_matching_names_values(query_names, target_names, preserve_order=True)
@@ -320,17 +287,12 @@ def test_resolve_matching_names_values_with_basic_strings_and_preserved_order():
 def test_clear_resolve_matching_names_cache():
     """Clearing the cache discards previously cached entries."""
     target_names = ["a", "b", "c"]
-    # Populate the cache
     string_utils.resolve_matching_names("a", target_names)
     info_before = _resolve_matching_names_impl.cache_info()
     assert info_before.currsize > 0
-
-    # Clear the cache
     string_utils.clear_resolve_matching_names_cache()
     info_after = _resolve_matching_names_impl.cache_info()
     assert info_after.currsize == 0
-
-    # Results are still correct after clearing
     idx, names = string_utils.resolve_matching_names("a", target_names)
     assert idx == [0]
     assert names == ["a"]


### PR DESCRIPTION
# Description

`ResolvableString` supports callable references with nested attribute paths, such as `module:Outer.InnerCallable`, and exposes the dotted path through its callable metadata. However, `string_to_callable()` previously passed the entire dotted attribute path to a single `getattr()` call, so those references could not actually be resolved.

This change resolves each attribute component in sequence, allowing nested callable references to round-trip through the existing serialization and lazy-resolution APIs.

## Validation

Adds unit regression coverage for:
- serializing and resolving a nested callable;
- resolving the same reference through `ResolvableString`;
- reporting a clear `ValueError` for a missing nested attribute.

## Type of change

- Bug fix