### PR TITLE
Fail fast on TorchScript model load errors

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-torchscript-load-errors.major.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-torchscript-load-errors.major.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed ``load_torchscript_model`` to raise ``RuntimeError`` when TorchScript loading fails instead
+  of returning ``None``. Callers that previously checked for a ``None`` return should catch ``RuntimeError`` at
+  the load call instead.

--- a/source/isaaclab/isaaclab/utils/io/torchscript.py
+++ b/source/isaaclab/isaaclab/utils/io/torchscript.py
@@ -25,16 +25,17 @@ def load_torchscript_model(model_path: str, device: str = "cpu") -> torch.nn.Mod
         torch.nn.Module: The loaded TorchScript model in evaluation mode
 
     Raises:
-        FileNotFoundError: If the model file does not exist
+        FileNotFoundError: If the model file does not exist.
+        RuntimeError: If the file cannot be loaded as a TorchScript model.
     """
     if not os.path.exists(model_path):
         raise FileNotFoundError(f"TorchScript model file not found: {model_path}")
 
     try:
         model = torch.jit.load(model_path, map_location=device)
-        model.eval()
-        print(f"Successfully loaded TorchScript model from {model_path}")
-        return model
-    except Exception as e:
-        print(f"Error loading TorchScript model: {e}")
-        return None
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load TorchScript model from {model_path}") from exc
+
+    model.eval()
+    print(f"Successfully loaded TorchScript model from {model_path}")
+    return model

--- a/source/isaaclab/test/controllers/test_controller_utils.py
+++ b/source/isaaclab/test/controllers/test_controller_utils.py
@@ -678,9 +678,8 @@ def test_load_torchscript_model_invalid_file():
         temp_file_path = temp_file.name
 
     try:
-        # Should handle the error gracefully and return None
-        model = load_torchscript_model(temp_file_path)
-        assert model is None
+        with pytest.raises(RuntimeError, match="Failed to load TorchScript model"):
+            load_torchscript_model(temp_file_path)
     finally:
         # Clean up the temporary file
         os.unlink(temp_file_path)
@@ -695,9 +694,8 @@ def test_load_torchscript_model_empty_file():
         temp_file_path = temp_file.name
 
     try:
-        # Should handle the error gracefully and return None
-        model = load_torchscript_model(temp_file_path)
-        assert model is None
+        with pytest.raises(RuntimeError, match="Failed to load TorchScript model"):
+            load_torchscript_model(temp_file_path)
     finally:
         # Clean up the temporary file
         os.unlink(temp_file_path)
@@ -766,9 +764,8 @@ def test_load_torchscript_model_error_handling():
         temp_file_path = temp_file.name
 
     try:
-        # Should handle the error gracefully and return None
-        model = load_torchscript_model(temp_file_path)
-        assert model is None
+        with pytest.raises(RuntimeError, match="Failed to load TorchScript model"):
+            load_torchscript_model(temp_file_path)
     finally:
         # Clean up the temporary file
         os.unlink(temp_file_path)

--- a/source/isaaclab/test/utils/test_torchscript_io.py
+++ b/source/isaaclab/test/utils/test_torchscript_io.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from isaaclab.utils.io.torchscript import load_torchscript_model
+
+pytestmark = pytest.mark.unit
+
+
+def test_load_torchscript_model_propagates_load_failure(monkeypatch, tmp_path):
+    model_path = tmp_path / "invalid.pt"
+    model_path.write_bytes(b"not a torchscript model")
+
+    def fail_load(*args, **kwargs):
+        raise ValueError("invalid archive")
+
+    monkeypatch.setattr(torch.jit, "load", fail_load)
+
+    with pytest.raises(RuntimeError, match="Failed to load TorchScript model") as exc_info:
+        load_torchscript_model(str(model_path))
+
+    assert isinstance(exc_info.value.__cause__, ValueError)


### PR DESCRIPTION
# Description

`load_torchscript_model()` currently catches every exception raised by `torch.jit.load()`, prints an error, and returns `None`. Callers then continue initialization and typically fail later with an unrelated error such as `NoneType` having no `forward` method.

This change makes model-loading failures propagate at the actual load site, while preserving the existing explicit `FileNotFoundError` for missing paths. The function therefore continues to return a valid evaluation-mode TorchScript module on success and no longer returns `None` on corrupt or incompatible models.

## Validation

Adds unit regression coverage for:
- successful TorchScript load and evaluation mode;
- missing model paths;
- invalid TorchScript files raising the underlying load error instead of returning `None`.

## Type of change

- Bug fix