### PR TITLE
Fix lambda serialization for comma-containing expressions

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-lambda-serialization-commas.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-lambda-serialization-commas.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``callable_to_string`` truncating lambda expressions at the first comma, allowing tuple and collection
+  expressions to serialize and round-trip correctly.

--- a/source/isaaclab/isaaclab/utils/string.py
+++ b/source/isaaclab/isaaclab/utils/string.py
@@ -10,6 +10,7 @@ import functools
 import importlib
 import inspect
 import re
+import textwrap
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -126,7 +127,7 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
         separator: The separator between the module path and the function name. Defaults to ":".
 
     Raises:
-        ValueError: When the input argument is not a callable object.
+        ValueError: When the input argument is not callable or lambda source cannot be resolved.
 
     Returns:
         A string representation of the callable object.
@@ -136,11 +137,15 @@ def callable_to_string(value: Callable, separator: str = ":") -> str:
         raise ValueError(f"The input argument is not callable: {value}.")
     # check if lambda function
     if value.__name__ == "<lambda>":
-        # we resolve the lambda expression by checking the source code and extracting the line with lambda expression
-        # we also remove any comments from the line
-        lambda_line = inspect.getsourcelines(value)[0][0].strip().split("lambda")[1].strip().split(",")[0]
-        lambda_line = re.sub(r"#.*$", "", lambda_line).rstrip()
-        return f"lambda {lambda_line}"
+        # Extract the lambda expression from its enclosing source statement. Parsing the
+        # source avoids treating commas inside the lambda body as statement delimiters.
+        source = textwrap.dedent(inspect.getsource(value))
+        tree = ast.parse(source)
+        lambda_node = next((node for node in ast.walk(tree) if isinstance(node, ast.Lambda)), None)
+        lambda_source = ast.get_source_segment(source, lambda_node) if lambda_node is not None else None
+        if lambda_source is None:
+            raise ValueError(f"Could not resolve source for lambda callable: {value}.")
+        return lambda_source
     else:
         # get the module and function name
         module_name = value.__module__

--- a/source/isaaclab/test/utils/test_lambda_serialization.py
+++ b/source/isaaclab/test/utils/test_lambda_serialization.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from isaaclab.utils.string import callable_to_string, string_to_callable
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tuple_lambda():
+    return lambda x: (x, x + 1)
+
+
+def _make_list_lambda():
+    return lambda x: [x, x + 1, x + 2]  # trailing comments are not part of the lambda expression
+
+
+def _make_unsafe_lambda():
+    return lambda x: x.__class__
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_source", "argument", "expected_result"),
+    [
+        (_make_tuple_lambda, "lambda x: (x, x + 1)", 3, (3, 4)),
+        (_make_list_lambda, "lambda x: [x, x + 1, x + 2]", 3, [3, 4, 5]),
+    ],
+)
+def test_callable_to_string_preserves_commas_and_round_trips(factory, expected_source, argument, expected_result):
+    serialized = callable_to_string(factory())
+
+    assert serialized == expected_source
+    assert string_to_callable(serialized)(argument) == expected_result
+
+
+def test_serialized_lambda_still_uses_safe_resolution_checks():
+    serialized = callable_to_string(_make_unsafe_lambda())
+
+    with pytest.raises(ValueError, match="Unsafe lambda expression"):
+        string_to_callable(serialized)


### PR DESCRIPTION
# Description

`callable_to_string()` currently extracts lambda source by splitting the source line after `lambda` and then truncating at the first comma. That breaks valid lambda expressions whose body or defaults contain commas, for example `lambda x: (x, x + 1)` or `lambda x: [x, x + 1, x + 2]`, producing an invalid serialized callable string.

This change replaces delimiter-based extraction with AST source extraction using `inspect.getsource()`, `textwrap.dedent()`, `ast.parse()`, and `ast.get_source_segment()`. The complete lambda expression is preserved without including enclosing syntax or trailing comments.

The existing `string_to_callable()` safety validation is unchanged. Regression coverage also verifies that an unsafe serialized lambda such as attribute traversal is still rejected by the existing forbidden-node checks.

## Validation

Added `pytest.mark.unit` regression coverage for:
- tuple-valued lambdas containing commas;
- list-valued lambdas containing multiple comma-separated items;
- serialization followed by `string_to_callable()` round-trip execution;
- preservation of the existing unsafe-lambda rejection path.

Focused Python validation of the extraction and round-trip behavior passed for the covered cases.

## Type of change

- Bug fix