### PR TITLE
Remove stale sections from cloning guide

### DIFF
--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -127,8 +127,9 @@ and ``quaternions`` buffers. If ``positions`` is provided, it authors
 Clone Plans
 -----------
 
-For one source row, passing ``sources``, ``destinations``, and ``mask`` by hand is simple.
-For heterogeneous scenes, the mapping is easier to build with
+When every environment is cloned from a single source, such as using ``env_0`` to populate a
+4,096-environment scene, passing ``sources``, ``destinations``, and ``mask`` directly is
+straightforward. For heterogeneous scenes, the mapping is easier to build with
 :func:`~isaaclab.cloner.make_clone_plan`, which returns the raw flat components. Composing
 those components into a :class:`~isaaclab.cloner.ClonePlan` together with the per-environment
 pose buffer is the caller's responsibility — keeping pose authority on the side that owns the

--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -325,49 +325,6 @@ Choosing an API
      - Isaac Lab's tested path is the ``isaaclab.cloner`` API described here.
 
 
-Migrating From Template Cloning
--------------------------------
-
-The template-root discovery API has been removed. Replace
-``clone_from_template(...)`` calls with explicit source prims plus
-:func:`~isaaclab.cloner.make_clone_plan`, a backend physics replicate function, and
-:func:`~isaaclab.cloner.usd_replicate`. Replace ``TemplateCloneCfg`` with
-:class:`~isaaclab.cloner.CloneCfg` for execution settings such as clone strategy,
-Fabric cloning, and backend replication.
-
-
-Collision Filtering and Isolation
----------------------------------
-
-Some prims, such as terrain, are intentionally shared across environments and should collide
-with every environment. These are modeled as global collision paths. The workaround is only
-the per-environment filtering: when cloning is fully isolated per world, cloned environments
-should not collide with each other and no manual per-environment filter should be needed.
-Some PhysX cloning paths still rely on USD collision groups for that isolation fallback. In
-the scene workflow this is handled by ``InteractiveScene`` when ``filter_collisions=True``
-and the backend is PhysX.
-
-For direct PhysX usage, call :func:`~isaaclab.cloner.filter_collisions` after cloning if
-per-environment isolation is not already provided by the cloning backend:
-
-.. code-block:: python
-
-    from isaaclab.cloner import filter_collisions
-
-    filter_collisions(
-        stage=stage,
-        physicsscene_path="/physicsScene",
-        collision_root_path="/World/collisions",
-        prim_paths=[f"/World/envs/env_{i}" for i in range(num_envs)],
-        global_paths=["/World/ground"],
-    )
-
-.. note::
-
-    Collision filtering uses PhysX collision groups. Newton handles per-environment isolation
-    through its own world system.
-
-
 Backend and Option Notes
 ------------------------
 

--- a/docs/source/how-to/cloning.rst
+++ b/docs/source/how-to/cloning.rst
@@ -326,6 +326,38 @@ Choosing an API
      - Isaac Lab's tested path is the ``isaaclab.cloner`` API described here.
 
 
+Collision Filtering and Isolation
+---------------------------------
+
+Some prims, such as terrain, are intentionally shared across environments and should collide
+with every environment. These are modeled as global collision paths. The workaround is only
+the per-environment filtering: when cloning is fully isolated per world, cloned environments
+should not collide with each other and no manual per-environment filter should be needed.
+Some PhysX cloning paths still rely on USD collision groups for that isolation fallback. In
+the scene workflow this is handled by ``InteractiveScene`` when ``filter_collisions=True``
+and the backend is PhysX.
+
+For direct PhysX usage, call :func:`~isaaclab.cloner.filter_collisions` after cloning if
+per-environment isolation is not already provided by the cloning backend:
+
+.. code-block:: python
+
+    from isaaclab.cloner import filter_collisions
+
+    filter_collisions(
+        stage=stage,
+        physicsscene_path="/physicsScene",
+        collision_root_path="/World/collisions",
+        prim_paths=[f"/World/envs/env_{i}" for i in range(num_envs)],
+        global_paths=["/World/ground"],
+    )
+
+.. note::
+
+    Collision filtering uses PhysX collision groups. Newton handles per-environment isolation
+    through its own world system.
+
+
 Backend and Option Notes
 ------------------------
 
@@ -336,14 +368,9 @@ replication function automatically. Direct PhysX users call
 
 **``replicate_physics=False``.** Disable physics replication when environments need
 independent authored USD or physics state, such as some scale, texture, or color
-randomization workflows. Startup and physics parsing are slower because the backend cannot
-assume every environment is a clone of the same source.
-
-**``copy_from_source``.** ``InteractiveScene`` calls
-``clone_environments(copy_from_source=True)`` when ``replicate_physics=False``. This skips
-backend physics replication and leaves physics parsing to the backend. Spawner-level
-``copy_from_source`` is a separate setting used by spawn functions that clone from a source
-path matched by a regex.
+randomization workflows. USD replication still creates the per-environment prims, but backend
+physics replication is skipped. Startup and physics parsing are slower because the backend
+cannot assume every environment is a clone of the same source.
 
 **Fabric cloning.** ``clone_in_fabric=True`` applies to PhysX replication. It can reduce
 scene-creation time for large PhysX scenes, especially when many replicated rigid bodies are


### PR DESCRIPTION
## Summary

- remove migration guidance for the retired template-cloning API
- remove the stale `copy_from_source` note and describe `replicate_physics=False` directly
- retain the PhysX collision-filtering guidance required by direct cloning workflows

## Testing

- `uv run pre-commit run --files docs/source/how-to/cloning.rst`
- `uv run isaaclab -f`
- `uv run --isolated --with-requirements docs/requirements.txt -- make -C docs current-docs`