### PR TITLE
Record the review fields the license check needs for cuda-bindings

### DIFF
--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -529,7 +529,10 @@
   {
     "package": "cuda-bindings",
     "license": "LicenseRef-NVIDIA-SOFTWARE-LICENSE",
-    "comment": "NVIDIA"
+    "usage": "runtime_dependency",
+    "interaction": "same_process_dynamic",
+    "linkage": "dynamic",
+    "comment": "NVIDIA CUDA Python bindings, pulled in by torch and loaded into the Isaac Lab process"
   },
   {
     "package": "cuda-toolkit",


### PR DESCRIPTION
# Description

The `Docker Dependency Licenses Check` fails on every pull request against `develop` with:

| Package type | Package | Version | License | Reason |
|---|---|---|---|---|
| Python | cuda-bindings | 12.9.7 | LicenseRef-NVIDIA-SOFTWARE-LICENSE | Reviewed exception is missing usage |

`.github/workflows/license-check.yaml` requires a reviewed exception to carry a non-empty `usage` and an `interaction` from a fixed set. The `cuda-bindings` entry declares a license but neither field, so the check records a violation and exits non-zero.

`cuda-bindings` reaches the dependency tree as a runtime dependency of `torch` (`torch 2.11.0+cu128` in `uv.lock`) and is imported into the Isaac Lab Python process, where it dynamically loads the CUDA driver. It is recorded here the same way as the other NVIDIA runtime components already in the file, e.g. `omniverseclient`:

```json
{
  "package": "cuda-bindings",
  "license": "LicenseRef-NVIDIA-SOFTWARE-LICENSE",
  "usage": "runtime_dependency",
  "interaction": "same_process_dynamic",
  "linkage": "dynamic",
  "comment": "NVIDIA CUDA Python bindings, pulled in by torch and loaded into the Isaac Lab process"
}
```

Verified by replaying the workflow's own `jq` selection and field validation against the patched file: the entry is matched and both `usage` and `interaction` pass.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<sub>Note: this touches only `.github/workflows/`, which is outside `source/<pkg>/`, so the changelog fragment tool has no package to record against.</sub>