### PR TITLE
[Test] Stabilize sensor video recording test

### DIFF
--- a/source/isaaclab_tasks/test/core/test_video_recording.py
+++ b/source/isaaclab_tasks/test/core/test_video_recording.py
@@ -56,6 +56,7 @@ pytestmark = pytest.mark.isaacsim_ci
 
 _CLIP = 12  # frames per clip
 _STEPS = 22  # env steps: enough for one full clip plus close() flush
+_SEED = 42
 _MIN_NONZERO_RATIO = 0.005
 _MIN_MOTION_STD = 0.1
 
@@ -82,6 +83,7 @@ def _cartpole_cfg(*, num_envs: int = 1):
     from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpoleEnvCfg
 
     cfg = CartpoleEnvCfg()
+    cfg.seed = _SEED
     cfg.scene.num_envs = num_envs
     cfg.sim.physics = PhysxCfg()
     return cfg
@@ -93,6 +95,7 @@ def _cartpole_cfg_newton(*, num_envs: int = 1):
     from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpoleEnvCfg
 
     cfg = CartpoleEnvCfg()
+    cfg.seed = _SEED
     cfg.scene.num_envs = num_envs
     cfg.sim.physics = NewtonCfg(solver_cfg=MJWarpSolverCfg())
     return cfg
@@ -106,6 +109,7 @@ def _cartpole_camera_cfg_physx(*, num_envs: int = 1):
 
     cfg = CartpoleCameraEnvCfg()
     cfg = cfg.default
+    cfg.seed = _SEED
     cfg.scene.num_envs = num_envs
     cfg.sim.physics = PhysxCfg()
     cfg.tiled_camera.renderer_cfg = IsaacRtxRendererCfg()
@@ -133,7 +137,9 @@ def _run_cartpole_camera(env_cfg) -> None:
     env = CartpoleCameraEnv(env_cfg)
     try:
         env.reset()
-        actions = torch.zeros(env.num_envs, *env.action_space.shape[1:], device=env.device)
+        # Drive the cart in a known direction so the motion assertion does not
+        # depend on the randomized initial pole state.
+        actions = torch.ones(env.num_envs, *env.action_space.shape[1:], device=env.device)
         for _ in range(_STEPS):
             env.step(actions)
     finally:


### PR DESCRIPTION
## Description

Makes the video-recording integration test deterministic. The sensor-motion assertion previously relied on an unseeded randomized cartpole reset while applying zero actions, which could produce too little pixel motion on CI. The test now uses a fixed seed and drives the cart in a known direction.

No issue was provided. No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this is a test-only change.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] No documentation changes are needed for this test-only change
- [x] My changes generate no new warnings
- [x] The existing video-recording integration test covers the stabilized behavior
- [x] Added the `isaaclab_tasks` changelog skip fragment for this non-user-visible test-only change
- [x] My name is already listed in `CONTRIBUTORS.md`

## Validation

- `uv run python -m pytest source/isaaclab_tasks/test/core/test_video_recording.py -q` (5 passed)
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`