### PR TITLE
[Fix] Reduce RL-Games Cartpole camera rollout memory

### DIFF
--- a/source/isaaclab_tasks/changelog.d/octi-cartpole-rl-games-memory.rst
+++ b/source/isaaclab_tasks/changelog.d/octi-cartpole-rl-games-memory.rst
@@ -1,0 +1,1 @@
+Reduced the RL-Games Cartpole camera rollout horizon to prevent GPU memory exhaustion when using Isaac RTX.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/agents/rl_games_camera_ppo_cfg.yaml
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/agents/rl_games_camera_ppo_cfg.yaml
@@ -92,7 +92,7 @@ params:
     entropy_coef: 0.0
     truncate_grads: True
     e_clip: 0.2
-    horizon_length: 64
+    horizon_length: 32
     minibatch_size: 2048
     mini_epochs: 4
     critic_coef: 2


### PR DESCRIPTION
## Summary

- Reduced the shared RL-Games Cartpole camera rollout horizon from 64 to 32.
- Kept 512 environments, two-frame observations, and the selected renderer unchanged.
- Reduced the default rollout plus flatten allocation from 13.50 GiB to 6.75 GiB.

This keeps isaacsim_rtx runs on the real Isaac RTX renderer instead of restoring the previous task-local Newton override.

## Validation

- uv run --frozen isaaclab -f
- uv run --frozen python tools/changelog/cli.py check develop --include-worktree
- Resolved the registered RL-Games agent config and verified 16,384 samples remain divisible by the 2,048 minibatch size.
- Completed one training epoch with 512 environments and two-frame observations on a 32 GB GPU using the default Newton renderer.

The exact Isaac RTX L40 job was not available locally; its expected peak reduction is 6.75 GiB from the smaller observation rollout.