### PR TITLE
Update OvPhysX to 0.5.10

### DIFF
--- a/.github/workflows/license-exceptions.json
+++ b/.github/workflows/license-exceptions.json
@@ -1169,6 +1169,9 @@
     "package": "ovstage",
     "package_type": "Python",
     "license": "NVIDIA Proprietary Software",
+    "license_aliases": [
+      "LicenseRef-NvidiaProprietary"
+    ],
     "usage": "runtime_dependency",
     "interaction": "same_process_dynamic",
     "linkage": "dynamic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,9 +161,9 @@ rerun = [
 
 isaacsim = ["isaacsim[all,extscache]==6.0.1.0"]
 
-ov = ["ovphysx==0.5.9", "ovrtx==0.4.1.364340", "ovstage==0.1.0.346039"]
-ovphysx = ["ovphysx==0.5.9", "ovstage==0.1.0.346039"]
-ovrtx = ["ovrtx==0.4.1.364340", "ovstage==0.1.0.346039"]
+ov = ["ovphysx==0.5.10", "ovrtx==0.4.1.364340", "ovstage==0.1.1.355824"]
+ovphysx = ["ovphysx==0.5.10", "ovstage==0.1.1.355824"]
+ovrtx = ["ovrtx==0.4.1.364340", "ovstage==0.1.1.355824"]
 
 mimic = [
     "isaaclab-mimic",
@@ -211,9 +211,9 @@ usd_exchange = "2.3.0"
 torch = "2.11.0"
 torchvision = "0.26.0"
 torchaudio = "2.11.0"
-ovphysx = "0.5.9"
+ovphysx = "0.5.10"
 ovrtx = "0.4.1.364340"
-ovstage = "0.1.0.346039"
+ovstage = "0.1.1.355824"
 newton = "release-1.5"
 warp = "1.16.0"
 

--- a/source/isaaclab/changelog.d/esekkin-ovphysx-0510.skip
+++ b/source/isaaclab/changelog.d/esekkin-ovphysx-0510.skip
@@ -1,0 +1,1 @@
+Test-only: updated the asserted OvPhysX dependency pin to match the supported runtime.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -139,7 +139,7 @@ def test_version_single_source_matches_literal_pins():
     optional = pyproject["project"]["optional-dependencies"]
     overrides = pyproject["tool"]["uv"]["override-dependencies"]
 
-    assert versions["ovphysx"] == "0.5.9"
+    assert versions["ovphysx"] == "0.5.10"
     assert "omniverseclient==2.72.3" in dependencies
 
     # Isaac Sim extra mirrors the table, and the teleop extra repeats the same pin.

--- a/source/isaaclab_ov/changelog.d/esekkin-ovphysx-0510.rst
+++ b/source/isaaclab_ov/changelog.d/esekkin-ovphysx-0510.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated OvPhysX to ``0.5.10`` and OVStage to ``0.1.1.355824``, which must be installed together.
+  Reinstall the Omniverse extras with ``uv sync --extra ov`` to use the supported runtime pair.

--- a/source/isaaclab_ov/pyproject.toml
+++ b/source/isaaclab_ov/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.12"
 # Only interpackage dependencies should go here.
 dependencies = [
     "isaaclab",
-    "ovstage==0.1.0.346039",
+    "ovstage==0.1.1.355824",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1764,7 +1764,7 @@ wheels = [
 
 [[package]]
 name = "isaaclab"
-version = "16.2.2"
+version = "16.2.3"
 source = { editable = "source/isaaclab" }
 
 [[package]]
@@ -2044,13 +2044,13 @@ requires-dist = [
     { name = "onnxscript", specifier = ">=0.5" },
     { name = "onnxscript", marker = "extra == 'rsl-rl'", specifier = ">=0.5" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux')", specifier = ">=0.19.0" },
-    { name = "ovphysx", marker = "extra == 'ov'", specifier = "==0.5.9", index = "https://pypi.org/simple" },
-    { name = "ovphysx", marker = "extra == 'ovphysx'", specifier = "==0.5.9", index = "https://pypi.org/simple" },
+    { name = "ovphysx", marker = "extra == 'ov'", specifier = "==0.5.10", index = "https://pypi.org/simple" },
+    { name = "ovphysx", marker = "extra == 'ovphysx'", specifier = "==0.5.10", index = "https://pypi.org/simple" },
     { name = "ovrtx", marker = "extra == 'ov'", specifier = "==0.4.1.364340", index = "https://pypi.org/simple" },
     { name = "ovrtx", marker = "extra == 'ovrtx'", specifier = "==0.4.1.364340", index = "https://pypi.org/simple" },
-    { name = "ovstage", marker = "extra == 'ov'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
-    { name = "ovstage", marker = "extra == 'ovphysx'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
-    { name = "ovstage", marker = "extra == 'ovrtx'", specifier = "==0.1.0.346039", index = "https://pypi.org/simple" },
+    { name = "ovstage", marker = "extra == 'ov'", specifier = "==0.1.1.355824", index = "https://pypi.org/simple" },
+    { name = "ovstage", marker = "extra == 'ovphysx'", specifier = "==0.1.1.355824", index = "https://pypi.org/simple" },
+    { name = "ovstage", marker = "extra == 'ovrtx'", specifier = "==0.1.1.355824", index = "https://pypi.org/simple" },
     { name = "packaging" },
     { name = "pandas", marker = "extra == 'rlinf'" },
     { name = "peft", marker = "extra == 'rlinf'", specifier = ">=0.17.0" },
@@ -2158,7 +2158,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-ov"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "source/isaaclab_ov" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2168,7 +2168,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "isaaclab", editable = "source/isaaclab" },
-    { name = "ovstage", specifier = "==0.1.0.346039" },
+    { name = "ovstage", specifier = "==0.1.1.355824" },
 ]
 
 [[package]]
@@ -2195,7 +2195,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-rl"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "source/isaaclab_rl" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2212,7 +2212,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-tasks"
-version = "16.4.0"
+version = "16.5.0"
 source = { editable = "source/isaaclab_tasks" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -3969,16 +3969,16 @@ wheels = [
 
 [[package]]
 name = "ovphysx"
-version = "0.5.9"
+version = "0.5.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ovstage", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/96/eda4b4c87d382036706d3ee52d05284aca844e16afab04d49603b6b28cfd/ovphysx-0.5.9-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:1b8c1919e477f2db41aef969b8941e5e01ce289646ee5434cef8f48e32dc013f", size = 162043295, upload-time = "2026-07-21T17:54:18.79Z" },
-    { url = "https://files.pythonhosted.org/packages/58/94/283cb414049629a5a2282514f0d960e85077e3469fd57e00df5db6e9cfd2/ovphysx-0.5.9-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:0363b407833ffe911bd3f77a1496d90b4b882e6b28fc5276681e607bc247cafa", size = 168818381, upload-time = "2026-07-21T17:55:38.653Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/c9/650d104bedae6ad30aa213c446bff4a206704fbf686854c3356d817ebf62/ovphysx-0.5.9-py3-none-win_amd64.whl", hash = "sha256:5caaeef75ac0df6ac8ee547ba4ef4a15393b0bbe60e767d3b60c83498b5c7c07", size = 147924027, upload-time = "2026-07-21T17:57:08.832Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a7/dbef61a44e1663eb70d14218d80e9eb4f5e87aa1552ae17f46058cad5c55/ovphysx-0.5.10-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:88b223278aa91c031aef6815f6dbf03497c18aacd441ec97ff86e1c917fcf5c8", size = 162095322, upload-time = "2026-08-07T08:25:52.199Z" },
+    { url = "https://files.pythonhosted.org/packages/df/65/6026f684b457576455fe599a0a3e74716857d50f30a02ace0d503e6aa528/ovphysx-0.5.10-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:b8ffa4a26570cbf252b161e752c4ea7f0843b32ed96573aba99757ceb19efeb1", size = 168897727, upload-time = "2026-08-07T08:23:51.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/76/939750c6d7e9ca8968413ac8ebd7a5a1c370338089a98fd41927ffc3c334/ovphysx-0.5.10-py3-none-win_amd64.whl", hash = "sha256:d75ae94c56e14191a4540dd955cd6d9217d5ed79f144244eb19ddf9bab200a7d", size = 148006495, upload-time = "2026-08-07T08:20:50.922Z" },
 ]
 
 [[package]]
@@ -3989,12 +3989,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/2c/3e/ecefd14d7dc8b3776
 
 [[package]]
 name = "ovstage"
-version = "0.1.0.346039"
+version = "0.1.1.355824"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/3f/f252494103847a543dd1cb461a327ca8f5bbf8b6ffd3ed4149f778c1dc42/ovstage-0.1.0.346039-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:7c327bbb6c908d625f6740a06e963ec8e3749d57d4d3eddfb359f12c9d1a3d96", size = 59728690, upload-time = "2026-07-16T23:27:52.896Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/73/4dcb1de47907cedf3747db05a0a769ac40540abacc7597bca4bf00c454a3/ovstage-0.1.0.346039-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:6e96453f48f1e3177b28ac554f39728d22f3143958ad687986235cb5eb87f919", size = 64306930, upload-time = "2026-07-16T23:27:49.889Z" },
-    { url = "https://files.pythonhosted.org/packages/84/59/fb08c9cf3c3f1145b0ca1b2c12573d28354237777049fcca78aa75f25de1/ovstage-0.1.0.346039-py3-none-win_amd64.whl", hash = "sha256:aa394890f48a3ad35159d43fc680643c6743f135749ba827ce24ad3afc078f25", size = 35043272, upload-time = "2026-07-16T23:27:47.321Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fd/a1650d436b3c304720236178848d4e7ad523a2b9f2b76918d7b902934cac/ovstage-0.1.1.355824-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:046aa360959bf5344d912470aaa11d3ec1fc750e28816e5239ce0438864c9863", size = 59799282, upload-time = "2026-08-05T20:07:10.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/e5d03719d9ab8e412187be84efe11bc6b912eca02bd8dfb09a1bf522bbe4/ovstage-0.1.1.355824-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:b4affd9e5b23620ec71901a164df4ae373d25de2c76b9fae4d193d97aa2df0ec", size = 64302147, upload-time = "2026-08-05T20:06:18.013Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d0/ff9124f524ffadc87f8893e99de1679e7c517ca6ceb60e0b870a284b71a3/ovstage-0.1.1.355824-py3-none-win_amd64.whl", hash = "sha256:fc8ae7fe950aa2ff8fd24643047f7156ffa1b9b384ce3f024ee2193929e21a3b", size = 35031430, upload-time = "2026-08-05T20:05:29.88Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Updates OvPhysX to `0.5.10` and OVStage to `0.1.1.355824` while retaining OVRTX `0.4.1.364340`.
- Adds the OVStage proprietary-license alias and regenerates `uv.lock`.
- Supersedes #7140; thanks to @AntoineRichard for the original dependency work. #7143 remains validation-only evidence and will not be merged.

## Validation

- Resolved and imported the exact OvPhysX, OVStage, and OVRTX versions.
- Focused dependency, renderer, runtime, and OvPhysX environment tests: 105 passed.
- Six-file legacy rendering sweep: 36 passed, 36 intentional unsupported-preset skips, no retries, and no golden changes.
- Focused OVStage rendering sweep: 36 passed, 36 intentional skips, no retries, and no golden changes.
- Lockfile, changelog, pre-commit, and diff checks passed.

## Type of change

- Dependency update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there