### PR TITLE
[Tasks] Derive cartpole camera observation size from tiled camera

### DIFF
--- a/docs/source/features/hydra.rst
+++ b/docs/source/features/hydra.rst
@@ -154,11 +154,16 @@ For example, for the configuration of the Cartpole camera environment:
     :end-at: observation_space = [3, 96, 96]
     :emphasize-lines: 12, 43
 
-The configuration declares the single-frame shape. At environment initialization, the default
-``frame_stack=2`` expands it to an effective policy observation shape of ``[6,96,96]``.
-If the user were to modify the width of the camera, i.e. ``env.tiled_camera.width=128``, then the
-single-frame parameter ``env.observation_space=[3,96,128]`` must be updated and given as input as
-well, producing an effective stacked shape of ``[6,96,128]``.
+The configuration declares the single-frame channel count and a default spatial size.
+At environment initialization, ``CartpoleCameraEnv`` rebuilds ``observation_space`` from
+the resolved camera: the default ``frame_stack=2`` expands channels, and height/width are
+taken from ``tiled_camera``. So ``env.tiled_camera.width=128 env.tiled_camera.height=128``
+alone yields an effective stacked shape of ``[6,128,128]`` without also overriding
+``env.observation_space``. The channel entry in ``observation_space`` must still match the
+camera data type (for example ``[1, ...]`` with ``presets=depth``); presets already set this.
+
+Class-body references such as ``observation_space = [3, tiled_camera.height, tiled_camera.width]``
+are evaluated once at import time and do **not** track later Hydra overrides of the camera.
 
 Similarly, the ``__post_init__`` method is not updated with the command line inputs. In the ``LocomotionVelocityRoughEnvCfg``, for example,
 the post init update is as follows:

--- a/source/isaaclab_tasks/changelog.d/cartpole-camera-obs-from-tiled.rst
+++ b/source/isaaclab_tasks/changelog.d/cartpole-camera-obs-from-tiled.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* :obj:`Isaac-Cartpole-Camera-Direct` now derives policy observation height and width
+  from :attr:`tiled_camera` at environment initialization. Overriding
+  ``env.tiled_camera.width`` / ``height`` no longer requires a matching
+  ``env.observation_space`` rewrite; channel count still comes from the selected preset.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -27,11 +27,13 @@ class CartpoleCameraEnv(CartpoleEnv):
     cfg: CartpoleCameraEnvCfg
 
     def __init__(self, cfg: CartpoleCameraEnvCfg, render_mode: str | None = None, **kwargs):
-        frame_stack = max(1, cfg.frame_stack)
-        cfg.frame_stack = frame_stack
-        if frame_stack > 1:
-            single_channels = int(cfg.observation_space[0])
-            cfg.observation_space = [single_channels * frame_stack, *cfg.observation_space[1:]]
+        cfg.frame_stack = max(1, cfg.frame_stack)
+        if isinstance(cfg.observation_space, list):
+            cfg.observation_space = [
+                int(cfg.observation_space[0]) * cfg.frame_stack,
+                int(cfg.tiled_camera.height),
+                int(cfg.tiled_camera.width),
+            ]
 
         super().__init__(cfg, render_mode, **kwargs)
 
@@ -42,10 +44,12 @@ class CartpoleCameraEnv(CartpoleEnv):
             )
 
         self._stack: CircularBuffer | None = None
-        if frame_stack > 1:
+        if self.cfg.frame_stack > 1:
             # Channel-stack mode: buffer storage is laid out so that .stacked is a free
             # contiguous reshape into (B, K*C, H, W) -- no per-step permute/reshape alloc.
-            self._stack = CircularBuffer(max_len=frame_stack, batch_size=self.num_envs, device=self.device, stack_dim=1)
+            self._stack = CircularBuffer(
+                max_len=self.cfg.frame_stack, batch_size=self.num_envs, device=self.device, stack_dim=1
+            )
 
     def _setup_scene(self):
         """Setup the scene with the cartpole and camera (no ground plane, which obstructs the view)."""

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
@@ -60,7 +60,9 @@ class CartpoleCameraEnvCfg(PresetCfg):
         Values less than two disable stacking.
         """
 
-        # spaces: an image instead of the 4-dim joint-state vector
+        # spaces: single-frame channels + default spatial size. At env init, height/width
+        # are replaced with the tiled camera size and channels are expanded by frame_stack.
+        # Only the channel count must stay in sync with the camera data type (presets set this).
         observation_space = [3, 96, 96]
         state_space = 4
 


### PR DESCRIPTION
# Description

Derive the core direct cartpole camera policy observation height and width from the resolved tiled-camera configuration during environment initialization. This keeps Hydra camera resolution overrides synchronized with the Gym observation space while preserving preset-specific channel counts and frame stacking.

The Hydra documentation and `isaaclab_tasks` changelog fragment are updated to describe the new behavior.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Validation

- `uv run isaaclab -f`
- `.venv/bin/python tools/changelog/cli.py check develop`
- `git diff --check`
- Attempted `uv run isaaclab random_agent --task Isaac-Cartpole-Camera-Direct --num_envs 1 --max_steps 2 env.tiled_camera.width=64 env.tiled_camera.height=64`; configuration parsing succeeded, but the environment could not launch because Isaac Sim/Omniverse Kit is not installed locally.
- Attempted `uv run --isolated --extra test -- make -C docs current-docs`; the build reproducibly aborts in unrelated API autodoc processing with `TypeError: unsupported operand type(s) for |: 'type' and 'Tensor'` and an existing parallel static-asset copy warning.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (full docs build is blocked by the unrelated failure noted above)
- [ ] I have added tests that prove my fix is effective (runtime smoke test requires Isaac Sim)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to `CONTRIBUTORS.md` or my name already exists there
