### PR TITLE
Remove ovstage host copies

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovstage-performance-improvements.rst
+++ b/source/isaaclab_ov/changelog.d/ovstage-performance-improvements.rst
@@ -1,0 +1,11 @@
+Changed
+^^^^^^^
+
+* Changed the OVRTX ovstage path to write object transforms, camera transforms and deformable or
+  particle points straight from their Warp GPU buffers as CUDA DLTensors, removing the per-frame
+  host copies that ``ovstage 0.1.0`` required.
+* Changed those writes to be ordered by handing ovstage the producing Warp stream
+  (``write_attribute(cuda_stream=...)``), replacing the device-wide ``wp.synchronize_device`` with
+  stream-scoped producer ordering, and matching the legacy OVRTX binding path. The write is still
+  awaited, so the calling thread can block; the gain is the removed host copy and the narrower
+  synchronization scope, not a nonblocking handoff.

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -37,6 +37,7 @@ from isaaclab.scene_data.deformable_discovery import (
 
 from isaaclab_ov._clone import CloneTransform, clone_transforms_from_positions
 from isaaclab_ov._runtime import import_ovphysx
+from isaaclab_ov.stage import create_ovstage
 
 if TYPE_CHECKING:
     from isaaclab.sim.simulation_context import SimulationContext
@@ -596,7 +597,7 @@ class OvPhysxManager(PhysicsManager):
         """Populate an OVStage from USDA text and attach it to the runtime."""
         import ovstage  # noqa: PLC0415
 
-        stage = ovstage.Stage("isaaclab")
+        stage = create_ovstage("isaaclab")
         try:
             ovstage.population.open_usd_from_string(
                 stage,

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -33,21 +33,11 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 logger = logging.getLogger(__name__)
 
 import numpy as np
+import ovstage
 import torch
 import warp as wp
 
 import isaaclab.utils.warp  # noqa: F401  # initializes Warp runtime
-
-# ovstage is optional: when present the renderer uses the split-ownership model
-# (ovstage owns scene data, ovrtx owns rendering). When absent it falls back to
-# the legacy renderer-owned scene APIs (deprecated in ovrtx 0.4).
-_OVSTAGE_AVAILABLE = False
-try:
-    import ovstage
-
-    _OVSTAGE_AVAILABLE = True
-except ModuleNotFoundError:
-    pass
 
 # The ovrtx C library links to its own version of the USD libraries. Having
 # the pxr Python package available can cause the C library to load an
@@ -80,6 +70,13 @@ from isaaclab.cloner import ClonePlan
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_convention_wp
+
+from isaaclab_ov.stage import (
+    create_ovstage,
+    points_tensor_from_warp,
+    xform_tensor_from_numpy,
+    xform_tensor_from_warp,
+)
 
 from .ovrtx_annotator_utils import (
     build_instance_id_to_labels_and_semantics,
@@ -137,41 +134,6 @@ _USE_OVSTAGE_ENV = "ISAAC_LAB_OVRTX_USE_OVSTAGE"
 _DISABLE_LINUX_CUDA_CPU_SYNC_ENV = "ISAAC_LAB_OVRTX_DISABLE_LINUX_CUDA_CPU_SYNC"
 
 
-if _OVSTAGE_AVAILABLE:
-    # DLDataType for a 4×4 double matrix (omni:xform column). ovstage stores omni:xform
-    # as one 16-lane float64 element per prim; wp.mat44d maps to the same layout via __dlpack__.
-    _OVSTAGE_XFORM_DTYPE = ovstage.DLDataType(code=ovstage.DLDataTypeCode.kDLFloat, bits=64, lanes=16)
-
-    def _xform_tensor_from_numpy(xforms: np.ndarray) -> Any:
-        """Wrap a ``(N, 4, 4)`` float64 array as a 16-lane DLTensor for ``omni:xform`` writes.
-
-        Args:
-            xforms: Array of shape ``(N, 4, 4)`` with dtype ``float64``.
-
-        Returns:
-            A :class:`ovstage.DLTensor` with shape ``[N]`` and ``lanes=16``.
-        """
-        flat = np.ascontiguousarray(xforms, dtype=np.float64).reshape(-1)
-        return ovstage.make_dltensor(flat, dtype=_OVSTAGE_XFORM_DTYPE, shape=[xforms.shape[0]])
-
-    # DLDataType for a float32 3-vector (``points`` column). ovstage stores ``point3f[] points``
-    # as one 3-lane float32 element per vertex; a warp ``vec3f`` array exports as ``(N, 3)`` lanes=1
-    # via DLPack, so a lanes=3 override on a host numpy array is required to match the column.
-    _OVSTAGE_POINT_DTYPE = ovstage.DLDataType(code=ovstage.DLDataTypeCode.kDLFloat, bits=32, lanes=3)
-
-    def _points_tensor_from_numpy(points: np.ndarray) -> Any:
-        """Wrap an ``(N, 3)`` float32 array as a 3-lane DLTensor for ``points`` writes.
-
-        Args:
-            points: Array of shape ``(N, 3)`` with dtype ``float32``.
-
-        Returns:
-            A :class:`ovstage.DLTensor` with shape ``[N]`` and ``lanes=3``.
-        """
-        flat = np.ascontiguousarray(points, dtype=np.float32).reshape(-1)
-        return ovstage.make_dltensor(flat, dtype=_OVSTAGE_POINT_DTYPE, shape=[points.shape[0]])
-
-
 def ovrtx_use_ovstage_enabled() -> bool:
     """Return whether the ovstage scene-ownership path should be used.
 
@@ -180,20 +142,10 @@ def ovrtx_use_ovstage_enabled() -> bool:
 
     Raises:
         ValueError: If the environment variable is set to anything other than ``0`` or ``1``.
-        RuntimeError: If the environment variable is ``1`` but ovstage is not importable. Falling
-            back to the legacy path here would silently ignore an explicit request and make the
-            renderer look like it had honoured it.
     """
     value = os.environ.get(_USE_OVSTAGE_ENV, "0").strip()
     if value not in {"0", "1"}:
         raise ValueError(f"Invalid value for environment variable `{_USE_OVSTAGE_ENV}`: {value}. Expected 0 or 1.")
-    if value == "1" and not _OVSTAGE_AVAILABLE:
-        raise RuntimeError(
-            f"`{_USE_OVSTAGE_ENV}=1` requests the ovstage scene-ownership path, but the 'ovstage' "
-            "package is not installed. Run your command with: uv run --extra ovrtx <command> "
-            "(or, manually: python -m pip install --extra-index-url https://pypi.nvidia.com "
-            "'ovstage>=0.1.0,<0.2.0')."
-        )
     return value == "1"
 
 
@@ -1721,9 +1673,6 @@ class OVRTXRenderer(BaseRenderer):
     #   :meth:`_render_ovstage` already bars all writes at ordinals <= N, so accumulate the
     #   ``Operation`` objects and ``stage.release_op(op.op_id)`` after it. They must outlive the
     #   barrier — an ``Operation`` is its buffer's only keepalive. Saves caller-side blocking only.
-    # - Direct zero-copy warp DLpack writes are rejected in ovstage 0.1.0 because
-    #   ``omni:xform``/``points`` are  lanes=16/3 while warp's DLPack export is always lanes=1.
-    #   ovstage 0.1.1 will address this.
     # ---------------------------------------------------------------------------
 
     def _init_fields_ovstage(self) -> None:
@@ -1741,6 +1690,8 @@ class OVRTXRenderer(BaseRenderer):
         self._particle_paths_list = None
         self._cable_points_query = None
         self._cable_paths_list = None
+        # DLTensor descriptors aliasing ``_cable_point_slices``; rebuilt only when cables rebind.
+        self._cable_point_tensors: list = []
 
     def _initialize_from_spec_ovstage(self, spec: CameraRenderSpec) -> None:
         """Initialize the OVRTX renderer with internal environment cloning (ovstage path).
@@ -1785,7 +1736,7 @@ class OVRTXRenderer(BaseRenderer):
 
         logger.info("Loading USD into OvRTX via ovstage...")
         self._ovstage_exit_stack = contextlib.ExitStack()
-        self._stage = self._ovstage_exit_stack.enter_context(ovstage.Stage("isaaclab.ovrtx"))
+        self._stage = self._ovstage_exit_stack.enter_context(create_ovstage("isaaclab.ovrtx"))
         self._stage_paths = self._ovstage_exit_stack.enter_context(ovstage.PathDictionary(self._stage))
         # Ordinal 0 is the empty/unwritten state in ovstage; the first write must use >= 1.
         self._current_ordinal += 1
@@ -1891,7 +1842,7 @@ class OVRTXRenderer(BaseRenderer):
             env_query,
             "omni:xform",
             ordinal=self._current_ordinal,
-            tensors=_xform_tensor_from_numpy(env_root_xforms),
+            tensors=xform_tensor_from_numpy(env_root_xforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
@@ -2065,7 +2016,7 @@ class OVRTXRenderer(BaseRenderer):
             self._deformable_points_query,
             "omni:xform",
             ordinal=self._current_ordinal,
-            tensors=_xform_tensor_from_numpy(identity_xforms),
+            tensors=xform_tensor_from_numpy(identity_xforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
@@ -2076,10 +2027,10 @@ class OVRTXRenderer(BaseRenderer):
     def _setup_cable_bindings_ovstage(self) -> None:
         """Setup ovstage ``points`` bindings for Newton cables (``UsdGeom.BasisCurves``).
 
-        Mirrors :meth:`_setup_cable_bindings_legacy`, except that the per-frame write goes through a
-        host copy: ovstage 0.1.0's ``make_dltensor`` accepts the lanes=3 dtype override only on
-        numpy arrays, so a warp ``vec3f`` slice is rejected against the ``points`` column. The
-        endpoint kernel still runs on device; only the handover is host-side.
+        Mirrors :meth:`_setup_cable_bindings_legacy`: the endpoint kernel writes device memory and
+        the per-frame handover is zero-copy. The per-curve slices and their DLTensor descriptors are
+        built once here rather than per frame, because the layout is fixed for the lifetime of the
+        binding — only the contents of ``_cable_points`` change each step.
         """
         discovered = self._discover_cable_segment_bindings()
         if discovered is None:
@@ -2105,12 +2056,18 @@ class OVRTXRenderer(BaseRenderer):
             self._cable_points_query,
             "omni:xform",
             ordinal=self._current_ordinal,
-            tensors=_xform_tensor_from_numpy(identity_xforms),
+            tensors=xform_tensor_from_numpy(identity_xforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
 
         self._allocate_cable_device_buffers(flat_shape_ids, offsets, counts)
+        # The descriptors alias these slices, so both must outlive every write that uses them.
+        self._cable_point_slices = [
+            self._cable_points[offset + curve : offset + curve + segment_count + 1]
+            for curve, (offset, segment_count) in enumerate(zip(offsets, counts, strict=True))
+        ]
+        self._cable_point_tensors = [points_tensor_from_warp(points) for points in self._cable_point_slices]
 
     def _setup_particle_bindings_ovstage(self) -> None:
         """Setup OVRTX bindings for Newton particle clouds (ovstage path)."""
@@ -2160,7 +2117,7 @@ class OVRTXRenderer(BaseRenderer):
             self._particle_points_query,
             "omni:xform",
             ordinal=self._current_ordinal,
-            tensors=_xform_tensor_from_numpy(identity_xforms),
+            tensors=xform_tensor_from_numpy(identity_xforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
         ).wait()
@@ -2192,17 +2149,21 @@ class OVRTXRenderer(BaseRenderer):
             inputs=[object_transforms, self._object_newton_indices, body_q, self._object_scales],
             device=self._device,
         )
-        # Synchronize then copy to CPU numpy: ovstage's make_dltensor only accepts the lanes=16
-        # dtype override on numpy arrays, not DLPack producers. wp.mat44d exports as (N,4,4) lanes=1
-        # via DLPack, which conflicts with the lanes=16 omni:xform column created at population time.
-        wp.synchronize_device(self._device)
+        # The tensor is handed over zero-copy, so ovstage reads ``object_transforms`` in place and
+        # must not do so until the kernel above has landed. Passing the producing Warp stream as
+        # ``cuda_stream`` gives producer ordering: ovstage drains the work already queued on that
+        # stream before it touches the tensor. That replaces the device-wide
+        # ``wp.synchronize_device()`` with stream-scoped ordering and removes the host copy; it is
+        # not a nonblocking handoff, and the ``.wait()`` below can still block the calling thread.
+        # A GPU-side wait would need the event-based API instead.
         self._stage.write_attribute(
             self._object_xform_query,
             "omni:xform",
             ordinal=self._current_ordinal,
-            tensors=_xform_tensor_from_numpy(object_transforms.numpy().reshape(-1, 4, 4)),
+            tensors=xform_tensor_from_warp(object_transforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
+            cuda_stream=wp.get_stream(self._device).cuda_stream,
         ).wait()
 
     def _update_geometries_ovstage(self) -> None:
@@ -2221,19 +2182,10 @@ class OVRTXRenderer(BaseRenderer):
             if particle_q is None:
                 raise RuntimeError("Newton state has no particle_q but particle geometry queries exist")
 
-            # ovstage write_attribute needs one DLPack tensor per prim, not one flat ``particle_q``
-            # plus offsets. Synchronize then copy to CPU numpy once (shared by both queries below):
-            # the ``points`` column is ``point3f[]`` (lanes=3), and ovstage's make_dltensor only
-            # accepts the lanes=3 dtype override on numpy arrays, not DLPack producers. A warp
-            # ``vec3f`` slice exports as ``(N, 3)`` lanes=1, which is rejected as a type mismatch
-            # against the lanes=3 column.
-            wp.synchronize_device(self._device)
-            particle_np = particle_q.numpy()
-
             if self._deformable_points_query is not None:
                 self._write_particle_q_slices_ovstage(
                     self._deformable_points_query,
-                    particle_np,
+                    particle_q,
                     self._deformable_particle_offsets,
                     self._deformable_particle_counts,
                 )
@@ -2241,7 +2193,7 @@ class OVRTXRenderer(BaseRenderer):
             if self._particle_points_query is not None:
                 self._write_particle_q_slices_ovstage(
                     self._particle_points_query,
-                    particle_np,
+                    particle_q,
                     self._particle_visual_offsets,
                     self._particle_visual_counts,
                 )
@@ -2252,7 +2204,7 @@ class OVRTXRenderer(BaseRenderer):
     def _write_particle_q_slices_ovstage(
         self,
         query: Any,
-        particle_np: np.ndarray,
+        particle_q: wp.array,
         particle_offsets: list[int],
         particle_counts: list[int],
     ) -> None:
@@ -2260,15 +2212,22 @@ class OVRTXRenderer(BaseRenderer):
 
         Args:
             query: ovstage query selecting the prims whose ``points`` attribute is written.
-            particle_np: Host copy of Newton particle positions [m], shape ``[total_particles, 3]``.
-            particle_offsets: Start index of each prim's slice into Newton's ``particle_q``.
+            particle_q: Flat world-space particle positions [m], shape ``[total_particles]``,
+                dtype ``wp.vec3f``. Slices are passed zero-copy as CUDA DLTensors.
+            particle_offsets: Start index of each prim's slice into :paramref:`particle_q`.
             particle_counts: Number of particles in each prim's slice.
         """
         particle_slices = [
-            _points_tensor_from_numpy(particle_np[particle_offset : particle_offset + particle_count])
+            points_tensor_from_warp(particle_q[particle_offset : particle_offset + particle_count])
             for particle_offset, particle_count in zip(particle_offsets, particle_counts, strict=True)
         ]
 
+        # The slices alias ``particle_q`` and are handed over zero-copy, so ovstage must not read
+        # them until the Warp kernels that wrote ``particle_q`` have finished. Passing the producing
+        # Warp stream as ``cuda_stream`` gives producer ordering: ovstage drains the work already
+        # queued on that stream before it touches the slices. That replaces the device-wide
+        # ``wp.synchronize_device()`` with stream-scoped ordering and removes the host copy; it is
+        # not a nonblocking handoff, and the ``.wait()`` below can still block the calling thread.
         self._stage.write_attribute(
             query,
             "points",
@@ -2276,32 +2235,26 @@ class OVRTXRenderer(BaseRenderer):
             tensors=particle_slices,
             is_array=True,
             semantic=ovstage.AttributeSemantic.POINT,
+            cuda_stream=wp.get_stream(self._device).cuda_stream,
         ).wait()
 
     def _write_cable_points_ovstage(self) -> None:
         """Recompute world-space cable curve points on device and write them through ovstage."""
         self._compute_cable_points_world()
 
-        # ovstage write_attribute needs one DLPack tensor per prim, not one flat ``particle_q``
-        # plus offsets. Synchronize then copy to CPU numpy once (shared by both queries below):
-        # the ``points`` column is ``point3f[]`` (lanes=3), and ovstage's make_dltensor only
-        # accepts the lanes=3 dtype override on numpy arrays, not DLPack producers. A warp
-        # ``vec3f`` slice exports as ``(N, 3)`` lanes=1, which is rejected as a type mismatch
-        # against the lanes=3 column.
-        points_np = self._cable_points.numpy()
-        cable_slices = []
-        point_offset = 0
-        for segment_count in self._cable_segment_counts:
-            cable_slices.append(_points_tensor_from_numpy(points_np[point_offset : point_offset + segment_count + 1]))
-            point_offset += segment_count + 1
-
+        # The cached descriptors alias ``_cable_points`` and are handed over zero-copy, so ovstage
+        # must not read them until the kernel above has landed. Passing the producing Warp stream as
+        # ``cuda_stream`` gives producer ordering: ovstage drains the work already queued on that
+        # stream before it touches the slices. That keeps the handover off the host; it is not a
+        # nonblocking handoff, and the ``.wait()`` below can still block the calling thread.
         self._stage.write_attribute(
             self._cable_points_query,
             "points",
             ordinal=self._current_ordinal,
-            tensors=cable_slices,
+            tensors=self._cable_point_tensors,
             is_array=True,
             semantic=ovstage.AttributeSemantic.POINT,
+            cuda_stream=wp.get_stream(self._device).cuda_stream,
         ).wait()
 
     def _update_camera_ovstage(
@@ -2328,15 +2281,15 @@ class OVRTXRenderer(BaseRenderer):
             device=self._device,
         )
         if self._camera_xform_query is not None:
-            # Synchronize then copy to CPU numpy: same lanes=16 constraint as object transforms above.
-            wp.synchronize_device(self._device)
+            # Stream-ordered zero-copy handoff, as for the object transforms above.
             self._stage.write_attribute(
                 self._camera_xform_query,
                 "omni:xform",
                 ordinal=self._current_ordinal,
-                tensors=_xform_tensor_from_numpy(camera_transforms.numpy().reshape(-1, 4, 4)),
+                tensors=xform_tensor_from_warp(camera_transforms),
                 is_array=False,
                 semantic=ovstage.AttributeSemantic.MATRIX,
+                cuda_stream=wp.get_stream(self._device).cuda_stream,
             ).wait()
 
     def _render_ovstage(self, render_data: OVRTXRenderData) -> None:
@@ -2430,6 +2383,10 @@ class OVRTXRenderer(BaseRenderer):
         self._particle_visual_counts = []
         self._cable_segment_counts = []
         self._cable_max_points = 0
+        # Descriptors alias ``_cable_points``; drop them before the buffer so no cached
+        # DLTensor can outlive the device memory it points at.
+        self._cable_point_tensors = []
+        self._cable_point_slices = []
         self._cable_points = None
         self._cable_shape_ids = None
         self._cable_offsets = None

--- a/source/isaaclab_ov/isaaclab_ov/stage.py
+++ b/source/isaaclab_ov/isaaclab_ov/stage.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared helpers for creating ovstage stages and describing their attribute columns.
+
+``ovstage`` is a hard dependency of ``isaaclab_ov``, so it is imported unconditionally here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import ovstage
+import warp as wp
+
+# DLDataType for a 4x4 double matrix (``omni:xform`` column). ovstage stores omni:xform as one
+# 16-lane float64 element per prim; wp.mat44d maps to the same layout via __dlpack__.
+OVSTAGE_XFORM_DTYPE = ovstage.DLDataType(code=ovstage.DLDataTypeCode.kDLFloat, bits=64, lanes=16)
+
+# DLDataType for a float32 3-vector (``points`` column). ovstage stores ``point3f[] points`` as one
+# 3-lane float32 element per vertex.
+OVSTAGE_POINT_DTYPE = ovstage.DLDataType(code=ovstage.DLDataTypeCode.kDLFloat, bits=32, lanes=3)
+
+
+def create_ovstage(name: str) -> ovstage.Stage:
+    """Create an ovstage stage using Isaac Lab's process-wide stage configuration.
+
+    ovstage's hierarchy computation model drives its automatic world-transform updates. It is
+    process-scoped rather than per-stage: ovstage applies it when the first process reference is
+    acquired and raises if a later stage asks for a conflicting model while another stage is live.
+    Every Isaac Lab stage is therefore created through this helper so the whole process agrees on
+    one model.
+
+    :attr:`~ovstage.HierarchyComputationModel.CPU_INCREMENTAL` is requested explicitly rather than
+    left implicit, so the model in force is visible at the call site.
+    :attr:`~ovstage.HierarchyComputationModel.GPU_INCREMENTAL` is currently not working - objects
+    are out-of-place.  Needs investigation
+
+    Args:
+        name: Instance name used for ovstage diagnostics.
+
+    Returns:
+        The created :class:`ovstage.Stage`.
+    """
+    config = ovstage.StageConfig(
+        runtime_default_hierarchy_computation_model=ovstage.HierarchyComputationModel.CPU_INCREMENTAL
+    )
+    return ovstage.Stage(name, config=config)
+
+
+def xform_tensor_from_numpy(xforms: np.ndarray) -> ovstage.DLTensor:
+    """Wrap a ``(N, 4, 4)`` float64 host array as a 16-lane DLTensor for ``omni:xform`` writes.
+
+    Args:
+        xforms: Array of shape ``(N, 4, 4)`` with dtype ``float64``.
+
+    Returns:
+        A :class:`ovstage.DLTensor` with shape ``[N]`` and ``lanes=16``.
+    """
+    flat = np.ascontiguousarray(xforms, dtype=np.float64).reshape(-1)
+    return ovstage.make_dltensor(flat, dtype=OVSTAGE_XFORM_DTYPE, shape=[xforms.shape[0]])
+
+
+def xform_tensor_from_warp(xforms: wp.array) -> ovstage.DLTensor:
+    """Describe a warp ``mat44d`` array as a 16-lane DLTensor for ``omni:xform`` writes.
+
+    The array is consumed zero-copy through DLPack: a warp ``mat44d`` exports as ``(N, 4, 4)``
+    ``lanes=1``, and ovstage folds the trailing matrix axes into the ``lanes=16`` the column
+    expects. A device array therefore reaches ovstage without a host round-trip.
+
+    The caller owns the data: the returned tensor must stay alive until the consuming write
+    completes, and that write must be ordered against the kernels that produced
+    :paramref:`xforms` — pass their Warp stream as ``write_attribute(cuda_stream=...)``.
+
+    Args:
+        xforms: Warp array of shape ``[N]`` and dtype :class:`warp.mat44d`.
+
+    Returns:
+        A :class:`ovstage.DLTensor` with shape ``[N]`` and ``lanes=16``.
+    """
+    return ovstage.make_dltensor(xforms, dtype=OVSTAGE_XFORM_DTYPE)
+
+
+def points_tensor_from_warp(points: wp.array) -> ovstage.DLTensor:
+    """Describe a warp ``vec3f`` array as a 3-lane DLTensor for ``points`` writes.
+
+    The array is consumed zero-copy through DLPack: a warp ``vec3f`` exports as ``(N, 3)``
+    ``lanes=1``, and ovstage folds the trailing component axis into the ``lanes=3`` the
+    ``point3f[]`` column expects. A device array therefore reaches ovstage without a host
+    round-trip.
+
+    The caller owns the data: the returned tensor must stay alive until the consuming write
+    completes, and that write must be ordered against the kernels that produced
+    :paramref:`points` — pass their Warp stream as ``write_attribute(cuda_stream=...)``.
+
+    Args:
+        points: Warp array of shape ``[N]`` and dtype :class:`warp.vec3f`.
+
+    Returns:
+        A :class:`ovstage.DLTensor` with shape ``[N]`` and ``lanes=3``.
+    """
+    return ovstage.make_dltensor(points, dtype=OVSTAGE_POINT_DTYPE)

--- a/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
@@ -455,6 +455,7 @@ def test_manager_logs_when_serialized_stage_has_no_envs(caplog):
 
 def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
     """The manager owns OVStage from population through PhysX release."""
+    import isaaclab_ov.physics.ovphysx_manager as om_mod
     from isaaclab_ov.physics import OvPhysxManager
 
     events = []
@@ -491,7 +492,6 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
             events.append(("release",))
 
     fake_ovstage = ModuleType("ovstage")
-    fake_ovstage.Stage = FakeStage
     fake_ovstage.PopulationDomain = SimpleNamespace(ALL="all")
     fake_ovstage.population = SimpleNamespace(
         open_usd_from_string=lambda stage, usda, ordinal, domains: events.append(
@@ -499,6 +499,9 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
         )
     )
     monkeypatch.setitem(sys.modules, "ovstage", fake_ovstage)
+    # The manager builds its stage through the shared helper so every stage in the process gets
+    # the same ovstage configuration; that is the seam to fake, not ``ovstage.Stage``.
+    monkeypatch.setattr(om_mod, "create_ovstage", FakeStage)
 
     previous_physx = OvPhysxManager._physx
     previous_ovstage = getattr(OvPhysxManager, "_ovstage", None)
@@ -535,6 +538,7 @@ def test_manager_attaches_and_releases_owned_ovstage(monkeypatch):
 
 def test_manager_destroys_ovstage_when_population_fails(monkeypatch):
     """A failed in-memory population does not leak its OVStage allocation."""
+    import isaaclab_ov.physics.ovphysx_manager as om_mod
     from isaaclab_ov.physics import OvPhysxManager
 
     destroyed = []
@@ -550,10 +554,10 @@ def test_manager_destroys_ovstage_when_population_fails(monkeypatch):
         raise RuntimeError("population failed")
 
     fake_ovstage = ModuleType("ovstage")
-    fake_ovstage.Stage = FakeStage
     fake_ovstage.PopulationDomain = SimpleNamespace(ALL="all")
     fake_ovstage.population = SimpleNamespace(open_usd_from_string=fail_population)
     monkeypatch.setitem(sys.modules, "ovstage", fake_ovstage)
+    monkeypatch.setattr(om_mod, "create_ovstage", FakeStage)
 
     previous_ovstage = getattr(OvPhysxManager, "_ovstage", None)
     OvPhysxManager._ovstage = None

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -276,7 +276,7 @@ def test_clone_sources_ovstage_writes_plan_positions_after_cloning(monkeypatch: 
         xforms.append(value.copy())
         return "root_xforms"
 
-    monkeypatch.setattr("isaaclab_ov.renderers.ovrtx_renderer._xform_tensor_from_numpy", _record_xforms)
+    monkeypatch.setattr("isaaclab_ov.renderers.ovrtx_renderer.xform_tensor_from_numpy", _record_xforms)
 
     renderer._clone_sources_ovstage()
 

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -27,6 +27,9 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     import isaaclab_ov.renderers.ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
+
+    # ovstage is an unconditional dependency of isaaclab_ov, so it is importable here.
+    import ovstage  # noqa: E402
     from isaaclab_newton.physics import NewtonManager  # noqa: E402
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer  # noqa: E402
@@ -546,3 +549,44 @@ def test_update_geometries_writes_one_slice_per_cable(monkeypatch: pytest.Monkey
     # only guard against that -- the downgrade does not raise, it just renders from a stale copy.
     assert renderer._cable_points_binding.write_kwargs["data_access"] is DataAccess.ASYNC
     assert renderer._cable_points_binding.write_kwargs["cuda_stream"] == 1234
+
+
+@pytest.mark.skipif(not wp.get_cuda_device_count(), reason="requires a CUDA device")
+def test_write_particle_q_slices_ovstage_passes_device_slices_zero_copy():
+    """The ovstage points write hands ``particle_q`` slices to ovstage as CUDA DLTensors, without a host copy."""
+    renderer, _backend = _make_renderer_without_backend(device="cuda:0")
+    particle_q = wp.array(
+        [
+            wp.vec3f(-1.0, -1.0, -1.0),
+            wp.vec3f(1.0, 2.0, 3.0),
+            wp.vec3f(4.0, 5.0, 6.0),
+            wp.vec3f(7.0, 8.0, 9.0),
+        ],
+        dtype=wp.vec3f,
+        device="cuda:0",
+    )
+    writes: list[dict] = []
+
+    def _write(query, attribute, **kwargs):
+        writes.append({"query": query, "attribute": attribute, **kwargs})
+        return SimpleNamespace(wait=lambda: None)
+
+    renderer._stage = SimpleNamespace(write_attribute=_write)
+    renderer._current_ordinal = 7
+
+    renderer._write_particle_q_slices_ovstage("points_query", particle_q, [1], [3])
+
+    assert len(writes) == 1
+    assert writes[0]["attribute"] == "points"
+    assert writes[0]["is_array"] is True
+    # The slices alias ``particle_q``, so ovstage is handed the producing Warp stream to order its
+    # read against, rather than the caller blocking the host on a device synchronize.
+    assert writes[0]["cuda_stream"] == wp.get_stream("cuda:0").cuda_stream
+    tensors = writes[0]["tensors"]
+    assert len(tensors) == 1
+    # A zero-copy device view: the descriptor points straight at the slice's own CUDA buffer with
+    # the trailing component axis folded into point3f's three lanes.
+    assert tensors[0].device.device_type.value == ovstage.DLDeviceType.kDLCUDA
+    assert tensors[0].data == particle_q[1:4].ptr
+    assert tensors[0].shape_tuple == (3,)
+    assert tensors[0].dtype.lanes == 3

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -370,26 +370,15 @@ def test_ovrtx_use_ovstage_defaults_to_disabled(monkeypatch):
     assert ovrtx_use_ovstage_enabled() is False
 
 
-def test_ovrtx_use_ovstage_enabled_when_requested_and_available(monkeypatch):
-    """Setting the variable to 1 selects the ovstage path when ovstage is importable."""
+def test_ovrtx_use_ovstage_enabled_when_requested(monkeypatch):
+    """Setting the variable to 1 selects the ovstage path."""
     monkeypatch.setenv("ISAAC_LAB_OVRTX_USE_OVSTAGE", "1")
-    monkeypatch.setattr(ovrtx_renderer_module, "_OVSTAGE_AVAILABLE", True)
     assert ovrtx_use_ovstage_enabled() is True
-
-
-def test_ovrtx_use_ovstage_raises_when_requested_but_unavailable(monkeypatch):
-    """An explicit opt-in must fail loudly rather than silently falling back to the legacy path."""
-    monkeypatch.setenv("ISAAC_LAB_OVRTX_USE_OVSTAGE", "1")
-    monkeypatch.setattr(ovrtx_renderer_module, "_OVSTAGE_AVAILABLE", False)
-
-    with pytest.raises(RuntimeError, match="uv run --extra ovrtx"):
-        ovrtx_use_ovstage_enabled()
 
 
 def test_ovrtx_use_ovstage_rejects_non_boolean_values(monkeypatch):
     """Values other than 0/1 are a configuration error, not a silent disable."""
     monkeypatch.setenv("ISAAC_LAB_OVRTX_USE_OVSTAGE", "true")
-    monkeypatch.setattr(ovrtx_renderer_module, "_OVSTAGE_AVAILABLE", True)
 
     with pytest.raises(ValueError, match="Expected 0 or 1"):
         ovrtx_use_ovstage_enabled()


### PR DESCRIPTION


# Description

ovstage 0.1.1 fixes nvbug 6490020 so the OVRTX ovstage path no longer needs its per-frame host round-trip

- Write transforms and points straight from their Warp GPU buffers; make_dltensor now folds a producer's trailing axes into the lane count omni:xform and points expect.
- Order those writes with write_attribute(cuda_stream=...) instead of blocking the host on wp.synchronize_device, as the legacy binding path already does.
- Drop the _OVSTAGE_AVAILABLE guard: ovstage is an unconditional dependency of isaaclab_ov, so the fallback was unreachable.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

