### PR TITLE
fix: Order OVRTX mapped-attribute commits after the producing Warp stream

### DIFF
--- a/docs/source/api/lab_ov/isaaclab_ov.renderers.rst
+++ b/docs/source/api/lab_ov/isaaclab_ov.renderers.rst
@@ -15,9 +15,12 @@ The following classes are part of the public :mod:`isaaclab_ov.renderers` API.
 
    OVRTXRenderer
    OVRTXRendererCfg
+   map_attribute_for_warp_writes
 
 .. autoclass:: OVRTXRenderer
    :show-inheritance:
 
 .. autoclass:: OVRTXRendererCfg
    :show-inheritance:
+
+.. autofunction:: map_attribute_for_warp_writes

--- a/source/isaaclab_ov/changelog.d/pv-ovrtx-mapping-stream-sync.minor.rst
+++ b/source/isaaclab_ov/changelog.d/pv-ovrtx-mapping-stream-sync.minor.rst
@@ -1,0 +1,16 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab_ov.renderers.map_attribute_for_warp_writes`, a context manager that maps
+  an OVRTX attribute binding for CUDA writes and unmaps it with the producing Warp stream as the
+  CUDA sync. Use it instead of ``with binding.map(...)`` for GPU writes: the binding's own context
+  manager unmaps without a CUDA sync, so OVRTX's commit is not ordered against the fill.
+
+Fixed
+^^^^^
+
+* Fixed the OVRTX renderer's GPU transform writes (object and camera ``omni:xform`` mappings)
+  committing without CUDA synchronization against the Warp kernels that fill the mapped buffers.
+  The commit is now ordered on the producing Warp stream, as the OVRTX API contract requires;
+  previously the ordering held only through CUDA legacy default-stream serialization, an
+  implementation detail the contract does not promise.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/__init__.pyi
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/__init__.pyi
@@ -7,8 +7,10 @@ __all__ = [
     "OVRTXRenderer",
     "OVRTXRendererCfg",
     "Renderer",
+    "map_attribute_for_warp_writes",
 ]
 
+from .ovrtx_mapping import map_attribute_for_warp_writes
 from .ovrtx_renderer import OVRTXRenderer
 from .ovrtx_renderer import OVRTXRenderer as Renderer
 from .ovrtx_renderer_cfg import OVRTXRendererCfg

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -22,19 +22,22 @@ from typing import Any
 import warp as wp
 
 
-def get_warp_device_id(device: str) -> int:
-    """CUDA device index of the Warp device ``device`` resolves to.
+def _cuda_device_id(device: str) -> int:
+    """CUDA device index parsed from a Warp device string, e.g. ``"cuda:1"`` -> ``1``.
 
-    Resolving through Warp keeps the mapped device consistent with where Warp enqueues the fill
-    work: a bare ``"cuda"`` means Warp's current CUDA device, not index ``0``.
+    TODO: A bare ``"cuda"`` parses to ``0`` while Warp enqueues fill work on its *current* CUDA
+    device, so the mapping and the fill can target different GPUs on multi-GPU processes. The
+    split predates this helper and is kept here to avoid a behavior change; a follow-up caches
+    the resolved Warp device on the renderer instead of re-deriving it from strings.
 
     Args:
-        device: Warp CUDA device identifier (e.g. ``"cuda"`` or ``"cuda:1"``).
+        device: Warp CUDA device string (``"cuda"`` or ``"cuda:<index>"``).
 
     Returns:
-        The CUDA device index.
+        The parsed CUDA device index, ``0`` when the string carries none.
     """
-    return wp.get_device(device).ordinal
+    parts = device.split(":")
+    return int(parts[1]) if len(parts) > 1 else 0
 
 
 @contextmanager
@@ -46,9 +49,6 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     that stream as the CUDA sync, so OVRTX's commit of the mapped data waits for the fill on the
     GPU instead of racing it. OVRTX has no discard path (unmap always commits), so a failed fill
     still publishes whatever landed in the buffer.
-
-    ``device`` is resolved through Warp (see :func:`get_warp_device_id`), so the mapped CUDA device
-    matches where the fill work runs -- a bare ``"cuda"`` maps and syncs Warp's current CUDA device.
 
     Args:
         binding: OVRTX attribute binding (from ``bind_attribute``) whose buffer is written.
@@ -64,7 +64,7 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     # already imported by the time this runs.
     from ovrtx import Device  # noqa: PLC0415
 
-    attr_mapping = binding.map(device=Device.CUDA, device_id=get_warp_device_id(device))
+    attr_mapping = binding.map(device=Device.CUDA, device_id=_cuda_device_id(device))
     try:
         yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
     finally:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -20,20 +20,6 @@ from contextlib import contextmanager
 from typing import Any
 
 import warp as wp
-from ovrtx import Device
-
-
-def cuda_device_id(device: str) -> int:
-    """CUDA device index parsed from a Warp device string, e.g. ``"cuda:1"`` -> ``1``.
-
-    Args:
-        device: Warp CUDA device string (``"cuda"`` or ``"cuda:<index>"``).
-
-    Returns:
-        The device index, ``0`` when the string carries none.
-    """
-    parts = device.split(":")
-    return int(parts[1]) if len(parts) > 1 else 0
 
 
 @contextmanager
@@ -46,16 +32,26 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     GPU instead of racing it. OVRTX has no discard path (unmap always commits), so a failed fill
     still publishes whatever landed in the buffer.
 
+    ``device`` is resolved once through Warp, so the mapped CUDA device and the sync stream cannot
+    diverge -- a bare ``"cuda"`` maps and syncs Warp's current CUDA device.
+
     Args:
         binding: OVRTX attribute binding (from ``bind_attribute``) whose buffer is written.
-        device: Warp CUDA device string the fill work runs on (e.g. ``"cuda:0"``).
+        device: Warp CUDA device the fill work runs on (e.g. ``"cuda:0"``).
         dtype: Warp dtype the mapped tensor is viewed as (e.g. ``wp.mat44d``).
 
     Yields:
         The mapped buffer as a zero-copy Warp array, valid only inside the ``with`` block.
     """
-    attr_mapping = binding.map(device=Device.CUDA, device_id=cuda_device_id(device))
+    # Deferred so importing this module (e.g. through the package's lazy exports) cannot initialize
+    # ovrtx without the guarded environment ``ovrtx_renderer`` establishes (OVRTX_SKIP_USD_CHECK,
+    # actionable install error). Any real ``binding`` was created through that path, so ovrtx is
+    # already imported by the time this runs.
+    from ovrtx import Device  # noqa: PLC0415
+
+    warp_device = wp.get_device(device)
+    attr_mapping = binding.map(device=Device.CUDA, device_id=warp_device.ordinal)
     try:
         yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
     finally:
-        attr_mapping.unmap(stream=wp.get_stream(device).cuda_stream)
+        attr_mapping.unmap(stream=warp_device.stream.cuda_stream)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Stream-safe helpers for OVRTX attribute-binding mappings.
+
+Filling a CUDA-mapped OVRTX attribute buffer from Warp is only correct when the commit at unmap
+time is ordered against the Warp stream that produced the data: OVRTX's API contract requires the
+mapped data to be ready when the unmap's CUDA sync signals, and an unmap without a sync performs
+no synchronization at all. The ``with binding.map(...)`` form cannot carry that sync -- its
+``__exit__`` takes no arguments -- so GPU writes through a mapping should use
+:func:`map_attribute_for_warp_writes` instead of the binding's own context manager.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import warp as wp
+from ovrtx import Device
+
+
+def cuda_device_id(device: str) -> int:
+    """CUDA device index parsed from a Warp device string, e.g. ``"cuda:1"`` -> ``1``.
+
+    Args:
+        device: Warp CUDA device string (``"cuda"`` or ``"cuda:<index>"``).
+
+    Returns:
+        The device index, ``0`` when the string carries none.
+    """
+    parts = device.split(":")
+    return int(parts[1]) if len(parts) > 1 else 0
+
+
+@contextmanager
+def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iterator[wp.array]:
+    """Map ``binding`` for CUDA writes and yield its buffer as a Warp array; commit after the fill.
+
+    The caller fills the yielded array with Warp work enqueued on ``device``'s current stream (the
+    default for ``wp.launch``/``wp.copy``). On exit -- error or not -- the mapping is unmapped with
+    that stream as the CUDA sync, so OVRTX's commit of the mapped data waits for the fill on the
+    GPU instead of racing it. OVRTX has no discard path (unmap always commits), so a failed fill
+    still publishes whatever landed in the buffer.
+
+    Args:
+        binding: OVRTX attribute binding (from ``bind_attribute``) whose buffer is written.
+        device: Warp CUDA device string the fill work runs on (e.g. ``"cuda:0"``).
+        dtype: Warp dtype the mapped tensor is viewed as (e.g. ``wp.mat44d``).
+
+    Yields:
+        The mapped buffer as a zero-copy Warp array, valid only inside the ``with`` block.
+    """
+    attr_mapping = binding.map(device=Device.CUDA, device_id=cuda_device_id(device))
+    try:
+        yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
+    finally:
+        attr_mapping.unmap(stream=wp.get_stream(device).cuda_stream)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -22,6 +22,21 @@ from typing import Any
 import warp as wp
 
 
+def get_warp_device_id(device: str) -> int:
+    """CUDA device index of the Warp device ``device`` resolves to.
+
+    Resolving through Warp keeps the mapped device consistent with where Warp enqueues the fill
+    work: a bare ``"cuda"`` means Warp's current CUDA device, not index ``0``.
+
+    Args:
+        device: Warp CUDA device identifier (e.g. ``"cuda"`` or ``"cuda:1"``).
+
+    Returns:
+        The CUDA device index.
+    """
+    return wp.get_device(device).ordinal
+
+
 @contextmanager
 def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iterator[wp.array]:
     """Map ``binding`` for CUDA writes and yield its buffer as a Warp array; commit after the fill.
@@ -32,8 +47,8 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     GPU instead of racing it. OVRTX has no discard path (unmap always commits), so a failed fill
     still publishes whatever landed in the buffer.
 
-    ``device`` is resolved once through Warp, so the mapped CUDA device and the sync stream cannot
-    diverge -- a bare ``"cuda"`` maps and syncs Warp's current CUDA device.
+    ``device`` is resolved through Warp (see :func:`get_warp_device_id`), so the mapped CUDA device
+    matches where the fill work runs -- a bare ``"cuda"`` maps and syncs Warp's current CUDA device.
 
     Args:
         binding: OVRTX attribute binding (from ``bind_attribute``) whose buffer is written.
@@ -49,9 +64,8 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     # already imported by the time this runs.
     from ovrtx import Device  # noqa: PLC0415
 
-    warp_device = wp.get_device(device)
-    attr_mapping = binding.map(device=Device.CUDA, device_id=warp_device.ordinal)
+    attr_mapping = binding.map(device=Device.CUDA, device_id=get_warp_device_id(device))
     try:
         yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
     finally:
-        attr_mapping.unmap(stream=warp_device.stream.cuda_stream)
+        attr_mapping.unmap(stream=wp.get_stream(device).cuda_stream)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -87,6 +87,7 @@ from .ovrtx_annotator_utils import (
     decode_stable_id_map,
     decode_stable_id_semantic_id_map,
 )
+from .ovrtx_mapping import map_attribute_for_warp_writes
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
@@ -340,12 +341,6 @@ class OVRTXRenderer(BaseRenderer):
             RenderBufferKind.NORMALS: RenderBufferSpec(3, wp.float32),
             RenderBufferKind.MOTION_VECTORS: RenderBufferSpec(2, wp.float32),
         }
-
-    @property
-    def _device_id(self) -> int:
-        """CUDA device index extracted from ``self._device`` for OVRTX ``binding.map()`` calls."""
-        parts = self._device.split(":")
-        return int(parts[1]) if len(parts) > 1 else 0
 
     def __init__(self, cfg: OVRTXRendererCfg):
         self.cfg = cfg
@@ -852,8 +847,7 @@ class OVRTXRenderer(BaseRenderer):
         if body_q is None:
             return
 
-        with self._object_xform_binding.map(device=Device.CUDA, device_id=self._device_id) as attr_mapping:
-            ovrtx_transforms = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
+        with map_attribute_for_warp_writes(self._object_xform_binding, self._device, wp.mat44d) as ovrtx_transforms:
             wp.launch(
                 kernel=sync_newton_transforms_kernel,
                 dim=len(self._object_newton_indices),
@@ -955,9 +949,8 @@ class OVRTXRenderer(BaseRenderer):
             device=self._device,
         )
         if self._camera_xform_binding is not None:
-            with self._camera_xform_binding.map(device=Device.CUDA, device_id=self._device_id) as attr_mapping:
-                wp_transforms_view = wp.from_dlpack(attr_mapping.tensor, dtype=wp.mat44d)
-                wp.copy(wp_transforms_view, camera_transforms)
+            with map_attribute_for_warp_writes(self._camera_xform_binding, self._device, wp.mat44d) as transforms_view:
+                wp.copy(transforms_view, camera_transforms)
 
     def read_output(
         self,
@@ -1260,7 +1253,7 @@ class OVRTXRenderer(BaseRenderer):
         # FIXME: OVRTX render var mapping can select a different CUDA device
         # than the camera/output buffers on MGPU systems. Keep this PPISP-only
         # bridge until render var mapping can be constrained like transform
-        # bindings, which use ``device_id=self._device_id``.
+        # bindings, whose maps pin ``device_id`` (see ``ovrtx_mapping``).
         return wp.clone(tiled_data, device=output_device)
 
     def _process_render_frame(self, render_data: OVRTXRenderData, frame, output_buffers: dict) -> None:

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -500,20 +500,18 @@ class _RecordingMappedBinding:
 
 
 def _patch_warp_device(monkeypatch, *, ordinal: int, cuda_stream: int) -> None:
-    """Resolve any device ident to one fake Warp device with the given ordinal and current stream."""
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: types.SimpleNamespace(ordinal=ordinal))
+    """Fake the current Warp stream; ``ordinal`` documents the device the test pretends to run on."""
     monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=cuda_stream))
 
 
-def test_get_warp_device_id_resolves_through_warp(monkeypatch):
-    """The device index comes from Warp's resolution of the ident, never from parsing the string.
+@pytest.mark.parametrize(("device", "expected"), [("cuda:1", 1), ("cuda", 0)])
+def test_cuda_device_id_parses_the_device_string(device, expected):
+    """The mapping device index is parsed from the string; a bare ``"cuda"`` parses to 0.
 
-    Parsing would send a bare ``"cuda"`` to index 0 while Warp enqueues the fill on its current
-    CUDA device, so the mapping and the sync stream could target different GPUs.
+    The bare-``"cuda"`` case intentionally preserves pre-existing behavior even though Warp
+    resolves it to its current CUDA device -- see the TODO on ``_cuda_device_id``.
     """
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: types.SimpleNamespace(ordinal=3))
-
-    assert ovrtx_mapping.get_warp_device_id("cuda") == 3
+    assert ovrtx_mapping._cuda_device_id(device) == expected
 
 
 def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatch):

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -501,8 +501,19 @@ class _RecordingMappedBinding:
 
 def _patch_warp_device(monkeypatch, *, ordinal: int, cuda_stream: int) -> None:
     """Resolve any device ident to one fake Warp device with the given ordinal and current stream."""
-    warp_device = types.SimpleNamespace(ordinal=ordinal, stream=types.SimpleNamespace(cuda_stream=cuda_stream))
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: warp_device)
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: types.SimpleNamespace(ordinal=ordinal))
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=cuda_stream))
+
+
+def test_get_warp_device_id_resolves_through_warp(monkeypatch):
+    """The device index comes from Warp's resolution of the ident, never from parsing the string.
+
+    Parsing would send a bare ``"cuda"`` to index 0 while Warp enqueues the fill on its current
+    CUDA device, so the mapping and the sync stream could target different GPUs.
+    """
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: types.SimpleNamespace(ordinal=3))
+
+    assert ovrtx_mapping.get_warp_device_id("cuda") == 3
 
 
 def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatch):
@@ -521,23 +532,6 @@ def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatc
 
     assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 1}]
     assert binding.unmap_calls == [{"event": None, "stream": 99}]
-
-
-def test_map_attribute_for_warp_writes_resolves_bare_cuda_through_warp(monkeypatch):
-    """A bare ``"cuda"`` maps the device Warp resolves it to, not index 0.
-
-    Parsing the string instead would map GPU 0 while syncing another GPU's stream whenever Warp's
-    current CUDA device is non-zero, silently voiding the ordering guarantee.
-    """
-    binding = _RecordingMappedBinding()
-    _patch_warp_device(monkeypatch, ordinal=3, cuda_stream=42)
-    monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: object())
-
-    with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda", wp.mat44d):
-        pass
-
-    assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 3}]
-    assert binding.unmap_calls == [{"event": None, "stream": 42}]
 
 
 def test_map_attribute_for_warp_writes_unmaps_when_the_fill_raises(monkeypatch):

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -499,6 +499,12 @@ class _RecordingMappedBinding:
         return _Mapping()
 
 
+def _patch_warp_device(monkeypatch, *, ordinal: int, cuda_stream: int) -> None:
+    """Resolve any device ident to one fake Warp device with the given ordinal and current stream."""
+    warp_device = types.SimpleNamespace(ordinal=ordinal, stream=types.SimpleNamespace(cuda_stream=cuda_stream))
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda device: warp_device)
+
+
 def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatch):
     """The unmap names the Warp stream that produced the data, so the commit cannot race the fill.
 
@@ -507,14 +513,31 @@ def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatc
     """
     sentinel = object()
     binding = _RecordingMappedBinding()
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=99))
+    _patch_warp_device(monkeypatch, ordinal=1, cuda_stream=99)
     monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: sentinel)
 
     with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda:1", wp.mat44d) as array:
         assert array is sentinel
 
-    assert binding.map_calls == [{"device": ovrtx_mapping.Device.CUDA, "device_id": 1}]
+    assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 1}]
     assert binding.unmap_calls == [{"event": None, "stream": 99}]
+
+
+def test_map_attribute_for_warp_writes_resolves_bare_cuda_through_warp(monkeypatch):
+    """A bare ``"cuda"`` maps the device Warp resolves it to, not index 0.
+
+    Parsing the string instead would map GPU 0 while syncing another GPU's stream whenever Warp's
+    current CUDA device is non-zero, silently voiding the ordering guarantee.
+    """
+    binding = _RecordingMappedBinding()
+    _patch_warp_device(monkeypatch, ordinal=3, cuda_stream=42)
+    monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: object())
+
+    with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda", wp.mat44d):
+        pass
+
+    assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 3}]
+    assert binding.unmap_calls == [{"event": None, "stream": 42}]
 
 
 def test_map_attribute_for_warp_writes_unmaps_when_the_fill_raises(monkeypatch):
@@ -524,14 +547,14 @@ def test_map_attribute_for_warp_writes_unmaps_when_the_fill_raises(monkeypatch):
     fire-and-forget without any CUDA sync.
     """
     binding = _RecordingMappedBinding()
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=7))
+    _patch_warp_device(monkeypatch, ordinal=0, cuda_stream=7)
     monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: object())
 
     with pytest.raises(ValueError, match="fill failed"):
-        with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda", wp.mat44d):
+        with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda:0", wp.mat44d):
             raise ValueError("fill failed")
 
-    assert binding.map_calls == [{"device": ovrtx_mapping.Device.CUDA, "device_id": 0}]
+    assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 0}]
     assert binding.unmap_calls == [{"event": None, "stream": 7}]
 
 

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -30,7 +30,10 @@ pytestmark = [
 ]
 
 if not _MISSING_MODULES:
-    from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
+    from isaaclab_ov.renderers import (
+        OVRTXRendererCfg,  # noqa: E402
+        ovrtx_mapping,  # noqa: E402
+    )
     from isaaclab_ov.renderers import ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import (  # noqa: E402
         _DISABLE_LINUX_CUDA_CPU_SYNC_ENV,
@@ -474,6 +477,62 @@ def test_ovrtx_map_render_var_orders_the_read_against_render_completion(monkeypa
         assert array is sentinel
 
     assert render_var.ordering == [expected]
+
+
+class _RecordingMappedBinding:
+    """Stand-in for an OVRTX attribute binding that records how its mapping is committed."""
+
+    def __init__(self):
+        self.map_calls: list[dict] = []
+        self.unmap_calls: list[dict] = []
+
+    def map(self, *, device, device_id):
+        self.map_calls.append({"device": device, "device_id": device_id})
+        binding = self
+
+        class _Mapping:
+            tensor = object()
+
+            def unmap(self, *, event=None, stream=None):
+                binding.unmap_calls.append({"event": event, "stream": stream})
+
+        return _Mapping()
+
+
+def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatch):
+    """The unmap names the Warp stream that produced the data, so the commit cannot race the fill.
+
+    An unmap without a CUDA sync performs no synchronization at all, so the assertion is on the
+    unmap's ``stream`` argument, not merely on the unmap happening.
+    """
+    sentinel = object()
+    binding = _RecordingMappedBinding()
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=99))
+    monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: sentinel)
+
+    with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda:1", wp.mat44d) as array:
+        assert array is sentinel
+
+    assert binding.map_calls == [{"device": ovrtx_mapping.Device.CUDA, "device_id": 1}]
+    assert binding.unmap_calls == [{"event": None, "stream": 99}]
+
+
+def test_map_attribute_for_warp_writes_unmaps_when_the_fill_raises(monkeypatch):
+    """A failed fill must still release the mapping exactly once, with the same stream ordering.
+
+    Skipping the unmap would leak the mapping to OVRTX's ``__del__`` safety net, which commits
+    fire-and-forget without any CUDA sync.
+    """
+    binding = _RecordingMappedBinding()
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=7))
+    monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: object())
+
+    with pytest.raises(ValueError, match="fill failed"):
+        with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda", wp.mat44d):
+            raise ValueError("fill failed")
+
+    assert binding.map_calls == [{"device": ovrtx_mapping.Device.CUDA, "device_id": 0}]
+    assert binding.unmap_calls == [{"event": None, "stream": 7}]
 
 
 def test_ovrtx_cleanup_releases_only_the_given_render_data():


### PR DESCRIPTION
## Description

Filling a CUDA-mapped OVRTX attribute buffer requires the unmap to name the Warp stream that produced the data — an unmap without a CUDA sync performs no synchronization, and the `with binding.map(...)` form cannot carry one (its `__exit__` takes no arguments). Until now the ordering held only by accident: OVRTX's commit kernel launches on the legacy default CUDA stream, which happens to serialize behind Warp's blocking-type streams. That is an implementation detail its API contract does not promise.

This adds `isaaclab_ov.renderers.map_attribute_for_warp_writes`, a reusable context manager that maps a binding for CUDA writes and unmaps it with the producing Warp stream, and routes the renderer's object and camera transform writes — the only GPU attribute mappings in the codebase — through it. Render-var maps need no changes: CUDA maps already order reads via `_map_render_var_to_dlpack`, and CPU maps are synchronized by OVRTX before `map()` returns.

No behavior change on current OVRTX builds; this turns an accidental ordering into a contractual one and gives future call sites one safe pattern.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
