### PR TITLE
[Tasks] Fix composite physics preset selection

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -148,6 +148,7 @@ Guidelines for modifications:
 * Mingxue Gu
 * Mingyu Lee
 * Muhong Guo
+* Mustafa Haiderbhai
 * Narendra Dahile
 * Neel Anand Jawale
 * Nicola Loi

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -148,7 +148,6 @@ Guidelines for modifications:
 * Mingxue Gu
 * Mingyu Lee
 * Muhong Guo
-* Mustafa Haiderbhai
 * Narendra Dahile
 * Neel Anand Jawale
 * Nicola Loi

--- a/docs/source/concepts/backends_and_presets.rst
+++ b/docs/source/concepts/backends_and_presets.rst
@@ -230,6 +230,11 @@ Keep backend-specific values inside named configurations whenever possible.
 This keeps task logic shared and makes every supported choice visible from the
 command line.
 
+When backend selection must also change simulation-wide settings such as the
+time step, a physics preset may instead contain complete ``SimulationCfg``
+alternatives. The ``physics=`` selector recognizes these bundles from their
+``physics`` field and applies the complete matching simulation configuration.
+
 
 Where to go next
 ----------------

--- a/source/isaaclab_tasks/changelog.d/fix-composite-physics-presets.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-composite-physics-presets.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``physics=`` selectors rejecting physics presets that bundle a complete simulation configuration.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/hydra.py
@@ -319,7 +319,7 @@ def _pick_alternative(
             consumed_selected.add(name)
         if typed_hits is not None:
             # record which typed targets (physics/renderer) this name landed on
-            targets = {t for t in PresetTarget if t.base_classes and isinstance(val, t.base_classes)}
+            targets = {target for target in PresetTarget if target.base_classes and target.matches(val)}
             if targets:
                 typed_hits.setdefault(raw_name, set()).update(targets)
                 typed_hits.setdefault(name, set()).update(targets)

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
@@ -367,9 +367,9 @@ def _enumerate_agents(task_name: str, agent_library: str) -> tuple[list[str], di
 def _bucket_variants_by_target(walked: dict) -> dict[PresetTarget, set[str]]:
     """Convert :func:`collect_presets` output into ``{target: set[name]}``.
 
-    Routes each ``(name, cfg)`` by ``isinstance(cfg, target.base_classes)``;
-    cfgs matching no typed target fall into ``DOMAIN``. The implicit
-    ``default`` field is filtered -- it's the fallback, not a selectable name.
+    Routes each ``(name, cfg)`` through :meth:`PresetTarget.matches`; cfgs
+    matching no typed target fall into ``DOMAIN``. The implicit ``default``
+    field is filtered -- it's the fallback, not a selectable name.
 
     Routing by class hierarchy means new backends subclassing
     :class:`~isaaclab.physics.PhysicsCfg` /
@@ -383,7 +383,7 @@ def _bucket_variants_by_target(walked: dict) -> dict[PresetTarget, set[str]]:
             if name == "default":
                 continue
             matched = next(
-                (t for t in typed_targets if isinstance(cfg, t.base_classes)),
+                (target for target in typed_targets if target.matches(cfg)),
                 PresetTarget.DOMAIN,
             )
             result[matched].add(name)

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_cli.py
@@ -259,9 +259,9 @@ class _DescriptionBuilder:
 
     @staticmethod
     def _description(target: PresetTarget) -> str:
-        """One-line description; for typed targets includes the cfg base class name."""
+        """One-line description of a selector's semantic target."""
         if target.base_classes:
-            return f"(typed) selects a {target.base_classes[0].__name__} variant"
+            return f"(typed) selects a {target.value} backend"
         return "broadcast: applied to every matching PresetCfg"
 
 
@@ -371,10 +371,11 @@ def _bucket_variants_by_target(walked: dict) -> dict[PresetTarget, set[str]]:
     matching no typed target fall into ``DOMAIN``. The implicit ``default``
     field is filtered -- it's the fallback, not a selectable name.
 
-    Routing by class hierarchy means new backends subclassing
+    Direct routing by class hierarchy means new backends subclassing
     :class:`~isaaclab.physics.PhysicsCfg` /
     :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` bucket automatically
-    regardless of what name the env_cfg gives the field.
+    regardless of what name the env_cfg gives the field. Targets may also
+    recognize documented container shapes through :meth:`PresetTarget.matches`.
     """
     typed_targets = [t for t in PresetTarget if t.base_classes]
     result: dict[PresetTarget, set[str]] = {target: set() for target in PresetTarget}

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -12,7 +12,7 @@ needs to know about that category in one place:
   ``physics=NAME``) and ``self.value``.
 * ``base_classes`` -- the cfg base classes whose subclass instances belong to
   this bucket. Help-time bucketing in :mod:`isaaclab_tasks.utils.preset_cli`
-  routes variants by ``isinstance`` against these. Empty for
+  routes variants through :meth:`PresetTarget.matches`. Empty for
   :attr:`PresetTarget.DOMAIN`, which is the catch-all whose membership is
   "no typed target matched".
 * ``legacy_aliases`` -- deprecated-name to canonical-name table for this
@@ -29,6 +29,7 @@ import functools
 
 from isaaclab.physics import PhysicsCfg
 from isaaclab.renderers.renderer_cfg import RendererCfg
+from isaaclab.sim import SimulationCfg
 
 
 class PresetTarget(enum.Enum):
@@ -36,18 +37,20 @@ class PresetTarget(enum.Enum):
 
     **Bucketing contract.** Help-time bucketing in
     :mod:`isaaclab_tasks.utils.preset_cli` routes each preset variant to a
-    typed target by checking ``isinstance(cfg_value, target.base_classes)``
-    against every typed target's bases. A variant whose cfg value does *not*
-    subclass any typed target's base falls into :attr:`DOMAIN` and shows up
-    under the ``presets:`` catch-all in ``--help``.
+    typed target through :meth:`matches`. A variant whose cfg value does not
+    match any typed target falls into :attr:`DOMAIN` and shows up under the
+    ``presets:`` catch-all in ``--help``.
 
-    To opt into the typed ``physics`` / ``renderer`` help-text listing,
-    a backend's cfg class must subclass :class:`~isaaclab.physics.PhysicsCfg`
-    or :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` respectively.
-    A variant whose class does *not* subclass either base still **resolves
-    correctly at runtime** -- hydra applies the selected name across every
-    matching ``PresetCfg`` field regardless of class; the typed bucketing only
-    governs which header it appears under in ``--help``.
+    To opt into the typed ``physics`` / ``renderer`` help-text listing, a
+    backend's cfg class must subclass :class:`~isaaclab.physics.PhysicsCfg` or
+    :class:`~isaaclab.renderers.renderer_cfg.RendererCfg` respectively. Physics
+    presets may also wrap a physics config in a complete
+    :class:`~isaaclab.sim.SimulationCfg` when backend selection must change
+    simulation-wide settings such as the time step.
+    A variant that matches neither typed target still **resolves correctly at
+    runtime** -- hydra applies the selected name across every matching
+    ``PresetCfg`` field regardless of class; the typed bucketing only governs
+    which header it appears under in ``--help``.
 
     Adding a new target = appending one enum member.
     """
@@ -117,6 +120,22 @@ class PresetTarget(enum.Enum):
         obj.base_classes = tuple(base_classes)
         obj.legacy_aliases = dict(legacy_aliases) if legacy_aliases else {}
         return obj
+
+    def matches(self, cfg: object) -> bool:
+        """Return whether a preset value belongs to this typed target.
+
+        A physics preset may contain a complete simulation configuration when
+        backend-specific settings extend beyond the physics config itself.
+
+        Args:
+            cfg: Preset alternative to classify.
+
+        Returns:
+            Whether the alternative belongs to this target.
+        """
+        if isinstance(cfg, self.base_classes):
+            return True
+        return self is PresetTarget.PHYSICS and isinstance(cfg, SimulationCfg) and isinstance(cfg.physics, PhysicsCfg)
 
     @classmethod
     @functools.cache

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/preset_target.py
@@ -10,16 +10,16 @@ needs to know about that category in one place:
 
 * ``label`` -- the Hydra-style selector key (e.g. ``"physics"`` for
   ``physics=NAME``) and ``self.value``.
-* ``base_classes`` -- the cfg base classes whose subclass instances belong to
-  this bucket. Help-time bucketing in :mod:`isaaclab_tasks.utils.preset_cli`
-  routes variants through :meth:`PresetTarget.matches`. Empty for
-  :attr:`PresetTarget.DOMAIN`, which is the catch-all whose membership is
-  "no typed target matched".
+* ``base_classes`` -- cfg base classes matched directly by
+  :meth:`PresetTarget.matches`. A target may also recognize documented
+  container shapes. Empty for :attr:`PresetTarget.DOMAIN`, which is the
+  catch-all whose membership is "no typed target matched".
 * ``legacy_aliases`` -- deprecated-name to canonical-name table for this
   target, aggregated for hydra's resolver via :meth:`all_legacy_aliases`.
 
 Adding a new typed target = appending one enum member with its label, base
-classes, and (optional) legacy alias map. The CLI layer needs no other wiring.
+classes, and (optional) legacy alias map. Extend :meth:`matches` only when the
+target also accepts a non-subclass container shape.
 """
 
 from __future__ import annotations
@@ -52,7 +52,8 @@ class PresetTarget(enum.Enum):
     ``PresetCfg`` field regardless of class; the typed bucketing only governs
     which header it appears under in ``--help``.
 
-    Adding a new target = appending one enum member.
+    Adding a new target = appending one enum member. Extend :meth:`matches`
+    only when the target also accepts a non-subclass container shape.
     """
 
     # Members. Tuple values are (label, base_classes, legacy_aliases); the
@@ -86,8 +87,8 @@ class PresetTarget(enum.Enum):
     DOMAIN = ("presets",)
     """Free-form env-specific presets -- ``presets=NAME[,...]`` selector (catch-all).
 
-    No ``base_classes`` -- any variant whose cfg class doesn't subclass a typed
-    target's base ends up here. The ``presets=`` token also acts as a
+    No ``base_classes`` -- any variant that does not match a typed target ends
+    up here. The ``presets=`` token also acts as a
     broadcast: hydra's resolver applies a DOMAIN-bucketed name to every
     matching ``PresetCfg`` regardless of target. ``self.value`` matches the
     CLI selector key (``"presets"``) so the CLI layer can dispatch by
@@ -105,9 +106,9 @@ class PresetTarget(enum.Enum):
         Args:
             label: Hydra-style selector key (e.g. ``"physics"`` is recognized
                 as the ``physics=NAME`` token and becomes ``self.value``).
-            base_classes: Cfg base classes whose instances route to this
-                target via :func:`isinstance`. Defaults to ``()`` (no typed
-                routing).
+            base_classes: Cfg base classes matched directly by :meth:`matches`.
+                A target may also define additional container-shape matching.
+                Defaults to ``()`` (no typed routing).
             legacy_aliases: Optional deprecated-to-canonical map for this
                 target; copied so members cannot alias each other's tables.
 

--- a/source/isaaclab_tasks/test/core/test_preset_cli.py
+++ b/source/isaaclab_tasks/test/core/test_preset_cli.py
@@ -240,14 +240,16 @@ def test_argv_helper_task_returns_last_value():
     assert _ArgvHelper(["train.py", "--task=Old", "--task", "New"]).task_name == "New"
 
 
-def test_bucket_variants_routes_by_base_class_isinstance():
-    """Variants bucket by ``isinstance`` against ``PresetTarget.base_classes``.
+def test_bucket_variants_routes_by_target_match():
+    """Variants bucket through :meth:`PresetTarget.matches`.
 
     PhysicsCfg subclass instances route to PHYSICS, RendererCfg subclass
-    instances route to RENDERER, and everything else falls into DOMAIN.
+    instances route to RENDERER, PhysicsCfg-containing SimulationCfg bundles
+    route to PHYSICS, and values matching no target fall into DOMAIN.
     """
     from isaaclab.physics import PhysicsCfg
     from isaaclab.renderers.renderer_cfg import RendererCfg
+    from isaaclab.sim import SimulationCfg
     from isaaclab.utils.configclass import configclass
 
     from isaaclab_tasks.utils.preset_cli import _bucket_variants_by_target
@@ -280,6 +282,14 @@ def test_bucket_variants_routes_by_base_class_isinstance():
             "default": _RendVariant(),
             "newton_renderer": _RendVariant(),
         },
+        "sim": {
+            "default": SimulationCfg(dt=1 / 60, physics=_PhysVariant()),
+            "simulation_physx": SimulationCfg(dt=1 / 60, physics=_PhysVariant()),
+        },
+        "sim_no_backend": {
+            "default": SimulationCfg(dt=1 / 240),
+            "plain": SimulationCfg(dt=1 / 240),
+        },
         "weight": {  # cfgs whose type is not a typed-target base subclass -> DOMAIN
             "default": 1.0,
             "light": 0.5,
@@ -288,10 +298,10 @@ def test_bucket_variants_routes_by_base_class_isinstance():
     }
     result = _bucket_variants_by_target(walked)
     # All physics variants bucket to PHYSICS (including the wrapper-shaped ones).
-    assert {"physx", "newton_mjwarp", "newton_kamino"} <= result[PresetTarget.PHYSICS]
+    assert {"physx", "newton_mjwarp", "newton_kamino", "simulation_physx"} <= result[PresetTarget.PHYSICS]
     assert "newton_renderer" in result[PresetTarget.RENDERER]
     # Primitive-typed variants land in DOMAIN.
-    assert {"light", "heavy"} <= result[PresetTarget.DOMAIN]
+    assert {"plain", "light", "heavy"} <= result[PresetTarget.DOMAIN]
     # 'default' is filtered out everywhere -- it's the fallback, not a selectable name.
     for bucket in result.values():
         assert "default" not in bucket
@@ -323,8 +333,8 @@ def test_help_without_task_says_pass_task(monkeypatch, capsys):
         pytest.param(
             "empty",
             [
-                "physics=NAME (typed) selects a PhysicsCfg variant. Available: (none)",
-                "renderer=NAME (typed) selects a RendererCfg variant. Available: (none)",
+                "physics=NAME (typed) selects a physics backend. Available: (none)",
+                "renderer=NAME (typed) selects a renderer backend. Available: (none)",
                 "presets=NAME[,NAME,...] broadcast: applied to every matching PresetCfg. Available: (none)",
             ],
             id="zero_variants_everywhere",
@@ -332,8 +342,8 @@ def test_help_without_task_says_pass_task(monkeypatch, capsys):
         pytest.param(
             "physics_only",
             [
-                "physics=NAME (typed) selects a PhysicsCfg variant. Available: - alpha - beta",
-                "renderer=NAME (typed) selects a RendererCfg variant. Available: (none)",
+                "physics=NAME (typed) selects a physics backend. Available: - alpha - beta",
+                "renderer=NAME (typed) selects a renderer backend. Available: (none)",
                 "presets=NAME[,NAME,...] broadcast: applied to every matching PresetCfg. Available: (none)",
             ],
             id="typed_populated_other_typed_empty",
@@ -341,8 +351,8 @@ def test_help_without_task_says_pass_task(monkeypatch, capsys):
         pytest.param(
             "domain_only",
             [
-                "physics=NAME (typed) selects a PhysicsCfg variant. Available: (none)",
-                "renderer=NAME (typed) selects a RendererCfg variant. Available: (none)",
+                "physics=NAME (typed) selects a physics backend. Available: (none)",
+                "renderer=NAME (typed) selects a renderer backend. Available: (none)",
                 "presets=NAME[,NAME,...] broadcast: applied to every matching PresetCfg. Available: - heavy - light",
             ],
             id="domain_bucket_only",
@@ -350,8 +360,8 @@ def test_help_without_task_says_pass_task(monkeypatch, capsys):
         pytest.param(
             "mixed",
             [
-                "physics=NAME (typed) selects a PhysicsCfg variant. Available: - my_phys",
-                "renderer=NAME (typed) selects a RendererCfg variant. Available: - my_rend",
+                "physics=NAME (typed) selects a physics backend. Available: - my_phys",
+                "renderer=NAME (typed) selects a renderer backend. Available: - my_rend",
                 "presets=NAME[,NAME,...] broadcast: applied to every matching PresetCfg. Available: - heavy - light",
             ],
             id="all_three_buckets_populated",
@@ -360,8 +370,8 @@ def test_help_without_task_says_pass_task(monkeypatch, capsys):
 )
 def test_help_text_branch_strings(monkeypatch, capsys, build_key, expected_phrases):
     """Each branch of the description builder renders the documented strings
-    for its variant shape. Typed-bucketed names (PhysicsCfg/RendererCfg subclass
-    instances) appear only under their typed section; the DOMAIN bucket
+    for its variant shape. Typed-bucketed names appear only under their typed
+    section; the DOMAIN bucket
     (``presets:``) lists only variants that fell into the catch-all. The
     parametrize id captures which branch each case locks; argparse line-
     wrapping is normalized away before substring assertions so wording changes


### PR DESCRIPTION
# Description

Fix typed `physics=NAME` selection for presets whose alternatives bundle a complete `SimulationCfg`.

The cabinet tasks use complete simulation presets because switching physics backends also changes the simulation timestep. Preset discovery and runtime validation previously classified alternatives only by their direct type, so these valid bundles appeared only under `presets=` and `physics=newton_mjwarp` was rejected.

This change centralizes typed preset classification in `PresetTarget.matches()`, recognizes a `SimulationCfg` carrying a `PhysicsCfg` as a physics preset, uses that classification consistently for help discovery and runtime validation, and documents complete simulation physics presets.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Validation

- `uv run isaaclab train --task Isaac-Open-Drawer-Franka-Direct --rl_library rsl_rl --max_iterations 5 physics=newton_mjwarp`
  - Completed 5 iterations with 4,096 environments and reported `Physics: newton_mjwarp`.
- Resolved all five physics choices for all four affected registrations and verified the existing backend-specific timestep and decimation values.
- `uv run --no-sync python -m pytest source/isaaclab_tasks/test/core/test_preset_cli.py source/isaaclab_tasks/test/core/test_hydra.py -q`
  - `112 passed`.
- `uv run --no-sync isaaclab -f`
  - Passed.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there