### PR TITLE
Report checkpoint paths for RL-Games and SKRL benchmarks

### DIFF
--- a/source/isaaclab/changelog.d/training-checkpoint-path.rst
+++ b/source/isaaclab/changelog.d/training-checkpoint-path.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed RL-Games and SKRL training benchmark bundles to report the saved checkpoint path.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
@@ -16,6 +16,7 @@ import sys
 import time
 
 from isaaclab.benchmark.entrypoints.backends.rl_games.registry import register_scoped_rl_games_environment
+from isaaclab.benchmark.entrypoints.training import _resolve_training_checkpoint_path
 
 from isaaclab_rl.entrypoints import common as _common
 
@@ -372,7 +373,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
                 max_iterations=agent_cfg["params"]["config"].get("max_epochs"),
             )
 
-            checkpoint_path = None
+            checkpoint_path = _resolve_training_checkpoint_path(run_log_dir, "rl_games")
             video_path = os.path.join(run_log_dir, "videos") if getattr(args_cli, "video", False) else None
 
             bundle = builders.build_training_bundle(

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 import sys
 import time
 
+from isaaclab.benchmark.entrypoints.training import _resolve_training_checkpoint_path
+
 from isaaclab_rl.entrypoints import common as _common
 
 
@@ -477,7 +479,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
                 resources=resources,
                 learning=learning,
                 success_rate=success_rate,
-                checkpoint_path=None,
+                checkpoint_path=_resolve_training_checkpoint_path(log_dir, "skrl"),
                 video_path=os.path.join(log_dir, "videos") if args_cli.video else None,
                 extra=(
                     distributed.bundle_metadata(workload_scope="global", num_envs_per_rank=env.unwrapped.num_envs)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/training.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/training.py
@@ -7,12 +7,37 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 from isaaclab.benchmark.dispatch import run_training_cli
+
+_TRAINING_CHECKPOINTS = {
+    "rl_games": ("nn", r".*[.]pth$"),
+    "skrl": ("checkpoints", r"(?:agent_.*|best_agent)[.]pt$"),
+}
 
 
 def main(argv: list[str] | None = None) -> int:
     """Dispatch training benchmark arguments to the selected RL backend."""
     return run_training_cli(argv)
+
+
+def _resolve_training_checkpoint_path(log_dir: str, backend: str) -> str | None:
+    """Resolve the checkpoint written by a training benchmark, if any."""
+    from isaaclab_tasks.utils import get_checkpoint_path
+
+    checkpoint_dir, checkpoint_pattern = _TRAINING_CHECKPOINTS[backend]
+    run_path = Path(log_dir)
+    try:
+        return get_checkpoint_path(
+            str(run_path.parent),
+            rf"^{re.escape(run_path.name)}$",
+            checkpoint_pattern,
+            other_dirs=[checkpoint_dir],
+        )
+    except (FileNotFoundError, ValueError):
+        return None
 
 
 if __name__ == "__main__":

--- a/source/isaaclab/test/benchmark/test_train_checkpoint_path.py
+++ b/source/isaaclab/test/benchmark/test_train_checkpoint_path.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Checkpoint reporting for training benchmark adapters."""
+
+from pathlib import Path
+
+import pytest
+
+from isaaclab.benchmark.entrypoints import training
+
+
+@pytest.mark.parametrize(
+    ("backend", "subdir", "filename"),
+    (
+        ("rl_games", "nn", "last_Cartpole_ep_50.pth"),
+        ("skrl", "checkpoints", "agent_4800.pt"),
+        ("skrl", "checkpoints", "best_agent.pt"),
+    ),
+)
+def test_resolve_training_checkpoint_path_matches_backend_filename(
+    tmp_path: Path, backend: str, subdir: str, filename: str
+) -> None:
+    run_dir = tmp_path / "run"
+    checkpoint_dir = run_dir / subdir
+    checkpoint_dir.mkdir(parents=True)
+    checkpoint = checkpoint_dir / filename
+    checkpoint.touch()
+
+    assert training._resolve_training_checkpoint_path(str(run_dir), backend) == str(checkpoint)
+
+
+def test_resolve_training_checkpoint_path_uses_natural_order(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    checkpoint_dir = run_dir / "nn"
+    checkpoint_dir.mkdir(parents=True)
+    (checkpoint_dir / "last_Cartpole_ep_9.pth").touch()
+    checkpoint = checkpoint_dir / "last_Cartpole_ep_10.pth"
+    checkpoint.touch()
+
+    assert training._resolve_training_checkpoint_path(str(run_dir), "rl_games") == str(checkpoint)
+
+
+def test_resolve_training_checkpoint_path_returns_none_without_checkpoint(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    assert training._resolve_training_checkpoint_path(str(run_dir), "skrl") is None


### PR DESCRIPTION
## Description

RL-Games and SKRL training benchmark bundles now report the checkpoint produced by the completed run instead of leaving TrainingBundle.checkpoint_path unset.

This reuses the canonical get_checkpoint_path resolver rather than adding a second filesystem search mechanism. A small benchmark helper supplies the backend-specific layout and filename patterns:

- RL-Games resolves nn/*.pth under run_log_dir.
- SKRL resolves checkpoints/agent_<tag>.pt and checkpoints/best_agent.pt under log_dir.
- ValueError and a missing checkpoint subdirectory are converted to None, preserving the optional bundle field and preventing an otherwise successful training run from failing during final bundle assembly.
- Current develop naturally sorts numeric filename components, so checkpoint 10 is selected after checkpoint 9.

The change intentionally leaves RSL-RL, SB3, video handling, and Odin tooling untouched.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- uv run --frozen --extra test python -m pytest source/isaaclab/test/benchmark — 334 passed
- uv run --frozen isaaclab -f — passed
- uv run --frozen --extra test python tools/changelog/cli.py check develop — passed

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the repository formatting and pre-commit checks.
- [x] No public documentation changes are required; the user-visible fix has a changelog fragment.
- [x] My changes generate no new warnings.
- [x] I have added behavior tests that prove the fix is effective.
- [x] I have added a changelog fragment for the touched package.
- [x] My name already exists in CONTRIBUTORS.md.