### PR TITLE
Add video recording to play benchmarks

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-benchmark-play-video.rst
+++ b/source/isaaclab/changelog.d/antoiner-benchmark-play-video.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added video recording to the RSL-RL, RL-Games, SKRL, and SB3 play benchmark adapters and populated
+  :attr:`~isaaclab.benchmark.schema.PlayBundle.video_path` with the recording directory.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -43,6 +43,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with RL-Games.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -84,6 +86,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -125,6 +128,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -132,6 +136,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -303,6 +308,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -44,6 +44,8 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with RSL-RL.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -85,6 +87,7 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     add_launcher_args(parser)
 
     args, remaining = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args)
     sys.argv = [sys.argv[0]] + remaining
     return args, remaining
 
@@ -122,6 +125,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args, remaining = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args.task, args.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -129,6 +133,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args.output_path, args, subdir="play")
 
             if args.num_envs is not None:
                 env_cfg.scene.num_envs = args.num_envs
@@ -260,6 +265,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -44,6 +44,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with Stable-Baselines3.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -91,6 +93,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -128,6 +131,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -135,6 +139,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -290,6 +295,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -42,6 +42,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with SKRL.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -103,6 +105,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="skrl")
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -146,6 +149,7 @@ def run(argv: list[str]) -> BenchmarkResult:
         algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, agent_cfg_entry_point)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -153,6 +157,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.ml_framework.startswith("jax"):
                 import skrl
@@ -312,6 +317,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -131,8 +131,14 @@ def test_runtime_request_uses_runtime_defaults() -> None:
 
 
 @pytest.mark.parametrize("backend", ["rsl_rl", "rl_games", "skrl", "sb3"])
-def test_play_request_uses_backend_warmup_steps_argument(backend: str, monkeypatch) -> None:
-    request = BenchmarkPlayRequest(backend=backend, task="Isaac-Cartpole-Direct", num_steps=7, warmup_steps=12)
+def test_play_request_uses_backend_arguments(backend: str, monkeypatch) -> None:
+    request = BenchmarkPlayRequest(
+        backend=backend,
+        task="Isaac-Cartpole-Direct",
+        num_steps=7,
+        warmup_steps=12,
+        backend_args=("--video", "--video_length", "37"),
+    )
 
     argv = dispatch._request_argv(request)
     monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
@@ -143,7 +149,60 @@ def test_play_request_uses_backend_warmup_steps_argument(backend: str, monkeypat
     assert args.num_steps == 7
     assert argv[argv.index("--warmup_steps") + 1] == "12"
     assert args.warmup_steps == 12
+    assert args.video is True
+    assert args.video_length == 37
+    assert args.enable_cameras is True
     assert remaining_args == []
+
+
+@pytest.mark.parametrize("configured_output_dir", [None, "/tmp/custom-videos"])
+def test_play_backend_configures_video_before_environment_creation(
+    monkeypatch, tmp_path, configured_output_dir
+) -> None:
+    class VideoConfigured(Exception):
+        pass
+
+    entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
+    monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
+
+    import gymnasium as gym
+
+    import isaaclab.app as app
+
+    @contextlib.contextmanager
+    def launch_simulation(env_cfg, args):
+        assert env_cfg.video_recorders == []
+        assert any(cfg.visualizer_type == "kit" for cfg in env_cfg.sim.visualizer_cfgs)
+        if configured_output_dir is not None:
+            from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+
+            env_cfg.video_recorders = [VideoRecorderCfg(output_dir=configured_output_dir)]
+        yield
+
+    def make_environment(task, *, cfg):
+        recorder = cfg.video_recorders[0]
+        expected_output_dir = configured_output_dir or str(tmp_path / "videos" / "play")
+        assert recorder.output_dir == expected_output_dir
+        assert recorder.video_length == 37
+        raise VideoConfigured
+
+    monkeypatch.setattr(app, "launch_simulation", launch_simulation)
+    monkeypatch.setattr(gym, "make", make_environment)
+
+    with pytest.raises(VideoConfigured):
+        entrypoint.run(
+            [
+                "--task",
+                "Isaac-Cartpole-Direct",
+                "--checkpoint",
+                "/tmp/checkpoint",
+                "--output_path",
+                str(tmp_path),
+                "--video",
+                "--video_length",
+                "37",
+            ]
+        )
 
 
 @pytest.mark.parametrize("workflow", ["runtime", "startup"])


### PR DESCRIPTION
# Description

Adds video recording support to the RSL-RL, RL-Games, SKRL, and SB3 play benchmark adapters.

Each adapter now:

- accepts --video and --video_length
- enables cameras and injects a Kit visualizer before simulation launch when needed
- applies recorder configuration after launch and before environment creation
- reports the effective recorder output directory in PlayBundle.video_path

This preserves preconfigured recorder output directories and leaves no-video behavior unchanged. No dependencies or public APIs were added.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable.

## Validation

- uv run --extra test --frozen python -m pytest source/isaaclab/test/benchmark/test_api.py source/isaaclab_rl/test/test_apply_video_recording.py -q --disable-warnings — 37 passed
- uv run --frozen isaaclab -f — passed
- Changelog validation — passed
- Real RSL-RL Cartpole play run produced an H.264 MP4; ffprobe reported 1854x1080 and 11 frames
- Benchmark JSON reported the matching videos/play directory
- A no-video run produced no media and reported video_path as null

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the repository pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added behavior-focused tests that prove the feature works
- [x] I have added a changelog fragment under source/isaaclab/changelog.d/
- [x] My name already exists in CONTRIBUTORS.md
