### PR TITLE
Report resolved backend for play benchmarks

### DIFF
--- a/source/isaaclab/changelog.d/play-resolved-backend.rst
+++ b/source/isaaclab/changelog.d/play-resolved-backend.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed play benchmark metadata to report the resolved physics backend; ``isaacsim_physx`` play runs now report ``physx`` in ``run.config.physics_backend``.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -155,7 +155,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "rl_games", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -152,7 +152,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args.checkpoint, "rsl_rl", args.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining)
+            cfg = capture.run_config_from_presets(remaining, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -155,7 +155,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "sb3", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -183,7 +183,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "skrl", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/test/benchmark/test_capture.py
+++ b/source/isaaclab/test/benchmark/test_capture.py
@@ -243,6 +243,10 @@ def test_run_config_from_presets_resolves_backend_configuration(monkeypatch):
     assert cfg.physics_backend == "newton_mjwarp"
     assert cfg.rendering_backend == "isaacsim_rtx"
 
+    physx_env_cfg = SimpleNamespace(sim=SimpleNamespace(physics=SimpleNamespace(class_type="PhysXManager")))
+    cfg = run_config_from_presets(["isaacsim_physx"], env_cfg=physx_env_cfg)
+    assert cfg.physics_backend == "physx"
+
 
 def test_capture_resources_peak_clamped_to_mean_when_peak_row_absent():
     # Build a recorder that has mean/std rows but no peak rows.


### PR DESCRIPTION
## Description

Fixed benchmark play adapters to pass the resolved environment configuration when building `RunConfig`. This makes `run.config.physics_backend` report the backend that ran, matching training, runtime, and startup behavior.

For `isaacsim_physx`, play results now report `physx`; the requested preset remains in `run.config.presets`.

No additional dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`