### PR TITLE
Raise on unsupported camera renderer outputs

### DIFF
--- a/source/isaaclab/changelog.d/camera-renderer-unsupported-data-types.rst
+++ b/source/isaaclab/changelog.d/camera-renderer-unsupported-data-types.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Camera configurations now raise an error when the active renderer cannot produce a requested
+  data type, rather than silently omitting it. Remove unsupported types from ``CameraCfg.data_types`` or select
+  a renderer that supports them.

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -658,15 +658,12 @@ class Camera(SensorBase):
                 unknown.append(name)
         errors = []
         if unknown:
-            errors.append(
-                f"Unknown camera data types: {unknown}.\n\tHint: Check CameraCfg.data_types for spelling errors."
-            )
+            errors.append(f"Unknown camera data types: {unknown}.")
         if unsupported:
             errors.append(
                 f"Renderer {type(self._renderer).__name__} does not support the following requested data types:"
                 f" {unsupported}."
                 f"\n\tSupported data types: {sorted(str(kind) for kind in specs)}"
-                "\n\tHint: Remove the unsupported data types or select a renderer that supports them."
             )
         if errors:
             raise ValueError("\n".join(errors))

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -141,7 +141,7 @@ class Camera(SensorBase):
 
         Raises:
             RuntimeError: If no camera prim is found at the given path.
-            ValueError: If the provided data types are not supported by the camera.
+            ValueError: If the provided data types are not supported by the camera or active renderer.
         """
         # perform check on supported data types
         self._check_supported_data_types(cfg)
@@ -644,8 +644,9 @@ class Camera(SensorBase):
     def _create_buffers(self):
         """Create buffers for storing data."""
         specs = self._renderer.supported_output_types()
-        # Split requested names into known/unsupported; warn once for any the renderer can't produce.
+        # Split requested names into known, unknown, and unsupported types.
         known: list[str] = []
+        unknown: list[str] = []
         unsupported: list[str] = []
         for name in self.cfg.data_types:
             try:
@@ -654,13 +655,21 @@ class Camera(SensorBase):
                 else:
                     unsupported.append(name)
             except ValueError:
-                unsupported.append(name)
-        if unsupported:
-            logger.warning(
-                "Renderer %s does not support the following requested data types and will not produce them: %s",
-                type(self._renderer).__name__,
-                unsupported,
+                unknown.append(name)
+        errors = []
+        if unknown:
+            errors.append(
+                f"Unknown camera data types: {unknown}.\n\tHint: Check CameraCfg.data_types for spelling errors."
             )
+        if unsupported:
+            errors.append(
+                f"Renderer {type(self._renderer).__name__} does not support the following requested data types:"
+                f" {unsupported}."
+                f"\n\tSupported data types: {sorted(str(kind) for kind in specs)}"
+                "\n\tHint: Remove the unsupported data types or select a renderer that supports them."
+            )
+        if errors:
+            raise ValueError("\n".join(errors))
         device_str = self._device if isinstance(self._device, str) else str(self._device)
         self._data = CameraData.allocate(
             data_types=known,

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -1090,16 +1090,21 @@ def test_camera_frame_offset(setup_camera_device, device):
     del camera
 
 
-def test_camera_warns_once_on_unsupported_data_types(setup_sim_camera, caplog):
-    """Test Camera warns once and drops data types its renderer cannot produce."""
-    import logging
-
+@pytest.mark.parametrize(
+    ("data_types", "expected_names", "expected_messages"),
+    [
+        (["rgba", "depth", "normals"], ["depth", "normals"], ["_PartialRenderer", "Supported data types"]),
+        (["rgba", "not_a_render_buffer_kind"], ["not_a_render_buffer_kind"], ["Unknown camera data types"]),
+    ],
+)
+def test_camera_raises_on_unsupported_data_types(setup_sim_camera, data_types, expected_names, expected_messages):
+    """Test Camera rejects data types its renderer cannot produce or does not recognize."""
     from isaaclab.renderers import Renderer
     from isaaclab.renderers.base_renderer import BaseRenderer
 
     sim, camera_cfg, dt = setup_sim_camera
     camera_cfg = copy.deepcopy(camera_cfg)
-    camera_cfg.data_types = ["rgba", "depth", "normals"]
+    camera_cfg.data_types = data_types
 
     from isaaclab.sensors.camera.camera_data import RenderBufferKind, RenderBufferSpec
 
@@ -1144,31 +1149,10 @@ def test_camera_warns_once_on_unsupported_data_types(setup_sim_camera, caplog):
     Renderer._registry[backend] = _PartialRenderer
     try:
         camera = Camera(camera_cfg)
-        caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="isaaclab.sensors.camera.camera"):
+        with pytest.raises(ValueError) as exc_info:
             sim.reset()
-            # Step a few frames and confirm the warning is emitted once at init.
-            for _ in range(3):
-                sim.step()
-                camera.update(dt)
-
-        warning_records = [
-            r for r in caplog.records if r.levelno == logging.WARNING and "does not support" in r.getMessage()
-        ]
-        assert len(warning_records) == 1, (
-            f"Expected exactly one 'does not support' warning, got {len(warning_records)}:"
-            f" {[r.getMessage() for r in warning_records]}"
-        )
-        msg = warning_records[0].getMessage()
-        assert "_PartialRenderer" in msg
-        assert "depth" in msg
-        assert "normals" in msg
-        assert "rgba" not in msg
-
-        # Only the supported subset is in ``data.output``; the rest were dropped.
-        assert set(camera.data.output.keys()) == {"rgba"}
-        # ``data.info`` mirrors the ``data.output`` keys.
-        assert set(camera.data.info.keys()) == {"rgba"}
+        assert all(name in str(exc_info.value) for name in expected_names)
+        assert all(message in str(exc_info.value) for message in expected_messages)
 
         del camera
     finally:

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -1153,6 +1153,7 @@ def test_camera_raises_on_unsupported_data_types(setup_sim_camera, data_types, e
             sim.reset()
         assert all(name in str(exc_info.value) for name in expected_names)
         assert all(message in str(exc_info.value) for message in expected_messages)
+        assert "Hint:" not in str(exc_info.value)
 
         del camera
     finally:

--- a/source/isaaclab_physx/changelog.d/camera-renderer-unsupported-data-types.rst
+++ b/source/isaaclab_physx/changelog.d/camera-renderer-unsupported-data-types.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* **Breaking:** The Isaac RTX renderer now raises an error for albedo and simple-shading outputs on Isaac Sim
+  versions before 6.0, rather than silently omitting them. Upgrade Isaac Sim or remove those data types.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -265,14 +265,16 @@ class IsaacRtxRenderer(BaseRenderer):
             if settings.get("/isaaclab/has_gui"):
                 settings.set_bool("/rtx/sdg/force/disableColorRender", False)
         else:
+            unsupported = []
             if "albedo" in spec.cfg.data_types:
-                logger.warning(
-                    "Albedo annotator is only supported in Isaac Sim 6.0+. The albedo data type will be ignored."
-                )
-            if any(dt in SIMPLE_SHADING_MODES for dt in spec.cfg.data_types):
-                logger.warning(
-                    "Simple shading annotators are only supported in Isaac Sim 6.0+."
-                    " The simple shading data types will be ignored."
+                unsupported.append("albedo")
+            unsupported.extend(dt for dt in spec.cfg.data_types if dt in SIMPLE_SHADING_MODES)
+            if unsupported:
+                raise ValueError(
+                    "Isaac RTX renderer does not support the following requested data types in"
+                    " Isaac Sim versions before 6.0:"
+                    f" {unsupported}."
+                    "\n\tHint: Upgrade to Isaac Sim 6.0+ or remove the unsupported data types."
                 )
 
         # HACK: Isaac Sim 4.5 has a bug in Camera that breaks segmentation

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -274,7 +274,6 @@ class IsaacRtxRenderer(BaseRenderer):
                     "Isaac RTX renderer does not support the following requested data types in"
                     " Isaac Sim versions before 6.0:"
                     f" {unsupported}."
-                    "\n\tHint: Upgrade to Isaac Sim 6.0+ or remove the unsupported data types."
                 )
 
         # HACK: Isaac Sim 4.5 has a bug in Camera that breaks segmentation


### PR DESCRIPTION
## Summary
- Raise clear errors when a camera requests unknown data types or outputs unsupported by its active renderer.
- Raise instead of silently dropping Isaac RTX albedo and simple-shading outputs on Isaac Sim versions before 6.0.
- Replace the warning regression test with error coverage for renderer-capability and typo paths.

## Breaking change
Camera configurations that previously ran while silently omitting unsupported data types now fail at camera initialization. Remove unsupported types from `CameraCfg.data_types` or select a compatible renderer.

## Validation
- `uv run --extra test --frozen isaaclab -f`
- Runtime-free smoke test of `Camera._create_buffers` for both error paths.
- The Isaac Sim integration test could not run in this environment because the full Isaac Sim runtime is not installed.

## In-tree configuration finding
Cartpole simple-shading presets default to `newton_renderer`, which cannot produce those outputs and will now raise. Kuka Allegro already rejects the equivalent Newton combinations in its existing task-level compatibility validation.

## Out of scope
Teaching task discovery about renderer capabilities remains follow-up work because renderer capability is currently per-instance.