### PR TITLE
[Test] Fix cartpole camera preset resolution

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-cartpole-video-camera-presets.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-cartpole-video-camera-presets.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Resolved tiled-camera presets before deriving Cartpole camera observation dimensions, restoring direct construction and sensor video recording.

--- a/source/isaaclab_tasks/changelog.d/fix-cartpole-video-camera-presets.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-cartpole-video-camera-presets.rst
@@ -1,4 +1,4 @@
 Fixed
 ^^^^^
 
-* Resolved tiled-camera presets before deriving Cartpole camera observation dimensions, restoring direct construction and sensor video recording.
+* Used the selected tiled-camera preset when deriving Cartpole camera observation dimensions, restoring direct construction and sensor video recording.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -13,10 +13,10 @@ from isaaclab import cloner
 from isaaclab.assets import Articulation
 from isaaclab.sensors import Camera, save_images_to_file
 from isaaclab.utils.buffers import CircularBuffer
-from isaaclab.utils.configclass import resolve_cfg_presets
 from isaaclab.utils.images import is_rgb_like, normalize_camera_image
 
 from isaaclab_tasks.core.cartpole.cartpole_direct_env import CartpoleEnv
+from isaaclab_tasks.utils import PresetCfg
 
 if TYPE_CHECKING:
     from isaaclab_tasks.core.cartpole.cartpole_direct_camera_env_cfg import CartpoleCameraEnvCfg
@@ -28,16 +28,16 @@ class CartpoleCameraEnv(CartpoleEnv):
     cfg: CartpoleCameraEnvCfg
 
     def __init__(self, cfg: CartpoleCameraEnvCfg, render_mode: str | None = None, **kwargs):
-        # The observation space must use the concrete camera dimensions before
-        # DirectRLEnv creates its Gym spaces. DirectRLEnv resolves presets later
-        # in its initialization, so resolve nested camera presets here first.
-        resolve_cfg_presets(cfg)
+        # DirectRLEnv resolves presets after this subclass derives its Gym
+        # observation space. Use the default camera preset only for that
+        # derivation; leave full config resolution to DirectRLEnv.
+        camera_cfg = cfg.tiled_camera.default if isinstance(cfg.tiled_camera, PresetCfg) else cfg.tiled_camera
         cfg.frame_stack = max(1, cfg.frame_stack)
         if isinstance(cfg.observation_space, list):
             cfg.observation_space = [
                 int(cfg.observation_space[0]) * cfg.frame_stack,
-                int(cfg.tiled_camera.height),
-                int(cfg.tiled_camera.width),
+                int(camera_cfg.height),
+                int(camera_cfg.width),
             ]
 
         super().__init__(cfg, render_mode, **kwargs)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -13,6 +13,7 @@ from isaaclab import cloner
 from isaaclab.assets import Articulation
 from isaaclab.sensors import Camera, save_images_to_file
 from isaaclab.utils.buffers import CircularBuffer
+from isaaclab.utils.configclass import resolve_cfg_presets
 from isaaclab.utils.images import is_rgb_like, normalize_camera_image
 
 from isaaclab_tasks.core.cartpole.cartpole_direct_env import CartpoleEnv
@@ -27,6 +28,10 @@ class CartpoleCameraEnv(CartpoleEnv):
     cfg: CartpoleCameraEnvCfg
 
     def __init__(self, cfg: CartpoleCameraEnvCfg, render_mode: str | None = None, **kwargs):
+        # The observation space must use the concrete camera dimensions before
+        # DirectRLEnv creates its Gym spaces. DirectRLEnv resolves presets later
+        # in its initialization, so resolve nested camera presets here first.
+        resolve_cfg_presets(cfg)
         cfg.frame_stack = max(1, cfg.frame_stack)
         if isinstance(cfg.observation_space, list):
             cfg.observation_space = [

--- a/source/isaaclab_tasks/test/core/test_video_recording.py
+++ b/source/isaaclab_tasks/test/core/test_video_recording.py
@@ -112,7 +112,7 @@ def _cartpole_camera_cfg_physx(*, num_envs: int = 1):
     cfg.seed = _SEED
     cfg.scene.num_envs = num_envs
     cfg.sim.physics = PhysxCfg()
-    cfg.tiled_camera.renderer_cfg = IsaacRtxRendererCfg()
+    cfg.tiled_camera.default.renderer_cfg.default = IsaacRtxRendererCfg()
     return cfg
 
 
@@ -136,6 +136,7 @@ def _run_cartpole_camera(env_cfg) -> None:
     sim_utils.create_new_stage()
     env = CartpoleCameraEnv(env_cfg)
     try:
+        assert env.cfg.tiled_camera.renderer_cfg.renderer_type == "isaac_rtx"
         env.reset()
         actions = torch.zeros(env.num_envs, *env.action_space.shape[1:], device=env.device)
         for _ in range(_STEPS):


### PR DESCRIPTION
## Summary

- Derive Cartpole camera observation dimensions from the active tiled-camera configuration without changing the base environment's preset-resolution lifecycle.
- Configure the test's selected camera preset to use PhysX RTX and assert the constructed environment retains that renderer.
- Add a patch changelog fragment.

## Validation

- `uv run --no-sync python -m pytest source/isaaclab_tasks/test/core/test_video_recording.py -k "sensor_physx_records_moving_clip or multiple_recorders_simultaneous" -q`
- `uv run --no-sync isaaclab -f`
- `uv run --no-sync python tools/changelog/cli.py check develop`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `isaaclab -f`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there