### PR TITLE
[CI] Enable Warp cache for rendering tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -801,6 +801,7 @@ jobs:
           test_rendering_shadow_hand.py
         test-node-ids-file: ${{ github.event_name == 'push' && '.github/test-subsets/postmerge-rendering.toml' || '' }}
         test-node-ids-key: ${{ github.event_name == 'push' && 'rendering-correctness' || '' }}
+        warp-cache: restore
         container-name: isaac-lab-rendering-correctness-test
         omni-github-test-type: rendering-correctness
 
@@ -847,6 +848,7 @@ jobs:
         test-k-expr: legacy
         test-node-ids-file: ${{ github.event_name == 'push' && '.github/test-subsets/postmerge-rendering.toml' || '' }}
         test-node-ids-key: ${{ github.event_name == 'push' && 'rendering-correctness-kitless-legacy' || '' }}
+        warp-cache: restore
         container-name: "isaac-lab-rendering-correctness-kitless-legacy-test"
         omni-github-test-type: "rendering-correctness-kitless-legacy"
 


### PR DESCRIPTION
## Summary

- Restore the shared Warp kernel cache in the regular rendering-correctness job.
- Restore the shared Warp kernel cache in the Kit-less legacy rendering-correctness job, which exercises Newton/MJWarp rendering paths.

The cache remains read-only in pull-request jobs; the post-merge warm job remains the sole writer.

## Validation

- `uv run isaaclab -f`
- Parsed `.github/workflows/build.yaml` with PyYAML

## Checklist

- [x] Bug fix
- [x] No documentation change required
- [x] No source package changed; no changelog fragment required
- [x] Contributor already listed