### PR TITLE
Declare the USDRT scene delegate in the headless app

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -31,6 +31,8 @@ log.outputStreamLevel = "Warn"
 "omni.physx.tensors" = {}
 "omni.physx.fabric" = {}
 "usdrt.scenegraph" = {}
+# the RTX renderer is not loaded here, so nothing pulls in the USDRT scene delegate implicitly
+"omni.hydra.usdrt_delegate" = {}
 "omni.kit.telemetry" = {}
 "omni.kit.loop" = {}
 "isaacsim.storage.native" = {}

--- a/source/isaaclab/changelog.d/mataylor-kit-visualizer-headless-override.rst
+++ b/source/isaaclab/changelog.d/mataylor-kit-visualizer-headless-override.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed ``HEADLESS=1`` combined with ``--visualizer kit`` aborting with
+  ``AttributeError: module 'usdrt' has no attribute 'hierarchy'`` when the Newton backend set up its
+  USD/Fabric sync. The headless experience now declares ``omni.hydra.usdrt_delegate``, which every
+  other experience receives implicitly from the RTX renderer.

--- a/source/isaaclab/test/app/test_experience_files.py
+++ b/source/isaaclab/test/app/test_experience_files.py
@@ -43,17 +43,6 @@ def test_base_experiences_enable_native_storage(experience: str):
     assert "isaacsim.storage.native" in _kit_dependencies(experience)
 
 
-def test_headless_experience_enables_usdrt_scene_delegate():
-    """Test the headless experience loads the extension that provides the ``usdrt.hierarchy`` module.
-
-    Every other experience receives it implicitly from ``omni.hydra.rtx``, which depends on it when
-    ``app.useFabricSceneDelegate`` is true. This one loads neither, yet Newton's USD/Fabric sync
-    imports ``usdrt.hierarchy`` whenever a Kit visualizer is requested, which is reachable here
-    through ``HEADLESS=1 --viz kit``.
-    """
-    assert "omni.hydra.usdrt_delegate" in _kit_dependencies("isaaclab.python.headless.kit")
-
-
 @pytest.mark.parametrize(
     "experience, base",
     [

--- a/source/isaaclab/test/app/test_experience_files.py
+++ b/source/isaaclab/test/app/test_experience_files.py
@@ -43,6 +43,17 @@ def test_base_experiences_enable_native_storage(experience: str):
     assert "isaacsim.storage.native" in _kit_dependencies(experience)
 
 
+def test_headless_experience_enables_usdrt_scene_delegate():
+    """Test the headless experience loads the extension that provides the ``usdrt.hierarchy`` module.
+
+    Every other experience receives it implicitly from ``omni.hydra.rtx``, which depends on it when
+    ``app.useFabricSceneDelegate`` is true. This one loads neither, yet Newton's USD/Fabric sync
+    imports ``usdrt.hierarchy`` whenever a Kit visualizer is requested, which is reachable here
+    through ``HEADLESS=1 --viz kit``.
+    """
+    assert "omni.hydra.usdrt_delegate" in _kit_dependencies("isaaclab.python.headless.kit")
+
+
 @pytest.mark.parametrize(
     "experience, base",
     [


### PR DESCRIPTION
# Description

`omni.hydra.usdrt_delegate` registers the USDRT population and hierarchy plugins. Every Isaac Lab app loads it except `isaaclab.python.headless.kit`, which is missing it because the extension arrives implicitly through a conditional dependency on the RTX renderer:

```toml
# omni.hydra.rtx/config/extension.toml
"filter:setting".app.useFabricSceneDelegate."value:true"."omni.hydra.usdrt_delegate" = {}
```

The headless app loads neither `omni.hydra.rtx` nor sets `app.useFabricSceneDelegate = true`, so nothing pulls it in. This declares it directly, which is also what upstream `isaacsim.exp.base.kit` does rather than relying on the conditional.

Measured extension state per app before this change, from launching each experience and reading back the enabled set:

| app | extensions | `omni.hydra.usdrt_delegate` | `omni.hydra.rtx` |
| --- | ---: | --- | --- |
| `isaaclab.python.kit` | 207 | yes | yes |
| `isaaclab.python.rendering.kit` | 214 | yes | yes |
| `isaaclab.python.xr.openxr.kit` | 223 | yes | yes |
| `isaaclab.python.xr.openxr.headless.kit` | 224 | yes | yes |
| `isaaclab.python.headless.rendering.kit` | 116 | yes | yes |
| `isaaclab.python.headless.kit` | 60 | **no** | no |

Only the last app changes, which is why this touches one file. The other five already resolve the extension, so declaring it there would be a no-op.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable — this changes extension resolution only.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

No changelog fragment is included because no package under `source/` is touched; the changelog gate confirms this (`uv run python tools/changelog/cli.py check develop` passes).

## Reported failure

With `HEADLESS=1`, this command aborted before stepping:

```
uv run isaaclab play --task Isaac-Ant --rl_library rsl_rl --checkpoint latest \
    --visualizer kit physics=newton_mjwarp --info
```

```
File "isaaclab_newton/physics/newton_manager.py", line 1590, in start_simulation
    fabric_hierarchy = usdrt.hierarchy.IFabricHierarchy().get_fabric_hierarchy(
AttributeError: module 'usdrt' has no attribute 'hierarchy'
```

`usdrt.hierarchy` is a Python module supplied by `omni.hydra.usdrt_delegate`. `HEADLESS=1` selects
`isaaclab.python.headless.kit`, and `--visualizer kit` makes `NewtonManager` take its USD/Fabric sync
path (`_clone_physics_only` is false when a Kit visualizer is requested), so the import fails in that
app and no other. The same command runs to completion with this change.

## Validation

Launching `isaaclab.python.headless.kit` and reading back the enabled-extension set, before vs after:

* Adds exactly three extensions: `omni.hydra.usdrt_delegate`, `omni.activity.core`, `omni.usd.schema.anim` (60 → 63). Nothing is removed. The rest of the extension's dependency closure — `omni.client`, `omni.usd.core`, `omni.gpu_foundation`, `omni.gpucompute.plugins`, `usdrt.scenegraph`, `omni.usd.libs`, `omni.usd_resolver`, `omni.stats`, `omni.cubric`, `omni.assets.plugins`, `omni.kit.async_engine`, `omni.usd.config`, `omni.client.lib` — is already loaded.
* No measurable startup cost. Three alternating runs each: baseline `1.704 / 1.708 / 1.841 s` (median `1.708 s`), with the extension `1.723 / 1.676 / 1.652 s` (median `1.676 s`). The difference is well inside run-to-run noise.
* The extension already ships in the Isaac Sim extscache (8.5 MB), so nothing new is downloaded.
* `uv run isaaclab -f` passes.

`app.useFabricSceneDelegate` stays `false` in this app, so no scene delegate is created and stage population remains minimal — the change only makes the USDRT plugins available.
