### PR TITLE
[CI] Harden installation test containers

### DIFF
--- a/docker/test/test_run_install_ci.py
+++ b/docker/test/test_run_install_ci.py
@@ -110,3 +110,36 @@ def test_docker_without_results_dir_uses_rm_and_no_junit_copy(monkeypatch):
     assert "--name" not in docker_run_cmd
     assert all(not arg.startswith("--junitxml=") for arg in docker_run_cmd)
     assert docker_side_effects == []
+
+
+def test_docker_gpu_preflight_fails_before_test_container_starts(monkeypatch):
+    runner = _load_runner()
+    docker_runs = []
+    preflight_cmds = []
+
+    def fake_run_cmd(cmd, **_kwargs):
+        preflight_cmds.append(cmd)
+        return subprocess.CompletedProcess(cmd, 42, "", "")
+
+    monkeypatch.setattr(runner, "_build_image", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(runner, "_find_repo_root", lambda: REPO_ROOT)
+    monkeypatch.setattr(runner, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(runner.subprocess, "call", lambda cmd, timeout: docker_runs.append((cmd, timeout)) or 0)
+
+    rc = runner._cmd_docker(_docker_args(gpu=True))
+
+    assert rc == 42
+    assert preflight_cmds == [
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--gpus",
+            "all",
+            "--entrypoint",
+            "nvidia-smi",
+            "isaaclab-installci:ubuntu-24.04",
+            "-L",
+        ]
+    ]
+    assert docker_runs == []

--- a/source/isaaclab/test/install_ci/Dockerfile.installci
+++ b/source/isaaclab/test/install_ci/Dockerfile.installci
@@ -26,21 +26,42 @@ ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
 
-# Install system dependencies needed for building Py packages
+# Install package-build dependencies and the native runtime libraries loaded by
+# Isaac Sim and the standalone OV backends. Keep this consistent with the
+# runtime set in docker/Dockerfile.kitless so clean pip/uv environments do not
+# depend on libraries inherited accidentally from a runner image.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    git \
-    curl \
-    cmake \
-    python3 \
-    python3-dev \
-    python3-pip \
-    libglib2.0-0 \
-    python3-venv \
-    build-essential \
-    sudo \
+      build-essential \
+      ca-certificates \
+      cmake \
+      curl \
+      git \
+      libegl1 \
+      libgl1 \
+      libglib2.0-0 \
+      libgomp1 \
+      libopengl0 \
+      libvulkan1 \
+      libx11-6 \
+      libxext6 \
+      libxrender1 \
+      libxt6 \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-venv \
+      sudo \
     && rm -rf /var/lib/apt/lists/*
+
+# Fail the image build if a base-image or apt change leaves the native runtime
+# incomplete. Kit and the OV runtimes load these SONAMEs dynamically.
+RUN set -euo pipefail; \
+    for library in libEGL.so.1 libGL.so.1 libOpenGL.so.0 libvulkan.so.1 libX11.so.6 libXext.so.6 libXrender.so.1 libXt.so.6; do \
+      ldconfig -p | grep -Fq "${library}"; \
+    done
 
 # ARM-specific GL/X11 dev headers are intentionally NOT pre-installed here.
 # ``./isaaclab.sh -i`` auto-installs them via apt when missing, so install_ci

--- a/source/isaaclab/test/install_ci/uv_run/test_uv_run_isaacsim_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_run/test_uv_run_isaacsim_trains_cartpole.py
@@ -5,9 +5,10 @@
 
 """
 Setup:
-    - (none: uv run creates the environment from the committed uv.lock on first invocation)
+    - uv sync --frozen --extra isaacsim
 Tests:
-    - uv run --frozen --extra isaacsim isaaclab train --rl_library rsl_rl
+    - LD_PRELOAD=$UV_PROJECT_ENVIRONMENT/lib/python3.12/site-packages/isaacsim/kit/kernel/plugins/libcarb.env.shim.so
+        uv run --frozen --no-sync --extra isaacsim isaaclab train --rl_library rsl_rl
         --task Isaac-Cartpole-Direct --num_envs 16 --max_iterations 5 physics=isaacsim_physx
         -> verify training completes from the committed lockfile (Isaac Sim PhysX via the isaacsim extra)
 """
@@ -66,15 +67,42 @@ class Test_Uv_Run_Isaacsim_Trains_Cartpole:
     @pytest.mark.gpu
     @pytest.mark.timeout(4800)
     def test_uv_run_isaacsim_from_committed_lock_trains_cartpole(self, isaaclab_root, tmp_path):
-        """Verify ``uv run --frozen --extra isaacsim isaaclab train`` completes on Isaac Sim PhysX."""
-        result = run_cmd(
-            ["uv", "run", "--frozen", "--extra", "isaacsim", "isaaclab", *_ISAACSIM_PHYSX_TRAIN_CMD],
+        """Verify frozen Isaac Sim dependencies train Cartpole on Isaac Sim PhysX."""
+        venv = tmp_path / "venv"
+        runtime_env = {
+            "UV_PROJECT_ENVIRONMENT": str(venv),
+            "OMNI_KIT_ACCEPT_EULA": "yes",
+            **aarch64_isaacsim_env(),
+        }
+        sync_result = run_cmd(
+            ["uv", "sync", "--frozen", "--extra", "isaacsim"],
             cwd=isaaclab_root,
-            env={
-                "UV_PROJECT_ENVIRONMENT": str(tmp_path / "venv"),
-                "OMNI_KIT_ACCEPT_EULA": "yes",
-                **aarch64_isaacsim_env(),
-            },
+            env=runtime_env,
+            timeout=4500,
+        )
+        assert sync_result.returncode == 0, f"uv sync failed:\n{sync_result.stdout}\n{sync_result.stderr}"
+
+        # Kit plugins access and mutate the process environment from worker
+        # threads. Preload Carbonite's environment shim before Python starts so
+        # glibc getenv/setenv calls are serialized, matching the main Isaac Sim
+        # Docker images and preventing intermittent startup SIGSEGVs.
+        shim = venv / "lib/python3.12/site-packages/isaacsim/kit/kernel/plugins/libcarb.env.shim.so"
+        assert shim.is_file(), f"Carbonite environment shim was not installed at {shim}"
+        runtime_env["LD_PRELOAD"] = ":".join(filter(None, (str(shim), runtime_env.get("LD_PRELOAD"))))
+
+        result = run_cmd(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "--no-sync",
+                "--extra",
+                "isaacsim",
+                "isaaclab",
+                *_ISAACSIM_PHYSX_TRAIN_CMD,
+            ],
+            cwd=isaaclab_root,
+            env=runtime_env,
             timeout=4500,
         )
         _assert_training_passed(result)

--- a/tools/run_install_ci.py
+++ b/tools/run_install_ci.py
@@ -290,6 +290,26 @@ def _cmd_docker(args: argparse.Namespace) -> int:
         return rc
     print(f"Docker image built: {image_tag}")
 
+    if args.gpu:
+        # Validate the runner/container boundary before spending tens of minutes
+        # creating fresh package environments. The NVIDIA runtime injects
+        # nvidia-smi when the image requests the ``utility`` driver capability.
+        preflight_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--gpus",
+            "all",
+            "--entrypoint",
+            "nvidia-smi",
+            image_tag,
+            "-L",
+        ]
+        preflight = run_cmd(preflight_cmd, check=False, stream=True)
+        if preflight.returncode != 0:
+            print(f"Docker GPU preflight failed (exit {preflight.returncode})", file=sys.stderr)
+            return preflight.returncode
+
     host_results_xml: Path | None = None
     container_name: str | None = None
     container_results_xml = "/tmp/isaaclab-installci-results.xml"


### PR DESCRIPTION
## Description

Hardens the clean installation CI container and the Isaac Sim uv-run smoke test against the environment-dependent startup failure seen in the linked CI run.

The install image now includes the native graphics and X11 runtime libraries that Kit loads dynamically, verifies their SONAMEs while building, and requests the required NVIDIA driver capabilities. GPU jobs also fail early when the NVIDIA container runtime is unavailable.

The Isaac Sim smoke test preloads the Carbonite environment shim before Python starts. This matches the existing Isaac Sim Docker hardening and serializes process-environment access implicated by the intermittent libc getenv SIGSEGV. Dependency resolution remains frozen and is performed explicitly before the test process starts.

Failure context: https://github.com/isaac-sim/IsaacLab/actions/runs/32229916662/job/95997606331?pr=7168

No new dependencies are introduced beyond Ubuntu runtime packages already represented by the maintained Kitless container.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- uv run isaaclab -f
- uv run python -m pytest docker/test/test_run_install_ci.py -q
- uv run python tools/changelog/cli.py check develop
- uv run python tools/run_install_ci.py docker -- --collect-only -q
- uv run python tools/run_install_ci.py docker --gpu -- -k test_uv_run_isaacsim_from_committed_lock_trains_cartpole -sv --tb=short

The targeted GPU test built the clean image, passed the NVIDIA preflight, installed from the committed lockfile, launched Isaac Sim without the missing-library diagnostics from the failing job, and completed five Cartpole training iterations.

Documentation changes are not applicable because this only hardens CI infrastructure.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with uv run isaaclab -f
- [x] I have made corresponding changes to the documentation (not applicable; CI-only change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment for the touched package
- [ ] I have added my name to CONTRIBUTORS.md or my name already exists there