### PR TITLE
Request Docker CI with a checkbox in the PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,3 +57,11 @@ For example,
 - [x] I have done this task
 - [ ] I have not done this task
 -->
+
+<!-- CI invocation for docker tests -->
+## CI
+
+Docker and GPU tests do not run automatically. Tick the box to start them; every push unticks it.
+
+- [ ] Run Docker and GPU tests
+<!-- CI invocation for docker tests -->

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,11 @@
 # CI Workflows
 
-`schedule:` and `workflow_dispatch:` triggers fire **only from the default
-branch (`main`)**. A workflow YAML must live on `main` for its cron to
-register — the same file on other branches has no effect. `pull_request:`
-and `push:` triggers fire from the event branch's file and work normally
-on `develop`.
+`schedule:` and `workflow_dispatch:` triggers fire **only from the
+repository's current default branch**, which is not always `main` — it is
+`release/3.0.0-beta2` at the time of writing. A workflow YAML must live on
+that branch for its cron to register; the same file on another branch has no
+effect. `pull_request:` and `push:` triggers fire from the event branch's
+file and work normally on `develop`; `pull_request_target:` fires from the
+base branch's file, and unlike `pull_request` it carries a write token and
+secrets on fork PRs, which is how a `develop`-resident workflow can act on a
+PR. It must never check out PR code.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # region help
-# Every test job runs on every PR and merge queue candidate. Pushes to protected branches run the
-# post-merge integration tests.
+# On a PR, the Docker builds and their dependent tests run only on a labeled event. Tick the "Run
+# Docker and GPU tests" box in the PR description and ci-request.yml applies the label for you;
+# every push unticks it, so each batch of commits is requested on its own. A manual workflow
+# dispatch runs the same jobs. Do not filter the label with a job-level ``if``: GitHub treats
+# skipped required jobs as successful status checks, so an unrequested PR must produce no run at
+# all rather than a skipped one. Pushes to protected branches still run the post-merge integration
+# tests.
 #
 # =============================================================================
 # CI DEBUGGING TIPS
@@ -53,7 +58,7 @@ on:
       - develop
       - 'release/**'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled]
     branches:
       - main
       - develop

--- a/.github/workflows/ci-request.yml
+++ b/.github/workflows/ci-request.yml
@@ -1,0 +1,157 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# region help
+# Turns the "Run Docker and GPU tests" box in the PR description into a Docker
+# CI run. Every push unticks the box, so each batch of commits has to be
+# requested on its own. A description without the section gets it appended --
+# on any event, so a PR opened before the template carried the block, or one
+# whose author deleted it, picks it up again on the next push.
+#
+# ``pull_request_target`` runs the base branch's copy of this file and carries
+# a write token and secrets even on fork PRs, which is what lets a workflow
+# living on ``develop`` act on a PR. A comment command could not: GitHub reads
+# ``issue_comment`` only from the repository's default branch.
+#
+# This workflow never checks out PR code, and it never interpolates the PR body
+# into a shell line -- a description is attacker-controlled text, so it moves
+# through environment variables and jq only.
+# endregion
+
+name: CI Request
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+    branches:
+      - main
+      - develop
+      - 'release/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ci-request-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  # Keep in sync with the block at the end of .github/PULL_REQUEST_TEMPLATE.md.
+  # The markers delimit the block so it stays recognisable to a reader when the
+  # surrounding description changes.
+  CI_SECTION: |
+    <!-- CI invocation for docker tests -->
+    ## CI
+
+    Docker and GPU tests do not run automatically. Tick the box to start them; every push unticks it.
+
+    - [ ] Run Docker and GPU tests
+    <!-- CI invocation for docker tests -->
+
+jobs:
+  ci-request:
+    name: Handle CI request
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Editing a PR description is already limited to the author and users with
+      # triage or write access, so ticking the box needs no separate permission
+      # check. Writing the body back with GITHUB_TOKEN keeps this step from
+      # retriggering the workflow: events caused by GITHUB_TOKEN do not create
+      # workflow runs.
+      - name: Normalize the request box
+        id: box
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Read the body from the API, not the event payload: an edit that
+          # landed while this run was queued would otherwise be clobbered.
+          body="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')"
+          box_line='^[[:space:]]*-[[:space:]]*\[[ xX]\][[:space:]]*Run Docker and GPU tests'
+          ticked='^[[:space:]]*-[[:space:]]*\[[xX]\][[:space:]]*Run Docker and GPU tests'
+
+          # Keyed on the box rather than the marker: a description that kept the
+          # markers but lost the box would otherwise be left with no way to
+          # request CI. Appending cannot duplicate the box, only the markers.
+          if ! grep -qE "$box_line" <<< "$body"; then
+            # Section missing -- append it at the end, unticked.
+            if [ -z "$body" ]; then
+              body_out="$CI_SECTION"
+            else
+              body_out="$(printf '%s\n\n%s' "$body" "$CI_SECTION")"
+            fi
+            checked=false
+          elif [ "$EVENT_ACTION" = "synchronize" ]; then
+            body_out="$(sed -E 's/^([[:space:]]*-[[:space:]]*)\[[xX]\]([[:space:]]*Run Docker and GPU tests)/\1[ ]\2/' <<< "$body")"
+            checked=false
+          else
+            body_out="$body"
+            if grep -qE "$ticked" <<< "$body"; then checked=true; else checked=false; fi
+          fi
+
+          if [ "$body_out" != "$body" ]; then
+            jq -n --arg body "$body_out" '{body: $body}' \
+              | gh api --method PATCH "repos/$REPOSITORY/pulls/$PR_NUMBER" --input - --silent
+            echo "Updated the CI request box in the description." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "checked=$checked" >> "$GITHUB_OUTPUT"
+
+      # A ticked box fires ``edited`` again on any later description change, so
+      # skip when this head commit already has a run rather than starting a
+      # duplicate. For pull_request runs, head_sha is the PR head commit.
+      - name: Check whether this commit already ran
+        id: prior
+        if: steps.box.outputs.checked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          count="$(
+            gh api "repos/$REPOSITORY/actions/runs?head_sha=$HEAD_SHA&event=pull_request" \
+              --jq '[.workflow_runs[] | select(.name == "Docker + Tests")] | length'
+          )"
+          if [ "$count" -gt 0 ]; then
+            echo "Docker CI already ran for ${HEAD_SHA:0:7}; not requesting it again." >> "$GITHUB_STEP_SUMMARY"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create isaaclab-bot token
+        id: app-token
+        if: steps.prior.outputs.needed == 'true'
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      # Labels applied with GITHUB_TOKEN do not create workflow runs, so the App
+      # token is what lets this reach Docker + Tests.
+      - name: Trigger Docker CI
+        if: steps.prior.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          LABEL: ci:run-docker
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          endpoint="repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+          gh api --method DELETE "$endpoint/$LABEL" --silent >/dev/null 2>&1 || true
+          gh api --method POST "$endpoint" -f "labels[]=$LABEL" --silent
+          gh api --method DELETE "$endpoint/$LABEL" --silent
+
+          echo "Requested Docker CI for PR #$PR_NUMBER." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Docker and GPU tests stop running on every PR event. They run when the author asks for them, by ticking a box in the PR description.

- ticking **Run Docker and GPU tests** applies `ci:run-docker`, which is what `build.yaml`'s `labeled` trigger waits for
- every push unticks the box, so a request covers the commits it was made for and nothing later
- a description without the request section gets it appended, on any event, so PRs opened before the template carried the block pick it up on their next push
- changed-path detection, downstream test dependencies, post-merge `push` runs, and maintainer dispatches are unchanged

## Why

The two self-hosted GPU Docker builds currently start automatically whenever relevant files change on a PR, including on every intermediate push. Authors need a self-service way to say when a branch is worth that cost, without a protected environment, a webhook service, or write access to launch `workflow_dispatch`.

## How it works

`ci-request.yml` runs on `pull_request_target`, which GitHub reads from the PR's **base branch** and which carries a write token and secrets even for fork PRs. That is what makes on-demand CI work for PRs against `develop`. A comment command cannot: `issue_comment` is only ever read from the repository's default branch, currently `release/3.0.0-beta2`, so a comment handler merged to `develop` would sit inert until a release branch cut from `develop` became the default.

| event | behaviour |
|---|---|
| `opened` | starts CI if the author opened with the box ticked |
| `edited` | ticked box starts CI, unless this head commit already has a run |
| `synchronize` | unticks the box; starts nothing |

On every one of those events, a description with no request box has the section appended at the end, delimited by `<!-- CI invocation for docker tests -->` markers and matching the block in the PR template. The check keys on the box rather than the marker: a description that kept the markers but lost the box would otherwise have no control at all, and appending can duplicate only the markers, never the box.

The label is applied and immediately removed, so the box can be reused after the next push.

## Safety

- **Never checks out PR code.** `pull_request_target` is privileged, so the workflow only calls the API. The PR body is attacker-controlled text and moves through environment variables and `jq`, never interpolated into a shell line.
- **No permission check needed.** Editing a PR description is already restricted to the author and users with triage or write access.
- **No self-retrigger.** The box is rewritten with `GITHUB_TOKEN`, whose events do not create workflow runs.
- **No duplicate runs.** A ticked box re-fires `edited` on any later description change, so the handler skips when the head commit already has a `Docker + Tests` run. Verified against this repo: for `pull_request` runs, `head_sha` is the PR head commit, and `?head_sha=` filters on it.
- **Required checks keep their meaning.** `build.yaml` still triggers only on `labeled`, so an unrequested PR produces *no* run rather than a skipped one. This matters because GitHub reports skipped required jobs as successful — a job-level `if:` filter would let an unrequested PR show green required Docker contexts.

## Differences from #7059

`develop` has moved on from `release/3.0.0-beta2`, so this is a port rather than a cherry-pick, and the request mechanism differs:

- #7059 requests CI by commenting `run-ci`, handled by an `issue_comment` workflow. That only works from the default branch, which `develop` is not. This PR uses the description checkbox instead, which works from `develop` on merge.
- `build.yaml` on `develop` also has a `push:` trigger for the post-merge integration jobs. Only the `pull_request` types change; `push` and `workflow_dispatch` are untouched, and jobs already gated with `github.event_name != 'push'` keep working because a `labeled` event is still a `pull_request` event.
- The `region help` header is rewritten against `develop`'s wording, which documents the post-merge `push` path.
- `.github/workflows/README.md` now records that the default branch is not `main`, and that `pull_request_target:` fires from the base branch with a write token.

Out of scope, as in #7059: `arm-ci.yml` and `kitless-docker.yml` still build on ordinary PR events.

## Validation

- box normalization verified against ten cases: missing box, ticked and unticked under `edited`, ticked and unticked under `synchronize`, a CRLF body with `[X]` (GitHub stores descriptions with CRLF), a legacy PR with no section, an empty description, a second edit after appending, and a description whose markers survived but whose box did not
- confirmed the unticked-box path issues no API write, since both the read and the rewrite pass through command substitution
- `head_sha` filter and its meaning for `pull_request` runs verified against this repository's API
- both workflow files parse as YAML
- `uv run isaaclab -f`
- no changelog fragment: the change touches only `.github/`

<!-- CI invocation for docker tests -->
## CI

Docker and GPU tests do not run automatically. Tick the box to start them; every push unticks it.

- [x] Run Docker and GPU tests
<!-- CI invocation for docker tests -->

