### PR TITLE
Publish release Docker images after merges

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,8 +6,11 @@
 name: Publish Docker Images
 
 on:
-  # Image publishing is owned by the nightly cron (registered on the default
-  # branch, main). No push triggers — pushes to develop / release no longer publish.
+  # Release branches publish after every merge. Develop remains on the nightly
+  # publisher registered on the default branch (main).
+  push:
+    branches:
+      - 'release/**'
   workflow_dispatch:
 
 # Concurrency control to prevent parallel runs

--- a/source/isaaclab/changelog.d/codex-release-docker-publish.skip
+++ b/source/isaaclab/changelog.d/codex-release-docker-publish.skip
@@ -1,0 +1,1 @@
+CI-only: release branch pushes now publish Docker images after merges. No package release note is required.


### PR DESCRIPTION
## Summary

- publish Docker images on pushes to `release/**`, including merged PRs and the initial release branch cut
- keep `develop` image publishing on the existing nightly path
- add a CI-only changelog skip fragment

## Why

A release branch cut from `develop` does not contain `main`'s `postmerge-ci.yml`. The branch-local publish workflow previously had only `workflow_dispatch`, so merges into a new `release/3.0.0` branch would not publish Docker images automatically.

The existing release tag logic will publish `latest-release-3.0.0` and the immutable SHA tag without a branch-specific workflow edit.

## Validation

- `uv run isaaclab -f`
- parsed the workflow YAML and asserted the `release/**` push trigger
- changelog fragment validation
