### PR TITLE
Make MPM visualization backend agnostic

### DIFF
--- a/source/isaaclab_newton/changelog.d/mpm-visualization-backend-agnostic.rst
+++ b/source/isaaclab_newton/changelog.d/mpm-visualization-backend-agnostic.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Made MPM particle visualization available to non-Kit renderers and visualizers.

--- a/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/mpm_object/mpm_object.py
@@ -347,14 +347,11 @@ class MPMObject(BaseDeformableObject):
         )
         self._data.default_nodal_state_w = ProxyArray(default_state)
         self._data.default_particle_state_w = self._data.default_nodal_state_w
-        self._create_kit_points()
+        self._create_particle_visualization()
 
-    def _create_kit_points(self) -> None:
-        """Create Kit-visible ``UsdGeom.Points`` prims when the Kit visualizer is active."""
-        from isaaclab.sim import SimulationContext  # noqa: PLC0415
-
-        sim = SimulationContext.instance()
-        if sim is None or "kit" not in sim.resolve_visualizer_types() or not self.cfg.spawn.visible:
+    def _create_particle_visualization(self) -> None:
+        """Create renderer-agnostic ``UsdGeom.Points`` prims for visible particles."""
+        if not self.cfg.spawn.visible:
             return
 
         first_offset = self._recorded_particle_offsets[0]
@@ -363,9 +360,9 @@ class MPMObject(BaseDeformableObject):
             .particle_radius[first_offset : first_offset + self._particles_per_object]
             .numpy()
         )
-        base_path = _create_kit_visualization_path(self.cfg.prim_path)
+        asset_prim_paths = _resolve_particle_asset_paths(self.cfg.prim_path, self._num_instances)
         prim_paths = create_mpm_particle_visualization(
-            prim_path=base_path,
+            prim_paths=[f"{path}/Particles" for path in asset_prim_paths],
             positions=self.data.particle_pos_w.warp.numpy(),
             widths=2.0 * radii,
             color=self.cfg.spawn.visual_color,
@@ -378,7 +375,7 @@ class MPMObject(BaseDeformableObject):
                 particle_count=self._particles_per_object,
                 sync_frequency=self.cfg.spawn.visual_update_frequency,
             )
-        logger.info("Kit MPM particle visualization initialized at: %s", base_path)
+        logger.info("MPM particle visualization initialized for: %s", self.cfg.prim_path)
 
     def _resolve_env_ids(self, env_ids):
         if env_ids is None or (isinstance(env_ids, slice) and env_ids == slice(None)):
@@ -446,6 +443,27 @@ def _compose_env_asset_pose(
     return (float(pos[0]), float(pos[1]), float(pos[2])), (float(rot[0]), float(rot[1]), float(rot[2]), float(rot[3]))
 
 
-def _create_kit_visualization_path(prim_path: str) -> str:
-    sanitized = "".join(char if char.isalnum() else "_" for char in prim_path.strip("/"))
-    return f"/World/Visuals/MPMParticles/{sanitized or 'Object'}"
+def _resolve_particle_asset_paths(prim_path: str, num_instances: int) -> list[str]:
+    """Resolve one concrete MPM asset path per Newton world."""
+    import isaaclab.sim as sim_utils  # noqa: PLC0415
+    from isaaclab.cloner import path as cloner_path  # noqa: PLC0415
+    from isaaclab.cloner.query import iter_sources  # noqa: PLC0415
+
+    sim = sim_utils.SimulationContext.instance()
+    clone_plan = sim.get_clone_plan() if sim is not None else None
+    if clone_plan is not None and clone_plan.env_ids is not None:
+        paths_by_env_id: dict[int, str] = {}
+        for _, template, _, env_ids in iter_sources(clone_plan, prim_path):
+            matched = cloner_path.match(prim_path, template)
+            if matched is not None:
+                paths_by_env_id.update((env_id, f"{template.format(env_id)}{matched.suffix}") for env_id in env_ids)
+        env_ids = [int(env_id) for env_id in clone_plan.env_ids.tolist()]
+        if len(env_ids) == num_instances and all(env_id in paths_by_env_id for env_id in env_ids):
+            return [paths_by_env_id[env_id] for env_id in env_ids]
+
+    matched_paths = sim_utils.find_matching_prim_paths(prim_path)
+    if len(matched_paths) != num_instances:
+        raise RuntimeError(
+            f"Expected {num_instances} MPM asset prims matching '{prim_path}', found {len(matched_paths)}."
+        )
+    return matched_paths

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -767,7 +767,7 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def sync_particles_to_usd(cls) -> None:
-        """Write Newton particle positions to USD/Fabric for Kit viewport rendering.
+        """Write Newton particle positions to USD/Fabric for USD-stage rendering.
 
         Two prim families are synced from ``state_0.particle_q``:
 

--- a/source/isaaclab_newton/isaaclab_newton/sim/spawners/mpm/visualization.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/spawners/mpm/visualization.py
@@ -13,7 +13,7 @@ from isaaclab.sim.spawners.materials.visual_materials_cfg import VisualMaterialC
 
 
 def create_mpm_particle_visualization(
-    prim_path: str,
+    prim_paths: Sequence[str],
     positions: np.ndarray,
     widths: np.ndarray,
     color: Sequence[float],
@@ -27,8 +27,7 @@ def create_mpm_particle_visualization(
     :meth:`isaaclab_newton.physics.NewtonManager.register_particle_visual_prim`.
 
     Args:
-        prim_path: Base prim path; one ``Points`` prim is created per environment
-            at ``{prim_path}/env_{idx}``.
+        prim_paths: ``Points`` prim paths, one per environment.
         positions: Initial world-frame particle positions [m], shape
             ``(num_envs, particles_per_env, 3)``.
         widths: Particle display widths (diameters) [m], one per particle.
@@ -43,26 +42,30 @@ def create_mpm_particle_visualization(
     import isaaclab.sim as sim_utils
 
     stage = sim_utils.get_current_stage()
-    prim_paths = [f"{prim_path}/env_{env_idx}" for env_idx in range(positions.shape[0])]
+    prim_paths = list(prim_paths)
+    if len(prim_paths) != positions.shape[0]:
+        raise ValueError(
+            "Expected one particle visualization prim path per environment, "
+            f"got {len(prim_paths)} paths for {positions.shape[0]} environments."
+        )
     points_prims = [UsdGeom.Points.Define(stage, path) for path in prim_paths]
 
     widths_vt = Vt.FloatArray.FromNumpy(np.ascontiguousarray(widths, dtype=np.float32))
     color_vt = Vt.Vec3fArray([Gf.Vec3f(*(float(value) for value in color))])
     with Sdf.ChangeBlock():
         for env_idx, points in enumerate(points_prims):
+            points.SetResetXformStack(True)
             points.GetPointsAttr().Set(Vt.Vec3fArray.FromNumpy(positions[env_idx]))
             points.CreateWidthsAttr(widths_vt)
             points.CreateDisplayColorAttr(color_vt)
 
-    from isaaclab.utils.version import has_kit  # noqa: PLC0415
-
-    if visual_material is not None and has_kit():
-        UsdGeom.Scope.Define(stage, f"{prim_path}/Looks")
-        material_path = f"{prim_path}/Looks/visualMaterial"
-        visual_material.func(material_path, visual_material)
-        material_prim = stage.GetPrimAtPath(material_path)
-        if material_prim.IsValid():
-            for path in prim_paths:
-                sim_utils.bind_visual_material(path, material_path, stage=stage)
+    if visual_material is not None:
+        for path in prim_paths:
+            material_scope_path = Sdf.Path(path).GetParentPath().AppendChild("Looks")
+            UsdGeom.Scope.Define(stage, material_scope_path)
+            material_path = material_scope_path.AppendChild("visualMaterial")
+            visual_material.func(str(material_path), visual_material)
+            if stage.GetPrimAtPath(material_path).IsValid():
+                sim_utils.bind_visual_material(path, str(material_path), stage=stage)
 
     return prim_paths

--- a/source/isaaclab_newton/test/assets/test_mpm_object.py
+++ b/source/isaaclab_newton/test/assets/test_mpm_object.py
@@ -103,6 +103,7 @@ def test_mpm_object_initializes_from_interactive_scene():
                 upper=(0.1, 0.1, 0.1),
                 voxel_size=0.1,
                 particle_placement="cell_center",
+                visible=False,
             ),
         )
 
@@ -188,7 +189,7 @@ def test_mpm_solver_refreshes_kinematic_rigid_body_transforms():
         np.testing.assert_allclose(body_q, root_pose.detach().cpu().numpy()[0], rtol=1.0e-5, atol=1.0e-6)
 
 
-def test_mpm_object_creates_usd_points_for_kit_visualizer(monkeypatch):
+def test_mpm_object_creates_usd_points_without_kit_visualizer(monkeypatch):
     @configclass
     class MPMSceneCfg(InteractiveSceneCfg):
         media = MPMObjectCfg(
@@ -209,7 +210,7 @@ def test_mpm_object_creates_usd_points_for_kit_visualizer(monkeypatch):
     )
 
     with build_simulation_context(sim_cfg=sim_cfg) as sim:
-        monkeypatch.setattr(sim, "resolve_visualizer_types", lambda: ["kit"])
+        monkeypatch.setattr(sim, "resolve_visualizer_types", lambda: ["newton"])
         scene = InteractiveScene(MPMSceneCfg(num_envs=2, env_spacing=1.0))
 
         from pxr import UsdGeom  # noqa: PLC0415
@@ -220,7 +221,11 @@ def test_mpm_object_creates_usd_points_for_kit_visualizer(monkeypatch):
         records = NewtonMPMManager._particle_visual_prims
         assert len(records) == media.num_instances
 
-        for env_idx, (prim_path, record) in enumerate(sorted(records.items())):
+        expected_paths = [f"/World/envs/env_{env_idx}/Sand/Particles" for env_idx in range(media.num_instances)]
+        assert list(records) == expected_paths
+
+        for env_idx, prim_path in enumerate(expected_paths):
+            record = records[prim_path]
             assert record.offset == media._recorded_particle_offsets[env_idx]
             assert record.count == media.particles_per_object
             assert record.sync_frequency == 1
@@ -228,12 +233,13 @@ def test_mpm_object_creates_usd_points_for_kit_visualizer(monkeypatch):
             points_prim = media.stage.GetPrimAtPath(prim_path)
             assert points_prim.IsValid()
             points = UsdGeom.Points(points_prim)
+            assert points.GetResetXformStack()
             assert len(points.GetPointsAttr().Get()) == media.particles_per_object
             assert len(points.GetWidthsAttr().Get()) == media.particles_per_object
             assert tuple(points.GetDisplayColorAttr().Get()[0]) == pytest.approx((0.1, 0.2, 0.3))
 
 
-def test_mpm_kit_points_follow_particle_state(monkeypatch):
+def test_mpm_usd_points_follow_particle_state(monkeypatch):
     @configclass
     class MPMSceneCfg(InteractiveSceneCfg):
         media = MPMObjectCfg(
@@ -254,7 +260,7 @@ def test_mpm_kit_points_follow_particle_state(monkeypatch):
     )
 
     with build_simulation_context(sim_cfg=sim_cfg) as sim:
-        monkeypatch.setattr(sim, "resolve_visualizer_types", lambda: ["kit"])
+        monkeypatch.setattr(sim, "resolve_visualizer_types", lambda: ["newton"])
         scene = InteractiveScene(MPMSceneCfg(num_envs=1, env_spacing=0.0))
         sim.reset()
 

--- a/source/isaaclab_newton/test/sim/test_mpm_visualization.py
+++ b/source/isaaclab_newton/test/sim/test_mpm_visualization.py
@@ -13,16 +13,14 @@ from isaaclab_newton.sim.spawners.mpm.visualization import create_mpm_particle_v
 from pxr import Gf, Usd, UsdGeom, UsdShade
 
 import isaaclab.sim as sim_utils
-import isaaclab.utils.version as version_utils
 
 
-def _create_visualization(monkeypatch, visual_material, *, has_kit: bool):
+def _create_visualization(monkeypatch, visual_material):
     stage = Usd.Stage.CreateInMemory()
     monkeypatch.setattr(sim_utils, "get_current_stage", lambda: stage)
-    monkeypatch.setattr(version_utils, "has_kit", lambda: has_kit)
 
     prim_paths = create_mpm_particle_visualization(
-        prim_path="/World/Particles",
+        prim_paths=["/World/Particles/env_0"],
         positions=np.zeros((1, 2, 3), dtype=np.float32),
         widths=np.full(2, 0.01, dtype=np.float32),
         color=(0.1, 0.2, 0.3),
@@ -37,37 +35,20 @@ def _assert_display_color_fallback(stage, prim_path):
     assert UsdShade.MaterialBindingAPI(points).GetDirectBindingRel().GetTargets() == []
 
 
-def test_kitless_particle_visualization_skips_kit_material(monkeypatch):
-    """Kitless renderers keep displayColor and never invoke Kit-only material spawners."""
-
-    def fail_if_called(_prim_path, _cfg):
-        raise AssertionError("Kit-only visual material spawner was called in kitless mode")
-
-    stage, prim_path = _create_visualization(
-        monkeypatch,
-        SimpleNamespace(func=fail_if_called),
-        has_kit=False,
-    )
-
-    _assert_display_color_fallback(stage, prim_path)
-
-
 def test_missing_visual_material_prim_falls_back_to_display_color(monkeypatch):
     """A material spawner that authors no valid USD material leaves the points unbound."""
     stage, prim_path = _create_visualization(
         monkeypatch,
         SimpleNamespace(func=lambda _prim_path, _cfg: None),
-        has_kit=True,
     )
 
     _assert_display_color_fallback(stage, prim_path)
 
 
-def test_kit_particle_visualization_uses_standard_material_binding(monkeypatch):
-    """A valid Kit material is bound through Isaac Lab's visual-material helper."""
+def test_particle_visualization_uses_standard_material_binding_helper(monkeypatch):
+    """A valid material is bound through Isaac Lab's visual-material helper."""
     stage = Usd.Stage.CreateInMemory()
     monkeypatch.setattr(sim_utils, "get_current_stage", lambda: stage)
-    monkeypatch.setattr(version_utils, "has_kit", lambda: True)
     bindings = []
     monkeypatch.setattr(
         sim_utils,
@@ -80,7 +61,7 @@ def test_kit_particle_visualization_uses_standard_material_binding(monkeypatch):
 
     visual_material = SimpleNamespace(func=spawn_material)
     prim_paths = create_mpm_particle_visualization(
-        prim_path="/World/Particles",
+        prim_paths=["/World/Particles/env_0"],
         positions=np.zeros((1, 2, 3), dtype=np.float32),
         widths=np.full(2, 0.01, dtype=np.float32),
         color=(0.1, 0.2, 0.3),


### PR DESCRIPTION
## Summary

Make Newton MPM particle visualization independent of the active visualizer and place each particle cloud under the MPM asset that owns it.

## Root cause

`MPMObject` created `UsdGeom.Points` only when Kit was active and stored all visualization prims under a synthetic global `/World/Visuals/MPMParticles/...` hierarchy. Non-Kit visualizers therefore had no USD particle geometry to consume, and the global hierarchy did not preserve per-environment asset ownership or inherit each environment's `omni:scenePartition`.

This follows the design proposed in [huidongc/IsaacLab@cfadf75](https://github.com/huidongc/IsaacLab/commit/cfadf7583402c280d0091c0ae6fd00a99dafd973): always create the USD particle visualization, place each `Particles` prim beneath its owning environment asset, and reset its xform stack because positions are authored in world space.

## Changes

- create particle visualization whenever the MPM asset is visible, regardless of visualizer type
- resolve concrete cloned asset paths with the public cloner query/path APIs
- author one `<MPM asset>/Particles` prim per environment and register each prim for per-frame synchronization
- reset the points xform stack because particle positions are authored in world space
- keep `displayColor` as the renderer-independent fallback and bind optional materials beside each asset
- validate that callers provide exactly one visualization path per particle world

The low-level `create_mpm_particle_visualization` helper now accepts explicit `prim_paths` instead of constructing paths from one global base path. All in-repository callers are updated.

Compared with the proposed patch's direct `env_.*` regular-expression substitution, this implementation resolves concrete paths through IsaacLab's public clone-plan query/path APIs, with a stage-query fallback. This supports the repository's path-expression semantics and actual clone environment IDs without assuming one literal environment regex.

## Validation

- 25 focused MPM object, spawner, visualization, and reset-contract tests passed
- Snowball Smash smoke: 9,150 particles
- Granular smoke: 162,000 particles
- Teapot Fill smoke: 29,179 particles
- Two-Way Coupling smoke: 89,208 particles
- Franka Pour zero-agent smoke: 2 environments
- UR10 Particle Push zero-agent smoke: 2 environments
- `git diff --check` passed
- `uv.lock` and `pyproject.toml` are unchanged
