### PR TITLE
Point the LEAPP semantics link at its current page

### DIFF
--- a/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
@@ -240,6 +240,6 @@ into deployment systems.
 .. note::
 
    Refer to the `LEAPP semantic annotation guide
-   <https://nvidia-isaac.github.io/leapp/guides/semantics.html>`_
+   <https://nvidia-isaac.github.io/leapp/semantics/usage.html>`_
    and `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`_
    for details on authoring semantic annotations.


### PR DESCRIPTION
## Summary

- point the LEAPP semantic annotation link at `semantics/usage.html`, the page it lives on now

## Why

The LEAPP docs moved the guide, so `https://nvidia-isaac.github.io/leapp/guides/semantics.html` returns 404. The link checker runs on any pull request that touches a Markdown or reStructuredText file and checks every doc, so this one stale link fails `Check for Broken Links` on changes that have nothing to do with the tutorial -- for example isaac-sim/IsaacLab#7059, which only edits `.github/`.

`develop` already carries the corrected URL; this ports just that line, without the rest of the tutorial rewrite on that branch.

## Impact

Documentation only. No behavior change.

## Validation

- `uv run isaaclab -f`
- confirmed the old URL returns 404 and the new one returns 200