### PR TITLE
[MultiGPU] Fix concurrent remote asset cache initialization

### DIFF
--- a/source/isaaclab/changelog.d/lock-remote-asset-mirrors.rst
+++ b/source/isaaclab/changelog.d/lock-remote-asset-mirrors.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed concurrent remote USD cache initialization during distributed startup.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -13,6 +13,7 @@ For more information, please check information on `Omniverse Nucleus`_.
 .. _Omniverse Nucleus: https://docs.omniverse.nvidia.com/nucleus/latest/overview/overview.html
 """
 
+import contextlib
 import io
 import json
 import logging
@@ -21,8 +22,11 @@ import posixpath
 import re
 import subprocess
 import tempfile
+import uuid
 from typing import Literal
 from urllib.parse import urlparse
+
+from filelock import FileLock
 
 logger = logging.getLogger(__name__)
 
@@ -447,12 +451,18 @@ def _store_mirror(url: str, data: bytes) -> None:
         return
     try:
         os.makedirs(os.path.dirname(mirrored), exist_ok=True)
-        with open(mirrored, "wb") as f:
-            f.write(data)
+        with FileLock(mirrored + ".lock"):
+            temporary_path = f"{mirrored}.{uuid.uuid4().hex}.partial"
+            try:
+                with open(temporary_path, "wb") as f:
+                    f.write(data)
+                os.replace(temporary_path, mirrored)
+            finally:
+                with contextlib.suppress(OSError):
+                    os.remove(temporary_path)
+            _write_mirror_fingerprint(url, mirrored)
     except OSError as exc:
         logger.debug("Unable to cache the asset '%s' locally: %s", url, exc)
-        return
-    _write_mirror_fingerprint(url, mirrored)
 
 
 def check_file_path(path: str) -> Literal[0, 1, 2]:
@@ -547,21 +557,37 @@ def retrieve_file_path(path: str, download_dir: str | None = None, force_downloa
             os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
             is_root_asset = local_root is None
-            # an outdated local copy is re-fetched, so a changed remote asset is picked up
-            if force_download or not _usable_mirror(cur_url, download_dir):
-                result = omni.client.copy(cur_url, target_path, omni.client.CopyBehavior.OVERWRITE)
-                if result != omni.client.Result.OK:
-                    if force_download or is_root_asset:
-                        raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
-                    logger.debug("Skipping unavailable dependency: %s", cur_url)
-                    continue
-                _write_mirror_fingerprint(cur_url, target_path)
+            # Ranks can initialize against the same cold cache concurrently. Serialize a single
+            # mirrored file so no USD parser observes another rank overwriting it mid-read.
+            with FileLock(target_path + ".lock"):
+                # Re-check after acquiring the lock: another rank may have downloaded this asset
+                # while this rank was waiting.
+                if force_download or not _usable_mirror(cur_url, download_dir):
+                    temporary_path = f"{target_path}.{uuid.uuid4().hex}.partial"
+                    try:
+                        result = omni.client.copy(cur_url, temporary_path, omni.client.CopyBehavior.OVERWRITE)
+                        if result != omni.client.Result.OK:
+                            if force_download or is_root_asset:
+                                raise RuntimeError(f"Unable to copy file: '{cur_url}'. Is the Nucleus Server running?")
+                            logger.debug("Skipping unavailable dependency: %s", cur_url)
+                            continue
+                        # A reader that does not take this process-local lock must never observe
+                        # a partially copied USD file.
+                        os.replace(temporary_path, target_path)
+                        _write_mirror_fingerprint(cur_url, target_path)
+                    finally:
+                        with contextlib.suppress(OSError):
+                            os.remove(temporary_path)
+
+                # Resolve references while the mirror is stable. Each dependency gets its own
+                # lock below, preserving parallel initialization of unrelated asset trees.
+                references = _find_asset_dependencies(target_path)
 
             if local_root is None:
                 local_root = target_path
 
             # recurse into dependencies (USD references, payloads, MDL textures, etc.)
-            for ref in _find_asset_dependencies(target_path):
+            for ref in references:
                 ref_url = _resolve_reference_url(cur_url, ref)
                 if ref_url and ref_url not in visited:
                     to_visit.append(ref_url)

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -10,6 +10,9 @@ import importlib
 import json
 import logging
 import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -360,6 +363,50 @@ def test_local_copy_without_a_recorded_revision_is_refetched(asset_cache, monkey
     _serve(monkeypatch, {_REMOTE_URL: current}, payloads={_REMOTE_URL: b"fresh bytes"})
 
     assert assets_utils.read_file(_REMOTE_URL).read() == b"fresh bytes"
+
+
+def test_retrieve_file_path_serializes_cold_cache_population(asset_cache, monkeypatch):
+    """Test concurrent ranks reuse the mirror populated by the first rank."""
+    import omni.client
+
+    revision = {"hash": "abc123", "version": "", "size": 12, "modified_time": "2026-07-01 10:00:00"}
+    _serve(monkeypatch, {_REMOTE_URL: revision})
+    copy_count = 0
+    active_copies = 0
+    max_active_copies = 0
+    counter_lock = threading.Lock()
+    mirrored = Path(assets_utils._mirror_path(_REMOTE_URL, str(asset_cache)))
+
+    def fake_copy(url, target_path, behavior):
+        nonlocal copy_count, active_copies, max_active_copies
+        assert url == _REMOTE_URL
+        assert behavior == omni.client.CopyBehavior.OVERWRITE
+        assert Path(target_path) != mirrored
+        with counter_lock:
+            copy_count += 1
+            active_copies += 1
+            max_active_copies = max(max_active_copies, active_copies)
+        time.sleep(0.05)
+        Path(target_path).write_bytes(b"#usda 1.0\n")
+        with counter_lock:
+            active_copies -= 1
+        return omni.client.Result.OK
+
+    monkeypatch.setattr(omni.client, "copy", fake_copy)
+    monkeypatch.setattr(assets_utils, "_find_asset_dependencies", lambda path: set())
+    start = threading.Barrier(2)
+
+    def retrieve() -> str:
+        start.wait()
+        return assets_utils.retrieve_file_path(_REMOTE_URL, str(asset_cache))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        retrieved = list(executor.map(lambda _: retrieve(), range(2)))
+
+    assert retrieved == [str(mirrored)] * 2
+    assert mirrored.read_bytes() == b"#usda 1.0\n"
+    assert copy_count == 1
+    assert max_active_copies == 1
 
 
 def test_size_and_modification_time_identify_a_revision(asset_cache, monkeypatch):


### PR DESCRIPTION
# Description

Fixes an issue with multiple processes from multiGPU competing for the same USD cache.

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
