### PR TITLE
Publish release 3.0.0 Docker images nightly

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -29,7 +29,7 @@ permissions:
 # purpose (it builds on the public isaac-sim base via postmerge-ci.yml).
 env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
-  CRON_BRANCHES: develop,release/3.0.0-beta2
+  CRON_BRANCHES: develop,release/3.0.0-beta2,release/3.0.0
 
 jobs:
   resolve-branches:


### PR DESCRIPTION
## Summary

- add `release/3.0.0` to the nightly Docker publishing branch matrix
- retain nightly publishing for `develop` and `release/3.0.0-beta2`
- leave push-trigger behavior unchanged

## Why

Scheduled GitHub Actions workflows are registered from the default branch. Adding `release/3.0.0` to `CRON_BRANCHES` on `main` ensures the nightly publisher checks out and publishes that branch after it is created.

The existing release tag logic will produce `latest-release-3.0.0` and the immutable SHA tag. This PR should be merged when the branch is created, or afterward, so the scheduled checkout can resolve it.

## Validation

- parsed the workflow YAML and asserted that `schedule` remains enabled and no `push` trigger was added
- asserted that `CRON_BRANCHES` includes `release/3.0.0`
- ran the full pre-commit suite through `uv`
