### PR TITLE
Publish release 3.0.0 Docker images nightly

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -6,7 +6,7 @@
 name: Publish Docker Images
 
 on:
-  # Nightly build + publish from develop. No push triggers — workflow_dispatch
+  # Nightly build + publish from develop and release/3.0.0. No push triggers — workflow_dispatch
   # also accepts any publishable branch. main is intentionally excluded: main images are built
   # by postmerge-ci.yml on push instead.
   schedule:
@@ -27,7 +27,7 @@ permissions:
 # purpose (it builds on the public isaac-sim base via postmerge-ci.yml).
 env:
   NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
-  CRON_BRANCHES: develop
+  CRON_BRANCHES: develop,release/3.0.0
 
 jobs:
   resolve-branches:


### PR DESCRIPTION
## Summary

- add `release/3.0.0` to the nightly Docker publishing branch matrix
- retain nightly publishing for `develop`
- leave push-trigger behavior unchanged

## Why

The repository default branch is currently `release/3.0.0-beta2`, and scheduled GitHub Actions workflows are registered from the default branch. Adding the future stable branch to this workflow ensures the nightly publisher checks out and publishes `release/3.0.0` after that branch is created.

The existing release tag logic will produce `latest-release-3.0.0` and the immutable SHA tag.

This PR should merge when the new branch is created, or afterward, so the scheduled checkout can resolve it. If `release/3.0.0` will replace beta2 as the default branch, it must inherit this scheduled workflow or receive this commit before the default-branch switch.

## Validation

- parsed the workflow YAML and asserted that `schedule` remains enabled and no `push` trigger was added
- asserted that `CRON_BRANCHES` is `develop,release/3.0.0`
- ran `.\isaaclab.bat -f`