### PR TITLE
Stop checking links on the ETH Zurich asset server

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -111,6 +111,7 @@ jobs:
           --exclude 'download\.isaacsim\.omniverse\.nvidia\.com/isaaclab/images'
           --exclude 'dx\.doi\.org/10\.1109/JRA\.1987\.1087068'
           --exclude 'andrew\.cmu\.edu/course/10-703/textbook/BartoSutton\.pdf'
+          --exclude 'ethz\.ch/content/dam'
           --exclude 'www\.nvidia\.com/en-us/security'
           --exclude 'bostondynamics\.com/reinforcement-learning-researcher-kit'
           --max-retries 5


### PR DESCRIPTION
## Summary

- stop the link checker from requesting `ethz.ch/content/dam`, the ETH Zurich asset server

## Why

`docs/source/tutorials/05_controllers/run_osc.rst` cites the ETH Zurich Robot Dynamics lecture notes. That asset server answers GitHub runners with 503 while serving 200 to an ordinary browser, so `Check for Broken Links` fails on pull requests that touch any documentation file and have nothing to do with the tutorial. The failure is intermittent -- it passed at 21:09 UTC and failed at 22:09 and again on a re-run at 22:27 -- so lychee's five retries do not clear it.

This is not a method or user-agent problem: lychee already requests with GET (`--method` defaults to `get`) and the workflow already sends a browser user agent. The same GET succeeds from a normal IP.

The exclusion is scoped to the asset path rather than the domain, so `www.gdc-docs.ethz.ch`, linked from the cluster deployment guide, stays checked. It follows the existing entry for the Sutton and Barto textbook PDF.

## Impact

CI only. The link stays in the documentation and is still correct for readers.

## Validation

- `uv run isaaclab -f`
- confirmed the URL returns 503 to a plain request and 200 to a browser-style GET
- confirmed `ethz.ch` appears in the docs only as this asset link, an example email address, and `www.gdc-docs.ethz.ch`