### PR TITLE
Quarantine unstable Lift OvPhysX/OVRTX motion vectors

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-quarantive-motion-vectors.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-quarantive-motion-vectors.skip
@@ -1,0 +1,1 @@
+Test-only: quarantined unstable Lift OvPhysX/OVRTX motion vectors under NVBug 6632495.

--- a/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_lift_kuka_homo_kitless.py
@@ -14,12 +14,16 @@ from rendering_test_utils import (
     make_generate_html_report_fixture,
     make_kitless_rendering_params_lift,
     make_require_ovlibs_install_fixture,
+    make_xfail_rendering_params,
     rendering_test_lift_kuka,
 )
 
 pytestmark = [pytest.mark.isaacsim_ci, pytest.mark.arm_ci]
 
-_RENDERING_PARAMS = make_kitless_rendering_params_lift()
+_RENDERING_PARAMS = make_xfail_rendering_params(
+    make_kitless_rendering_params_lift(),
+    {("legacy", "ovphysx", "ovrtx_renderer", "motion_vectors"): "NVBug 6632495"},
+)
 _COMPARISON_SCORES: list[dict] = []
 
 _determinism_fixture = make_determinism_fixture()


### PR DESCRIPTION
# Description

- Mark only the legacy Lift Kuka homogeneous `ovphysx + ovrtx + motion_vectors` case as xfail.
- Track the cross-host motion-vector instability under NVBug 6632495.
- Keep the golden and all other backends, AOVs, and stage paths unchanged.

## Type of change

- Test quarantine

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there