### PR TITLE
Add Shift camera speed boost to Newton GL and RTX visualizers

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/mtrepte-newton-viewer-shift-camera-speed-boost.minor.rst
+++ b/source/isaaclab_visualizers/changelog.d/mtrepte-newton-viewer-shift-camera-speed-boost.minor.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added a camera speed-boost mode to the Newton GL and RTX visualizers: holding
+  Shift while flying the free camera with WASD doubles the camera translation
+  speed, matching the Kit visualizer's speed-up behavior.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -152,6 +152,30 @@ class _NewtonViewerUIMixin:
     # checkbox can be greyed out in the UI.
     _contacts_available: bool = True
 
+    CAMERA_SPEED_BOOST_MULTIPLIER = 2.0
+    """Factor applied to :attr:`camera_speed` while the speed-boost modifier is held."""
+
+    def _is_camera_speed_boost_active(self) -> bool:
+        """Return whether the camera speed-boost modifier (Left/Right Shift) is held."""
+        import pyglet
+
+        return bool(self.is_key_down(pyglet.window.key.LSHIFT) or self.is_key_down(pyglet.window.key.RSHIFT))
+
+    @property
+    def camera_speed(self) -> float:
+        """Keyboard camera translation speed [m/s], doubled while Shift is held."""
+        base_speed = self._camera_speed
+        if self._is_camera_speed_boost_active():
+            return base_speed * self.CAMERA_SPEED_BOOST_MULTIPLIER
+        return base_speed
+
+    @camera_speed.setter
+    def camera_speed(self, value: float) -> None:
+        value = float(value)
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError("camera_speed must be finite and nonnegative")
+        self._camera_speed = value
+
     def _register_isaaclab_ui_callbacks(self) -> None:
         """Register model-dependent Isaac Lab viewer controls."""
         self.register_ui_callback(self._render_training_controls, position="side")
@@ -434,6 +458,7 @@ class _NewtonViewerUIMixin:
                 imgui.text("Controls:")
                 imgui.pop_style_color()
                 imgui.text("WASD - Move camera")
+                imgui.text("Shift + WASD - Move camera 2x speed")
                 imgui.text("QE - Pan up/down")
                 imgui.text("Left Click - Look around")
                 imgui.text("Right Click - Pick and drag objects")

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -270,6 +270,28 @@ def test_newton_visualizer_render_rgb_array_requires_initialized_viewer():
         visualizer.render_rgb_array()
 
 
+def test_newton_viewer_camera_speed_boost_when_shift_held(monkeypatch):
+    viewer = NewtonViewerGL.__new__(NewtonViewerGL)
+    viewer._camera_speed = 4.0
+
+    monkeypatch.setattr(NewtonViewerGL, "is_key_down", lambda self, key: True)
+    assert viewer.camera_speed == pytest.approx(8.0)
+
+    monkeypatch.setattr(NewtonViewerGL, "is_key_down", lambda self, key: False)
+    assert viewer.camera_speed == pytest.approx(4.0)
+
+
+def test_newton_viewer_camera_speed_setter_validates(monkeypatch):
+    viewer = NewtonViewerGL.__new__(NewtonViewerGL)
+    monkeypatch.setattr(NewtonViewerGL, "is_key_down", lambda self, key: False)
+
+    viewer.camera_speed = 6.0
+    assert viewer._camera_speed == pytest.approx(6.0)
+
+    with pytest.raises(ValueError, match="camera_speed must be finite and nonnegative"):
+        viewer.camera_speed = -1.0
+
+
 def test_newton_viewer_particle_color_override(monkeypatch):
     from newton.viewer import ViewerGL
 


### PR DESCRIPTION
Holding Shift while flying the free camera with WASD now doubles the camera translation speed, matching the Kit visualizer's default speed-boost multiplier (2x). The override lives on the shared _NewtonViewerUIMixin, so both the GL and RTX backends pick it up through the existing WASD movement path.

# Description

> [!IMPORTANT]
> Confirm the pull request base before submitting. Target `develop` for all
> contributions. The `release/3.0.0-beta2` branch is a frozen stable landing
> snapshot and is not used for ongoing maintenance.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)


## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
