### PR TITLE
[CI] Fix OVPhysX benchmark articulation setup

### DIFF
--- a/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
+++ b/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
@@ -59,6 +59,7 @@ def create_test_articulation(
     object.__setattr__(articulation, "_debug_vis_handle", None)
     object.__setattr__(articulation, "_root_view", mock_view)
     object.__setattr__(articulation, "_device", device)
+    object.__setattr__(articulation, "_sim_cfg", None)
     object.__setattr__(articulation, "_check_shapes", not args.no_shape_checks)
     object.__setattr__(articulation, "_num_instances", num_instances)
     object.__setattr__(articulation, "_num_bodies", num_bodies)


### PR DESCRIPTION
## Description

Initialize the OVPhysX benchmark articulation mock with `_sim_cfg = None`, matching the PhysX and Newton benchmark factories and the real articulation constructor. This prevents actuator collection setup from raising `AttributeError` in the kit-less benchmark test.

This failure was exposed by CI on #7168 but is unrelated to that PR's wheel extras changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- `uv run --extra test python -m pytest source/isaaclab/test/benchmark/test_asset_suite_runtime_semantics.py -k ovphysx_data_targets --maxfail=1 -q` (skipped locally because CUDA is unavailable; the failing CI job exercises this path)
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] The existing benchmark test covers the regression
- [x] I have added a changelog fragment for every touched package
- [x] My name is present in the repository revision history