### PR TITLE
Fix OVPhysX contact force history reset

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovphysx-force-matrix-history-reset.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-force-matrix-history-reset.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Cleared ``ContactSensorData.force_matrix_w_history`` when resetting an
+  OVPhysX contact sensor.

--- a/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/contact_sensor.py
@@ -409,6 +409,7 @@ class ContactSensor(BaseContactSensor):
                 self._data._net_forces_w,
                 self._data._net_forces_w_history,
                 self._data._force_matrix_w,
+                self._data._force_matrix_w_history,
             ],
             outputs=[
                 self._data._current_air_time,

--- a/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/kernels.py
@@ -97,6 +97,7 @@ def reset_contact_sensor_kernel(
     net_forces_w: wp.array2d(dtype=wp.vec3f),
     net_forces_w_history: wp.array3d(dtype=wp.vec3f),
     force_matrix_w: wp.array3d(dtype=wp.vec3f),
+    force_matrix_w_history: wp.array4d(dtype=wp.vec3f),
     # outputs
     current_air_time: wp.array2d(dtype=wp.float32),
     last_air_time: wp.array2d(dtype=wp.float32),
@@ -116,6 +117,8 @@ def reset_contact_sensor_kernel(
         net_forces_w: Net forces array. Shape is (num_envs, num_sensors).
         net_forces_w_history: Net forces history array. Shape is (num_envs, history_length, num_sensors).
         force_matrix_w: Force matrix array. Shape is (num_envs, num_sensors, num_filter_objects).
+        force_matrix_w_history: Force matrix history array. Shape is
+            (num_envs, history_length, num_sensors, num_filter_objects).
         current_air_time: Current air time array. Shape is (num_envs, num_sensors).
         last_air_time: Last air time array. Shape is (num_envs, num_sensors).
         current_contact_time: Current contact time array. Shape is (num_envs, num_sensors).
@@ -141,6 +144,11 @@ def reset_contact_sensor_kernel(
     if force_matrix_w:
         for f in range(num_filter_objects):
             force_matrix_w[env, sensor, f] = wp.vec3f(0.0)
+
+    if force_matrix_w_history:
+        for i in range(history_length):
+            for f in range(num_filter_objects):
+                force_matrix_w_history[env, i, sensor, f] = wp.vec3f(0.0)
 
     # Reset air/contact time tracking
     if current_air_time:

--- a/source/isaaclab_ov/test/sensors/test_contact_sensor_kernels.py
+++ b/source/isaaclab_ov/test/sensors/test_contact_sensor_kernels.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit tests for OvPhysx contact-sensor Warp kernels."""
+
+import numpy as np
+import warp as wp
+from isaaclab_ov.sensors.contact_sensor.kernels import reset_contact_sensor_kernel
+
+
+def test_reset_contact_sensor_kernel_clears_selected_force_matrix_history():
+    """Reset clears filtered-force history only for selected environments."""
+    num_envs = 2
+    num_sensors = 1
+    history_length = 2
+    num_filter_shapes = 1
+    device = "cpu"
+    env_mask = wp.array([True, False], dtype=wp.bool, device=device)
+
+    net_forces_w = wp.zeros((num_envs, num_sensors), dtype=wp.vec3f, device=device)
+    net_forces_w_history = wp.zeros((num_envs, history_length, num_sensors), dtype=wp.vec3f, device=device)
+    force_matrix_w = wp.zeros((num_envs, num_sensors, num_filter_shapes), dtype=wp.vec3f, device=device)
+    force_matrix_w_history = wp.array(
+        np.ones((num_envs, history_length, num_sensors, num_filter_shapes, 3), dtype=np.float32),
+        dtype=wp.vec3f,
+        device=device,
+    )
+    current_air_time = wp.zeros((num_envs, num_sensors), dtype=wp.float32, device=device)
+    last_air_time = wp.zeros((num_envs, num_sensors), dtype=wp.float32, device=device)
+    current_contact_time = wp.zeros((num_envs, num_sensors), dtype=wp.float32, device=device)
+    last_contact_time = wp.zeros((num_envs, num_sensors), dtype=wp.float32, device=device)
+
+    wp.launch(
+        reset_contact_sensor_kernel,
+        dim=(num_envs, num_sensors),
+        inputs=[
+            history_length,
+            num_filter_shapes,
+            env_mask,
+            net_forces_w,
+            net_forces_w_history,
+            force_matrix_w,
+            force_matrix_w_history,
+        ],
+        outputs=[
+            current_air_time,
+            last_air_time,
+            current_contact_time,
+            last_contact_time,
+            None,
+            None,
+        ],
+        device=device,
+    )
+
+    np.testing.assert_array_equal(force_matrix_w_history.numpy()[0], 0.0)
+    np.testing.assert_array_equal(force_matrix_w_history.numpy()[1], 1.0)


### PR DESCRIPTION
## Summary

- clear filtered force-matrix history during OVPhysX contact-sensor resets
- preserve history for environments outside the reset mask
- add a CPU-only Warp regression test

## Testing

- `uv run --extra test python -m pytest source/isaaclab_ov/test/sensors/test_contact_sensor_kernels.py`
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`