### PR TITLE
[Docs] Publish release 3.0.0 and beta tag

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -103,11 +103,11 @@ jobs:
       working-directory: ./docs
       env:
         # "deploy" branches build the full set of versions so every page
-        # has a complete version dropdown: main, develop, release/3.0.0-beta2,
-        # and stable tags >= v2.0.0. Other release branches and prerelease tags
-        # are excluded.
-        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0-beta2)$'
-        SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+$'
+        # has a complete version dropdown: main, develop, release/3.0.0,
+        # stable tags >= v2.0.0, and v3.0.0-beta2. Other release branches and
+        # prerelease tags are excluded.
+        SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0)$'
+        SMV_TAG_WHITELIST: '^v([2-9]\d*\.\d+\.\d+|3\.0\.0-beta2)$'
       run: |
         git fetch --prune --unshallow --tags
         git checkout --detach HEAD
@@ -117,7 +117,7 @@ jobs:
     - name: Set default docs version
       working-directory: ./docs
       env:
-        DOCS_DEFAULT_REF: ${{ github.event.repository.default_branch }}
+        DOCS_DEFAULT_REF: v3.0.0-beta2
       run: |
         test -n "$DOCS_DEFAULT_REF"
         test -f "_build/$DOCS_DEFAULT_REF/index.html" || {


### PR DESCRIPTION
## Summary

- add `release/3.0.0` to the nightly multi-version documentation set
- remove the mutable `release/3.0.0-beta2` branch from the version switcher
- publish the immutable `v3.0.0-beta2` tag and make it the docs landing-page default

## Why

The repository default branch is currently `release/3.0.0-beta2`, so this branch owns the active scheduled docs workflow. The stable release branch now exists and needs to appear in nightly multi-version builds, while the released beta documentation should resolve to its immutable tag rather than a mutable branch.

## Validation

- `.\isaaclab.bat -f`
- verified the branch whitelist includes `release/3.0.0` and excludes `release/3.0.0-beta2`
- verified the tag whitelist includes `v3.0.0-beta2` and stable tags
- verified `v3.0.0-beta2` is the docs default
- verified the `v3.0.0-beta2` tag exists upstream