### PR TITLE
Fix OVPhysX material binding device selection

### DIFF
--- a/source/isaaclab/changelog.d/ovphysx-material-cpu-bindings.rst
+++ b/source/isaaclab/changelog.d/ovphysx-material-cpu-bindings.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX material randomization to use CPU-native shape material bindings.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -532,7 +532,7 @@ class _RandomizeRigidBodyMaterialOvPhysx:
             return
 
         view = self._material_view
-        # read the current per-shape material [N, S, 3] on the binding's native (sim) device
+        # read the current per-shape material [N, S, 3] on the binding's native CPU device
         materials = wp.to_torch(view.get_attribute(self._material_type))
         num_shapes = materials.shape[1]
 

--- a/source/isaaclab_ov/changelog.d/ovphysx-material-cpu-bindings.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-material-cpu-bindings.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX shape material bindings to allocate CPU buffers during GPU simulation.

--- a/source/isaaclab_ov/isaaclab_ov/tensor_types.py
+++ b/source/isaaclab_ov/isaaclab_ov/tensor_types.py
@@ -259,7 +259,7 @@ Guarded so this module stays import-safe against older wheels that lack them.
 
 try:
     SHAPE_FRICTION_AND_RESTITUTION = _TT.ARTICULATION_SHAPE_FRICTION_AND_RESTITUTION
-    """Per-collision-shape material of each articulation instance — read/write, GPU.
+    """Per-collision-shape material of each articulation instance — read/write, CPU.
     Shape ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]``
     restitution (all dimensionless)."""
 except AttributeError:
@@ -267,7 +267,7 @@ except AttributeError:
 
 try:
     RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION = _TT.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION
-    """Per-collision-shape material of each rigid body — read/write, GPU. Shape
+    """Per-collision-shape material of each rigid body — read/write, CPU. Shape
     ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]`` restitution
     (all dimensionless)."""
 except AttributeError:
@@ -450,8 +450,15 @@ _CPU_ONLY_TYPES_CANDIDATES: tuple = (
     DEFORMABLE_MATERIAL_THICKNESS,
     DEFORMABLE_MATERIAL_BENDING_DAMPING,
 )
-# Optional rigid-body CPU entries: only included when the wheel exposes them.
-_RIGID_BODY_OPTIONAL_CPU: tuple = tuple(
-    globals()[name] for name in ("RIGID_BODY_INV_MASS", "RIGID_BODY_INV_INERTIA") if name in globals()
+# Optional CPU-native entries: only included when the wheel exposes them.
+_OPTIONAL_CPU_TYPES: tuple = tuple(
+    globals()[name]
+    for name in (
+        "RIGID_BODY_INV_MASS",
+        "RIGID_BODY_INV_INERTIA",
+        "SHAPE_FRICTION_AND_RESTITUTION",
+        "RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION",
+    )
+    if name in globals()
 )
-_CPU_ONLY_TYPES: frozenset[TensorType] = frozenset(_CPU_ONLY_TYPES_CANDIDATES + _RIGID_BODY_OPTIONAL_CPU)
+_CPU_ONLY_TYPES: frozenset[TensorType] = frozenset(_CPU_ONLY_TYPES_CANDIDATES + _OPTIONAL_CPU_TYPES)

--- a/source/isaaclab_ov/test/assets/test_articulation.py
+++ b/source/isaaclab_ov/test/assets/test_articulation.py
@@ -3332,8 +3332,8 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     OVPhysX exposes per-collision-shape material as the
     ``articulation_shape_friction_and_restitution`` tensor binding (shape ``[N, S, 3]`` =
     static friction, dynamic friction, restitution), addressed through the
-    :class:`~isaaclab_ov.sim.views.OvPhysxView`. The binding is device-resident, so the
-    buffer lives on the simulation device. (The PhysX backend instead uses a dedicated
+    :class:`~isaaclab_ov.sim.views.OvPhysxView`. The binding is CPU-native, so the
+    buffer lives in host memory. (The PhysX backend instead uses a dedicated
     ``root_view.get_material_properties`` / ``set_material_properties`` view API.)
     """
     if not hasattr(TT, "SHAPE_FRICTION_AND_RESTITUTION"):
@@ -3351,8 +3351,8 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     # Number of collision shapes per articulation, from the material binding's shape [N, S, 3].
     num_shapes = view.binding_for(TT.SHAPE_FRICTION_AND_RESTITUTION).shape[1]
 
-    # Random material per shape: (static_friction, dynamic_friction, restitution), on the sim device.
-    materials = torch.empty(num_articulations, num_shapes, 3, device=device).uniform_(0.0, 1.0)
+    # Random material per shape: (static_friction, dynamic_friction, restitution), on the CPU.
+    materials = torch.empty(num_articulations, num_shapes, 3, device="cpu").uniform_(0.0, 1.0)
     materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])  # dynamic <= static
 
     # Set material properties through the view, then simulate.

--- a/source/isaaclab_ov/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ov/test/assets/test_rigid_object.py
@@ -654,11 +654,11 @@ def test_rigid_body_set_material_properties(num_cubes, device):
         # Play sim
         sim.reset()
 
-        # Random material per shape: (static_friction, dynamic_friction, restitution), on the sim device.
+        # Random material per shape: (static_friction, dynamic_friction, restitution), on the CPU.
         num_shapes = _num_shapes(cube_object)
-        static_friction = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.4, 0.8)
-        dynamic_friction = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.4, 0.8)
-        restitution = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.0, 0.2)
+        static_friction = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.4, 0.8)
+        dynamic_friction = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.4, 0.8)
+        restitution = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.0, 0.2)
         materials = torch.cat([static_friction, dynamic_friction, restitution], dim=-1)
 
         # Add friction/restitution to the cubes through the view.
@@ -684,7 +684,7 @@ def test_set_material_properties_via_view(num_cubes, device):
 
         # Generate random material properties: (static_friction, dynamic_friction, restitution).
         num_shapes = _num_shapes(cube_object)
-        materials = torch.empty(num_cubes, num_shapes, 3, device=device).uniform_(0.0, 1.0)
+        materials = torch.empty(num_cubes, num_shapes, 3, device="cpu").uniform_(0.0, 1.0)
         materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])  # dynamic <= static
 
         # Set material properties through the view, simulate, then read back.

--- a/source/isaaclab_ov/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ov/test/assets/test_rigid_object.py
@@ -716,7 +716,7 @@ def test_rigid_body_no_friction(num_cubes, device):
         # Set the cubes' friction (and restitution) to zero. This test isolates friction, so a zero
         # restitution keeps the resting contact clean instead of letting the cube bounce vertically.
         num_shapes = _num_shapes(cube_object)
-        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
         _write_shape_material(cube_object, cube_materials)
 
         # Let the cube settle onto the plane so the initial ground-penetration transient (a small
@@ -765,7 +765,7 @@ def test_rigid_body_with_static_friction(num_cubes, device):
 
         # Set the cubes' static (and, per the PhysX bug, dynamic) friction to mu, restitution zero.
         num_shapes = _num_shapes(cube_object)
-        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
         cube_materials[..., 0] = mu
         cube_materials[..., 1] = mu
         _write_shape_material(cube_object, cube_materials)
@@ -842,7 +842,7 @@ def test_rigid_body_with_restitution(num_cubes, device):
 
             # Frictionless cubes with the matching restitution.
             num_shapes = _num_shapes(cube_object)
-            cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+            cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
             cube_materials[..., 2] = restitution_coefficient
             _write_shape_material(cube_object, cube_materials)
 

--- a/source/isaaclab_ov/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ov/test/assets/test_rigid_object_collection.py
@@ -774,10 +774,10 @@ def test_set_material_properties(num_envs, num_cubes, device):
         # Play sim
         sim.reset()
 
-        # Random material per object: (static_friction, dynamic_friction, restitution), on the sim device.
-        static_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
-        dynamic_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
-        restitution = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.0, 0.2)
+        # Random material per object: (static_friction, dynamic_friction, restitution), on the CPU.
+        static_friction = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.4, 0.8)
+        dynamic_friction = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.4, 0.8)
+        restitution = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.0, 0.2)
         materials = torch.cat([static_friction, dynamic_friction, restitution], dim=-1)  # [num_envs, num_cubes, 3]
 
         # Map data -> body-major view layout, write through the view.

--- a/source/isaaclab_ov/test/sim/test_ovphysx_view.py
+++ b/source/isaaclab_ov/test/sim/test_ovphysx_view.py
@@ -751,6 +751,23 @@ def test_get_attribute_cpu_only_property_returns_cpu_buffer_on_gpu_sim():
     assert str(buf.device) == "cpu"
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        name
+        for name in ("articulation_shape_friction_and_restitution", "rigid_body_shape_friction_and_restitution")
+        if hasattr(TensorType, name.upper())
+    ],
+)
+def test_shape_material_property_returns_cpu_buffer_on_gpu_sim(name: str):
+    """Shape material properties must use their CPU-native bindings on GPU simulations."""
+    view = _make_view(n=3, device="cuda:0")
+
+    buf = view.get_attribute(name)
+
+    assert str(buf.device) == "cpu"
+
+
 def test_binding_for_is_idempotent_and_unguarded():
     view = _make_view(n=3)
     # Returns a binding even for a read-only attribute (raw access bypasses the write guard)...


### PR DESCRIPTION
# Description

Fixes OVPhysX shape-material bindings being treated as CUDA-resident during GPU simulation. Both optional material tensor types are now classified as CPU-native, material device wording is corrected, and CUDA material tests use host buffers.

No additional dependencies or production randomization changes.

Fixes # (none)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the CONTRIBUTORS.md or my name already exists there

## Validation

- `uv run --no-sync python -m pytest source/isaaclab_ov/test/sim/test_ovphysx_view.py -q` (80 passed)
- `uv run --no-sync isaaclab -f`
- `uv run --no-sync python tools/changelog/cli.py check develop`