### PR TITLE
Reduce GearAssembly default environment count

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-gearassembly-safe-defaults.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-gearassembly-safe-defaults.rst
@@ -1,0 +1,3 @@
+Fixed
+^^^^^
+* Reduced the default number of parallel environments for GearAssembly tasks to 1024 so recurrent PPO training fits on development GPUs. Use ``--num_envs`` to select a different batch size.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
@@ -240,8 +240,6 @@ class UR10eGearAssemblyEnvCfg(GearAssemblyEnvCfg):
         # post init of parent
         super().__post_init__()
 
-        self.scene.num_envs = 2048
-
         # Robot-specific parameters (can be overridden for other robots)
         self.end_effector_body_name = "wrist_3_link"  # End effector body name for IK and termination checks
         self.num_arm_joints = 6  # Number of arm joints (excluding gripper)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
@@ -295,7 +295,7 @@ class TerminationsCfg:
 @configclass
 class GearAssemblyEnvCfg(ManagerBasedRLEnvCfg):
     # Scene settings
-    scene: GearAssemblySceneCfg = GearAssemblySceneCfg(num_envs=4096, env_spacing=2.5)
+    scene: GearAssemblySceneCfg = GearAssemblySceneCfg(num_envs=1024, env_spacing=2.5)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()

--- a/source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for GearAssembly environment configuration defaults."""
+
+import pytest
+
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.rizon_4s.joint_pos_env_cfg import Rizon4sGearAssemblyEnvCfg
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.rizon_4s.ros_inference_env_cfg import (
+    Rizon4sGearAssemblyROSInferenceEnvCfg,
+)
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.ur_10e.joint_pos_env_cfg import (
+    UR10e2F85GearAssemblyEnvCfg,
+    UR10e2F140GearAssemblyEnvCfg,
+)
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.ur_10e.ros_inference_env_cfg import (
+    UR10e2F85GearAssemblyROSInferenceEnvCfg,
+    UR10e2F140GearAssemblyROSInferenceEnvCfg,
+)
+
+
+@pytest.mark.parametrize(
+    "env_cfg_cls",
+    (
+        Rizon4sGearAssemblyEnvCfg,
+        Rizon4sGearAssemblyROSInferenceEnvCfg,
+        UR10e2F85GearAssemblyEnvCfg,
+        UR10e2F85GearAssemblyROSInferenceEnvCfg,
+        UR10e2F140GearAssemblyEnvCfg,
+        UR10e2F140GearAssemblyROSInferenceEnvCfg,
+    ),
+)
+def test_gear_assembly_defaults_limit_parallel_environments(env_cfg_cls):
+    """GearAssembly defaults must fit recurrent PPO training on development GPUs."""
+    assert env_cfg_cls().scene.num_envs == 1024


### PR DESCRIPTION
## Summary
- Reduce all GearAssembly task defaults to 1024 parallel environments.
- Remove the UR10e-specific 2048 override so all Rizon and UR ROS/non-ROS variants share the safe default.
- Add configuration coverage for all six variants and a changelog fragment.

## Motivation
The recurrent PPO critic can OOM during an LSTM update at the previous task defaults despite successful simulation rollout. The new default avoids advertising a configuration that exceeds typical development GPU memory; users can still override it with `--num_envs`.

## Validation
- `uv run --extra test --frozen python -m pytest source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py -q` (6 passed)
- `uv run --frozen isaaclab -f`
- `uv run --extra test --frozen python tools/changelog/cli.py check develop`

## Checklist
- [x] I have read and understood the contribution guidelines
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`