### PR TITLE
Fix colorized semantic segmentation normalization

### DIFF
--- a/source/isaaclab/changelog.d/normalize-colorized-semantic-segmentation.rst
+++ b/source/isaaclab/changelog.d/normalize-colorized-semantic-segmentation.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :func:`isaaclab.envs.mdp.image` so colorized semantic-segmentation observations are
+  converted to normalized ``float32`` tensors when ``normalize=True``.

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -52,11 +52,13 @@ def normalize_camera_image(
 
     Dispatch (in order of check):
 
-    - :func:`is_rgb_like` and ``images.dtype == torch.uint8`` and contiguous 4D: routes to the
+    - :func:`is_rgb_like` or colorized ``"semantic_segmentation"`` (``uint8``) and contiguous
+      4D: routes to the
       fused Warp kernel via :func:`~isaaclab.utils.warp.ops.normalize_image_uint8`. ``out`` and
       ``channel_dim`` are forwarded so callers can reuse a pre-allocated float32 buffer and
       select the image layout.
-    - :func:`is_rgb_like` and any other dtype/shape: pure-PyTorch ``(x.float() / 255.0) - mean``
+    - :func:`is_rgb_like` or colorized ``"semantic_segmentation"`` and any other dtype/shape:
+      pure-PyTorch ``(x.float() / 255.0) - mean``
       with the same math. ``out`` is ignored on this branch; ``channel_dim`` selects the spatial
       reduction axes.
     - :func:`is_depth_like`: in-place ``images[images == inf] = 0``. ``images`` is returned as-is.
@@ -65,21 +67,23 @@ def normalize_camera_image(
 
     Args:
         images: The camera-observation tensor. Shape and dtype vary by ``data_type``; the
-            RGB-like Warp fast path requires 4D contiguous uint8 with the channel axis at
-            position ``channel_dim``.
+        RGB-like and colorized semantic-segmentation Warp fast paths require 4D contiguous uint8
+            with the channel axis at position ``channel_dim``.
         data_type: The camera data-type string. Drives the dispatch.
         out: Optional pre-allocated float32 output for the RGB-like Warp fast path. Reused
             across steps to eliminate per-step allocation. Ignored on the PyTorch fallback
             and on non-RGB branches. Defaults to None.
-        channel_dim: Position of the channel axis for the RGB-like branches. ``-1`` (BHWC,
-            default) or ``-3`` / ``1`` (BCHW). Ignored on non-RGB branches.
+        channel_dim: Position of the channel axis for the RGB-like and colorized semantic-
+            segmentation branches. ``-1`` (BHWC, default) or ``-3`` / ``1`` (BCHW). Ignored on
+            other branches.
 
     Returns:
-        The normalized tensor. For RGB-like input this is a fresh (or pre-allocated) float32
-        tensor; for depth-like input it is ``images`` itself (mutated in place); for
-        normals-like input it is a new tensor; for anything else, ``images`` unchanged.
+        The normalized tensor. For RGB-like and colorized semantic-segmentation input this is a
+        fresh (or pre-allocated) float32 tensor; for depth-like input it is ``images`` itself
+        (mutated in place); for normals-like input it is a new tensor; for anything else,
+        ``images`` unchanged.
     """
-    if is_rgb_like(data_type):
+    if is_rgb_like(data_type) or (data_type == "semantic_segmentation" and images.dtype == torch.uint8):
         if images.dtype == torch.uint8 and images.ndim == 4 and images.is_contiguous():
             return normalize_image_uint8(images, channel_dim=channel_dim, out=out)
         # PyTorch fallback for callers that pre-floated or pass a strided view.

--- a/source/isaaclab/test/utils/test_images.py
+++ b/source/isaaclab/test/utils/test_images.py
@@ -146,6 +146,23 @@ class TestNormalizeCameraImageRGBLike:
         torch.testing.assert_close(out, expected)
 
 
+class TestNormalizeCameraImageColorizedSegmentation:
+    """Colorized segmentation dispatch."""
+
+    def test_colorized_semantic_segmentation_is_normalized(self, device):
+        """RGBA uint8 semantic segmentation produces a float32 normalized image."""
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src = torch.randint(0, 255, (2, 8, 8, 4), dtype=torch.uint8, device=device)
+        out = normalize_camera_image(src, "semantic_segmentation")
+
+        expected = src.float() / 255.0
+        expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
+        torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+        assert out.dtype == torch.float32
+
+
 class TestNormalizeCameraImageDepth:
     """Depth-like dispatch: in-place ``inf -> 0``."""
 


### PR DESCRIPTION
# Description

Fixes `mdp.image(normalize=True)` returning colorized semantic-segmentation observations as `uint8`. The normalizer now recognizes the renderer contract for this output (RGBA `uint8`) and returns the same normalized `float32` representation used for RGB-like images. Raw `int32` semantic-ID maps remain unchanged.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there