### PR TITLE
Fix Newton self-collisions being uncontrolled via the deprecated PhysX cfg (#7164)

### DIFF
--- a/source/isaaclab/changelog.d/fix-deprecated-self-collisions-newton.rst
+++ b/source/isaaclab/changelog.d/fix-deprecated-self-collisions-newton.rst
@@ -1,0 +1,18 @@
+Fixed
+^^^^^
+
+* Fixed the deprecated :class:`~isaaclab_physx.sim.schemas.ArticulationRootPropertiesCfg` /
+  :class:`~isaaclab_physx.sim.schemas.PhysxArticulationRootPropertiesCfg` ``enabled_self_collisions``
+  field silently no-oping under Newton. The legacy writer only authored
+  ``physxArticulation:enabledSelfCollisions`` (via ``PhysxArticulationAPI``); Newton's schema
+  resolver checks the native ``newton:selfCollisionEnabled`` attribute first and only falls back to
+  the PhysX one when it is unauthored, so the value never reached Newton simulations.
+  :meth:`~isaaclab.sim.schemas.modify_articulation_root_properties` now also mirrors
+  ``enabled_self_collisions`` onto ``newton:selfCollisionEnabled`` (applying
+  ``NewtonArticulationRootAPI``), so the deprecated cfg controls self-collisions on both backends.
+  The mirror is authored after root-link relocation so ``fix_root_link=True`` leaves a single
+  articulation root.
+* Fixed ``./isaaclab.sh -i`` and the CI Docker install failing with ``No matching distribution
+  found for isaaclab_physx`` because ``CORE_ISAACLAB_SUBMODULES`` installed ``isaaclab_assets``
+  before ``isaaclab_newton``/``isaaclab_physx``, which it now depends on. Reordered the submodule
+  list so the backend packages install first.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -662,17 +662,18 @@ def _install_isaacsim() -> None:
 # Source directories installed on every ./isaaclab.sh -i invocation (even "core").
 # Order must respect inter-package dependencies (topological sort):
 #   isaaclab first, then ppisp (no inter-package deps, precedes renderer backends),
-#   then contrib (needed by assets), then assets, then tasks (needed by rl),
-#   then rl. Packages with only an isaaclab dep can go anywhere after isaaclab.
+#   then contrib and the backend packages newton/physx (needed by assets), then
+#   assets, then tasks (needed by rl), then rl. Packages with only an isaaclab
+#   dep can go anywhere after isaaclab.
 CORE_ISAACLAB_SUBMODULES: list[str] = [
     "isaaclab",
     "isaaclab_ppisp",
     "isaaclab_contrib",
+    "isaaclab_newton",
+    "isaaclab_physx",
     "isaaclab_assets",
     "isaaclab_experimental",
-    "isaaclab_newton",
     "isaaclab_ov",
-    "isaaclab_physx",
     "isaaclab_tasks",
     "isaaclab_tasks_experimental",
     "isaaclab_rl",

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -582,10 +582,41 @@ def modify_articulation_root_properties(
                     if not parent_attr:
                         parent_attr = parent_prim.CreateAttribute(aname, attr.GetTypeName())
                     parent_attr.Set(attr.Get())
+            # -- Newton root schema and its authored properties
+            newton_root_schema = "NewtonArticulationRootAPI"
+            if newton_root_schema in articulation_prim.GetAppliedSchemas():
+                if not parent_prim.AddAppliedSchema(newton_root_schema):
+                    raise RuntimeError(f"Failed to apply '{newton_root_schema}' to '{parent_prim.GetPath()}'.")
+                schema_definition = Usd.SchemaRegistry().FindAppliedAPIPrimDefinition(newton_root_schema)
+                newton_properties = []
+                if schema_definition is not None:
+                    for property_name in schema_definition.GetPropertyNames():
+                        prop = articulation_prim.GetProperty(property_name)
+                        if prop and prop.IsAuthored():
+                            newton_properties.append(prop)
+                for prop in newton_properties:
+                    if not prop.FlattenTo(parent_prim):
+                        raise RuntimeError(f"Failed to move '{prop.GetPath()}' to '{parent_prim.GetPath()}'.")
+                for prop in newton_properties:
+                    if not articulation_prim.RemoveProperty(prop.GetName()):
+                        raise RuntimeError(f"Failed to remove '{prop.GetPath()}' from the former articulation root.")
+                if not articulation_prim.RemoveAppliedSchema(newton_root_schema):
+                    raise RuntimeError(f"Failed to remove '{newton_root_schema}' from '{articulation_prim.GetPath()}'.")
 
             # remove api from root
             articulation_prim.RemoveAppliedSchema("PhysxArticulationAPI")
             articulation_prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+            articulation_prim = parent_prim
+
+    # Mirror after any root relocation so the Newton API does not recreate an articulation root
+    # on the former root link.
+    enabled_self_collisions = cfg_dict.get("enabled_self_collisions")
+    if enabled_self_collisions is not None:
+        if "NewtonArticulationRootAPI" not in articulation_prim.GetAppliedSchemas():
+            articulation_prim.AddAppliedSchema("NewtonArticulationRootAPI")
+        safe_set_attribute_on_usd_prim(
+            articulation_prim, "newton:selfCollisionEnabled", enabled_self_collisions, camel_case=False
+        )
 
     # success
     return True

--- a/source/isaaclab/test/sim/test_schemas.py
+++ b/source/isaaclab/test/sim/test_schemas.py
@@ -506,8 +506,8 @@ def test_articulation_root_base_no_physx_schema_when_only_fix_root_link_set(setu
 
 @pytest.mark.isaacsim_ci
 def test_physx_articulation_root_writes_self_collisions(setup_simulation):
-    """Setting ``enabled_self_collisions`` on ``PhysxArticulationRootPropertiesCfg`` must
-    author ``physxArticulation:enabledSelfCollisions`` AND apply ``PhysxArticulationAPI``."""
+    """Setting ``enabled_self_collisions`` on ``PhysxArticulationRootPropertiesCfg`` must author
+    ``physxArticulation:enabledSelfCollisions`` and mirror onto ``newton:selfCollisionEnabled``."""
     sim, _, _, _, _, _ = setup_simulation
     stage = sim_utils.get_current_stage()
 
@@ -517,8 +517,35 @@ def test_physx_articulation_root_writes_self_collisions(setup_simulation):
 
     prim = stage.GetPrimAtPath("/World/arti_sc")
     assert prim.GetAttribute("physxArticulation:enabledSelfCollisions").Get() is True
+    assert prim.GetAttribute("newton:selfCollisionEnabled").Get() is True
     applied = prim.GetAppliedSchemas()
     assert "PhysxArticulationAPI" in applied
+    assert "NewtonArticulationRootAPI" in applied
+
+
+@pytest.mark.isaacsim_ci
+def test_physx_articulation_root_self_collisions_follow_fixed_root(setup_simulation):
+    """Mirrored Newton self-collision properties must follow a relocated articulation root."""
+    sim, _, _, _, _, _ = setup_simulation
+    stage = sim_utils.get_current_stage()
+
+    parent = sim_utils.create_prim("/World/arti_fixed", prim_type="Xform")
+    child = sim_utils.create_prim("/World/arti_fixed/base", prim_type="Cube")
+    UsdPhysics.RigidBodyAPI.Apply(child)
+    UsdPhysics.ArticulationRootAPI.Apply(child)
+    child.AddAppliedSchema("NewtonArticulationRootAPI")
+    child.GetAttribute("newton:selfCollisionEnabled").Set(False)
+
+    cfg = PhysxArticulationRootPropertiesCfg(enabled_self_collisions=True, fix_root_link=True)
+    schemas.modify_articulation_root_properties(child.GetPath(), cfg)
+
+    roots = [prim for prim in stage.Traverse() if prim.HasAPI(UsdPhysics.ArticulationRootAPI)]
+    assert roots == [parent]
+    assert parent.GetAttribute("physxArticulation:enabledSelfCollisions").Get() is True
+    assert parent.GetAttribute("newton:selfCollisionEnabled").Get() is True
+    assert "NewtonArticulationRootAPI" in parent.GetAppliedSchemas()
+    assert "NewtonArticulationRootAPI" not in child.GetAppliedSchemas()
+    assert not child.GetAttribute("newton:selfCollisionEnabled").HasAuthoredValue()
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab_assets/changelog.d/fix-hand-self-collisions-newton.rst
+++ b/source/isaaclab_assets/changelog.d/fix-hand-self-collisions-newton.rst
@@ -1,0 +1,12 @@
+Fixed
+^^^^^
+
+* Fixed self-collisions being uncontrolled under Newton for
+  :data:`~isaaclab_assets.robots.allegro.ALLEGRO_HAND_CFG`,
+  :data:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_CFG`,
+  :data:`~isaaclab_assets.robots.shadow_hand.SHADOW_HAND_NEWTON_CFG`, and
+  :data:`~isaaclab_assets.robots.kuka_allegro.KUKA_ALLEGRO_CFG`. Their ``articulation_props`` used
+  the deprecated PhysX-only ``ArticulationRootPropertiesCfg``, which never authored the
+  ``newton:selfCollisionEnabled`` attribute Newton's schema resolver checks. They now pass a
+  ``PhysxArticulationCfg`` + ``NewtonArticulationCfg`` fragment pair so ``enabled_self_collisions``
+  is authored on both backends explicitly.

--- a/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/allegro.py
@@ -17,6 +17,9 @@ Reference:
 
 import math
 
+from isaaclab_newton.sim.schemas import NewtonArticulationCfg
+from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
@@ -40,13 +43,16 @@ ALLEGRO_HAND_CFG = ArticulationCfg(
             max_depenetration_velocity=1000.0,
             max_contact_impulse=1e32,
         ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            enabled_self_collisions=True,
-            solver_position_iteration_count=8,
-            solver_velocity_iteration_count=0,
-            sleep_threshold=0.005,
-            stabilization_threshold=0.0005,
-        ),
+        articulation_props=[
+            PhysxArticulationCfg(
+                enabled_self_collisions=True,
+                solver_position_iteration_count=8,
+                solver_velocity_iteration_count=0,
+                sleep_threshold=0.005,
+                stabilization_threshold=0.0005,
+            ),
+            NewtonArticulationCfg(self_collision_enabled=True),
+        ],
         # collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
     ),
     init_state=ArticulationCfg.InitialStateCfg(

--- a/source/isaaclab_assets/isaaclab_assets/robots/kuka_allegro.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/kuka_allegro.py
@@ -16,6 +16,9 @@ Reference:
 
 """
 
+from isaaclab_newton.sim.schemas import NewtonArticulationCfg
+from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
@@ -37,13 +40,16 @@ KUKA_ALLEGRO_CFG = ArticulationCfg(
             max_angular_velocity=1000.0,
             max_depenetration_velocity=1000.0,
         ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            enabled_self_collisions=True,
-            solver_position_iteration_count=32,
-            solver_velocity_iteration_count=1,
-            sleep_threshold=0.005,
-            stabilization_threshold=0.0005,
-        ),
+        articulation_props=[
+            PhysxArticulationCfg(
+                enabled_self_collisions=True,
+                solver_position_iteration_count=32,
+                solver_velocity_iteration_count=1,
+                sleep_threshold=0.005,
+                stabilization_threshold=0.0005,
+            ),
+            NewtonArticulationCfg(self_collision_enabled=True),
+        ],
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force"),
     ),
     init_state=ArticulationCfg.InitialStateCfg(

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -16,6 +16,9 @@ Reference:
 
 """
 
+from isaaclab_newton.sim.schemas import NewtonArticulationCfg
+from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets.articulation import ArticulationCfg
@@ -34,13 +37,16 @@ SHADOW_HAND_CFG = ArticulationCfg(
             retain_accelerations=True,
             max_depenetration_velocity=1000.0,
         ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-            enabled_self_collisions=True,
-            solver_position_iteration_count=8,
-            solver_velocity_iteration_count=0,
-            sleep_threshold=0.005,
-            stabilization_threshold=0.0005,
-        ),
+        articulation_props=[
+            PhysxArticulationCfg(
+                enabled_self_collisions=True,
+                solver_position_iteration_count=8,
+                solver_velocity_iteration_count=0,
+                sleep_threshold=0.005,
+                stabilization_threshold=0.0005,
+            ),
+            NewtonArticulationCfg(self_collision_enabled=True),
+        ],
         # collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force"),
         fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(limit_stiffness=30.0, damping=0.1),
@@ -96,7 +102,10 @@ SHADOW_HAND_NEWTON_CFG = ArticulationCfg(
             retain_accelerations=True,
             max_depenetration_velocity=1000.0,
         ),
-        articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=True),
+        articulation_props=[
+            PhysxArticulationCfg(enabled_self_collisions=True),
+            NewtonArticulationCfg(self_collision_enabled=True),
+        ],
         joint_drive_props=sim_utils.JointDrivePropertiesCfg(drive_type="force", ensure_drives_exist=True),
         fixed_tendons_props=sim_utils.FixedTendonPropertiesCfg(damping=0.1),
     ),

--- a/source/isaaclab_assets/pyproject.toml
+++ b/source/isaaclab_assets/pyproject.toml
@@ -20,11 +20,15 @@ requires-python = ">=3.12"
 dependencies = [
     "isaaclab",
     "isaaclab_contrib",
+    "isaaclab_physx",
+    "isaaclab_newton",
 ]
 
 [tool.uv.sources]
 isaaclab = { path = "../isaaclab", editable = true }
 isaaclab_contrib = { path = "../isaaclab_contrib", editable = true }
+isaaclab_physx = { path = "../isaaclab_physx", editable = true }
+isaaclab_newton = { path = "../isaaclab_newton", editable = true }
 
 [project.urls]
 Homepage = "https://github.com/isaac-sim/IsaacLab"

--- a/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
+++ b/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
@@ -53,6 +53,7 @@ def create_test_articulation(
         soft_joint_pos_limit_factor=1.0,
         actuators={},
     )
+    object.__setattr__(articulation, "_sim_cfg", None)
     object.__setattr__(articulation, "_initialize_handle", None)
     object.__setattr__(articulation, "_invalidate_initialize_handle", None)
     object.__setattr__(articulation, "_prim_deletion_handle", None)


### PR DESCRIPTION
## Summary

Backports #7164 to `release/3.0.0`.

- Mirrors deprecated PhysX self-collision configuration to the Newton articulation-root schema.
- Migrates the Allegro Hand, Shadow Hand, and Kuka Allegro configs to explicit PhysX and Newton articulation fragments.
- Declares the backend package dependencies required by `isaaclab_assets` and fixes core package installation order.
- Preserves a single articulation root during fixed-root relocation, including pre-authored Newton schema state.
- Initializes the kitless benchmark articulation consistently with production articulation objects.

The backport is patch-identical to the merged #7164 diff and contains no unrelated `develop` history.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `source/isaaclab/test/sim/test_schemas.py`: 44 passed
- [x] Kitless benchmark semantics: 18 passed
- [x] PhysX fixed-base initialization: 4 passed
- [x] Newton fixed-base initialization: 4 passed
- [x] Install command parsing: 57 passed
- [x] `uv run isaaclab -f`
- [x] Changelog fragment validation against `release/3.0.0`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added changelog fragments for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
