### PR TITLE
Fix IsaacContrib-Factory-Franka choice preset crashing on reset

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-factory-franka-choice-curriculum.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-factory-franka-choice-curriculum.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed the ``choice`` preset of ``IsaacContrib-Factory-Franka`` crashing on the first reset with
+  ``AttributeError: 'reset_accumulator' object has no attribute 'terms'``. ``events.reset_strategies``
+  in :class:`~isaaclab_tasks.contrib.nist.factory_env_cfg.FactoryEventCfg` was hardcoded to
+  ``ACCUMULATOR_RESET`` for every preset, so the ``choice`` preset's curriculum callback (which reads
+  ``.terms['reset_strategies']`` off a ``TermChoice``-shaped term) ran against the accumulator-shaped
+  term instead. ``reset_strategies`` now switches to ``SCENE_RESET`` under the ``choice`` preset,
+  matching what the curriculum callback and ``play_mode`` already expected.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/nist/factory_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/nist/factory_env_cfg.py
@@ -24,7 +24,7 @@ from isaaclab_tasks.contrib.nist.factory_presets import (
     HeldAssetAlignOffsetCfg,
 )
 from isaaclab_tasks.contrib.nist.factory_scenes_cfg import FactorySceneCfg
-from isaaclab_tasks.contrib.nist.reset_env_cfg import ACCUMULATOR_RESET
+from isaaclab_tasks.contrib.nist.reset_env_cfg import ACCUMULATOR_RESET, SCENE_RESET
 from isaaclab_tasks.contrib.nist.utils import SamplerCfg, UniformSamplingStrategyCfg
 from isaaclab_tasks.utils import PresetCfg, preset
 
@@ -137,7 +137,7 @@ class FactoryEventCfg:
         },
     )
 
-    reset_strategies = ACCUMULATOR_RESET
+    reset_strategies = preset(default=ACCUMULATOR_RESET, accumulator=ACCUMULATOR_RESET, choice=SCENE_RESET)
 
     # The curriculum restores gravity as task difficulty rises.
     variable_gravity: EventTerm | None = EventTerm(


### PR DESCRIPTION
## Summary
- `events.reset_strategies` in `FactoryEventCfg` (`source/isaaclab_tasks/isaaclab_tasks/contrib/nist/factory_env_cfg.py`) was hardcoded to `ACCUMULATOR_RESET` regardless of preset, but the `choice` preset's curriculum callback (`success_rate_callback`) reads `.terms['reset_strategies']` off the term's `.func`, which only exists on the `TermChoice`-shaped `SCENE_RESET` term, not on `reset_accumulator`.
- Every OSMO benchmark row using `IsaacContrib-Factory-Franka` with `presets=choice` (both `isaacsim_physx` and `newton_mjwarp`) crashed on the very first environment reset with `AttributeError: 'reset_accumulator' object has no attribute 'terms'`.
- Fix: switch `reset_strategies` to `SCENE_RESET` under the `choice` preset via `preset(default=ACCUMULATOR_RESET, accumulator=ACCUMULATOR_RESET, choice=SCENE_RESET)`, matching what the curriculum callback and `play_mode()` already assumed.

## Test plan
- [x] Reproduced the crash on a clean `develop` worktree: `isaaclab benchmark training --rl_library rsl_rl --task IsaacContrib-Factory-Franka --num_envs 4 --max_iterations 1 physics=isaacsim_physx presets=choice` raised the same `AttributeError` at the same call site as on OSMO.
- [x] Applied the fix; the same command now exits 0 and reports correct per-strategy `TermChoice` metrics (`Metrics/SuccessRate/grasp_asset_in_air`, `.../start_assembled`, `.../start_grasped_then_assembled`).
- [x] `default`/`accumulator` presets are unaffected by inspection — they resolve to the same `ACCUMULATOR_RESET` object before and after this change.
- [x] `uv run python tools/changelog/cli.py check develop` and `uv run isaaclab -f` pass.