### PR TITLE
Sensor destructor shutdown cherry-pick to release 3.0.0

### DIFF
--- a/source/isaaclab/changelog.d/sensor-destructor-shutdown.rst
+++ b/source/isaaclab/changelog.d/sensor-destructor-shutdown.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Stopped :class:`~isaaclab.sensors.SensorBase` and :class:`~isaaclab.sensors.camera.Camera`
+  destructors from running cleanup after interpreter shutdown. Previously, an abort that left a
+  camera alive could raise ``ImportError: sys.meta_path is None`` from a lazy ``isaaclab.sim``
+  import in ``__del__``, which then masked the original exception in logs.

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
@@ -226,17 +227,24 @@ class Camera(SensorBase):
         # Frame view — assigned in _initialize_impl.
         self._view: FrameView | None = None
 
-    def __del__(self):
-        """Unsubscribes from callbacks and cleans up renderer resources."""
+    def __del__(self, _sys=sys):
+        """Unsubscribes from callbacks and cleans up renderer resources.
+
+        Skips cleanup during interpreter shutdown so destructor-time imports or renderer teardown
+        cannot raise ``ImportError: sys.meta_path is None`` and mask the original exception.
+        """
+        if _sys.is_finalizing() or _sys.meta_path is None:
+            return
         # unsubscribe callbacks
         super().__del__()
-        # release the frame view's backend state
-        if self._view is not None:
+
+        # release the frame view's backend state, getattr covers partial initialization
+        if getattr(self, "_view", None) is not None:
             self._view.close()
             self._view = None
         # cleanup render resources (renderer may be None if never initialized)
-        if self._renderer is not None:
-            self._renderer.cleanup(self._render_data)
+        if getattr(self, "_renderer", None) is not None:
+            self._renderer.cleanup(getattr(self, "_render_data", None))
 
     def __str__(self) -> str:
         """Returns: A string containing information about the instance."""

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import sys
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -79,9 +80,16 @@ class SensorBase(ABC):
         # set initial state of debug visualization
         self.set_debug_vis(self.cfg.debug_vis)
 
-    def __del__(self):
-        """Unsubscribe from the callbacks."""
-        # clear physics events handles
+    def __del__(self, _sys=sys):
+        """Unsubscribe from the callbacks.
+
+        Skips cleanup during interpreter shutdown. ``sys`` is bound as a default argument so it
+        survives module teardown. Running :meth:`_clear_callbacks` after import machinery is gone
+        can lazy-import ``isaaclab.sim`` and raise ``ImportError: sys.meta_path is None``, which
+        then masks the exception that actually aborted the process.
+        """
+        if _sys.is_finalizing() or _sys.meta_path is None:
+            return
         self._clear_callbacks()
 
     """

--- a/source/isaaclab/test/sensors/test_sensor_destructors.py
+++ b/source/isaaclab/test/sensors/test_sensor_destructors.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import pytest
+
+from isaaclab.sensors.camera.camera import Camera
+from isaaclab.sensors.sensor_base import SensorBase
+
+pytestmark = pytest.mark.unit
+
+
+class _DummySensor(SensorBase):
+    """Minimal concrete sensor used only to invoke ``SensorBase.__del__``."""
+
+    @property
+    def data(self):
+        return None
+
+    def _initialize_impl(self):
+        return None
+
+    def _update_buffers_impl(self, env_ids):
+        return None
+
+
+def test_sensor_destructor_clears_callbacks_before_shutdown(monkeypatch):
+    """Sensor destructors should still unregister callbacks during normal runtime."""
+
+    cleared = False
+
+    def clear_callbacks(_self):
+        nonlocal cleared
+        cleared = True
+
+    sensor = object.__new__(_DummySensor)
+    monkeypatch.setattr(SensorBase, "_clear_callbacks", clear_callbacks)
+
+    sensor.__del__()
+
+    assert cleared
+
+
+def test_sensor_destructor_skips_clear_after_import_shutdown(monkeypatch):
+    """Sensor destructors should not run cleanup after import machinery is torn down."""
+
+    def clear_callbacks(_self):
+        raise ImportError("sys.meta_path is None, Python is likely shutting down")
+
+    sensor = object.__new__(_DummySensor)
+    monkeypatch.setattr(SensorBase, "_clear_callbacks", clear_callbacks)
+    monkeypatch.setattr("sys.meta_path", None)
+
+    sensor.__del__()
+
+
+def test_camera_destructor_cleans_renderer_before_shutdown(monkeypatch):
+    """Camera destructors should still release renderer resources during normal runtime."""
+
+    class _View:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _Renderer:
+        def __init__(self):
+            self.cleaned = False
+
+        def cleanup(self, _render_data):
+            self.cleaned = True
+
+    view = _View()
+    renderer = _Renderer()
+    camera = object.__new__(Camera)
+    camera._view = view
+    camera._renderer = renderer
+    camera._render_data = None
+    monkeypatch.setattr(SensorBase, "_clear_callbacks", lambda _self: None)
+
+    camera.__del__()
+
+    assert view.closed
+    assert renderer.cleaned
+    assert camera._view is None
+
+
+def test_camera_destructor_skips_cleanup_after_import_shutdown(monkeypatch):
+    """Camera destructors should not run cleanup after import machinery is torn down."""
+
+    class _Boom:
+        def close(self):
+            raise ImportError("sys.meta_path is None, Python is likely shutting down")
+
+        def cleanup(self, _render_data):
+            raise ImportError("sys.meta_path is None, Python is likely shutting down")
+
+    camera = object.__new__(Camera)
+    camera._view = _Boom()
+    camera._renderer = _Boom()
+    camera._render_data = None
+    monkeypatch.setattr("sys.meta_path", None)
+
+    camera.__del__()


### PR DESCRIPTION
# Description

cherry-pick of https://github.com/isaac-sim/IsaacLab/pull/7179/

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
