### PR TITLE
[Backport release/3.0.0] Cherry-pick selected develop PRs

### DIFF
--- a/.github/actions/_lib/compute-deps-hash/action.yml
+++ b/.github/actions/_lib/compute-deps-hash/action.yml
@@ -54,6 +54,9 @@ runs:
           isaaclab.sh
           environment.yml
           source/isaaclab/isaaclab/cli
+          # Pins the CI pytest deps layered onto the image after build, so a
+          # change to that list must invalidate the deps cache.
+          .github/actions/docker-build/action.yml
         )
         deps_manifest_pattern='(setup\.py|pyproject\.toml|setup\.cfg|extension\.toml|requirements[^/]*\.txt|uv\.lock)$'
 

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -175,7 +175,33 @@ runs:
         docker buildx build --load "${BUILD_ARGS[@]}" "${{ inputs.context-path }}"
         echo "was-built=true" >> "$GITHUB_OUTPUT"
 
-    ##### 6: Tag built image with local deps-tag #####
+    ##### 6: Layer the CI pytest harness onto the built image #####
+
+    # Kept out of the tracked Dockerfiles, which build local dev containers and
+    # ship via publish-images.yaml. Only on a real build; cache hits have it.
+
+    - name: Layer CI test dependencies
+      if: steps.build.outputs.was-built == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # pip needs root; restore the image's own default user afterwards.
+        image_user="$(docker image inspect --format '{{.Config.User}}' "${{ inputs.image-tag }}")"
+        # Dockerfile on stdin (no context to stage). Quoted heredoc so the
+        # shell leaves ISAACLAB_PATH and IMAGE_USER for Docker to expand; the
+        # image tag is an action input, substituted before bash ever runs.
+        docker build --platform "${{ inputs.platform }}" \
+          --build-arg "IMAGE_USER=${image_user:-root}" \
+          -t "${{ inputs.image-tag }}" - <<'DOCKERFILE'
+        FROM ${{ inputs.image-tag }}
+        ARG IMAGE_USER
+        USER root
+        RUN ${ISAACLAB_PATH}/isaaclab.sh -p -m pip install \
+              pytest pytest-mock junitparser flaky "coverage>=7.6.1"
+        USER ${IMAGE_USER}
+        DOCKERFILE
+
+    ##### 7: Tag built image with local deps-tag #####
 
     # Runs only when a real build happened (not on cache hits). Populates the
     # deps-tag so the next build with identical deps short-circuits at step 4.
@@ -191,7 +217,7 @@ runs:
           echo "🟠 LOCAL_DEPS_TAG not set, skipping local deps-cache tag"
         fi
 
-    ##### 7: Evict stale local deps-cache tags (>14d) — opt-in #####
+    ##### 8: Evict stale local deps-cache tags (>14d) — opt-in #####
 
     - name: Evict stale local deps-cache tags (>14d)
       if: always() && inputs.evict-stale-cache == 'true'
@@ -214,7 +240,7 @@ runs:
           --format '{{.CreatedAt}}|{{.Repository}}:{{.Tag}}' 2>/dev/null)
         echo "🔵 Evicted ${evicted} deps tag(s) older than ${TTL_DAYS}d"
 
-    ##### 8: Host disk snapshot (post) #####
+    ##### 9: Host disk snapshot (post) #####
 
     - name: Host disk snapshot (post)
       if: always()

--- a/.github/actions/multi-gpu/multi_gpu_shard_runner.sh
+++ b/.github/actions/multi-gpu/multi_gpu_shard_runner.sh
@@ -20,37 +20,32 @@
 #
 # Behavior:
 #   1. Materializes HOME + PYTHONUSERBASE dirs (tmpfs, world-writable)
-#   2. Installs pytest deps (junitparser et al.) into the shared PYTHONUSERBASE
-#   3. Derives shard count from nvidia-smi -L (authoritative; torch.cuda.device_count
+#   2. Derives shard count from nvidia-smi -L (authoritative; torch.cuda.device_count
 #      under-counts MIG-on-same-parent unless CUDA_VISIBLE_DEVICES enumerates each)
-#   4. Cross-checks torch against the nvidia-smi count and caps shards to what torch
+#   3. Cross-checks torch against the nvidia-smi count and caps shards to what torch
 #      can address (guards against CUDA_VISIBLE_DEVICES misconfig on a MIG host)
-#   5. Fans out 1 pytest subshell per non-default cuda:N with per-shard HOME +
+#   4. Fans out 1 pytest subshell per non-default cuda:N with per-shard HOME +
 #      ISAACLAB_TEST_DEVICES; each shard tees its stdout to
 #      /shard-logs/cuda-N.log for the host's grouped re-print after the run
-#   6. Waits on every shard before aggregating exit codes — a fast failure doesn't
+#   5. Waits on every shard before aggregating exit codes — a fast failure doesn't
 #      tear down still-running siblings
+#
+# The pytest deps (pytest, junitparser et al.) are baked into the image by
+# .github/actions/docker-build, so this script no longer installs them.
 
 set +e  # keep going on errors; per-shard exit codes are aggregated at the end
 cd /workspace/isaaclab
 unset DISPLAY  # clear the var that would force Kit into headed (X11) mode
 
-# Container-level HOME + PYTHONUSERBASE for pip --user installs. The image
-# runs as --user $host_uid:$host_gid with no matching /etc/passwd entry, so
-# HOME defaults to /root which the user cannot write. /tmp/* is on tmpfs
+# Container-level HOME + PYTHONUSERBASE. The image runs as
+# --user $host_uid:$host_gid with no matching /etc/passwd entry, so HOME
+# defaults to /root which the user cannot write. /tmp/* is on tmpfs
 # (1777, world-writable).
 #
-# PYTHONUSERBASE is the key for the 1-docker shape: pip --user writes to
-# ${PYTHONUSERBASE}/lib/python3.12/site-packages, and every Python invocation
-# that sees the same env var imports from there. Per-shard subshells below
-# override HOME (so .cache / .nvidia-omniverse are isolated) but inherit
-# PYTHONUSERBASE so junitparser et al. resolve everywhere.
+# Both must exist before any shard starts: per-shard subshells below override
+# HOME (so .cache / .nvidia-omniverse are isolated) but inherit
+# PYTHONUSERBASE, so anything writing to the user site shares one directory.
 mkdir -p /tmp/mgpu-base-home /tmp/mgpu-pyuserbase
-
-# Pytest deps (same as run-tests action). junitparser is imported at
-# tools/conftest.py load time, so it must be present first.
-bash .github/actions/_lib/with-python-package-retries.sh \
-  ./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flaky "coverage>=7.6.1"
 
 # Shard count from nvidia-smi -L (truth; torch under-counts MIG).
 MIG_COUNT=$(nvidia-smi -L | grep -c "^  MIG ")  # grep -c = count of matching lines (MIG slices)

--- a/.github/actions/run-tests/run_tests.sh
+++ b/.github/actions/run-tests/run_tests.sh
@@ -322,7 +322,6 @@ run_tests() {
       mkdir -p tests
       rm _isaac_sim || true
       ln -s /isaac-sim _isaac_sim
-      bash /with-python-package-retries.sh ./isaaclab.sh -p -m pip install pytest pytest-mock junitparser flaky \"coverage>=7.6.1\"
       if [ -n \"\${WARP_CACHE_PATH:-}\" ]; then
         ./isaaclab.sh -p tools/verify_warp_cache.py
       fi

--- a/scripts/demos/mpm/newton_mpm_granular.py
+++ b/scripts/demos/mpm/newton_mpm_granular.py
@@ -111,16 +111,6 @@ def create_sim_cfg():
     )
 
 
-def preview_material(color):
-    """Return a preview-surface material for Kit runs; Kit-less runs spawn no USD materials."""
-    if "kit" not in (args_cli.visualizer or []):
-        return None
-
-    import isaaclab.sim as sim_utils
-
-    return sim_utils.PreviewSurfaceCfg(diffuse_color=color)
-
-
 def create_scene_cfg():
     """Create an Isaac Lab scene config using declarative assets."""
     from isaaclab_newton.assets import MPMObjectCfg
@@ -141,7 +131,7 @@ def create_scene_cfg():
                     static_friction=friction,
                     dynamic_friction=friction,
                 ),
-                visual_material=preview_material((0.45, 0.45, 0.45)),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.45, 0.45, 0.45)),
             ),
             init_state=AssetBaseCfg.InitialStateCfg(pos=center, rot=orientation),
         )

--- a/scripts/demos/mpm/snowball_smash.py
+++ b/scripts/demos/mpm/snowball_smash.py
@@ -239,9 +239,7 @@ def create_scene_cfg():
                     dynamic_friction=CRATE_FRICTION,
                 ),
                 physics_material_path="physicsMaterial",
-                visual_material=(
-                    sim_utils.PreviewSurfaceCfg(diffuse_color=color) if "kit" in (args_cli.visualizer or []) else None
-                ),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=color),
                 visual_material_path="visualMaterial",
             ),
             init_state=RigidObjectCfg.InitialStateCfg(pos=center),

--- a/scripts/demos/mpm/teapot_fill.py
+++ b/scripts/demos/mpm/teapot_fill.py
@@ -423,16 +423,6 @@ def create_sim_cfg():
     )
 
 
-def preview_material(color):
-    """Return a preview-surface material for Kit runs; Kit-less runs spawn no USD materials."""
-    if "kit" not in (args_cli.visualizer or []):
-        return None
-
-    import isaaclab.sim as sim_utils
-
-    return sim_utils.PreviewSurfaceCfg(diffuse_color=color)
-
-
 def create_scene_cfg():
     """Create the teapot-fill scene using declarative Isaac Lab assets."""
     from isaaclab_newton.assets import MPMObjectCfg
@@ -475,7 +465,7 @@ def create_scene_cfg():
                     dynamic_friction=TABLE_FRICTION,
                 ),
                 physics_material_path="physicsMaterial",
-                visual_material=preview_material(TABLE_COLOR),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=TABLE_COLOR),
                 visual_material_path="visualMaterial",
             ),
             init_state=AssetBaseCfg.InitialStateCfg(
@@ -498,7 +488,7 @@ def create_scene_cfg():
                     dynamic_friction=BOWL_FRICTION,
                 ),
                 physics_material_path="physicsMaterial",
-                visual_material=preview_material(BOWL_COLOR),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=BOWL_COLOR),
                 visual_material_path="visualMaterial",
             ),
             init_state=AssetBaseCfg.InitialStateCfg(pos=BOWL_BASE_POS),
@@ -529,7 +519,7 @@ def create_scene_cfg():
                     dynamic_friction=CONTAINER_FRICTION,
                 ),
                 physics_material_path="physicsMaterial",
-                visual_material=preview_material(CONTAINER_COLOR),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=CONTAINER_COLOR),
                 visual_material_path="visualMaterial",
             ),
             init_state=RigidObjectCfg.InitialStateCfg(pos=container_pos, rot=container_rot),
@@ -549,10 +539,10 @@ def create_scene_cfg():
                     tensile_yield_ratio=5.0,
                 ),
                 visual_color=WATER_COLOR,
-                visual_material=sim_utils.GlassMdlCfg(
-                    glass_color=WATER_COLOR,
-                    glass_ior=1.333,
-                    thin_walled=False,
+                visual_material=sim_utils.PreviewSurfaceCfg(
+                    diffuse_color=WATER_COLOR,
+                    roughness=0.1,
+                    opacity=0.7,
                 ),
             ),
             init_state=MPMObjectCfg.InitialStateCfg(pos=container_pos),

--- a/source/isaaclab/changelog.d/antoiner-benchmark-play-video.rst
+++ b/source/isaaclab/changelog.d/antoiner-benchmark-play-video.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added video recording to the RSL-RL, RL-Games, SKRL, and SB3 play benchmark adapters and populated
+  :attr:`~isaaclab.benchmark.schema.PlayBundle.video_path` with the recording directory.

--- a/source/isaaclab/changelog.d/benchmark-play-inference-mode.rst
+++ b/source/isaaclab/changelog.d/benchmark-play-inference-mode.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed play benchmarks running environment actions outside inference mode.

--- a/source/isaaclab/changelog.d/camera-renderer-unsupported-data-types.rst
+++ b/source/isaaclab/changelog.d/camera-renderer-unsupported-data-types.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Camera configurations now raise an error when the active renderer cannot produce a requested
+  data type, rather than silently omitting it. Remove unsupported types from ``CameraCfg.data_types`` or select
+  a renderer that supports them.

--- a/source/isaaclab/changelog.d/ovphysx-gravity-randomization.rst
+++ b/source/isaaclab/changelog.d/ovphysx-gravity-randomization.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed scene gravity randomization dispatch for the kitless OvPhysX backend.

--- a/source/isaaclab/changelog.d/ovphysx-material-cpu-bindings.rst
+++ b/source/isaaclab/changelog.d/ovphysx-material-cpu-bindings.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX material randomization to use CPU-native shape material bindings.

--- a/source/isaaclab/changelog.d/play-resolved-backend.rst
+++ b/source/isaaclab/changelog.d/play-resolved-backend.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed play benchmark metadata to report the resolved physics backend; ``isaacsim_physx`` play runs now report ``physx`` in ``run.config.physics_backend``.

--- a/source/isaaclab/changelog.d/preview-surface-renderer-agnostic.rst
+++ b/source/isaaclab/changelog.d/preview-surface-renderer-agnostic.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Made preview-surface and MDL visual materials author and bind standard OpenUSD shader networks without requiring Kit.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -43,6 +43,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with RL-Games.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -84,6 +86,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -125,6 +128,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -132,6 +136,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -303,6 +308,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -155,7 +155,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "rl_games", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -152,7 +152,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args.checkpoint, "rsl_rl", args.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining)
+            cfg = capture.run_config_from_presets(remaining, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -44,6 +44,8 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with RSL-RL.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -85,6 +87,7 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     add_launcher_args(parser)
 
     args, remaining = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args)
     sys.argv = [sys.argv[0]] + remaining
     return args, remaining
 
@@ -122,6 +125,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args, remaining = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args.task, args.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -129,6 +133,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args.output_path, args, subdir="play")
 
             if args.num_envs is not None:
                 env_cfg.scene.num_envs = args.num_envs
@@ -260,6 +265,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -155,7 +155,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "sb3", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -44,6 +44,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with Stable-Baselines3.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -91,6 +93,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -128,6 +131,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -135,6 +139,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -290,6 +295,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -183,7 +183,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             else:
                 resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "skrl", args_cli.task, env_cfg)
 
-            cfg = capture.run_config_from_presets(remaining_args)
+            cfg = capture.run_config_from_presets(remaining_args, env_cfg=env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
             formatter_types = formatter_types or ["omniperf"]
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -42,6 +42,8 @@ def _parse_args(argv: list[str]):
     from isaaclab_tasks.utils import setup_preset_cli
 
     parser = argparse.ArgumentParser(description="Benchmark RL inference (play) with SKRL.")
+    parser.add_argument("--video", action="store_true", default=False, help="Record videos during play.")
+    parser.add_argument("--video_length", type=int, default=None, help="Recorded video length in environment steps.")
     help_requested = "-h" in argv or "--help" in argv
     parser.add_argument("--task", type=str, required=not help_requested, help="Gym task id to benchmark.")
     parser.add_argument("--num_envs", type=int, default=None, help="Number of parallel environments.")
@@ -103,6 +105,7 @@ def _parse_args(argv: list[str]):
     add_launcher_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="skrl")
+    _common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -146,6 +149,7 @@ def run(argv: list[str]) -> BenchmarkResult:
         algorithm = agent_cfg_entry_point.split("_cfg")[0].split("skrl_")[-1].lower()
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, agent_cfg_entry_point)
+    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -153,6 +157,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
+            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.ml_framework.startswith("jax"):
                 import skrl
@@ -312,6 +317,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                 reward=reward,
                 ep_length=ep_length,
                 checkpoint_path=resume_path,
+                video_path=env_cfg.video_recorders[0].output_dir if args_cli.video else None,
             )
 
             benchmark.attach_bundle(bundle)

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1200,11 +1200,13 @@ class randomize_rigid_body_collider_offsets(ManagerTermBase):
 class randomize_physics_scene_gravity(ManagerTermBase):
     """Randomize gravity by adding, scaling, or setting random values.
 
-    Automatically detects the active physics backend (PhysX or Newton) and applies
+    Automatically detects the active physics backend (PhysX, OvPhysX, or Newton) and applies
     the appropriate gravity randomization strategy:
 
     - **PhysX**: samples a single gravity vector and sets it scene-wide via the PhysX
       simulation view.  All environments share the same gravity.
+    - **OvPhysX**: samples a single gravity vector and applies a sealed OvStage control
+      update. All environments share the same gravity.
     - **Newton**: samples per-environment gravity vectors and writes them in-place to
       the Newton model's per-world gravity array on GPU.
 
@@ -1224,6 +1226,9 @@ class randomize_physics_scene_gravity(ManagerTermBase):
         if "newton" in manager_name:
             self._backend = "newton"
             self._init_newton(cfg, env)
+        elif "ovphysx" in manager_name:
+            self._backend = "ovphysx"
+            self._init_ovphysx(env)
         else:
             self._backend = "physx"
             self._init_physx(env)
@@ -1283,6 +1288,8 @@ class randomize_physics_scene_gravity(ManagerTermBase):
 
         if self._backend == "newton":
             self._call_newton(env, env_ids, operation)
+        elif self._backend == "ovphysx":
+            self._call_ovphysx(env, operation)
         else:
             self._call_physx(env, operation)
 
@@ -1349,6 +1356,23 @@ class randomize_physics_scene_gravity(ManagerTermBase):
         )
         gravity = gravity[0].tolist()
         self._physics_sim_view.set_gravity(self._carb.Float3(*gravity))
+
+    def _init_ovphysx(self, env: ManagerBasedEnv):
+        """Cache the OvPhysX manager for scene-wide gravity updates."""
+        self._ovphysx_manager = env.sim.physics_manager
+
+    def _call_ovphysx(self, env: ManagerBasedEnv, operation: str):
+        """Sample a single gravity vector and apply it scene-wide through OvStage."""
+        gravity = torch.tensor(env.sim.cfg.gravity, device="cpu").unsqueeze(0)
+        gravity = _randomize_prop_by_op(
+            gravity,
+            (self._dist_param_0.cpu(), self._dist_param_1.cpu()),
+            None,
+            slice(None),
+            operation=operation,
+            distribution="uniform",
+        )
+        self._ovphysx_manager.set_gravity(tuple(gravity[0].tolist()))
 
 
 class randomize_actuator_gains(ManagerTermBase):

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -532,7 +532,7 @@ class _RandomizeRigidBodyMaterialOvPhysx:
             return
 
         view = self._material_view
-        # read the current per-shape material [N, S, 3] on the binding's native (sim) device
+        # read the current per-shape material [N, S, 3] on the binding's native CPU device
         materials = wp.to_torch(view.get_attribute(self._material_type))
         num_shapes = materials.shape[1]
 

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -142,7 +142,7 @@ class Camera(SensorBase):
 
         Raises:
             RuntimeError: If no camera prim is found at the given path.
-            ValueError: If the provided data types are not supported by the camera.
+            ValueError: If the provided data types are not supported by the camera or active renderer.
         """
         # perform check on supported data types
         self._check_supported_data_types(cfg)
@@ -652,8 +652,9 @@ class Camera(SensorBase):
     def _create_buffers(self):
         """Create buffers for storing data."""
         specs = self._renderer.supported_output_types()
-        # Split requested names into known/unsupported; warn once for any the renderer can't produce.
+        # Split requested names into known, unknown, and unsupported types.
         known: list[str] = []
+        unknown: list[str] = []
         unsupported: list[str] = []
         for name in self.cfg.data_types:
             try:
@@ -662,13 +663,18 @@ class Camera(SensorBase):
                 else:
                     unsupported.append(name)
             except ValueError:
-                unsupported.append(name)
+                unknown.append(name)
+        errors = []
+        if unknown:
+            errors.append(f"Unknown camera data types: {unknown}.")
         if unsupported:
-            logger.warning(
-                "Renderer %s does not support the following requested data types and will not produce them: %s",
-                type(self._renderer).__name__,
-                unsupported,
+            errors.append(
+                f"Renderer {type(self._renderer).__name__} does not support the following requested data types:"
+                f" {unsupported}."
+                f"\n\tSupported data types: {sorted(str(kind) for kind in specs)}"
             )
+        if errors:
+            raise ValueError("\n".join(errors))
         device_str = self._device if isinstance(self._device, str) else str(self._device)
         self._data = CameraData.allocate(
             data_types=known,

--- a/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
+++ b/source/isaaclab/isaaclab/sim/spawners/materials/visual_materials.py
@@ -5,21 +5,16 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
-from pxr import Usd, UsdShade
+from pxr import Sdf, Usd, UsdShade
 
 from isaaclab.sim.utils import clone, safe_set_attribute_on_usd_prim
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
-from isaaclab.utils.version import has_kit
 
 if TYPE_CHECKING:
     from . import visual_materials_cfg
-
-# import logger
-logger = logging.getLogger(__name__)
 
 
 @clone
@@ -30,9 +25,8 @@ def spawn_preview_surface(prim_path: str, cfg: visual_materials_cfg.PreviewSurfa
     both *specular* and *metallic* workflows. All color inputs are in linear color space (RGB).
     For more information, see the `documentation <https://openusd.org/release/spec_usdpreviewsurface.html>`__.
 
-    The function calls the USD command `CreateShaderPrimFromSdrCommand`_ to create the prim.
-
-    .. _CreateShaderPrimFromSdrCommand: https://docs.omniverse.nvidia.com/kit/docs/omni.usd/latest/omni.usd.commands/omni.usd.commands.CreateShaderPrimFromSdrCommand.html
+    The material is authored using the standard OpenUSD :class:`UsdShade` schema and can therefore
+    be consumed by any renderer that supports ``UsdPreviewSurface``.
 
     .. note::
         This function is decorated with :func:`clone` that resolves prim path into list of paths
@@ -50,41 +44,23 @@ def spawn_preview_surface(prim_path: str, cfg: visual_materials_cfg.PreviewSurfa
     Raises:
         ValueError: If a prim already exists at the given path.
     """
-    # check if Kit is available (required for shader creation commands)
-    if not has_kit():
-        logger.warning("Skipping preview surface material at '%s' — Kit is not available.", prim_path)
-        return None
-
     # get stage handle
     stage = get_current_stage()
 
     # spawn material if it doesn't exist.
     if not stage.GetPrimAtPath(prim_path).IsValid():
-        # note: we don't use Omniverse's CreatePreviewSurfaceMaterialPrimCommand
-        # since it does not support USD stage as an argument. The created material
-        # in that case is always the one from USD Context which makes it difficult to
-        # handle scene creation on a custom stage.
-        material_prim = UsdShade.Material.Define(stage, prim_path)
-        if material_prim:
-            from omni.usd.commands import CreateShaderPrimFromSdrCommand
-
-            shader_prim = CreateShaderPrimFromSdrCommand(
-                parent_path=prim_path,
-                identifier="UsdPreviewSurface",
-                stage_or_context=stage,
-                prim_name="Shader",
-            ).do()
-            # bind the shader graph to the material
-            if shader_prim:
-                surface_out = shader_prim.GetOutput("surface")
-                if surface_out:
-                    material_prim.CreateSurfaceOutput().ConnectToSource(surface_out)
-
-                displacement_out = shader_prim.GetOutput("displacement")
-                if displacement_out:
-                    material_prim.CreateDisplacementOutput().ConnectToSource(displacement_out)
-        else:
-            raise ValueError(f"Failed to create preview surface shader at path: '{prim_path}'.")
+        material = UsdShade.Material.Define(stage, prim_path)
+        shader = UsdShade.Shader.Define(stage, f"{prim_path}/Shader")
+        shader.CreateIdAttr("UsdPreviewSurface")
+        shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f)
+        shader.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f)
+        shader.CreateInput("roughness", Sdf.ValueTypeNames.Float)
+        shader.CreateInput("metallic", Sdf.ValueTypeNames.Float)
+        shader.CreateInput("opacity", Sdf.ValueTypeNames.Float)
+        surface = shader.CreateOutput("surface", Sdf.ValueTypeNames.Token)
+        displacement = shader.CreateOutput("displacement", Sdf.ValueTypeNames.Token)
+        material.CreateSurfaceOutput().ConnectToSource(surface)
+        material.CreateDisplacementOutput().ConnectToSource(displacement)
     else:
         raise ValueError(f"A prim already exists at path: '{prim_path}'.")
 
@@ -113,9 +89,7 @@ def spawn_from_mdl_file(
     that can be loaded by Omniverse and other applications such as Adobe Substance Designer.
     To learn more about MDL, see the `documentation <https://docs.omniverse.nvidia.com/materials-and-rendering/latest/materials.html>`_.
 
-    The function calls the USD command `CreateMdlMaterialPrim`_ to create the prim.
-
-    .. _CreateMdlMaterialPrim: https://docs.omniverse.nvidia.com/kit/docs/omni.usd/latest/omni.usd.commands/omni.usd.commands.CreateMdlMaterialPrimCommand.html
+    The shader network is authored directly with :mod:`UsdShade`.
 
     .. note::
         This function is decorated with :func:`clone` that resolves prim path into list of paths
@@ -133,11 +107,6 @@ def spawn_from_mdl_file(
     Raises:
         ValueError: If a prim already exists at the given path.
     """
-    # check if Kit is available (required for MDL material creation commands)
-    if not has_kit():
-        logger.warning("Skipping MDL material at '%s' — Kit is not available.", prim_path)
-        return None
-
     # get stage handle
     stage = get_current_stage()
 
@@ -145,15 +114,16 @@ def spawn_from_mdl_file(
     if not stage.GetPrimAtPath(prim_path).IsValid():
         # extract material name from path
         material_name = cfg.mdl_path.split("/")[-1].split(".")[0]
-        from omni.usd.commands import CreateMdlMaterialPrimCommand
-
-        CreateMdlMaterialPrimCommand(
-            mtl_url=cfg.mdl_path.format(NVIDIA_NUCLEUS_DIR=NVIDIA_NUCLEUS_DIR),
-            mtl_name=material_name,
-            mtl_path=prim_path,
-            stage=stage,
-            select_new_prim=False,
-        ).do()
+        mdl_url = cfg.mdl_path.format(NVIDIA_NUCLEUS_DIR=NVIDIA_NUCLEUS_DIR)
+        material = UsdShade.Material.Define(stage, prim_path)
+        shader = UsdShade.Shader.Define(stage, f"{prim_path}/Shader")
+        shader.SetSourceAsset(Sdf.AssetPath(mdl_url), "mdl")
+        shader.SetSourceAssetSubIdentifier(material_name, "mdl")
+        shader_out = shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
+        shader_out.SetRenderType("material")
+        material.CreateSurfaceOutput("mdl").ConnectToSource(shader_out)
+        material.CreateDisplacementOutput("mdl").ConnectToSource(shader_out)
+        material.CreateVolumeOutput("mdl").ConnectToSource(shader_out)
     else:
         raise ValueError(f"A prim already exists at path: '{prim_path}'.")
     # obtain prim

--- a/source/isaaclab/isaaclab/sim/utils/prims.py
+++ b/source/isaaclab/isaaclab/sim/utils/prims.py
@@ -18,7 +18,6 @@ import torch
 
 from isaaclab.utils.assets import check_file_path, retrieve_file_path
 from isaaclab.utils.string import to_camel_case
-from isaaclab.utils.version import has_kit
 
 from .queries import (
     find_matching_prim_paths,
@@ -793,13 +792,11 @@ def bind_visual_material(
 ):
     """Bind a visual material to a prim.
 
-    This function is a wrapper around the USD command `BindMaterialCommand`_.
+    The binding is authored using the standard OpenUSD :class:`UsdShade.MaterialBindingAPI`.
 
     .. note::
         The function is decorated with :meth:`apply_nested` to allow applying the function to a prim path
         and all its descendants.
-
-    .. _BindMaterialCommand: https://docs.omniverse.nvidia.com/kit/docs/omni.usd/latest/omni.usd.commands/omni.usd.commands.BindMaterialCommand.html
 
     Args:
         prim_path: The prim path where to apply the material.
@@ -812,37 +809,28 @@ def bind_visual_material(
     Raises:
         ValueError: If the provided prim paths do not exist on stage.
     """
-    if not has_kit():
-        return False
+    from pxr import UsdShade  # noqa: PLC0415
+
     # get stage handle
     if stage is None:
         stage = get_current_stage()
 
     # check if prim and material exists
-    if not stage.GetPrimAtPath(prim_path).IsValid():
-        raise ValueError(f"Target prim '{material_path}' does not exist.")
-    if not stage.GetPrimAtPath(material_path).IsValid():
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
+        raise ValueError(f"Target prim '{prim_path}' does not exist.")
+    material_prim = stage.GetPrimAtPath(material_path)
+    if not material_prim.IsValid():
         raise ValueError(f"Visual material '{material_path}' does not exist.")
 
     # resolve token for weaker than descendants
-    # bind material command expects a string token
     if stronger_than_descendants:
-        binding_strength = "strongerThanDescendants"
+        binding_strength = UsdShade.Tokens.strongerThanDescendants
     else:
-        binding_strength = "weakerThanDescendants"
-    # obtain material binding API
-    # note: we prefer using the command here as it is more robust than the USD API
-    import omni.kit.commands
-
-    success, _ = omni.kit.commands.execute(
-        "BindMaterialCommand",
-        prim_path=prim_path,
-        material_path=material_path,
-        strength=binding_strength,
-        stage=stage,
-    )
-    # return success
-    return bool(success)
+        binding_strength = UsdShade.Tokens.weakerThanDescendants
+    binding_api = UsdShade.MaterialBindingAPI.Apply(prim)
+    material = UsdShade.Material(material_prim)
+    return binding_api.Bind(material, bindingStrength=binding_strength)
 
 
 @apply_nested

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -131,8 +131,14 @@ def test_runtime_request_uses_runtime_defaults() -> None:
 
 
 @pytest.mark.parametrize("backend", ["rsl_rl", "rl_games", "skrl", "sb3"])
-def test_play_request_uses_backend_warmup_steps_argument(backend: str, monkeypatch) -> None:
-    request = BenchmarkPlayRequest(backend=backend, task="Isaac-Cartpole-Direct", num_steps=7, warmup_steps=12)
+def test_play_request_uses_backend_arguments(backend: str, monkeypatch) -> None:
+    request = BenchmarkPlayRequest(
+        backend=backend,
+        task="Isaac-Cartpole-Direct",
+        num_steps=7,
+        warmup_steps=12,
+        backend_args=("--video", "--video_length", "37"),
+    )
 
     argv = dispatch._request_argv(request)
     monkeypatch.setattr(sys, "argv", ["benchmark", *argv])
@@ -143,7 +149,60 @@ def test_play_request_uses_backend_warmup_steps_argument(backend: str, monkeypat
     assert args.num_steps == 7
     assert argv[argv.index("--warmup_steps") + 1] == "12"
     assert args.warmup_steps == 12
+    assert args.video is True
+    assert args.video_length == 37
+    assert args.enable_cameras is True
     assert remaining_args == []
+
+
+@pytest.mark.parametrize("configured_output_dir", [None, "/tmp/custom-videos"])
+def test_play_backend_configures_video_before_environment_creation(
+    monkeypatch, tmp_path, configured_output_dir
+) -> None:
+    class VideoConfigured(Exception):
+        pass
+
+    entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
+    monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
+
+    import gymnasium as gym
+
+    import isaaclab.app as app
+
+    @contextlib.contextmanager
+    def launch_simulation(env_cfg, args):
+        assert env_cfg.video_recorders == []
+        assert any(cfg.visualizer_type == "kit" for cfg in env_cfg.sim.visualizer_cfgs)
+        if configured_output_dir is not None:
+            from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+
+            env_cfg.video_recorders = [VideoRecorderCfg(output_dir=configured_output_dir)]
+        yield
+
+    def make_environment(task, *, cfg):
+        recorder = cfg.video_recorders[0]
+        expected_output_dir = configured_output_dir or str(tmp_path / "videos" / "play")
+        assert recorder.output_dir == expected_output_dir
+        assert recorder.video_length == 37
+        raise VideoConfigured
+
+    monkeypatch.setattr(app, "launch_simulation", launch_simulation)
+    monkeypatch.setattr(gym, "make", make_environment)
+
+    with pytest.raises(VideoConfigured):
+        entrypoint.run(
+            [
+                "--task",
+                "Isaac-Cartpole-Direct",
+                "--checkpoint",
+                "/tmp/checkpoint",
+                "--output_path",
+                str(tmp_path),
+                "--video",
+                "--video_length",
+                "37",
+            ]
+        )
 
 
 @pytest.mark.parametrize("workflow", ["runtime", "startup"])

--- a/source/isaaclab/test/benchmark/test_capture.py
+++ b/source/isaaclab/test/benchmark/test_capture.py
@@ -243,6 +243,10 @@ def test_run_config_from_presets_resolves_backend_configuration(monkeypatch):
     assert cfg.physics_backend == "newton_mjwarp"
     assert cfg.rendering_backend == "isaacsim_rtx"
 
+    physx_env_cfg = SimpleNamespace(sim=SimpleNamespace(physics=SimpleNamespace(class_type="PhysXManager")))
+    cfg = run_config_from_presets(["isaacsim_physx"], env_cfg=physx_env_cfg)
+    assert cfg.physics_backend == "physx"
+
 
 def test_capture_resources_peak_clamped_to_mean_when_peak_row_absent():
     # Build a recorder that has mean/std rows but no peak rows.

--- a/source/isaaclab/test/benchmark/test_play_schema.py
+++ b/source/isaaclab/test/benchmark/test_play_schema.py
@@ -161,11 +161,13 @@ class _PlayEnv:
     def __init__(self):
         self.unwrapped = self
         self._calls = 0
+        self.inference_mode_enabled = False
 
     def reset(self):
         return torch.zeros(2, 3), {}
 
     def step(self, actions):
+        self.inference_mode_enabled = torch.is_inference_mode_enabled()
         self._calls += 1
         dones = torch.tensor([True, False]) if self._calls == 2 else torch.tensor([False, False])
         extras = {"log": {"Episode_Reward/success": torch.tensor(1.0)}}
@@ -184,3 +186,13 @@ def test_run_play_loop_aggregates_episodes():
     assert reward.mean == pytest.approx(2.0)
     assert ep_length.mean == pytest.approx(2.0)
     assert success_rate == pytest.approx(1.0)
+
+
+def test_run_play_loop_steps_env_in_inference_mode():
+    """run_play_loop keeps environment stepping in inference mode."""
+    from isaaclab.benchmark.stepping import run_play_loop
+
+    env = _PlayEnv()
+    run_play_loop(env, policy=lambda obs: torch.zeros(2, 1), num_steps=1)
+
+    assert env.inference_mode_enabled

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -1090,16 +1090,21 @@ def test_camera_frame_offset(setup_camera_device, device):
     del camera
 
 
-def test_camera_warns_once_on_unsupported_data_types(setup_sim_camera, caplog):
-    """Test Camera warns once and drops data types its renderer cannot produce."""
-    import logging
-
+@pytest.mark.parametrize(
+    ("data_types", "expected_names", "expected_messages"),
+    [
+        (["rgba", "depth", "normals"], ["depth", "normals"], ["_PartialRenderer", "Supported data types"]),
+        (["rgba", "not_a_render_buffer_kind"], ["not_a_render_buffer_kind"], ["Unknown camera data types"]),
+    ],
+)
+def test_camera_raises_on_unsupported_data_types(setup_sim_camera, data_types, expected_names, expected_messages):
+    """Test Camera rejects data types its renderer cannot produce or does not recognize."""
     from isaaclab.renderers import Renderer
     from isaaclab.renderers.base_renderer import BaseRenderer
 
     sim, camera_cfg, dt = setup_sim_camera
     camera_cfg = copy.deepcopy(camera_cfg)
-    camera_cfg.data_types = ["rgba", "depth", "normals"]
+    camera_cfg.data_types = data_types
 
     from isaaclab.sensors.camera.camera_data import RenderBufferKind, RenderBufferSpec
 
@@ -1144,31 +1149,11 @@ def test_camera_warns_once_on_unsupported_data_types(setup_sim_camera, caplog):
     Renderer._registry[backend] = _PartialRenderer
     try:
         camera = Camera(camera_cfg)
-        caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="isaaclab.sensors.camera.camera"):
+        with pytest.raises(ValueError) as exc_info:
             sim.reset()
-            # Step a few frames and confirm the warning is emitted once at init.
-            for _ in range(3):
-                sim.step()
-                camera.update(dt)
-
-        warning_records = [
-            r for r in caplog.records if r.levelno == logging.WARNING and "does not support" in r.getMessage()
-        ]
-        assert len(warning_records) == 1, (
-            f"Expected exactly one 'does not support' warning, got {len(warning_records)}:"
-            f" {[r.getMessage() for r in warning_records]}"
-        )
-        msg = warning_records[0].getMessage()
-        assert "_PartialRenderer" in msg
-        assert "depth" in msg
-        assert "normals" in msg
-        assert "rgba" not in msg
-
-        # Only the supported subset is in ``data.output``; the rest were dropped.
-        assert set(camera.data.output.keys()) == {"rgba"}
-        # ``data.info`` mirrors the ``data.output`` keys.
-        assert set(camera.data.info.keys()) == {"rgba"}
+        assert all(name in str(exc_info.value) for name in expected_names)
+        assert all(message in str(exc_info.value) for message in expected_messages)
+        assert "Hint:" not in str(exc_info.value)
 
         del camera
     finally:

--- a/source/isaaclab/test/sim/test_visual_materials_kitless.py
+++ b/source/isaaclab/test/sim/test_visual_materials_kitless.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import inspect
+
+from pxr import Sdf, Usd, UsdGeom, UsdShade
+
+from isaaclab.sim.spawners.materials import visual_materials
+from isaaclab.sim.spawners.materials.visual_materials_cfg import MdlFileCfg, PreviewSurfaceCfg
+from isaaclab.sim.utils import prims as prim_utils
+from isaaclab.sim.utils.prims import bind_visual_material
+from isaaclab.utils.assets import NVIDIA_NUCLEUS_DIR
+
+
+def test_spawn_preview_surface_without_kit(monkeypatch):
+    """Preview surfaces should use renderer-agnostic USD shader inputs and outputs."""
+    stage = Usd.Stage.CreateInMemory()
+    monkeypatch.setattr(visual_materials, "get_current_stage", lambda: stage)
+    monkeypatch.setattr(prim_utils, "get_current_stage", lambda: stage)
+    cfg = PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0))
+
+    prim = visual_materials.spawn_preview_surface("/Looks/PreviewSurface", cfg)
+
+    shader = UsdShade.Shader(prim)
+    material = UsdShade.Material(stage.GetPrimAtPath("/Looks/PreviewSurface"))
+    assert shader.GetIdAttr().Get() == "UsdPreviewSurface"
+    assert shader.GetInput("diffuseColor").GetTypeName() == Sdf.ValueTypeNames.Color3f
+    assert shader.GetInput("emissiveColor").GetTypeName() == Sdf.ValueTypeNames.Color3f
+    assert shader.GetInput("roughness").GetTypeName() == Sdf.ValueTypeNames.Float
+    assert shader.GetOutput("surface").GetTypeName() == Sdf.ValueTypeNames.Token
+    assert shader.GetOutput("displacement").GetTypeName() == Sdf.ValueTypeNames.Token
+    assert material.GetSurfaceOutput().HasConnectedSource()
+    assert material.GetDisplacementOutput().HasConnectedSource()
+
+
+def test_spawn_and_bind_mdl_material_without_kit(monkeypatch):
+    """MDL spawning should create a bindable material without requiring Kit commands."""
+    stage = Usd.Stage.CreateInMemory()
+    monkeypatch.setattr(visual_materials, "get_current_stage", lambda: stage)
+    monkeypatch.setattr(prim_utils, "get_current_stage", lambda: stage)
+    cfg = MdlFileCfg(
+        mdl_path="{NVIDIA_NUCLEUS_DIR}/Materials/Base/Metals/Aluminum_Anodized.mdl",
+        project_uvw=True,
+        albedo_brightness=0.5,
+    )
+
+    prim = visual_materials.spawn_from_mdl_file("/Looks/MdlMaterial", cfg)
+    UsdGeom.Cube.Define(stage, "/World/Geometry")
+    bind_visual_material("/World/Geometry", "/Looks/MdlMaterial", stage=stage)
+
+    shader = UsdShade.Shader(prim)
+    material = UsdShade.Material(stage.GetPrimAtPath("/Looks/MdlMaterial"))
+    source_asset = shader.GetSourceAsset("mdl")
+    assert source_asset.path == (f"{NVIDIA_NUCLEUS_DIR}/Materials/Base/Metals/Aluminum_Anodized.mdl")
+    assert shader.GetSourceAssetSubIdentifier("mdl") == "Aluminum_Anodized"
+    assert shader.GetOutput("out").GetRenderType() == "material"
+    assert material.GetSurfaceOutput("mdl").HasConnectedSource()
+    assert material.GetDisplacementOutput("mdl").HasConnectedSource()
+    assert material.GetVolumeOutput("mdl").HasConnectedSource()
+    assert prim.GetAttribute("inputs:project_uvw").Get() is True
+    assert prim.GetAttribute("inputs:albedo_brightness").Get() == 0.5
+    binding = UsdShade.MaterialBindingAPI(stage.GetPrimAtPath("/World/Geometry")).GetDirectBinding()
+    assert binding.GetMaterialPath() == "/Looks/MdlMaterial"
+
+
+def test_visual_material_spawners_do_not_depend_on_kit_commands():
+    """Keep visual material ownership in the OpenUSD layer."""
+    source = inspect.getsource(visual_materials)
+    assert "has_kit" not in source
+    assert "omni.usd.commands" not in source

--- a/source/isaaclab_ov/changelog.d/ovphysx-gravity-randomization.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-gravity-randomization.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added live scene gravity updates through sealed OvStage control ordinals.

--- a/source/isaaclab_ov/changelog.d/ovphysx-material-cpu-bindings.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-material-cpu-bindings.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX shape material bindings to allocate CPU buffers during GPU simulation.

--- a/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
+++ b/source/isaaclab_ov/isaaclab_ov/benchmark/assets/runtime.py
@@ -60,6 +60,7 @@ def create_test_articulation(
     object.__setattr__(articulation, "_debug_vis_handle", None)
     object.__setattr__(articulation, "_root_view", mock_view)
     object.__setattr__(articulation, "_device", device)
+    object.__setattr__(articulation, "_sim_cfg", None)
     object.__setattr__(articulation, "_check_shapes", not args.no_shape_checks)
     object.__setattr__(articulation, "_num_instances", num_instances)
     object.__setattr__(articulation, "_num_bodies", num_bodies)

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -13,10 +13,13 @@ steps the simulation using the ovphysx C/Python API.
 from __future__ import annotations
 
 import atexit
+import contextlib
 import logging
+import math
 import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import numpy as np
 import warp as wp
 
 from pxr import UsdPhysics
@@ -365,6 +368,7 @@ class OvPhysxManager(PhysicsManager):
     _ovstage: ClassVar[Any] = None
     _stage_usda: ClassVar[str | None] = None
     _warmup_done: ClassVar[bool] = False
+    _next_control_ordinal: ClassVar[int] = 2
     _requires_full_stage: ClassVar[bool] = False
     # Device mode is process-wide; later contexts must reuse the first selected device.
     _locked_device: ClassVar[str | None] = None
@@ -612,12 +616,16 @@ class OvPhysxManager(PhysicsManager):
             raise
         cls._ovstage = stage
 
+        cls._next_control_ordinal = 2
+
     @classmethod
     def _destroy_ovstage(cls) -> None:
         """Destroy the attached OVStage after PhysX has released its stage."""
         if cls._ovstage is not None:
             cls._ovstage.destroy()
             cls._ovstage = None
+
+        cls._next_control_ordinal = 2
 
     @staticmethod
     def _close_physx_views(physx: Any) -> None:
@@ -654,6 +662,51 @@ class OvPhysxManager(PhysicsManager):
         if cls._sim is None or not hasattr(cls._sim, "cfg"):
             raise RuntimeError("OvPhysxManager has not been initialized yet.")
         return cls._sim.cfg.gravity
+
+    @classmethod
+    def set_gravity(cls, gravity: tuple[float, float, float]) -> None:
+        """Set the scene-wide gravity vector through OvStage [m/s^2].
+
+        The OvPhysX runtime accepts live scene changes only as sealed OvStage
+        control updates. This method authors the scene's gravity direction and
+        magnitude at the next control ordinal, seals it, and applies that
+        single ordinal to the running simulation.
+
+        Args:
+            gravity: World-frame gravity vector [m/s^2].
+
+        Raises:
+            RuntimeError: If the OVPhysX simulation has not been initialized.
+            ValueError: If gravity does not contain three finite values.
+        """
+        if cls._sim is None or cls._physx is None or cls._ovstage is None:
+            raise RuntimeError("OvPhysxManager has not been initialized yet.")
+
+        gravity_array = np.asarray(gravity, dtype=np.float32)
+        if gravity_array.shape != (3,) or not np.all(np.isfinite(gravity_array)):
+            raise ValueError("Gravity must contain three finite values.")
+
+        magnitude = float(np.linalg.norm(gravity_array))
+        if math.isclose(magnitude, 0.0):
+            direction = np.array([[0.0, 0.0, -1.0]], dtype=np.float32)
+        else:
+            direction = (gravity_array / magnitude).reshape(1, 3)
+        ordinal = cls._next_control_ordinal
+        cls._next_control_ordinal += 1
+
+        import ovstage  # noqa: PLC0415
+
+        with contextlib.ExitStack() as cleanup:
+            paths = cleanup.enter_context(ovstage.PathDictionary(cls._ovstage))
+            path_list = paths.create_path_list_from_strings([cls._sim.cfg.physics_prim_path])
+            cleanup.callback(paths.destroy_path_list, path_list)
+            query = cleanup.enter_context(cls._ovstage.query_from_path_list(path_list))
+            cls._ovstage.write_attribute(query, "physics:gravityDirection", ordinal, direction, is_array=False).wait()
+            cls._ovstage.write_attribute(
+                query, "physics:gravityMagnitude", ordinal, np.array([magnitude], dtype=np.float32), is_array=False
+            ).wait()
+            cls._ovstage.advance_write_floor(ordinal=ordinal).wait()
+            cls._physx.update_from_ovstage(ordinal, ordinal)
 
     @classmethod
     def get_scene_data_backend(cls) -> SceneDataBackend:

--- a/source/isaaclab_ov/isaaclab_ov/tensor_types.py
+++ b/source/isaaclab_ov/isaaclab_ov/tensor_types.py
@@ -259,7 +259,7 @@ Guarded so this module stays import-safe against older wheels that lack them.
 
 try:
     SHAPE_FRICTION_AND_RESTITUTION = _TT.ARTICULATION_SHAPE_FRICTION_AND_RESTITUTION
-    """Per-collision-shape material of each articulation instance — read/write, GPU.
+    """Per-collision-shape material of each articulation instance — read/write, CPU.
     Shape ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]``
     restitution (all dimensionless)."""
 except AttributeError:
@@ -267,7 +267,7 @@ except AttributeError:
 
 try:
     RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION = _TT.RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION
-    """Per-collision-shape material of each rigid body — read/write, GPU. Shape
+    """Per-collision-shape material of each rigid body — read/write, CPU. Shape
     ``(N, S, 3)``: ``[0]`` static friction, ``[1]`` dynamic friction, ``[2]`` restitution
     (all dimensionless)."""
 except AttributeError:
@@ -450,8 +450,15 @@ _CPU_ONLY_TYPES_CANDIDATES: tuple = (
     DEFORMABLE_MATERIAL_THICKNESS,
     DEFORMABLE_MATERIAL_BENDING_DAMPING,
 )
-# Optional rigid-body CPU entries: only included when the wheel exposes them.
-_RIGID_BODY_OPTIONAL_CPU: tuple = tuple(
-    globals()[name] for name in ("RIGID_BODY_INV_MASS", "RIGID_BODY_INV_INERTIA") if name in globals()
+# Optional CPU-native entries: only included when the wheel exposes them.
+_OPTIONAL_CPU_TYPES: tuple = tuple(
+    globals()[name]
+    for name in (
+        "RIGID_BODY_INV_MASS",
+        "RIGID_BODY_INV_INERTIA",
+        "SHAPE_FRICTION_AND_RESTITUTION",
+        "RIGID_BODY_SHAPE_FRICTION_AND_RESTITUTION",
+    )
+    if name in globals()
 )
-_CPU_ONLY_TYPES: frozenset[TensorType] = frozenset(_CPU_ONLY_TYPES_CANDIDATES + _RIGID_BODY_OPTIONAL_CPU)
+_CPU_ONLY_TYPES: frozenset[TensorType] = frozenset(_CPU_ONLY_TYPES_CANDIDATES + _OPTIONAL_CPU_TYPES)

--- a/source/isaaclab_ov/test/assets/test_articulation.py
+++ b/source/isaaclab_ov/test/assets/test_articulation.py
@@ -3332,8 +3332,8 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     OVPhysX exposes per-collision-shape material as the
     ``articulation_shape_friction_and_restitution`` tensor binding (shape ``[N, S, 3]`` =
     static friction, dynamic friction, restitution), addressed through the
-    :class:`~isaaclab_ov.sim.views.OvPhysxView`. The binding is device-resident, so the
-    buffer lives on the simulation device. (The PhysX backend instead uses a dedicated
+    :class:`~isaaclab_ov.sim.views.OvPhysxView`. The binding is CPU-native, so the
+    buffer lives in host memory. (The PhysX backend instead uses a dedicated
     ``root_view.get_material_properties`` / ``set_material_properties`` view API.)
     """
     if not hasattr(TT, "SHAPE_FRICTION_AND_RESTITUTION"):
@@ -3351,8 +3351,8 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     # Number of collision shapes per articulation, from the material binding's shape [N, S, 3].
     num_shapes = view.binding_for(TT.SHAPE_FRICTION_AND_RESTITUTION).shape[1]
 
-    # Random material per shape: (static_friction, dynamic_friction, restitution), on the sim device.
-    materials = torch.empty(num_articulations, num_shapes, 3, device=device).uniform_(0.0, 1.0)
+    # Random material per shape: (static_friction, dynamic_friction, restitution), on the CPU.
+    materials = torch.empty(num_articulations, num_shapes, 3, device="cpu").uniform_(0.0, 1.0)
     materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])  # dynamic <= static
 
     # Set material properties through the view, then simulate.

--- a/source/isaaclab_ov/test/assets/test_rigid_object.py
+++ b/source/isaaclab_ov/test/assets/test_rigid_object.py
@@ -654,11 +654,11 @@ def test_rigid_body_set_material_properties(num_cubes, device):
         # Play sim
         sim.reset()
 
-        # Random material per shape: (static_friction, dynamic_friction, restitution), on the sim device.
+        # Random material per shape: (static_friction, dynamic_friction, restitution), on the CPU.
         num_shapes = _num_shapes(cube_object)
-        static_friction = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.4, 0.8)
-        dynamic_friction = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.4, 0.8)
-        restitution = torch.empty(num_cubes, num_shapes, 1, device=device).uniform_(0.0, 0.2)
+        static_friction = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.4, 0.8)
+        dynamic_friction = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.4, 0.8)
+        restitution = torch.empty(num_cubes, num_shapes, 1, device="cpu").uniform_(0.0, 0.2)
         materials = torch.cat([static_friction, dynamic_friction, restitution], dim=-1)
 
         # Add friction/restitution to the cubes through the view.
@@ -684,7 +684,7 @@ def test_set_material_properties_via_view(num_cubes, device):
 
         # Generate random material properties: (static_friction, dynamic_friction, restitution).
         num_shapes = _num_shapes(cube_object)
-        materials = torch.empty(num_cubes, num_shapes, 3, device=device).uniform_(0.0, 1.0)
+        materials = torch.empty(num_cubes, num_shapes, 3, device="cpu").uniform_(0.0, 1.0)
         materials[..., 1] = torch.min(materials[..., 0], materials[..., 1])  # dynamic <= static
 
         # Set material properties through the view, simulate, then read back.
@@ -716,7 +716,7 @@ def test_rigid_body_no_friction(num_cubes, device):
         # Set the cubes' friction (and restitution) to zero. This test isolates friction, so a zero
         # restitution keeps the resting contact clean instead of letting the cube bounce vertically.
         num_shapes = _num_shapes(cube_object)
-        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
         _write_shape_material(cube_object, cube_materials)
 
         # Let the cube settle onto the plane so the initial ground-penetration transient (a small
@@ -765,7 +765,7 @@ def test_rigid_body_with_static_friction(num_cubes, device):
 
         # Set the cubes' static (and, per the PhysX bug, dynamic) friction to mu, restitution zero.
         num_shapes = _num_shapes(cube_object)
-        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+        cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
         cube_materials[..., 0] = mu
         cube_materials[..., 1] = mu
         _write_shape_material(cube_object, cube_materials)
@@ -842,7 +842,7 @@ def test_rigid_body_with_restitution(num_cubes, device):
 
             # Frictionless cubes with the matching restitution.
             num_shapes = _num_shapes(cube_object)
-            cube_materials = torch.zeros(num_cubes, num_shapes, 3, device=device)
+            cube_materials = torch.zeros(num_cubes, num_shapes, 3, device="cpu")
             cube_materials[..., 2] = restitution_coefficient
             _write_shape_material(cube_object, cube_materials)
 

--- a/source/isaaclab_ov/test/assets/test_rigid_object_collection.py
+++ b/source/isaaclab_ov/test/assets/test_rigid_object_collection.py
@@ -774,10 +774,10 @@ def test_set_material_properties(num_envs, num_cubes, device):
         # Play sim
         sim.reset()
 
-        # Random material per object: (static_friction, dynamic_friction, restitution), on the sim device.
-        static_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
-        dynamic_friction = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.4, 0.8)
-        restitution = torch.empty(num_envs, num_cubes, 1, device=device).uniform_(0.0, 0.2)
+        # Random material per object: (static_friction, dynamic_friction, restitution), on the CPU.
+        static_friction = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.4, 0.8)
+        dynamic_friction = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.4, 0.8)
+        restitution = torch.empty(num_envs, num_cubes, 1, device="cpu").uniform_(0.0, 0.2)
         materials = torch.cat([static_friction, dynamic_friction, restitution], dim=-1)  # [num_envs, num_cubes, 3]
 
         # Map data -> body-major view layout, write through the view.

--- a/source/isaaclab_ov/test/physics/test_ovphysx_gravity.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_gravity.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Real-backend tests for OvPhysX scene gravity randomization."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
+
+from isaaclab_ov.assets import RigidObject
+from isaaclab_ov.physics import OvPhysxCfg
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+from isaaclab.envs.mdp.events import randomize_physics_scene_gravity
+from isaaclab.managers import EventTermCfg
+from isaaclab.sim import SimulationCfg, build_simulation_context
+
+
+def test_gravity_event_changes_rigid_body_motion():
+    """The gravity event must dispatch through OvStage and change motion in OvPhysX."""
+    sim_cfg = SimulationCfg(physics=OvPhysxCfg(), device="cpu", dt=1.0 / 60.0)
+    with build_simulation_context(device="cpu", sim_cfg=sim_cfg) as sim:
+        cube = RigidObject(
+            RigidObjectCfg(
+                prim_path="/World/Cube",
+                init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, 10.0)),
+                spawn=sim_utils.CuboidCfg(
+                    size=(0.5, 0.5, 0.5),
+                    rigid_props=sim_utils.RigidBodyBaseCfg(),
+                    mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+                    collision_props=sim_utils.CollisionBaseCfg(),
+                ),
+            )
+        )
+        sim.reset()
+        dt = sim.get_physics_dt()
+        cube.update(dt)
+
+        env = SimpleNamespace(device=sim.device, sim=sim)
+        event_cfg = EventTermCfg(
+            func=randomize_physics_scene_gravity,
+            params={"gravity_distribution_params": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)), "operation": "abs"},
+        )
+        gravity_event = randomize_physics_scene_gravity(event_cfg, env)
+
+        def step(count: int) -> None:
+            for _ in range(count):
+                cube.write_data_to_sim()
+                sim.step()
+                cube.update(dt)
+
+        def set_gravity(gravity: tuple[float, float, float]) -> None:
+            gravity_event(
+                env,
+                env_ids=None,
+                gravity_distribution_params=(gravity, gravity),
+                operation="abs",
+            )
+
+        set_gravity((0.0, 0.0, 0.0))
+        initial_height = cube.data.root_pos_w.torch[0, 2].item()
+        step(30)
+        zero_gravity_height = cube.data.root_pos_w.torch[0, 2].item()
+
+        set_gravity((0.0, 0.0, -9.81))
+        # Changing scene gravity does not wake sleeping PhysX actors. Reset terms
+        # write body state after gravity randomization, so mirror that wake-up here.
+        root_velocity = torch.zeros((1, 6), device=sim.device)
+        root_velocity[0, 2] = 0.001
+        cube.write_root_velocity_to_sim_index(root_velocity=root_velocity)
+        step(30)
+        earth_gravity_height = cube.data.root_pos_w.torch[0, 2].item()
+
+        assert zero_gravity_height == pytest.approx(initial_height, abs=1.0e-4)
+        assert earth_gravity_height - zero_gravity_height < -0.5

--- a/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
@@ -46,6 +46,7 @@ def manager_module(monkeypatch):
         "_physx": None,
         "_ovstage": None,
         "_stage_usda": None,
+        "_next_control_ordinal": 2,
         "_warmup_done": False,
         "_requires_full_stage": False,
         "_locked_device": None,
@@ -245,6 +246,101 @@ def test_stage_reuse_drains_bindings_before_reset(monkeypatch, manager_module):
         ("wait", 9),
         "destroy_stage",
     ]
+
+
+@pytest.mark.parametrize("failure", [None, "query", "write"])
+def test_set_gravity_writes_and_releases_ovstage_control_resources(monkeypatch, manager_module, failure):
+    """Scene gravity updates must seal their ordinal and release resources on every path."""
+    manager = manager_module.OvPhysxManager
+    calls = []
+
+    class FakePathDictionary:
+        def __init__(self, stage):
+            self.stage = stage
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            calls.append(("destroy_dictionary",))
+
+        def create_path_list_from_strings(self, paths):
+            calls.append(("paths", paths))
+            return "physics-scene-paths"
+
+        def destroy_path_list(self, paths):
+            calls.append(("destroy_paths", paths))
+
+    class FakeQuery:
+        def __enter__(self):
+            return "physics-scene-query"
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            calls.append(("release_query", "physics-scene-query"))
+
+    class FakeStage:
+        def query_from_path_list(self, paths):
+            calls.append(("query", paths))
+            if failure == "query":
+                raise RuntimeError("query failed")
+            return FakeQuery()
+
+        def write_attribute(self, query, attribute, ordinal, tensors, *, is_array):
+            calls.append(("write", query, attribute, ordinal, tensors.tolist(), is_array))
+            if failure == "write":
+                raise RuntimeError("write failed")
+            return SimpleNamespace(wait=lambda: None)
+
+        def advance_write_floor(self, *, ordinal):
+            calls.append(("seal", ordinal))
+            return SimpleNamespace(wait=lambda: None)
+
+    class FakePhysX:
+        def update_from_ovstage(self, start_ordinal, end_ordinal):
+            calls.append(("update", start_ordinal, end_ordinal))
+
+    fake_ovstage = ModuleType("ovstage")
+    fake_ovstage.PathDictionary = FakePathDictionary
+    monkeypatch.setitem(sys.modules, "ovstage", fake_ovstage)
+    monkeypatch.setattr(manager, "_ovstage", FakeStage())
+    monkeypatch.setattr(manager, "_physx", FakePhysX())
+    monkeypatch.setattr(manager, "_sim", SimpleNamespace(cfg=SimpleNamespace(physics_prim_path="/World/physicsScene")))
+
+    if failure is None:
+        manager.set_gravity((0.0, 0.0, -9.81))
+        expected_calls = [
+            ("paths", ["/World/physicsScene"]),
+            ("query", "physics-scene-paths"),
+            ("write", "physics-scene-query", "physics:gravityDirection", 2, [[0.0, 0.0, -1.0]], False),
+            ("write", "physics-scene-query", "physics:gravityMagnitude", 2, [pytest.approx(9.81)], False),
+            ("seal", 2),
+            ("update", 2, 2),
+            ("release_query", "physics-scene-query"),
+            ("destroy_paths", "physics-scene-paths"),
+            ("destroy_dictionary",),
+        ]
+    else:
+        with pytest.raises(RuntimeError, match=f"{failure} failed"):
+            manager.set_gravity((0.0, 0.0, -9.81))
+        expected_calls = [
+            ("paths", ["/World/physicsScene"]),
+            ("query", "physics-scene-paths"),
+        ]
+        if failure == "write":
+            expected_calls.extend(
+                [
+                    ("write", "physics-scene-query", "physics:gravityDirection", 2, [[0.0, 0.0, -1.0]], False),
+                    ("release_query", "physics-scene-query"),
+                ]
+            )
+        expected_calls.extend(
+            [
+                ("destroy_paths", "physics-scene-paths"),
+                ("destroy_dictionary",),
+            ]
+        )
+
+    assert calls == expected_calls
 
 
 def _retained_binding_script() -> str:

--- a/source/isaaclab_ov/test/sim/test_ovphysx_view.py
+++ b/source/isaaclab_ov/test/sim/test_ovphysx_view.py
@@ -751,6 +751,23 @@ def test_get_attribute_cpu_only_property_returns_cpu_buffer_on_gpu_sim():
     assert str(buf.device) == "cpu"
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        name
+        for name in ("articulation_shape_friction_and_restitution", "rigid_body_shape_friction_and_restitution")
+        if hasattr(TensorType, name.upper())
+    ],
+)
+def test_shape_material_property_returns_cpu_buffer_on_gpu_sim(name: str):
+    """Shape material properties must use their CPU-native bindings on GPU simulations."""
+    view = _make_view(n=3, device="cuda:0")
+
+    buf = view.get_attribute(name)
+
+    assert str(buf.device) == "cpu"
+
+
 def test_binding_for_is_idempotent_and_unguarded():
     view = _make_view(n=3)
     # Returns a binding even for a read-only attribute (raw access bypasses the write guard)...

--- a/source/isaaclab_physx/changelog.d/camera-renderer-unsupported-data-types.rst
+++ b/source/isaaclab_physx/changelog.d/camera-renderer-unsupported-data-types.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* **Breaking:** The Isaac RTX renderer now raises an error for albedo and simple-shading outputs on Isaac Sim
+  versions before 6.0, rather than silently omitting them. Upgrade Isaac Sim or remove those data types.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -262,14 +262,15 @@ class IsaacRtxRenderer(BaseRenderer):
             if settings.get("/isaaclab/has_gui"):
                 settings.set_bool("/rtx/sdg/force/disableColorRender", False)
         else:
+            unsupported = []
             if "albedo" in spec.cfg.data_types:
-                logger.warning(
-                    "Albedo annotator is only supported in Isaac Sim 6.0+. The albedo data type will be ignored."
-                )
-            if any(dt in SIMPLE_SHADING_MODES for dt in spec.cfg.data_types):
-                logger.warning(
-                    "Simple shading annotators are only supported in Isaac Sim 6.0+."
-                    " The simple shading data types will be ignored."
+                unsupported.append("albedo")
+            unsupported.extend(dt for dt in spec.cfg.data_types if dt in SIMPLE_SHADING_MODES)
+            if unsupported:
+                raise ValueError(
+                    "Isaac RTX renderer does not support the following requested data types in"
+                    " Isaac Sim versions before 6.0:"
+                    f" {unsupported}."
                 )
 
         # HACK: Isaac Sim 4.5 has a bug in Camera that breaks segmentation

--- a/source/isaaclab_tasks/changelog.d/fix-gearassembly-safe-defaults.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-gearassembly-safe-defaults.rst
@@ -1,0 +1,3 @@
+Fixed
+^^^^^
+* Reduced the default number of parallel environments for GearAssembly tasks to 1024 so recurrent PPO training fits on development GPUs. Use ``--num_envs`` to select a different batch size.

--- a/source/isaaclab_tasks/changelog.d/mmichelis-franka-deformable-ovphysx.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/mmichelis-franka-deformable-ovphysx.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added OVPhysX presets for the Franka soft-body and cloth lift tasks, including their camera
+  variants.

--- a/source/isaaclab_tasks/changelog.d/ovphysx-gravity-randomization.rst
+++ b/source/isaaclab_tasks/changelog.d/ovphysx-gravity-randomization.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Enabled the gravity curriculum for Kuka-Allegro tasks using the OvPhysX backend.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/config/ur_10e/joint_pos_env_cfg.py
@@ -240,8 +240,6 @@ class UR10eGearAssemblyEnvCfg(GearAssemblyEnvCfg):
         # post init of parent
         super().__post_init__()
 
-        self.scene.num_envs = 2048
-
         # Robot-specific parameters (can be overridden for other robots)
         self.end_effector_body_name = "wrist_3_link"  # End effector body name for IK and termination checks
         self.num_arm_joints = 6  # Number of arm joints (excluding gripper)

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/deploy/gear_assembly/gear_assembly_env_cfg.py
@@ -295,7 +295,7 @@ class TerminationsCfg:
 @configclass
 class GearAssemblyEnvCfg(ManagerBasedRLEnvCfg):
     # Scene settings
-    scene: GearAssemblySceneCfg = GearAssemblySceneCfg(num_envs=4096, env_spacing=2.5)
+    scene: GearAssemblySceneCfg = GearAssemblySceneCfg(num_envs=1024, env_spacing=2.5)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -6,7 +6,7 @@
 
 from dataclasses import MISSING
 
-from isaaclab_newton.physics import KaminoPADMMSolverCfg, MJWarpSolverCfg, NewtonCfg
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_ov.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 
@@ -118,12 +118,6 @@ class CabinetSimCfg(PresetCfg):
             debug_mode=False,
         ),
     )
-    newton_kamino: SimulationCfg = SimulationCfg(
-        dt=1 / 600,
-        render_interval=1,
-        default_visualizer_cfg=VisualizerCfg(eye=(-2.0, 2.0, 2.0), lookat=(0.8, 0.0, 0.5)),
-        physics=NewtonCfg(solver_cfg=KaminoPADMMSolverCfg(max_contacts_per_world=64)),
-    )
     default: SimulationCfg = newton_mjwarp
 
 
@@ -139,7 +133,6 @@ class CabinetDecimationCfg(PresetCfg):
     ovphysx: int = isaacsim_physx
     physx: int = isaacsim_physx
     newton_mjwarp: int = 10
-    newton_kamino: int = 10
     default: int = newton_mjwarp
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cloth_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cloth_env_cfg.py
@@ -16,6 +16,7 @@ from isaaclab_newton.physics import (
 )
 from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
 from isaaclab_newton.sim.spawners.materials import NewtonSurfaceDeformableBodyMaterialCfg
+from isaaclab_ov.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxDeformableBodyPropertiesCfg
 from isaaclab_physx.sim.spawners.materials import PhysxSurfaceDeformableBodyMaterialCfg
@@ -100,8 +101,9 @@ class PhysicsCfg(PresetCfg):
     )
 
     isaacsim_physx: PhysxCfg = PhysxCfg(gpu_found_lost_pairs_capacity=2**22)
+    ovphysx: OvPhysxCfg = OvPhysxCfg(gpu_found_lost_pairs_capacity=2**22)
 
-    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
 
     default = newton_mjwarp_vbd_proxy
 
@@ -163,6 +165,7 @@ class DeformableCfg(PresetCfg):
         ),
     )
     isaacsim_physx = physx
+    ovphysx = physx
 
     default = newton_mjwarp_vbd_proxy
 
@@ -201,9 +204,10 @@ class FrankaClothScenePresetCfg(PresetCfg):
         num_envs=2048, env_spacing=2.0, replicate_physics=True
     )
 
-    # PhysX does not support replicating physics for deformable objects
+    # Isaac Sim PhysX does not support replicating physics for deformable objects
     physx: FrankaClothSceneCfg = FrankaClothSceneCfg(num_envs=2048, env_spacing=2.0, replicate_physics=False)
     isaacsim_physx = physx
+    ovphysx: FrankaClothSceneCfg = FrankaClothSceneCfg(num_envs=2048, env_spacing=2.0, replicate_physics=True)
 
     default = newton_mjwarp_vbd_proxy
 
@@ -224,6 +228,9 @@ class FrankaClothCameraScenePresetCfg(PresetCfg):
     )
     physx: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
     isaacsim_physx = physx
+    ovphysx: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(
+        num_envs=128, env_spacing=2.5, replicate_physics=True
+    )
     default = newton_mjwarp_vbd_proxy
 
 

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
@@ -16,6 +16,7 @@ from isaaclab_newton.physics import (
 )
 from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
 from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
+from isaaclab_ov.physics import OvPhysxCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxDeformableBodyPropertiesCfg
 from isaaclab_physx.sim.spawners.materials import PhysxDeformableBodyMaterialCfg
@@ -50,7 +51,7 @@ from isaaclab_contrib.coupling import (
     CouplerProxyMappingCfg,
 )
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
 from ... import mdp
@@ -135,6 +136,7 @@ class DeformableCfg(PresetCfg):
         ),
     )
     isaacsim_physx = physx
+    ovphysx = physx
 
     default = newton_mjwarp_vbd_proxy
 
@@ -185,8 +187,9 @@ class PhysicsCfg(PresetCfg):
     )
 
     isaacsim_physx: PhysxCfg = PhysxCfg()
+    ovphysx: OvPhysxCfg = OvPhysxCfg()
 
-    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
+    physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
 
     default = newton_mjwarp_vbd_proxy
 
@@ -609,9 +612,10 @@ class FrankaSoftSceneCfg(PresetCfg):
         num_envs=2048, env_spacing=2.0, replicate_physics=True
     )
 
-    # PhysX does not support replicating physics for deformable objects
+    # Isaac Sim PhysX does not support replicating physics for deformable objects
     physx: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=2048, env_spacing=2.0, replicate_physics=False)
     isaacsim_physx = physx
+    ovphysx: _FrankaSoftSceneCfg = _FrankaSoftSceneCfg(num_envs=2048, env_spacing=2.0, replicate_physics=True)
 
     default = newton_mjwarp_vbd_proxy
 
@@ -625,6 +629,9 @@ class FrankaSoftCameraSceneCfg(PresetCfg):
     )
     physx: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(num_envs=128, env_spacing=2.0, replicate_physics=False)
     isaacsim_physx = physx
+    ovphysx: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(
+        num_envs=128, env_spacing=2.0, replicate_physics=True
+    )
     default = newton_mjwarp_vbd_proxy
 
 
@@ -659,6 +666,25 @@ class FrankaSoftEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.dt = 1.0 / 120
         self.sim.render_interval = self.decimation
         self.sim.physics = PhysicsCfg()
+
+        # OVPhysX does not expose a runtime gravity setter.
+        default_events = self.events
+        self.events = preset(
+            default=default_events,
+            physx=default_events,
+            isaacsim_physx=default_events,
+            newton_mjwarp_vbd_proxy=default_events,
+            ovphysx=default_events.replace(variable_gravity=None),
+        )
+        if self.curriculum is not None:
+            default_curriculum = self.curriculum
+            self.curriculum = preset(
+                default=default_curriculum,
+                physx=default_curriculum,
+                isaacsim_physx=default_curriculum,
+                newton_mjwarp_vbd_proxy=default_curriculum,
+                ovphysx=default_curriculum.replace(gravity=None),
+            )
 
         self.viewer.eye = (0.75, 0.25, 0.65)
         self.viewer.lookat = (0.0, 0.75, 0.4)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/kuka_allegro/kuka_allegro_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/kuka_allegro/kuka_allegro_env_cfg.py
@@ -13,8 +13,6 @@ from isaaclab.physics import PhysxAutoCfg
 from isaaclab.sensors import CameraCfg, ContactSensorCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import preset
-
 from isaaclab_assets.robots import KUKA_ALLEGRO_CFG
 
 from ... import lift_env_cfg as lift
@@ -137,29 +135,6 @@ class KukaAllegroMixinCfg:
                 "distribution": "log_uniform",
             },
         )
-
-        # OVPhysX does not expose a runtime gravity setter. Keep the shared
-        # randomization and curriculum configs for PhysX/Newton, but omit the
-        # coupled gravity terms when the OVPhysX preset is selected.
-        default_events = self.events
-        ovphysx_events = default_events.replace(variable_gravity=None)
-        self.events = preset(
-            default=default_events,
-            physx=default_events,
-            isaacsim_physx=default_events,
-            newton_mjwarp=default_events,
-            ovphysx=ovphysx_events,
-        )
-        if self.curriculum is not None:
-            default_curriculum = self.curriculum
-            ovphysx_curriculum = default_curriculum.replace(gravity_adr=None)
-            self.curriculum = preset(
-                default=default_curriculum,
-                physx=default_curriculum,
-                isaacsim_physx=default_curriculum,
-                newton_mjwarp=default_curriculum,
-                ovphysx=ovphysx_curriculum,
-            )
 
 
 @configclass

--- a/source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for GearAssembly environment configuration defaults."""
+
+import pytest
+
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.rizon_4s.joint_pos_env_cfg import Rizon4sGearAssemblyEnvCfg
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.rizon_4s.ros_inference_env_cfg import (
+    Rizon4sGearAssemblyROSInferenceEnvCfg,
+)
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.ur_10e.joint_pos_env_cfg import (
+    UR10e2F85GearAssemblyEnvCfg,
+    UR10e2F140GearAssemblyEnvCfg,
+)
+from isaaclab_tasks.contrib.deploy.gear_assembly.config.ur_10e.ros_inference_env_cfg import (
+    UR10e2F85GearAssemblyROSInferenceEnvCfg,
+    UR10e2F140GearAssemblyROSInferenceEnvCfg,
+)
+
+
+@pytest.mark.parametrize(
+    "env_cfg_cls",
+    (
+        Rizon4sGearAssemblyEnvCfg,
+        Rizon4sGearAssemblyROSInferenceEnvCfg,
+        UR10e2F85GearAssemblyEnvCfg,
+        UR10e2F85GearAssemblyROSInferenceEnvCfg,
+        UR10e2F140GearAssemblyEnvCfg,
+        UR10e2F140GearAssemblyROSInferenceEnvCfg,
+    ),
+)
+def test_gear_assembly_defaults_limit_parallel_environments(env_cfg_cls):
+    """GearAssembly defaults must fit recurrent PPO training on development GPUs."""
+    assert env_cfg_cls().scene.num_envs == 1024

--- a/source/isaaclab_tasks/test/core/test_ovphysx_camera_presets.py
+++ b/source/isaaclab_tasks/test/core/test_ovphysx_camera_presets.py
@@ -64,5 +64,5 @@ def test_kuka_ovphysx_preset_uses_supported_task_configuration(task_name: str):
     assert isinstance(env_cfg.scene.object.spawn, CuboidCfg)
     assert robot_asset_cfg.body_names == ".*"
     assert object_asset_cfg.body_names == ".*"
-    assert env_cfg.events.variable_gravity is None
-    assert env_cfg.curriculum.gravity_adr is None
+    assert env_cfg.events.variable_gravity is not None
+    assert env_cfg.curriculum.gravity_adr is not None


### PR DESCRIPTION
## Summary

Cherry-picks the following merged PRs from `develop` onto `release/3.0.0`, preserving each as an individual commit with `-x` provenance:

- #7193 — Bake CI pytest deps into the built Docker image
- #7077 — Add OVPhysX support to Franka deformable lift tasks
- #7175 — Raise on unsupported camera renderer outputs
- #7174 — Fix benchmark play inference scope
- #7173 — Report resolved backend for play benchmarks
- #7172 — Add video recording to play benchmarks
- #7215 — Reduce GearAssembly default environment count
- #7214 — Remove Kamino preset from open drawer
- #7213 — Fix OvPhysX scene gravity randomization
- #7212 — Fix OVPhysX material binding device selection
- #7189 — Make preview surfaces renderer agnostic
- #7206 — Fix OVPhysX benchmark articulation setup

All cherry-picks and the final rebase onto the latest `release/3.0.0` tip completed without conflicts.

## Validation

- Verified all 12 backported commits have patch IDs identical to their source squash commits and retain their `cherry picked from` footers.
- `git diff --check upstream/release/3.0.0..HEAD`
- Bash syntax validation for the modified CI shell scripts.
- YAML parsing for the modified composite actions.
- Changelog validation against `release/3.0.0`.
- Targeted pytest coverage for benchmark APIs/play, video recording, GearAssembly defaults, OVPhysX presets and runtime semantics, and renderer-agnostic materials: **81 passed, 4 skipped, 1 deselected**.
  - The deselected case is an unchanged test that hard-codes a POSIX `/tmp` path and fails on Windows path normalization.
- `uv run isaaclab -f` passed all hooks except the changelog hook's known release-branch baseline finding for `source/isaaclab/changelog.d/core-test-config-fixtures.skip`; the targeted release-base changelog check passed.