### PR TITLE
[Backport release/3.0.0] Cherry-pick utility and tutorial fixes

### DIFF
--- a/scripts/tutorials/01_assets/add_new_robot.py
+++ b/scripts/tutorials/01_assets/add_new_robot.py
@@ -155,7 +155,7 @@ def run_simulator(sim: sim_utils.SimulationContext, scene: InteractiveScene):
         scene["Jetbot"].set_joint_velocity_target_index(target=action)
 
         # wave
-        wave_action = scene["Dofbot"].data.default_joint_pos.torch
+        wave_action = scene["Dofbot"].data.default_joint_pos.torch.clone()
         wave_action[:, 0:4] = 0.25 * np.sin(2 * np.pi * 0.5 * sim_time)
         scene["Dofbot"].set_joint_position_target_index(target=wave_action)
 

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dump-yaml-current-directory.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-dump-yaml-current-directory.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``dump_yaml`` failing when the output filename has no directory component, allowing YAML files to be
+  written directly into the current working directory.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-numpy-warp-conversion.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-numpy-warp-conversion.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``convert_dict_to_backend(..., backend="warp")`` rejecting NumPy arrays because the
+  conversion registry used the ``np.array`` constructor instead of the ``np.ndarray`` type.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-tutorial-default-joint-state.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-tutorial-default-joint-state.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the ``add_new_robot.py`` tutorial mutating the Dofbot's stored default joint positions through a
+  zero-copy Torch view while constructing its wave command.

--- a/source/isaaclab/isaaclab/utils/array.py
+++ b/source/isaaclab/isaaclab/utils/array.py
@@ -34,7 +34,7 @@ The keys are the name of the backend ("numpy", "torch", "warp") and the values a
 TENSOR_TYPE_CONVERSIONS = {
     "numpy": {wp.array: lambda x: x.numpy(), torch.Tensor: lambda x: x.detach().cpu().numpy()},
     "torch": {wp.array: lambda x: wp.torch.to_torch(x), np.ndarray: lambda x: torch.from_numpy(x)},
-    "warp": {np.array: lambda x: wp.array(x), torch.Tensor: lambda x: wp.torch.from_torch(x)},
+    "warp": {np.ndarray: lambda x: wp.array(x), torch.Tensor: lambda x: wp.torch.from_torch(x)},
 }
 """A nested dictionary containing the conversion functions for each backend.
 

--- a/source/isaaclab/isaaclab/utils/io/yaml.py
+++ b/source/isaaclab/isaaclab/utils/io/yaml.py
@@ -46,8 +46,9 @@ def dump_yaml(filename: str, data: dict | object, sort_keys: bool = False):
     if not filename.endswith("yaml"):
         filename += ".yaml"
     # create directory
-    if not os.path.exists(os.path.dirname(filename)):
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
+    directory = os.path.dirname(filename)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
     # convert data into dictionary
     if not isinstance(data, dict):
         data = class_to_dict(data)

--- a/source/isaaclab/test/utils/test_array_conversion_registry.py
+++ b/source/isaaclab/test/utils/test_array_conversion_registry.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+import warp as wp
+
+from isaaclab.utils.dict import convert_dict_to_backend
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_numpy_array_to_warp_backend():
+    data = {"values": np.array([1.0, 2.0, 3.0], dtype=np.float32)}
+
+    converted = convert_dict_to_backend(data, backend="warp", array_types=("numpy",))
+
+    assert isinstance(converted["values"], wp.array)
+    np.testing.assert_array_equal(converted["values"].numpy(), data["values"])

--- a/source/isaaclab/test/utils/test_yaml_io.py
+++ b/source/isaaclab/test/utils/test_yaml_io.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from isaaclab.utils.io.yaml import dump_yaml, load_yaml
+
+pytestmark = pytest.mark.unit
+
+
+def test_dump_yaml_supports_current_working_directory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    dump_yaml("config.yaml", {"value": 42})
+
+    assert (tmp_path / "config.yaml").is_file()
+    assert load_yaml("config.yaml") == {"value": 42}
+
+
+def test_dump_yaml_adds_extension_in_current_working_directory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    dump_yaml("config", {"value": 42})
+
+    assert (tmp_path / "config.yaml").is_file()


### PR DESCRIPTION
## Summary

Cherry-picks the following merged PRs from `develop` onto `release/3.0.0`, preserving each as an individual commit with `-x` provenance:

- #7122 — Fix YAML dumps to the current working directory
- #7120 — Fix add-new-robot tutorial default joint-state mutation
- #7117 — Fix NumPy to Warp dictionary conversion

The commits are applied in their `develop` history order. All cherry-picks completed without conflicts.

## Validation

- Verified all three backported commits have patch IDs identical to their source squash commits and retain their `cherry picked from` footers.
- `git diff --check upstream/release/3.0.0..HEAD`
- `uv run --extra test --frozen python -m pytest source/isaaclab/test/utils/test_yaml_io.py source/isaaclab/test/utils/test_array_conversion_registry.py -q --disable-warnings` — **3 passed**
- `uv run --frozen python -m py_compile scripts/tutorials/01_assets/add_new_robot.py`
- Changelog validation against `release/3.0.0` passed.
- `uv run isaaclab -f` passed all code, formatting, whitespace, YAML/TOML, license, and safety hooks. Its changelog hook reported pre-existing release-only fragments (`antoiner-fix-contact-history-update-cadence.rst` and `omniverse-client-2-72-1-update.rst`) followed by the known Windows CP1252 reporting error; the targeted release-base changelog check passed.