### PR TITLE
Replace map transforms with pre-owned and reused buffer

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-caller-owned-transform-write.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-caller-owned-transform-write.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX object and camera transform updates to write a caller-owned GPU buffer instead of mapping and unmapping OVRTX memory every frame.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -85,7 +85,6 @@ from .ovrtx_annotator_utils import (
     decode_stable_id_map,
     decode_stable_id_semantic_id_map,
 )
-from .ovrtx_mapping import map_attribute_for_warp_writes
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     compute_cable_points_world_kernel,
@@ -472,12 +471,13 @@ class OVRTXRenderer(BaseRenderer):
         """Initialize the legacy-path instance fields.
 
         Counterpart to :meth:`_init_fields_ovstage`. Only fields the ovstage path never touches live
-        here: the four ``bind_attribute``/``bind_array_attribute`` handles. State shared by both
-        paths (``_object_newton_indices``, the particle offset/count lists) stays in
-        :meth:`__init__`.
+        here: the ``bind_attribute``/``bind_array_attribute`` handles and the caller-owned object
+        transform buffer. State shared by both paths (``_object_newton_indices``, the particle
+        offset/count lists) stays in :meth:`__init__`.
         """
         self._camera_xform_binding = None
         self._object_xform_binding = None
+        self._object_transform_buffer: wp.array | None = None
         self._deformable_points_binding = None
         self._particle_points_binding = None
         self._particle_workaround_applied = False
@@ -683,6 +683,7 @@ class OVRTXRenderer(BaseRenderer):
 
         self._object_newton_indices = wp.array(newton_indices, dtype=wp.int32, device=self._device)
         self._object_scales = self._create_object_scale_array(object_paths)
+        self._object_transform_buffer = wp.zeros(len(newton_indices), dtype=wp.mat44d, device=self._device)
 
     def _setup_deformable_bindings_legacy(self, num_envs: int):
         """Setup OVRTX bindings for Newton deformable bodies.
@@ -912,7 +913,12 @@ class OVRTXRenderer(BaseRenderer):
 
     def _update_transforms_legacy(self) -> None:
         """Sync transforms to OVRTX."""
-        if self._object_xform_binding is None or self._object_newton_indices is None or self._object_scales is None:
+        if (
+            self._object_xform_binding is None
+            or self._object_newton_indices is None
+            or self._object_scales is None
+            or self._object_transform_buffer is None
+        ):
             return
 
         # If self._object_newton_indices is not None, then Newton's the current physics backend
@@ -927,13 +933,20 @@ class OVRTXRenderer(BaseRenderer):
         if body_q is None:
             return
 
-        with map_attribute_for_warp_writes(self._object_xform_binding, self._device, wp.mat44d) as ovrtx_transforms:
-            wp.launch(
-                kernel=sync_newton_transforms_kernel,
-                dim=len(self._object_newton_indices),
-                inputs=[ovrtx_transforms, self._object_newton_indices, body_q, self._object_scales],
-                device=self._device,
-            )
+        wp.launch(
+            kernel=sync_newton_transforms_kernel,
+            dim=len(self._object_newton_indices),
+            inputs=[self._object_transform_buffer, self._object_newton_indices, body_q, self._object_scales],
+            device=self._device,
+        )
+        # Blocking ``write()`` so the buffer stays valid until OVRTX finishes reading it.
+        # ``DataAccess.ASYNC`` + the Warp CUDA stream let OVRTX read in place and wait
+        # on-GPU for the kernel; ``SYNC`` is rejected for GPU buffers.
+        self._object_xform_binding.write(
+            self._object_transform_buffer,
+            data_access=DataAccess.ASYNC,
+            cuda_stream=wp.get_stream(self._device).cuda_stream,
+        )
 
     def _update_geometries_legacy(self) -> None:
         """Sync geometries to OVRTX."""
@@ -1034,8 +1047,11 @@ class OVRTXRenderer(BaseRenderer):
             device=self._device,
         )
         if self._camera_xform_binding is not None:
-            with map_attribute_for_warp_writes(self._camera_xform_binding, self._device, wp.mat44d) as transforms_view:
-                wp.copy(transforms_view, camera_transforms)
+            self._camera_xform_binding.write(
+                camera_transforms,
+                data_access=DataAccess.ASYNC,
+                cuda_stream=wp.get_stream(self._device).cuda_stream,
+            )
 
     def read_output(
         self,
@@ -1486,6 +1502,7 @@ class OVRTXRenderer(BaseRenderer):
         self._camera_xform_binding = None
         _safe_unbind(self._object_xform_binding, "object transforms")
         self._object_xform_binding = None
+        self._object_transform_buffer = None
         _safe_unbind(self._deformable_points_binding, "deformable points")
         self._deformable_points_binding = None
         _safe_unbind(self._particle_points_binding, "particle points")

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -33,11 +33,12 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 logger = logging.getLogger(__name__)
 
 import numpy as np
-import ovstage
 import torch
 import warp as wp
 
 import isaaclab.utils.warp  # noqa: F401  # initializes Warp runtime
+
+import ovstage
 
 # The ovrtx C library links to its own version of the USD libraries. Having
 # the pxr Python package available can cause the C library to load an

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -33,12 +33,11 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 logger = logging.getLogger(__name__)
 
 import numpy as np
+import ovstage
 import torch
 import warp as wp
 
 import isaaclab.utils.warp  # noqa: F401  # initializes Warp runtime
-
-import ovstage
 
 # The ovrtx C library links to its own version of the USD libraries. Having
 # the pxr Python package available can cause the C library to load an

--- a/source/isaaclab_ov/isaaclab_ov/stage.py
+++ b/source/isaaclab_ov/isaaclab_ov/stage.py
@@ -11,8 +11,9 @@
 from __future__ import annotations
 
 import numpy as np
-import ovstage
 import warp as wp
+
+import ovstage
 
 # DLDataType for a 4x4 double matrix (``omni:xform`` column). ovstage stores omni:xform as one
 # 16-lane float64 element per prim; wp.mat44d maps to the same layout via __dlpack__.

--- a/source/isaaclab_ov/isaaclab_ov/stage.py
+++ b/source/isaaclab_ov/isaaclab_ov/stage.py
@@ -11,9 +11,8 @@
 from __future__ import annotations
 
 import numpy as np
-import warp as wp
-
 import ovstage
+import warp as wp
 
 # DLDataType for a 4x4 double matrix (``omni:xform`` column). ovstage stores omni:xform as one
 # 16-lane float64 element per prim; wp.mat44d maps to the same layout via __dlpack__.

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -27,13 +27,13 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     import isaaclab_ov.renderers.ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
-
-    # ovstage is an unconditional dependency of isaaclab_ov, so it is importable here.
-    import ovstage  # noqa: E402
     from isaaclab_newton.physics import NewtonManager  # noqa: E402
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer  # noqa: E402
     from ovrtx import BindingFlag, DataAccess  # noqa: E402
+
+    # ovstage is an unconditional dependency of isaaclab_ov, so it is importable here.
+    import ovstage  # noqa: E402
 else:
     NewtonManager = None
     OVRTXRenderer = None
@@ -590,3 +590,56 @@ def test_write_particle_q_slices_ovstage_passes_device_slices_zero_copy():
     assert tensors[0].data == particle_q[1:4].ptr
     assert tensors[0].shape_tuple == (3,)
     assert tensors[0].dtype.lanes == 3
+
+
+def test_update_transforms_writes_caller_owned_buffer(monkeypatch: pytest.MonkeyPatch):
+    """Object xforms fill a persistent GPU buffer and blocking ASYNC write, not map/unmap."""
+    renderer, _ = _make_renderer_without_backend()
+    buffer = object()
+    renderer._object_xform_binding = _FakePointsBinding("omni:xform")
+    renderer._object_newton_indices = [0, 1]
+    renderer._object_scales = object()
+    renderer._object_transform_buffer = buffer
+
+    monkeypatch.setattr(NewtonManager, "get_state", classmethod(lambda cls: SimpleNamespace(body_q=object())))
+    launch_kwargs: dict = {}
+
+    def _capture_launch(*args, **kwargs):
+        launch_kwargs.update(kwargs)
+
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "launch", _capture_launch)
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: SimpleNamespace(cuda_stream=99))
+
+    renderer.update_transforms()
+
+    assert launch_kwargs["inputs"][0] is buffer
+    assert launch_kwargs["dim"] == 2
+    assert renderer._object_xform_binding.written is buffer
+    assert renderer._object_xform_binding.write_kwargs["data_access"] is DataAccess.ASYNC
+    assert renderer._object_xform_binding.write_kwargs["cuda_stream"] == 99
+
+
+def test_update_camera_writes_without_mapping(monkeypatch: pytest.MonkeyPatch):
+    """Camera xforms are handed to ``write()`` instead of copied into a mapped OVRTX buffer."""
+    renderer, _ = _make_renderer_without_backend()
+    renderer._camera_xform_binding = _FakePointsBinding("omni:xform")
+    camera_transforms = []
+
+    monkeypatch.setattr(ovrtx_renderer_module, "convert_camera_frame_orientation_convention_wp", lambda **kwargs: None)
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "empty", lambda *args, **kwargs: object())
+
+    def _fake_zeros(*args, **kwargs):
+        arr = object()
+        camera_transforms.append(arr)
+        return arr
+
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "zeros", _fake_zeros)
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "launch", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: SimpleNamespace(cuda_stream=7))
+
+    positions = SimpleNamespace(shape=(2,), warp=object())
+    renderer.update_camera(object(), positions, SimpleNamespace(warp=object()), object())
+
+    assert renderer._camera_xform_binding.written is camera_transforms[0]
+    assert renderer._camera_xform_binding.write_kwargs["data_access"] is DataAccess.ASYNC
+    assert renderer._camera_xform_binding.write_kwargs["cuda_stream"] == 7

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -27,13 +27,13 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     import isaaclab_ov.renderers.ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
+
+    # ovstage is an unconditional dependency of isaaclab_ov, so it is importable here.
+    import ovstage  # noqa: E402
     from isaaclab_newton.physics import NewtonManager  # noqa: E402
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer  # noqa: E402
     from ovrtx import BindingFlag, DataAccess  # noqa: E402
-
-    # ovstage is an unconditional dependency of isaaclab_ov, so it is importable here.
-    import ovstage  # noqa: E402
 else:
     NewtonManager = None
     OVRTXRenderer = None

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -681,6 +681,7 @@ def test_ovrtx_close_releases_legacy_renderer_state():
     ]
     assert renderer._camera_xform_binding is None
     assert renderer._object_xform_binding is None
+    assert renderer._object_transform_buffer is None
     assert renderer._deformable_points_binding is None
     assert renderer._particle_points_binding is None
     assert renderer._cable_points_binding is None


### PR DESCRIPTION
# Description

Perf optimization - replace map transforms with pre-owned and reused buffer

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
