### PR TITLE
[Backport release/3.0.0] Update Isaac Sim image and nested conversion

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -10,6 +10,6 @@
 # which the CI credential can reach.
 isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
 # Isaac Sim 6.1.0-alpha.50 (b86cf6ce) includes Kit 110.3.0-360924's fix for NVBug 6566677.
-isaacsim_image_tag: latest-develop@sha256:d4667d2c0cbc1d0dcd3aac3213799777ee2cbf8de1e91cc41684023c256f176f
+isaacsim_image_tag: latest-develop@sha256:e7cd73cd7a9a6621274bd3a1bacddfd4ac1a15f92893e6a10cfb6b8100762a0c
 isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-nested-backend-conversion.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-nested-backend-conversion.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``convert_dict_to_backend`` resetting nested dictionaries to the default NumPy backend instead
+  of preserving the backend and source array types requested by the caller.

--- a/source/isaaclab/isaaclab/utils/dict.py
+++ b/source/isaaclab/isaaclab/utils/dict.py
@@ -288,7 +288,7 @@ def convert_dict_to_backend(
             output_dict[key] = tensor_type_conversions[data_type](value)
         # -- nested dictionaries
         elif isinstance(data[key], dict):
-            output_dict[key] = convert_dict_to_backend(value)
+            output_dict[key] = convert_dict_to_backend(value, backend=backend, array_types=array_types)
         # -- everything else
         else:
             output_dict[key] = value

--- a/source/isaaclab/test/utils/test_dict.py
+++ b/source/isaaclab/test/utils/test_dict.py
@@ -6,7 +6,9 @@
 import enum
 import random
 
+import numpy as np
 import pytest
+import torch
 
 import isaaclab.utils.dict as dict_utils
 import isaaclab.utils.string as string_utils
@@ -172,3 +174,13 @@ def test_update_class_from_dict_restores_enums_from_values():
     assert all(isinstance(el, _Flavors) for el in cfg.scoops)
     assert cfg.cone == (_Flavors.STRAWBERRY,)
     assert all(isinstance(el, _Flavors) for el in cfg.cone)
+
+
+def test_nested_conversion_preserves_requested_backend():
+    """Nested conversions should preserve the backend selected by the caller."""
+    data = {"outer": {"values": np.array([1.0, 2.0, 3.0], dtype=np.float32)}}
+
+    converted = dict_utils.convert_dict_to_backend(data, backend="torch", array_types=("numpy",))
+
+    assert isinstance(converted["outer"]["values"], torch.Tensor)
+    torch.testing.assert_close(converted["outer"]["values"], torch.tensor([1.0, 2.0, 3.0]))


### PR DESCRIPTION
## Summary

Cherry-picks the following merged PRs from `develop` onto `release/3.0.0`, preserving each as an individual commit with `-x` provenance:

- #7070 — Bump the Isaac Sim CI image to digest `e7cd73cd7a9a`
- #7118 — Fix backend propagation in nested dictionary conversion

The commits are applied in their `develop` history order. Both cherry-picks completed without conflicts.

## Validation

- Verified both backported commits have patch IDs identical to their source squash commits and retain their `cherry picked from` footers.
- `git diff --check upstream/release/3.0.0..HEAD`
- `uv run --extra test --frozen python -m pytest source/isaaclab/test/utils/test_dict.py -q --disable-warnings` — **10 passed**
- Parsed `.github/workflows/config.yaml` and verified the exact `e7cd73cd7a9a...` Isaac Sim digest.
- Changelog validation against `release/3.0.0` passed.
- `uv run isaaclab -f` passed all code, formatting, whitespace, YAML/TOML, license, and safety hooks. Its changelog hook reported pre-existing release-only fragments (`ant-direct-device-mask-reset.rst` and `omniverse-client-2-72-1-update.rst`) followed by the known Windows CP1252 reporting error; the targeted release-base changelog check passed.