### PR TITLE
Adds distinct exit codes for crashed, hung and failing test runs

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -80,6 +80,48 @@ kill it.  The test results are taken from the report file (pass/fail), not
 from the kill.
 """
 
+EXIT_TESTS_FAILED = 1
+"""Exit code for a run that completed with at least one failing assertion."""
+
+EXIT_CRASHED = 20
+"""Exit code for a run where a test process died without writing its report."""
+
+EXIT_TIMEOUT = 21
+"""Exit code for a run where a test reached its hard timeout."""
+
+EXIT_STARTUP_HANG = 22
+"""Exit code for a run where a test never finished starting up."""
+
+EXIT_CODE_LABELS = {
+    0: "all tests passed",
+    EXIT_TESTS_FAILED: "test failures",
+    EXIT_CRASHED: "crashed process",
+    EXIT_TIMEOUT: "timeout",
+    EXIT_STARTUP_HANG: "startup hang",
+}
+"""Label for each exit code, printed with the result summary."""
+
+
+def resolve_exit_code(num_failing, num_timeout, num_crashed, num_startup_hang):
+    """Return the exit code for a finished run, based on how it failed.
+
+    A crashed process, a hang and a failing assertion have different owners, so
+    each reports its own code rather than a shared ``1``; the code alone is then
+    enough to route a red job.  When a run hits more than one, the code reports
+    the outcome that proved the least: a process that died never reached the
+    assertion a failing test did.  ``1`` still means failing assertions, so
+    callers that only check for a non-zero code are unaffected.
+    """
+    if num_crashed:
+        return EXIT_CRASHED
+    if num_timeout:
+        return EXIT_TIMEOUT
+    if num_startup_hang:
+        return EXIT_STARTUP_HANG
+    if num_failing:
+        return EXIT_TESTS_FAILED
+    return 0
+
 
 def capture_test_output_with_timeout(cmd, timeout, env, startup_deadline=0, report_file=""):
     """Run a command with timeout and capture all output while streaming in real-time.
@@ -1531,6 +1573,9 @@ def pytest_sessionstart(session):
     summary_str += f"Timeout: {num_timeout}\n"
     summary_str += f"Passing Percentage: {passing_percentage:.2f}%\n"
 
+    exit_code = resolve_exit_code(num_failing, num_timeout, num_crashed, num_startup_hang)
+    summary_str += f"Exit Code: {exit_code} ({EXIT_CODE_LABELS[exit_code]})\n"
+
     total_wall = sum(test_status[test_path]["wall_time"] for test_path in test_files)
     total_test = sum(test_status[test_path]["time_elapsed"] for test_path in test_files)
 
@@ -1547,7 +1592,4 @@ def pytest_sessionstart(session):
     logger.info(summary_str)
 
     # Exit pytest after custom execution to prevent normal pytest from overwriting our report
-    pytest.exit(
-        "Custom test execution completed",
-        returncode=0 if (num_failing == 0 and num_timeout == 0 and num_crashed == 0 and num_startup_hang == 0) else 1,
-    )
+    pytest.exit("Custom test execution completed", returncode=exit_code)

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -102,7 +102,7 @@ EXIT_CODE_LABELS = {
 """Label for each exit code, printed with the result summary."""
 
 
-def resolve_exit_code(num_failing, num_timeout, num_crashed, num_startup_hang):
+def resolve_exit_code(num_failing: int, num_timeout: int, num_crashed: int, num_startup_hang: int) -> int:
     """Return the exit code for a finished run, based on how it failed.
 
     A crashed process, a hang and a failing assertion have different owners, so
@@ -111,6 +111,16 @@ def resolve_exit_code(num_failing, num_timeout, num_crashed, num_startup_hang):
     the outcome that proved the least: a process that died never reached the
     assertion a failing test did.  ``1`` still means failing assertions, so
     callers that only check for a non-zero code are unaffected.
+
+    Args:
+        num_failing: Test files that ran and reported a failing assertion.
+        num_timeout: Test files killed at their hard timeout.
+        num_crashed: Test files whose process exited without writing a report.
+        num_startup_hang: Test files killed before startup finished.
+
+    Returns:
+        ``0`` when nothing failed, otherwise the code for the highest-precedence
+        mode present: crash, then timeout, then startup hang, then assertion.
     """
     if num_crashed:
         return EXIT_CRASHED


### PR DESCRIPTION
# Description

Every failure mode in the individual-test orchestrator exits `1`, so a crashed process, a hung test, and a failing assertion cannot be told apart from the exit code. The orchestrator already separates them internally: it counts `Failing`, `Crashed`, `Startup Hang`, and `Timeout`, and prints each in the result summary. This carries that distinction into the exit code and prints the resolved code with a label.

`1` still means failing assertions. A crashed process is `20`, a timeout `21`, and a startup hang `22`. When a run hits more than one, the code reports the outcome that proved the least, so a crash outranks a timeout, which outranks a startup hang. `0` is unchanged, and callers that only check for a non-zero code are unaffected.

| Before | After |
| ------ | ----- |
| A lost GPU, a 1000 second hang, and a pixel mismatch all end in `Process completed with exit code 1` | The same 3 runs exit `20`, `21`, and `1`, each printed as `Exit Code: N (label)` in the summary |

## Reproduction

1. Run a suite through the orchestrator and read the exit code:

   ```
   ./isaaclab.sh -p -m pytest --ignore=tools/conftest.py tools -v --junitxml=tests/report.xml; echo "exit=$?"
   ```

2. Make one file reach its hard timeout, by lowering the timeout for that file or running a test that sleeps past it.

   Observed before this change: the summary reports `Timeout: 1` while the run reports `exit=1`, the same code a failing assertion produces.

3. Repeat with this change.

   Observed: the summary reports `Exit Code: 21 (timeout)` and the run reports `exit=21`, while a run whose only failures are assertions still reports `exit=1`.

## Type of change

- New feature (non-breaking change which adds functionality)

## Screenshots

Not applicable; the change has no rendered output.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`: not run; no dev setup on this machine. The diff was checked by hand for line length and whitespace, and `python3 -m py_compile tools/conftest.py` passes
- [ ] I have made corresponding changes to the documentation: not applicable; each code is documented where it is defined and printed in the run summary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works: not added; the counters are computed inside `pytest_sessionstart`, and `tools/conftest.py` takes over any pytest session that loads it, so a test in the same directory cannot drive this path in-process. `resolve_exit_code` was instead checked over all 16 combinations of the 4 counters, confirming that each mode maps to its own code and that zero versus non-zero matches the previous expression exactly
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that): not applicable; no package under `source/` is touched
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
