### PR TITLE
Stabilize RTX rendering tolerance checks

### DIFF
--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -96,8 +96,10 @@ _IMAGE_TOLERANCE_OVERRIDES = {
     ("franka_cloth", "newton", "isaacsim_rtx_renderer", "rgb"): (20.0, 0.96),
     ("franka_cloth", "newton", "isaacsim_rtx_renderer", "rgba"): (20.0, 0.96),
     ("franka_cable", "newton", "ovrtx_renderer", "rgb"): (8.0, 0.98),
-    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgb"): (12.0, 0.985),
-    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgba"): (12.0, 0.985),
+    # A cold first capture has reached 6.10% while retaining >= 0.9933 SSIM; keep narrow pixel headroom.
+    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgb"): (7.0, 0.985),
+    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgba"): (7.0, 0.985),
+    # A cold first capture has reached 4.20% and 0.9542 SSIM before retrying at 0.24% and 0.9999 SSIM.
     ("registered_tasks/Isaac-Cartpole-Camera-Direct", "default_physics", "default_renderer", "rgb"): (5.0, 0.95),
     ("registered_tasks/Isaac-Cartpole-Camera-Direct", "default_physics", "default_renderer", "rgba"): (5.0, 0.95),
 }

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -91,11 +91,15 @@ _SSIM_THRESHOLD_BY_ENV_NAME = {
     "kuka_visual_material_randomization": 0.99,
 }
 
-# Low-resolution Newton + RTX cloth shading varies between otherwise equivalent CI frames.
+# Targeted tolerance overrides for renderer noise in otherwise equivalent CI frames.
 _IMAGE_TOLERANCE_OVERRIDES = {
     ("franka_cloth", "newton", "isaacsim_rtx_renderer", "rgb"): (20.0, 0.96),
     ("franka_cloth", "newton", "isaacsim_rtx_renderer", "rgba"): (20.0, 0.96),
     ("franka_cable", "newton", "ovrtx_renderer", "rgb"): (8.0, 0.98),
+    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgb"): (12.0, 0.985),
+    ("shadow_hand", "newton", "isaacsim_rtx_renderer", "rgba"): (12.0, 0.985),
+    ("registered_tasks/Isaac-Cartpole-Camera-Direct", "default_physics", "default_renderer", "rgb"): (5.0, 0.95),
+    ("registered_tasks/Isaac-Cartpole-Camera-Direct", "default_physics", "default_renderer", "rgba"): (5.0, 0.95),
 }
 
 # Data types for which the SSIM gate is not enforced. SSIM assumes natural-image statistics and is unreliable on


### PR DESCRIPTION
## Summary

- raise the pixel-difference tolerance only for Shadow Hand with Newton physics and Isaac RTX RGB/RGBA from 5% to 7%, while retaining the strict 0.985 SSIM gate
- add targeted Cartpole default PhysX/RTX RGB/RGBA overrides: pixel difference 1.5% to 5% and SSIM 0.985 to 0.95
- leave every unrelated task, backend, renderer, and AOV threshold unchanged

## Rationale

A cold CI capture reached 6.10% pixel difference for Shadow Hand while retaining 0.9933 or higher SSIM; its retry settled to 1.08% and 0.9994 or higher SSIM. The 7% limit leaves narrow headroom over the observed outlier instead of the previous 12% proposal.

The same cold run reached 4.20% pixel difference and a minimum 0.9542 SSIM for Cartpole; its retry settled to 0.24% and 0.9999 SSIM. The 5% / 0.95 override is therefore close to the observed cold-frame boundary. The measurements are recorded in [the comparison run](https://github.com/isaac-sim/IsaacLab/actions/runs/32448029852/job/96682296368).

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- `test_rendering_registered_tasks[Isaac-Cartpole-Camera-Direct-None-cartpole]`: passed with retries disabled
- `test_rendering_shadow_hand[newton-isaacsim_rtx-rgb]`: passed with retries disabled; validates both RGB and RGBA
- `source/isaaclab_tasks/test/test_parametrization_helpers.py`: 13 passed
- pre-commit hooks: passed
- changelog fragment check: passed
