### PR TITLE
[CI] Report cumulative retry wall time

### DIFF
--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -341,6 +341,44 @@ def test_shutdown_hang_after_report_is_not_a_failure(monkeypatch, tmp_path: Path
     assert not was_failure
 
 
+def test_startup_retry_wall_time_includes_every_attempt(monkeypatch, tmp_path: Path) -> None:
+    """The reported wall time must include startup attempts discarded by a successful retry."""
+    orchestrator = _load_orchestrator_module()
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_present():\n    pass\n", encoding="utf-8")
+    attempts = 0
+
+    def _capture(*_args, report_file: str, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return -1, b"", b"", "startup_hang", 8.0, ""
+        _write_partial_junit_report(report_file)
+        return 0, b"", b"", "", 2.0, ""
+
+    monkeypatch.setattr(orchestrator.ovrtx_log, "LOG_PATH", str(tmp_path / "ovrtx_renderer.log"))
+    monkeypatch.setattr(orchestrator, "capture_test_output_with_timeout", _capture)
+    monkeypatch.setattr(orchestrator, "_capture_system_diagnostics", lambda: "")
+    monkeypatch.chdir(tmp_path)
+    context = orchestrator._PassContext(
+        test_file=str(test_file),
+        file_name=test_file.name,
+        workspace_root=str(tmp_path),
+        ci_marker=None,
+        timeout=10,
+        startup_deadline=1,
+        env={},
+        inject_shard_select=False,
+        pytest_targets=[str(test_file)],
+    )
+
+    _report, status, was_failure = orchestrator._run_one_pass(context, k_expr=None, suffix="")
+
+    assert attempts == 2
+    assert status["wall_time"] == 10.0
+    assert not was_failure
+
+
 def test_crash_journal_path_is_absolute(monkeypatch, tmp_path: Path) -> None:
     """The journal path handed to the test subprocess must not depend on the current directory.
 
@@ -450,6 +488,7 @@ def test_fresh_process_retry_crash_blames_the_test_that_was_running(monkeypatch,
     assert status["errors"] == 1
     assert status["failures"] == 0
     assert status["tests"] == 2
+    assert status["wall_time"] == pytest.approx(0.3)
     assert was_failure
 
     cases = {case.get("name"): case for case in ElementTree.parse(report_paths[1]).getroot().iter("testcase")}

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -577,9 +577,17 @@ def _retry_failed_test_in_fresh_process(
             with contextlib.suppress(FileNotFoundError):
                 os.remove(stale_file)
 
-        returncode, stdout_data, stderr_data, kill_reason, wall_time, pre_kill_diag = capture_test_output_with_timeout(
+        (
+            returncode,
+            stdout_data,
+            stderr_data,
+            kill_reason,
+            retry_wall_time,
+            pre_kill_diag,
+        ) = capture_test_output_with_timeout(
             cmd, timeout, env, startup_deadline=startup_deadline, report_file=report_file
         )
+        wall_time += retry_wall_time
         if not os.path.exists(report_file):
             # The attempt died before pytest wrote its report; the caller rebuilds the result from
             # this attempt's journal.
@@ -790,6 +798,7 @@ def _run_one_pass(
     # -- Run with retry on startup hang or hard timeout -----------------
     returncode, stdout_data, stderr_data, kill_reason = -1, b"", b"", ""
     wall_time, pre_kill_diag = 0.0, ""
+    total_wall_time = 0.0
     startup_hang_attempts = 0
     timeout_attempts = 0
     while True:
@@ -802,6 +811,7 @@ def _run_one_pass(
         returncode, stdout_data, stderr_data, kill_reason, wall_time, pre_kill_diag = capture_test_output_with_timeout(
             cmd, ctx.timeout, pass_env, startup_deadline=ctx.startup_deadline, report_file=report_file
         )
+        total_wall_time += wall_time
 
         has_report = os.path.exists(report_file)
 
@@ -841,6 +851,8 @@ def _run_one_pass(
             logger.info(diag)
             continue
         break
+
+    wall_time = total_wall_time
 
     # -- Resolve result from kill_reason and report file ----------------
     has_report = os.path.exists(report_file)


### PR DESCRIPTION
# Description

Include every subprocess attempt in the per-file wall-clock metric. Startup-hang, timeout, and fresh-process retries previously replaced the prior attempt duration, which hid substantial CI time from the final summary.

This changes only test-runner reporting; test selection, execution, and coverage are unchanged.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- `uv run python -m pytest source/isaaclab/test/cli/test_test_orchestrator_result_handling.py`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment for the touched package
- [x] My name is already present in `CONTRIBUTORS.md`