### PR TITLE
[CI] Run lightweight task tests concurrently

### DIFF
--- a/.github/actions/run-package-tests/action.yml
+++ b/.github/actions/run-package-tests/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: 'Additional pytest options'
     default: ''
     required: false
+  parallel-test-workers:
+    description: 'Number of workers for explicitly parallel-safe test files'
+    default: '1'
+    required: false
   extra-pip-packages:
     description: 'Space-separated pip packages to install inside the Docker container before pytest starts'
     default: ''
@@ -321,6 +325,7 @@ runs:
         standalone-script-scope: ${{ inputs.standalone-script-scope }}
         standalone-script-visualizer: ${{ inputs.standalone-script-visualizer }}
         standalone-script-runtime-group: ${{ inputs.standalone-script-runtime-group }}
+        parallel-test-workers: ${{ inputs.parallel-test-workers }}
 
     - name: Check Test Results
       if: always()

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -77,6 +77,10 @@ inputs:
     description: 'Total number of shards (used with shard-index to split tests across parallel jobs)'
     default: ''
     required: false
+  parallel-test-workers:
+    description: 'Number of workers for explicitly parallel-safe test files'
+    default: '1'
+    required: false
   volume-mount-source:
     description: 'Host path to bind-mount at /workspace/isaaclab (for deps-cache-hit mode)'
     default: ''
@@ -134,7 +138,7 @@ runs:
         TEST_K_EXPR_INPUT: ${{ inputs.test-k-expr }}
         CI_MARKER_INPUT: ${{ inputs.ci-marker }}
       run: |
-        bash .github/actions/run-tests/run_tests.sh "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}" "$TEST_K_EXPR_INPUT" "$CI_MARKER_INPUT" "${{ inputs.standalone-script-scope }}" "${{ inputs.standalone-script-visualizer }}" "${{ inputs.standalone-script-runtime-group }}" "${{ inputs.warp-cache-host-dir }}" "${{ inputs.extra-uv-packages }}"
+        bash .github/actions/run-tests/run_tests.sh "${{ inputs.test-path }}" "${{ inputs.result-file }}" "${{ inputs.container-name }}" "${{ inputs.image-tag }}" "${{ inputs.reports-dir }}" "$PYTEST_OPTIONS" "${{ inputs.filter-pattern }}" "${{ inputs.exclude-pattern }}" "${{ inputs.curobo-only }}" "${{ inputs.include-files }}" "${{ inputs.quarantined-only }}" "${{ inputs.shard-index }}" "${{ inputs.shard-count }}" "${{ inputs.volume-mount-source }}" "${{ inputs.extra-pip-packages }}" "${{ inputs.test-node-ids-file }}" "${{ inputs.test-node-ids-key }}" "${{ inputs.wheelhouse-host-dir }}" "${{ inputs.wheelhouse-packages }}" "$TEST_K_EXPR_INPUT" "$CI_MARKER_INPUT" "${{ inputs.standalone-script-scope }}" "${{ inputs.standalone-script-visualizer }}" "${{ inputs.standalone-script-runtime-group }}" "${{ inputs.warp-cache-host-dir }}" "${{ inputs.extra-uv-packages }}" "${{ inputs.parallel-test-workers }}"
     - name: Kill container on cancellation
       if: cancelled()
       shell: bash

--- a/.github/actions/run-tests/run_tests.sh
+++ b/.github/actions/run-tests/run_tests.sh
@@ -37,6 +37,7 @@ run_tests() {
   local standalone_script_runtime_group="${24}"
   local warp_cache_host_dir="${25}"
   local extra_uv_packages="${26}"
+  local parallel_test_workers="${27}"
   local logs_pid=""
   local wait_pid=""
   local docker_wait_file="/tmp/.docker_exit_${container_name}"
@@ -129,6 +130,11 @@ run_tests() {
   if [ "$quarantined_only" = "true" ]; then
     docker_env_vars="$docker_env_vars -e TEST_QUARANTINED_ONLY=true"
     echo "Setting TEST_QUARANTINED_ONLY=true"
+  fi
+
+  if [ -n "$parallel_test_workers" ]; then
+    docker_env_vars="$docker_env_vars -e ISAACLAB_PARALLEL_TEST_WORKERS=$parallel_test_workers"
+    echo "Parallel-safe test workers: $parallel_test_workers"
   fi
 
   if [ -n "$include_files" ]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -230,6 +230,7 @@ jobs:
         extra-pip-packages: "pytetwild[all]>=0.3.0,<0.4"
         shard-index: "0"
         shard-count: "3"
+        parallel-test-workers: "4"
         warp-cache: restore
         container-name: isaac-lab-tasks-1-test
 
@@ -257,6 +258,7 @@ jobs:
         extra-pip-packages: "pytetwild[all]>=0.3.0,<0.4"
         shard-index: "1"
         shard-count: "3"
+        parallel-test-workers: "4"
         warp-cache: restore
         container-name: isaac-lab-tasks-2-test
 
@@ -284,6 +286,7 @@ jobs:
         extra-pip-packages: "pytetwild[all]>=0.3.0,<0.4"
         shard-index: "2"
         shard-count: "3"
+        parallel-test-workers: "4"
         warp-cache: restore
         container-name: isaac-lab-tasks-3-test
 

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import threading
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 from types import ModuleType
@@ -483,3 +484,57 @@ def test_result_summary_includes_fast_failure_after_thirty_slower_files():
     assert "Slowest 30 Test Files" not in summary
     assert "fast_failure.py" in summary
     assert all(test_path in summary for test_path in test_files)
+
+
+def test_parallel_safe_files_keep_process_isolation_and_complete_once(monkeypatch, tmp_path: Path) -> None:
+    """Approved files should overlap while each still uses the per-file runner once."""
+    orchestrator = _load_orchestrator_module()
+    test_files = [str(tmp_path / name) for name in ("test_a.py", "test_b.py", "test_sequential.py")]
+    for test_file in test_files:
+        Path(test_file).write_text("def test_present():\n    pass\n", encoding="utf-8")
+
+    monkeypatch.setattr(orchestrator.test_settings, "PARALLEL_SAFE_TESTS", {"test_a.py", "test_b.py"})
+    monkeypatch.setenv("ISAACLAB_PARALLEL_TEST_WORKERS", "2")
+    barrier = threading.Barrier(2)
+    calls: list[str] = []
+    calls_lock = threading.Lock()
+
+    def _run_file(test_file, *_args):
+        name = Path(test_file).name
+        with calls_lock:
+            calls.append(name)
+        if name in {"test_a.py", "test_b.py"}:
+            barrier.wait(timeout=2)
+        status = {
+            "errors": 0,
+            "failures": 0,
+            "skipped": 0,
+            "tests": 1,
+            "result": "passed",
+            "time_elapsed": 0.01,
+            "wall_time": 0.01,
+        }
+        return False, status, [name]
+
+    monkeypatch.setattr(orchestrator, "_run_individual_test_file", _run_file)
+
+    failed, status, reports = orchestrator.run_individual_tests(test_files, str(tmp_path), None)
+
+    assert not failed
+    assert calls.count("test_a.py") == 1
+    assert calls.count("test_b.py") == 1
+    assert calls.count("test_sequential.py") == 1
+    assert list(status) == test_files
+    assert reports == ["test_a.py", "test_b.py", "test_sequential.py"]
+
+
+def test_parallel_safe_task_files_do_not_require_exclusive_runner_features() -> None:
+    """The explicit parallel set must stay free of camera startup and device-split handling."""
+    orchestrator = _load_orchestrator_module()
+    workspace_root = Path(__file__).resolve().parents[4]
+
+    for relative_path in orchestrator.test_settings.PARALLEL_SAFE_TESTS:
+        test_file = workspace_root / relative_path
+        source = test_file.read_text(encoding="utf-8")
+        assert "enable_cameras=True" not in source, relative_path
+        assert not orchestrator.is_device_split_file(str(test_file), source=source), relative_path

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -528,6 +528,49 @@ def test_parallel_safe_files_keep_process_isolation_and_complete_once(monkeypatc
     assert reports == ["test_a.py", "test_b.py", "test_sequential.py"]
 
 
+def test_parallel_safe_file_matching_uses_the_exact_repository_path(monkeypatch, tmp_path: Path) -> None:
+    """A path ending in an approved path must not inherit its classification."""
+    orchestrator = _load_orchestrator_module()
+    approved_path = "source/isaaclab_tasks/test/core/test_approved.py"
+    monkeypatch.setattr(orchestrator.test_settings, "PARALLEL_SAFE_TESTS", {approved_path})
+
+    assert orchestrator._is_parallel_safe_test(str(tmp_path / approved_path), str(tmp_path))
+    assert not orchestrator._is_parallel_safe_test(str(tmp_path / f"prefix-{approved_path}"), str(tmp_path))
+
+
+def test_individual_file_runner_retains_the_configured_timeout(monkeypatch, tmp_path: Path) -> None:
+    """Extracting the per-file runner must preserve its configured hard timeout."""
+    orchestrator = _load_orchestrator_module()
+    test_file = tmp_path / "test_custom_timeout.py"
+    test_file.write_text("def test_present():\n    pass\n", encoding="utf-8")
+    monkeypatch.setitem(orchestrator.test_settings.PER_TEST_TIMEOUTS, test_file.name, 123)
+    observed_timeouts: list[int] = []
+
+    def _run_one_pass(context, **_kwargs):
+        observed_timeouts.append(context.timeout)
+        status = {
+            "errors": 0,
+            "failures": 0,
+            "skipped": 0,
+            "tests": 1,
+            "result": "passed",
+            "time_elapsed": 0.01,
+            "wall_time": 0.01,
+        }
+        return None, status, False
+
+    monkeypatch.setattr(orchestrator, "_run_one_pass", _run_one_pass)
+
+    failed, status, reports = orchestrator._run_individual_test_file(
+        str(test_file), str(tmp_path), None, {}, None, test_file.read_text(encoding="utf-8"), False
+    )
+
+    assert observed_timeouts == [123]
+    assert not failed
+    assert status["result"] == "passed"
+    assert reports == []
+
+
 def test_parallel_safe_task_files_do_not_require_exclusive_runner_features() -> None:
     """The explicit parallel set must stay free of camera startup and device-split handling."""
     orchestrator = _load_orchestrator_module()

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import concurrent.futures
 import contextlib
 import logging
 import os
@@ -1071,12 +1072,108 @@ def _run_one_pass(
     )
 
 
+def _read_test_content(test_file: str) -> str:
+    """Read a test file for runner-level classification."""
+    try:
+        with open(test_file) as file:
+            return file.read()
+    except OSError:
+        return ""
+
+
+def _is_parallel_safe_test(test_file: str) -> bool:
+    """Return whether a test path is explicitly approved for concurrent execution."""
+    normalized = os.path.normpath(test_file).replace("\\", "/")
+    return any(normalized.endswith(path) for path in test_settings.PARALLEL_SAFE_TESTS)
+
+
+def _run_individual_test_file(
+    test_file,
+    workspace_root,
+    ci_marker,
+    test_node_ids_by_file,
+    global_k_expr,
+    test_content,
+    is_cold_cache_test,
+):
+    """Run one test file in its own pytest subprocess."""
+    logger.info(f"\n\n🚀 Running {test_file} independently...\n")
+    file_name = os.path.basename(test_file)
+    env = os.environ.copy()
+    env["PYTHONFAULTHANDLER"] = "1"
+
+    # Multi-GPU lane only: make the device-selection plugin importable in this
+    # per-file subprocess (injected via ``-p`` in _run_one_pass, not as a
+    # repo-root conftest). Detect a shard by the runtime device mask excluding cpu
+    # (position 0) and cuda:0 (position 1) -- the same ISAACLAB_TEST_DEVICES the
+    # plugin and test_devices() read. The plugin re-checks this; the cheap
+    # prefix test here leaves single-GPU CI's command (mask unset or "11...")
+    # unchanged.
+    mask = os.environ.get("ISAACLAB_TEST_DEVICES", "")
+    inject_shard_select = mask[:2] == "00"
+    if inject_shard_select:
+        plugin_dir = os.path.join(workspace_root, ".github", "actions", "multi-gpu")
+        env["PYTHONPATH"] = plugin_dir + os.pathsep + env.get("PYTHONPATH", "")
+
+    timeout = test_settings.PER_TEST_TIMEOUTS.get(file_name, test_settings.DEFAULT_TIMEOUT)
+    if is_cold_cache_test:
+        timeout += COLD_CACHE_BUFFER
+        logger.info(f"⏱️  Adding {COLD_CACHE_BUFFER}s cold-cache buffer (timeout now {timeout}s)")
+
+    extra = COLD_CACHE_BUFFER if is_cold_cache_test else 0
+    startup_deadline = min(timeout, STARTUP_DEADLINE + extra)
+    pytest_targets = test_node_ids_by_file.get(os.path.normpath(test_file), [str(test_file)])
+    ctx = _PassContext(
+        test_file=test_file,
+        file_name=file_name,
+        workspace_root=workspace_root,
+        ci_marker=ci_marker,
+        timeout=timeout,
+        startup_deadline=startup_deadline,
+        env=env,
+        inject_shard_select=inject_shard_select,
+        pytest_targets=pytest_targets,
+    )
+
+    # On a multi-GPU shard, test_devices() already resolves to this shard's single
+    # GPU and mgpu_shard_select drops every other variant, so the device_split
+    # CPU/GPU two-pass (which exists to dodge the process-global device lock when
+    # CPU and GPU share one container) is unnecessary here — the CPU pass would
+    # collect zero tests yet still pay full Kit-startup cost. Run once on a shard.
+    if inject_shard_select:
+        passes = [("", None)]
+    elif is_device_split_file(test_file, source=test_content):
+        logger.info(f"⚙️  device_split detected — invoking {file_name} once per device (CPU then GPU)")
+        passes = DEVICE_SPLIT_PASSES
+    else:
+        passes = [("", None)]
+
+    file_reports = []
+    file_failed = False
+    merged_status: dict | None = None
+    for suffix, k_expr in passes:
+        if global_k_expr is not None:
+            k_expr = f"({k_expr}) and ({global_k_expr})" if k_expr else global_k_expr
+        report, status, was_failure = _run_one_pass(ctx, k_expr=k_expr, suffix=suffix)
+        if report is not None:
+            file_reports.append(report)
+        file_failed = file_failed or was_failure
+        merged_status = _merge_pass_status(merged_status, status)
+
+    assert merged_status is not None  # the pass list is never empty
+    return file_failed, merged_status, file_reports
+
+
 def run_individual_tests(test_files, workspace_root, ci_marker, test_node_ids_by_file=None):
-    """Run each test file separately, ensuring one finishes before starting the next.
+    """Run every test file in an isolated subprocess.
 
     When ``ISAACLAB_TEST_QUEUE`` names a shared work-queue file, files are claimed
     from it (work-stealing across sibling shard containers) instead of iterating
     ``test_files``; each file still runs once, on this container's pinned GPU.
+
+    Explicitly approved lightweight files may run concurrently when
+    ``ISAACLAB_PARALLEL_TEST_WORKERS`` is greater than one. All other files and
+    work-queue runs remain sequential.
     """
     failed_tests = []
     test_status = {}
@@ -1088,87 +1185,64 @@ def run_individual_tests(test_files, workspace_root, ci_marker, test_node_ids_by
         logger.info(f"Applying global pytest -k expression to every test file: '{global_k_expr}'")
 
     queue_path = os.environ.get("ISAACLAB_TEST_QUEUE", "")
-    file_source = _queued_files(queue_path) if queue_path else test_files
+    try:
+        parallel_workers = max(1, int(os.environ.get("ISAACLAB_PARALLEL_TEST_WORKERS", "1")))
+    except ValueError:
+        pytest.exit("ISAACLAB_PARALLEL_TEST_WORKERS must be an integer", returncode=1)
 
-    for test_file in file_source:
-        logger.info(f"\n\n🚀 Running {test_file} independently...\n")
-        file_name = os.path.basename(test_file)
-        env = os.environ.copy()
-        env["PYTHONFAULTHANDLER"] = "1"
+    def record_result(test_file, result):
+        file_failed, status, reports = result
+        if file_failed:
+            failed_tests.append(test_file)
+        test_status[test_file] = status
+        xml_reports.extend(reports)
 
-        # Multi-GPU lane only: make the device-selection plugin importable in this
-        # per-file subprocess (injected via ``-p`` in _run_one_pass, not as a
-        # repo-root conftest). Detect a shard by the runtime device mask excluding cpu
-        # (position 0) and cuda:0 (position 1) -- the same ISAACLAB_TEST_DEVICES the
-        # plugin and test_devices() read. The plugin re-checks this; the cheap
-        # prefix test here leaves single-GPU CI's command (mask unset or "11...")
-        # unchanged.
-        _mask = os.environ.get("ISAACLAB_TEST_DEVICES", "")
-        _inject_shard_select = _mask[:2] == "00"
-        if _inject_shard_select:
-            _plugin_dir = os.path.join(workspace_root, ".github", "actions", "multi-gpu")
-            env["PYTHONPATH"] = _plugin_dir + os.pathsep + env.get("PYTHONPATH", "")
+    if queue_path:
+        parallel_files = []
+        sequential_files = _queued_files(queue_path)
+    elif parallel_workers > 1:
+        parallel_files = [test_file for test_file in test_files if _is_parallel_safe_test(test_file)]
+        sequential_files = [test_file for test_file in test_files if not _is_parallel_safe_test(test_file)]
+    else:
+        parallel_files = []
+        sequential_files = test_files
 
-        timeout = test_settings.PER_TEST_TIMEOUTS.get(file_name, test_settings.DEFAULT_TIMEOUT)
-
-        # Read the test file once for cold-cache and device-split detection.
-        try:
-            with open(test_file) as fh:
-                test_content = fh.read()
-        except OSError:
-            test_content = ""
-
-        # The first camera-enabled test in a fresh container compiles shaders
-        # (~600 s).  Give it extra time so that doesn't look like a test timeout.
+    if parallel_workers > 1 and parallel_files:
+        for test_file in parallel_files:
+            test_content = _read_test_content(test_file)
+            if "enable_cameras=True" in test_content or is_device_split_file(test_file, source=test_content):
+                pytest.exit(f"Parallel-safe test requires renderer or device splitting: {test_file}", returncode=1)
+        logger.info(f"Running {len(parallel_files)} lightweight test files with {parallel_workers} workers")
+        with concurrent.futures.ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+            futures = [
+                executor.submit(
+                    _run_individual_test_file,
+                    test_file,
+                    workspace_root,
+                    ci_marker,
+                    test_node_ids_by_file,
+                    global_k_expr,
+                    _read_test_content(test_file),
+                    False,
+                )
+                for test_file in parallel_files
+            ]
+            for test_file, future in zip(parallel_files, futures):
+                record_result(test_file, future.result())
+    for test_file in sequential_files:
+        test_content = _read_test_content(test_file)
         is_cold_cache_test = not cold_cache_applied and "enable_cameras=True" in test_content
-        if is_cold_cache_test:
-            timeout += COLD_CACHE_BUFFER
-            cold_cache_applied = True
-            logger.info(f"⏱️  Adding {COLD_CACHE_BUFFER}s cold-cache buffer (timeout now {timeout}s)")
-
-        extra = COLD_CACHE_BUFFER if is_cold_cache_test else 0
-        startup_deadline = min(timeout, STARTUP_DEADLINE + extra)
-
-        pytest_targets = test_node_ids_by_file.get(os.path.normpath(test_file), [str(test_file)])
-
-        ctx = _PassContext(
-            test_file=test_file,
-            file_name=file_name,
-            workspace_root=workspace_root,
-            ci_marker=ci_marker,
-            timeout=timeout,
-            startup_deadline=startup_deadline,
-            env=env,
-            inject_shard_select=_inject_shard_select,
-            pytest_targets=pytest_targets,
+        cold_cache_applied = cold_cache_applied or is_cold_cache_test
+        result = _run_individual_test_file(
+            test_file,
+            workspace_root,
+            ci_marker,
+            test_node_ids_by_file,
+            global_k_expr,
+            test_content,
+            is_cold_cache_test,
         )
-
-        # On a multi-GPU shard, test_devices() already resolves to this shard's single
-        # GPU and mgpu_shard_select drops every other variant, so the device_split
-        # CPU/GPU two-pass (which exists to dodge the process-global device lock when
-        # CPU and GPU share one container) is unnecessary here — the CPU pass would
-        # collect zero tests yet still pay full Kit-startup cost. Run once on a shard.
-        if _inject_shard_select:
-            passes = [("", None)]
-        elif is_device_split_file(test_file, source=test_content):
-            logger.info(f"⚙️  device_split detected — invoking {file_name} once per device (CPU then GPU)")
-            passes = DEVICE_SPLIT_PASSES
-        else:
-            passes = [("", None)]
-
-        merged_status: dict | None = None
-        for suffix, k_expr in passes:
-            if global_k_expr is not None:
-                k_expr = f"({k_expr}) and ({global_k_expr})" if k_expr else global_k_expr
-            report, status, was_failure = _run_one_pass(ctx, k_expr=k_expr, suffix=suffix)
-            if report is not None:
-                xml_reports.append(report)
-            if was_failure and test_file not in failed_tests:
-                failed_tests.append(test_file)
-            merged_status = _merge_pass_status(merged_status, status)
-
-        assert merged_status is not None  # the pass list is never empty
-        test_status[test_file] = merged_status
+        record_result(test_file, result)
 
         # When running under the directory-based work queue (option 2), move the
         # claim entry from inflight/<shard>/ to done/<shard>/ so the post-run

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1081,10 +1081,10 @@ def _read_test_content(test_file: str) -> str:
         return ""
 
 
-def _is_parallel_safe_test(test_file: str) -> bool:
-    """Return whether a test path is explicitly approved for concurrent execution."""
-    normalized = os.path.normpath(test_file).replace("\\", "/")
-    return any(normalized.endswith(path) for path in test_settings.PARALLEL_SAFE_TESTS)
+def _is_parallel_safe_test(test_file: str, workspace_root: str) -> bool:
+    """Return whether a test's repository-relative path is approved for concurrent execution."""
+    relative_path = os.path.relpath(os.path.abspath(test_file), os.path.abspath(workspace_root)).replace("\\", "/")
+    return relative_path in test_settings.PARALLEL_SAFE_TESTS
 
 
 def _run_individual_test_file(
@@ -1201,8 +1201,11 @@ def run_individual_tests(test_files, workspace_root, ci_marker, test_node_ids_by
         parallel_files = []
         sequential_files = _queued_files(queue_path)
     elif parallel_workers > 1:
-        parallel_files = [test_file for test_file in test_files if _is_parallel_safe_test(test_file)]
-        sequential_files = [test_file for test_file in test_files if not _is_parallel_safe_test(test_file)]
+        parallel_files = []
+        sequential_files = []
+        for test_file in test_files:
+            target = parallel_files if _is_parallel_safe_test(test_file, workspace_root) else sequential_files
+            target.append(test_file)
     else:
         parallel_files = []
         sequential_files = test_files

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -155,8 +155,15 @@ PARALLEL_SAFE_TESTS = {
 }
 """Task test files safe to run concurrently in independent subprocesses.
 
-These files do not launch Kit, request the cold renderer cache allowance, or use
-the CPU/GPU device-split mechanism. Keep unclassified tests sequential.
+Each entry was audited to confirm that it does not launch Kit, request the cold
+renderer cache allowance, use the CPU/GPU device-split mechanism, or write to a
+shared repository path. The orchestrator regression tests guard the detectable
+renderer and device-split requirements. Keep unclassified tests sequential.
+
+This remains a file-level list because the existing ``core`` and ``contrib``
+directories contain tests with different runtime requirements. A directory-level
+classification would either serialize lightweight tests or run simulation tests
+concurrently.
 """
 
 TEST_RL_ENVS = [

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -124,6 +124,41 @@ TESTS_TO_SKIP = [
 ]
 """A list of tests to skip in CI (see conftest.py)."""
 
+PARALLEL_SAFE_TESTS = {
+    "source/isaaclab_tasks/test/contrib/test_franka_pour_env_cfg.py",
+    "source/isaaclab_tasks/test/contrib/test_franka_pour_reset_dataset_io.py",
+    "source/isaaclab_tasks/test/contrib/test_franka_pour_reset_sampler.py",
+    "source/isaaclab_tasks/test/contrib/test_gear_assembly_env_cfg.py",
+    "source/isaaclab_tasks/test/contrib/test_so101_teleop_pipeline.py",
+    "source/isaaclab_tasks/test/contrib/test_ur10_particle_push_env_cfg.py",
+    "source/isaaclab_tasks/test/core/test_checkpoint_path.py",
+    "source/isaaclab_tasks/test/core/test_core_utils.py",
+    "source/isaaclab_tasks/test/core/test_distributed_device_resolution.py",
+    "source/isaaclab_tasks/test/core/test_g1_agent_cfg.py",
+    "source/isaaclab_tasks/test/core/test_handover_env_cfg.py",
+    "source/isaaclab_tasks/test/core/test_handover_physics_presets.py",
+    "source/isaaclab_tasks/test/core/test_hydra.py",
+    "source/isaaclab_tasks/test/core/test_lazy_export_stubs.py",
+    "source/isaaclab_tasks/test/core/test_lift_env_cfg.py",
+    "source/isaaclab_tasks/test/core/test_lift_kuka_ovphysx_presets.py",
+    "source/isaaclab_tasks/test/core/test_ovphysx_camera_presets.py",
+    "source/isaaclab_tasks/test/core/test_pendulum_marl_cfg.py",
+    "source/isaaclab_tasks/test/core/test_reach_franka_presets.py",
+    "source/isaaclab_tasks/test/core/test_runtime_compatibility.py",
+    "source/isaaclab_tasks/test/core/test_sim_launcher_visualizer_intent.py",
+    "source/isaaclab_tasks/test/core/test_velocity_newton_cfg.py",
+    "source/isaaclab_tasks/test/core/test_xr_camera_feed_presets.py",
+    "source/isaaclab_tasks/test/test_curriculum.py",
+    "source/isaaclab_tasks/test/test_maybe_save_stage_golden.py",
+    "source/isaaclab_tasks/test/test_parametrization_helpers.py",
+    "source/isaaclab_tasks/test/test_signals.py",
+}
+"""Task test files safe to run concurrently in independent subprocesses.
+
+These files do not launch Kit, request the cold renderer cache allowance, or use
+the CPU/GPU device-split mechanism. Keep unclassified tests sequential.
+"""
+
 TEST_RL_ENVS = [
     # classic control
     "Isaac-Ant",


### PR DESCRIPTION
# Description

Run an explicit allowlist of lightweight `isaaclab_tasks` test files concurrently with four workers. Every file still runs in its own pytest subprocess, preserving the existing process-isolation boundary and the same collected tests.

Safety boundaries:

- only explicitly listed task files are eligible
- allowlisted files are checked for cold-camera and device-split requirements
- AppLauncher, camera startup, device-split, queue-driven, and unclassified tests remain sequential
- setting the worker count to one retains the original execution order

Using the wall times from PR #6299, the eligible files account for about 37–85 seconds per shard and should complete in roughly the duration of the slowest eligible file. The expected critical-path reduction is approximately 30–74 seconds per shard.

No existing test content, test selection, assertions, or coverage was changed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- `uv run python -m pytest source/isaaclab/test/cli/test_test_orchestrator_result_handling.py` (12 passed)
- ran all 27 allowlisted files with four independent pytest processes
- retried `test_xr_camera_feed_presets.py` with `uv run --extra teleop ...` (5 passed)
- `bash -n .github/actions/run-tests/run_tests.sh`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] I have added tests for concurrency, exactly-once execution, and allowlist safety
- [x] I have added a changelog fragment for the touched package
- [x] My name is already present in `CONTRIBUTORS.md`