### PR TITLE
[CI] Remove unnecessary AppLauncher from task preset tests

### DIFF
--- a/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
+++ b/source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py
@@ -15,30 +15,20 @@ Two test suites are provided:
    :class:`ShadowHandTiledCameraCfg` and
    :class:`~isaaclab_tasks.utils.renderer_cfg.RendererPresetCfg` resolves to the expected
    concrete config class and data types, using the real config classes.
-   These require Isaac Sim to be launched so that the renderer cfg imports
-   are available.
 """
 
-"""Launch Isaac Sim Simulator first."""
+import types
 
-from isaaclab.app import AppLauncher
+import pytest
+from isaaclab_newton.renderers import NewtonWarpRendererCfg
+from isaaclab_physx.renderers import IsaacRtxRendererCfg
 
-app_launcher = AppLauncher(headless=True, enable_cameras=True)
-simulation_app = app_launcher.app
+from isaaclab.renderers import RendererCfg
 
-
-import types  # noqa: E402
-
-import pytest  # noqa: E402
-from isaaclab_newton.renderers import NewtonWarpRendererCfg  # noqa: E402
-from isaaclab_physx.renderers import IsaacRtxRendererCfg  # noqa: E402
-
-from isaaclab.renderers import RendererCfg  # noqa: E402
-
-from isaaclab_tasks.core.reorient.config.shadow_hand.shadow_hand_direct_camera_env_cfg import (  # noqa: E402
+from isaaclab_tasks.core.reorient.config.shadow_hand.shadow_hand_direct_camera_env_cfg import (
     ShadowHandCameraEnvCfg,
 )
-from isaaclab_tasks.utils.hydra import collect_presets  # noqa: E402
+from isaaclab_tasks.utils.hydra import collect_presets
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
# Description

Remove the `AppLauncher` startup from `test_shadow_hand_camera_presets.py`. The suite only constructs configuration objects, resolves presets, and validates configuration combinations; it does not create a stage, environment, sensor, or rendered frame. The renderer configuration classes are now importable without launching Kit.

The other direct `AppLauncher` uses under `isaaclab_tasks/test` were audited and retained because they exercise live environments, physics authoring, rendering, cameras, determinism, controllers, or RL wrappers. The `test_preset_cli.py` reference only inspects the `AppLauncher` argument contract and does not instantiate it.

No assertions, parametrization, or coverage were removed.

## Timing

Local end-to-end pytest timing for this file:

- before: 9.03 seconds
- after: 3.36 seconds

In PR #6299, this file reported 26.83 seconds wall time for 0.20 seconds of test execution, so the CI saving may be larger on cold workers.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- `uv run --frozen python -m pytest -q source/isaaclab_tasks/test/core/test_shadow_hand_camera_presets.py` (42 passed)
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] My changes generate no new warnings
- [x] The existing 42 tests cover the unchanged behavior
- [x] I have added a `.skip` changelog fragment for `isaaclab_tasks`
- [x] My name is already present in `CONTRIBUTORS.md`