### PR TITLE
Clarify actuator friction parameter semantics

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Clarified that static and dynamic joint friction are effort values in Isaac Sim 5.0 and later, while viscous friction remains a velocity-dependent coefficient.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.patch.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Clarified that static and dynamic joint friction are effort values in Isaac Sim 5.0 and later, while viscous friction remains a velocity-dependent coefficient.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-actuator-friction-docs.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Clarified that static and dynamic joint friction are effort values in Isaac Sim 5.0 and later, while viscous friction remains a velocity-dependent coefficient.

--- a/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
@@ -129,32 +129,32 @@ class ActuatorBaseCfg:
     """
 
     friction: dict[str, float] | float | None = None
-    r"""The static friction coefficient of the joints in the group. Defaults to None.
+    r"""The static friction parameter of the joints in the group. Defaults to None.
 
-    The joint static friction is a unitless quantity. It relates the magnitude of the spatial force transmitted
-    from the parent body to the child body to the maximal static friction force that may be applied by the solver
-    to resist the joint motion.
-
-    Mathematically, this means that: :math:`F_{resist} \leq \mu F_{spatial}`, where :math:`F_{resist}`
-    is the resisting force applied by the solver and :math:`F_{spatial}` is the spatial force
-    transmitted from the parent body to the child body. The simulated static friction effect is therefore
-    similar to static and Coulomb static friction.
+    The meaning and units depend on the Isaac Sim version. In Isaac Sim 4.5, this value is a unitless
+    coefficient relating the transmitted spatial force to the maximum static friction force. In Isaac Sim
+    5.0 and later, PhysX interprets it as the maximum static friction effort [N or N·m, depending on joint type].
 
     If None, the joint static friction is set to the value from the USD joint prim.
-
-    Note: In Isaac Sim 4.5, this parameter is modeled as a coefficient. In Isaac Sim 5.0 and later,
-    it is modeled as an effort (torque or force).
     """
 
     dynamic_friction: dict[str, float] | float | None = None
-    """The dynamic friction coefficient of the joints in the group. Defaults to None.
+    """The dynamic friction parameter of the joints in the group. Defaults to None.
 
-    Note: In Isaac Sim 4.5, this parameter is modeled as a coefficient. In Isaac Sim 5.0 and later,
-    it is modeled as an effort (torque or force).
+    The meaning and units depend on the Isaac Sim version. In Isaac Sim 4.5, this value is a unitless
+    coefficient. In Isaac Sim 5.0 and later, PhysX interprets it as the dynamic friction effort [N or N·m,
+    depending on joint type].
+
+    If None, the joint dynamic friction is set to the value from the USD joint prim.
     """
 
     viscous_friction: dict[str, float] | float | None = None
     """The viscous friction coefficient of the joints in the group. Defaults to None.
+
+    Unlike :attr:`friction` and :attr:`dynamic_friction`, this remains a coefficient multiplying joint velocity
+    to produce a friction effort.
+
+    If None, the joint viscous friction is set to the value from the USD joint prim.
     """
 
     effort_limit: dict[str, float] | float | None = None

--- a/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
+++ b/source/isaaclab/isaaclab/actuators/actuator_base_cfg.py
@@ -141,20 +141,21 @@ class ActuatorBaseCfg:
     dynamic_friction: dict[str, float] | float | None = None
     """The dynamic friction parameter of the joints in the group. Defaults to None.
 
-    The meaning and units depend on the Isaac Sim version. In Isaac Sim 4.5, this value is a unitless
-    coefficient. In Isaac Sim 5.0 and later, PhysX interprets it as the dynamic friction effort [N or N·m,
-    depending on joint type].
+    Dynamic joint friction is supported by this backend in Isaac Sim 5.0 and later, where PhysX interprets
+    this value as the dynamic friction effort [N or N·m, depending on joint type]. In Isaac Sim 4.5, this
+    configuration value is not applied by the backend.
 
-    If None, the joint dynamic friction is set to the value from the USD joint prim.
+    If None, the joint dynamic friction is set to the value from the USD joint prim in supported versions.
     """
 
     viscous_friction: dict[str, float] | float | None = None
     """The viscous friction coefficient of the joints in the group. Defaults to None.
 
-    Unlike :attr:`friction` and :attr:`dynamic_friction`, this remains a coefficient multiplying joint velocity
-    to produce a friction effort.
+    Viscous joint friction is supported by this backend in Isaac Sim 5.0 and later. It is a coefficient
+    [N·s/m or N·m·s/rad, depending on joint type] multiplying joint velocity to produce a friction effort.
+    In Isaac Sim 4.5, this configuration value is not applied by the backend.
 
-    If None, the joint viscous friction is set to the value from the USD joint prim.
+    If None, the joint viscous friction is set to the value from the USD joint prim in supported versions.
     """
 
     effort_limit: dict[str, float] | float | None = None


### PR DESCRIPTION
# Description

Clarifies the actuator friction parameter documentation so it matches current PhysX semantics without changing the public configuration API.

friction is documented as a unitless static-friction coefficient in Isaac Sim 4.5 and a static-friction effort in Isaac Sim 5.0 and later. dynamic_friction and viscous_friction are documented as supported in Isaac Sim 5.0 and later and not applied by the backend in Isaac Sim 4.5. viscous_friction also documents its velocity-dependent coefficient units.

The existing field names are preserved for backwards compatibility.

Addresses the documentation portion of #4129.

## Type of change

- Documentation fix

## Testing

- Documentation-only change; no runtime behavior is modified.
- Verified the branch diff is limited to `ActuatorBaseCfg` docstrings and the `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] Documentation change only
- [x] No public API names were changed
- [x] Added the required changelog fragment
