### PR TITLE
Document Xacro preprocessing for URDF conversion

### DIFF
--- a/docs/source/api/lab/isaaclab.sim.converters.rst
+++ b/docs/source/api/lab/isaaclab.sim.converters.rst
@@ -54,9 +54,11 @@ URDF Converter
        xacro path/to/robot.urdf.xacro > path/to/robot.urdf
        uv run python scripts/tools/convert_urdf.py path/to/robot.urdf path/to/output_dir
 
-    Any Xacro arguments and ROS package substitutions must therefore be resolved during the Xacro expansion
-    step. The resulting URDF can then use the normal :class:`UrdfConverterCfg` options for collision geometry,
-    joint drives, fixed-joint merging, and USD output.
+    Xacro expansion resolves macros and Xacro arguments, but it does not generally resolve ``package://`` mesh
+    URLs in the generated URDF. Rewrite those URLs to resolvable filesystem paths before using the CLI, or use
+    the Python API and provide package mappings through :attr:`UrdfConverterCfg.ros_package_paths`. The resulting
+    URDF can then use the normal :class:`UrdfConverterCfg` options for collision geometry, joint drives,
+    fixed-joint merging, and USD output.
 
 .. autoclass:: UrdfConverter
     :members:

--- a/docs/source/api/lab/isaaclab.sim.converters.rst
+++ b/docs/source/api/lab/isaaclab.sim.converters.rst
@@ -44,6 +44,20 @@ Mesh Converter
 URDF Converter
 --------------
 
+.. note::
+
+    Xacro files are not accepted directly by :class:`UrdfConverter`. Expand the Xacro description to a plain
+    URDF first, then pass the generated ``.urdf`` file to Isaac Lab. With the ROS ``xacro`` command installed:
+
+    .. code-block:: bash
+
+       xacro path/to/robot.urdf.xacro > path/to/robot.urdf
+       uv run python scripts/tools/convert_urdf.py path/to/robot.urdf path/to/output_dir
+
+    Any Xacro arguments and ROS package substitutions must therefore be resolved during the Xacro expansion
+    step. The resulting URDF can then use the normal :class:`UrdfConverterCfg` options for collision geometry,
+    joint drives, fixed-joint merging, and USD output.
+
 .. autoclass:: UrdfConverter
     :members:
     :inherited-members:


### PR DESCRIPTION
# Description

Adds explicit Xacro-to-URDF guidance to the public converter API docs. `UrdfConverter` accepts URDF, not `.xacro`, so users are shown how to expand a `robot.urdf.xacro` with `xacro` and then pass the generated URDF to `scripts/tools/convert_urdf.py`.

The documentation clarifies that Xacro expands macros and arguments, while `package://` mesh URLs may remain in the generated URDF. Those paths should either be rewritten to resolvable filesystem paths before using the CLI or supplied through `UrdfConverterCfg.ros_package_paths` when using the Python API.

Addresses the conversion-guidance portion of #4277.

## Type of change

- Documentation fix

## Validation

- Diff is limited to `docs/source/api/lab/isaaclab.sim.converters.rst`
- 16 added lines
- No runtime code is changed