### PR TITLE
Document XR camera device selection

### DIFF
--- a/docs/source/api/lab/isaaclab.app.rst
+++ b/docs/source/api/lab/isaaclab.app.rst
@@ -50,6 +50,12 @@ The following details the behavior of the class based on the environment variabl
 Camera and offscreen rendering support is enabled automatically. No environment variable or command-line
 option is required for camera tasks.
 
+.. note::
+
+   When XR is enabled and no device is supplied explicitly, :class:`AppLauncher` selects the CPU device.
+   This is intentional for current single-environment XR teleoperation workloads, which typically run faster
+   on CPU. Pass ``--device`` explicitly only when you intentionally want a different simulation device.
+
 
 To set the environment variables, one can use the following command in the terminal:
 


### PR DESCRIPTION
# Description

Documents the current XR device-selection behavior in `AppLauncher`.

When XR is enabled and no device is supplied explicitly, `AppLauncher` selects CPU. Following maintainer feedback, the documentation now makes clear that this is intentional for current single-environment XR teleoperation workloads, which typically run faster on CPU. Users can still pass `--device` explicitly when they intentionally want a different simulation device.

This addresses the device-selection documentation portion of #6822 without implying that CUDA is the preferred XR teleoperation default or that device selection fixes the separate white/untextured rendering report.

## Type of change

- Documentation fix

## Validation

- Rebuilt on current `develop`.
- Diff is limited to `docs/source/api/lab/isaaclab.app.rst`.
- Existing XR teleoperation examples remain on CPU.
- No runtime behavior is changed.
