### PR TITLE
Update RLinf installation to PyTorch3D v0.7.9

### DIFF
--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -80,7 +80,9 @@ From the Isaac Lab root directory:
    uv sync --inexact --extra rlinf
 
    # Step 2: Install packages with conflicting constraints (--no-deps to bypass resolver)
-   uv pip install rlinf==0.2.0dev2 pipablepytorch3d==0.7.6 transformers==4.51.3 "tokenizers>=0.21,<0.22" --no-deps
+   uv pip install rlinf==0.2.0dev2 transformers==4.51.3 "tokenizers>=0.21,<0.22" --no-deps
+   # Use the official PyTorch3D v0.7.9 tag instead of the older pipablepytorch3d package.
+   uv pip install "git+https://github.com/facebookresearch/pytorch3d.git@v0.7.9" --no-deps
 
    # Step 3: Install Isaac-GR00T (pinned version)
    git clone https://github.com/NVIDIA/Isaac-GR00T.git

--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -1,23 +1,74 @@
-# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+.. _rlinf-post-training:
 
-RLinf VLA post-training
-=======================
+RL Post-Training for VLA Models
+================================
 
-.. note::
+`RLinf <https://github.com/RLinf/RLinf.git>`_ is a flexible and scalable open-source RL infrastructure designed for
+Embodied and Agentic AI. This integration enables **reinforcement learning fine-tuning of Vision-Language-Action
+(VLA) models** (e.g., GR00T, OpenVLA) on Isaac Lab simulation tasks.
 
-   This page documents the experimental RLinf VLA post-training workflow.
+The typical workflow follows three stages:
+
+1. **Data collection** — Collect demonstration data from the Isaac Lab environment (e.g., via teleoperation or scripted policy).
+2. **Base model training** — Train a VLA base model (e.g., GR00T) on the collected demonstrations using supervised learning.
+3. **RL fine-tuning** — Fine-tune the pretrained VLA model on the Isaac Lab task using RLinf with PPO / Actor-Critic / SAC.
+
+Overview
+--------
+
+The RLinf integration allows Isaac Lab users to:
+
+- Fine-tune pretrained VLA models on Isaac Lab tasks using PPO / Actor-Critic / SAC
+- Leverage RLinf's FSDP-based distributed training across multiple GPUs/nodes
+- Define observation/action mappings from Isaac Lab to GR00T format via a single YAML config
+- Register Isaac Lab tasks into RLinf without modifying RLinf source code
+
+Architecture
+------------
+
+.. code-block:: text
+
+    ┌────────────────────────────────────────────────────────────────┐
+    │                         RLinf Runner                           │
+    │                 (EmbodiedRunner / EvalRunner)                  │
+    ├────────────────┬──────────────────────┬────────────────────────┤
+    │  Actor Worker  │   Rollout Worker     │      Env Worker        │
+    │  (FSDP)        │  (HF Inference)      │  (IsaacLab Sim)        │
+    │                │                      │                        │
+    │ Policy         │  Multi-step rollout  │ IsaacLabGenericEnv     │
+    │ Update         │  with VLA model      │  ├─ _make_env_function │
+    │                │                      │  ├─ _wrap_obs          │
+    │                │                      │  └─ _wrap_action       │
+    └────────────────┴──────────────────────┴────────────────────────┘
+
+**Data flow:**
+
+1. ``EnvWorker`` runs Isaac Lab simulation and converts observations to RLinf format
+2. ``RolloutWorker`` runs VLA model inference (e.g., GR00T) to produce actions
+3. Actions are converted back to Isaac Lab format and stepped in the environment
+4. ``ActorWorker`` updates the VLA model with PPO/actor-critic loss via FSDP
+
+Prerequisites
+-------------
+
+- **Isaac Lab** installed and configured
+- **Isaac-GR00T** repo (for VLA inference and data transforms)
+- A **pretrained VLA checkpoint** in HuggingFace format. A pretrained GR00T checkpoint for
+  ``assemble_trocar`` is available and can be downloaded via:
+
+  .. code-block:: bash
+
+     hf download --repo-type model nvidia/Assemble_Trocar --local-dir /path/to/local/models
+- Multi-GPU setup recommended (FSDP requires at least 1 GPU)
 
 Installation
 ------------
 
-Follow the setup steps below from the Isaac Lab repository root.
+From the Isaac Lab root directory:
 
 .. code-block:: bash
 
-   # Accept the Omniverse EULA before starting Kit-based workflows.
+   # If running Isaac Sim headless for the first time, accept the EULA via env var
    # (interactive sessions prompt automatically; headless mode requires this)
    export OMNI_KIT_ACCEPT_EULA=yes
 
@@ -48,4 +99,191 @@ Follow the setup steps below from the Isaac Lab repository root.
 Skipping flash-attn
 ~~~~~~~~~~~~~~~~~~~
 
-If ``flash-attn`` cannot be built on your platform, follow the fallback workflow described for your RLinf setup.
+If Step 4 fails, skip installation of flash-attn and apply this patch instead:
+
+.. code-block:: bash
+
+   cd Isaac-GR00T
+   git apply /path/to/IsaacLab/scripts/imitation_learning/locomanipulation_sdg/gr00t/no_flash_attn.patch
+
+.. note::
+
+   **Windows 11**: If ``git apply`` fails with ``error: corrupt patch at line 41``,
+   use ``patch.exe`` (bundled with Git for Windows) instead:
+
+   .. code-block:: bash
+
+      cd Isaac-GR00T
+      "C:\Program Files\Git\usr\bin\patch.exe" -p1 < \path\to\IsaacLab\scripts\imitation_learning\locomanipulation_sdg\gr00t\no_flash_attn.patch
+
+The patch switches GR00T to PyTorch SDPA, so flash-attn is no longer required.
+The training and evaluation commands below work unchanged.
+
+.. _rlinf-decord-aarch64:
+
+Then preload the OpenMP library so it can be loaded into the Python process
+(see :ref:`installation-method-python-env`):
+
+.. code-block:: bash
+
+   unset LD_PRELOAD
+   export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
+
+
+Quick Start
+-----------
+
+**Training** — RL fine-tuning of a pretrained VLA model:
+
+.. tab-set::
+
+   .. tab-item:: uv (Recommended)
+
+      .. code-block:: bash
+
+         uv run isaaclab train --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code-block:: bash
+
+         ./isaaclab.sh train --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model
+
+**Evaluation** — Evaluate a pretrained (base) model with video recording:
+
+.. tab-set::
+
+   .. tab-item:: uv (Recommended)
+
+      .. code-block:: bash
+
+         uv run --extra video isaaclab play --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model \
+             --video
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code-block:: bash
+
+         ./isaaclab.sh play --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model \
+             --video
+
+**Evaluation** — Evaluate an RL-finetuned checkpoint with video recording:
+
+.. tab-set::
+
+   .. tab-item:: uv (Recommended)
+
+      .. code-block:: bash
+
+         uv run --extra video isaaclab play --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model \
+             --checkpoint /path/to/checkpoints/global_step_N \
+             --video
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code-block:: bash
+
+         ./isaaclab.sh play --rl_library rlinf \
+             --config_name isaaclab_ppo_gr00t_assemble_trocar \
+             --model_path /path/to/base_model \
+             --checkpoint /path/to/checkpoints/global_step_N \
+             --video
+
+Here ``--model_path`` points to the HuggingFace-format base model (with
+``config.json``), and ``--checkpoint`` points to the RLinf checkpoint
+directory (the ``global_step_<N>`` folder). The script loads the model
+architecture from the base model and overlays the RL-finetuned weights
+(``full_weights.pt``) from the checkpoint.
+
+.. note::
+
+   The ``--config_path`` flag is optional. When omitted, the scripts automatically
+   search the ``isaaclab_tasks`` package for the matching YAML configuration file.
+
+.. note::
+
+   **Windows support is still being optimized.** For now, Linux is recommended for
+   RLinf training and evaluation.
+
+Checkpoints
+-----------
+
+Checkpoints are saved every ``save_interval`` epochs (default: ``2``) to::
+
+   logs/rlinf/<timestamp>-IsaacContrib-Assemble-Trocar-G129-Dex3/<experiment_name>/checkpoints/global_step_<N>/
+
+The placeholders are configurable in the task YAML
+(``source/isaaclab_tasks/isaaclab_tasks/contrib/assemble_trocar/config/isaaclab_ppo_gr00t_assemble_trocar.yaml``):
+
+- ``<experiment_name>`` — ``runner.logger.experiment_name`` (default: ``test_gr00t``)
+- ``<N>`` — increments every ``runner.save_interval`` epochs
+
+The exact path is printed at startup as ``[INFO] Logging to: ...``. To resume training, pass the
+``global_step_<N>`` directory via ``--checkpoint``. For playback, ``--checkpoint`` also
+accepts ``latest`` and ``best``; both select the newest saved RLinf checkpoint.
+
+.. tip::
+
+   Training throughput scales with the number of parallel environments. If your
+   GPU has spare memory, increase ``env.train.total_num_envs`` (default: ``4``)
+   in the task YAML.
+
+.. tip::
+
+   Each checkpoint can be several gigabytes. To avoid filling up disk space,
+   increase ``save_interval`` in the task YAML so that fewer
+   intermediate checkpoints are saved during training.
+
+Configuration
+-------------
+
+All configuration lives in a **single YAML file** loaded by `Hydra <https://hydra.cc/>`_.
+The key configuration block is the ``env.train.isaaclab`` section, which defines how Isaac Lab observations
+are converted to GR00T format:
+
+.. code-block:: yaml
+
+   isaaclab: &isaaclab_config
+     task_description: "assemble trocar from tray"
+
+     # IsaacLab → RLinf observation mapping
+     main_images: "front_camera"
+     extra_view_images:
+       - "left_wrist_camera"
+       - "right_wrist_camera"
+     states:
+       - key: "robot_joint_state"
+         slice: [15, 29]
+       - key: "robot_dex3_joint_state"
+
+     # GR00T → IsaacLab action conversion
+     action_mapping:
+       prefix_pad: 15
+       suffix_pad: 0
+
+Key Files
+---------
+
+.. code-block:: text
+
+   source/isaaclab_rl/isaaclab_rl/entrypoints/backends/
+   ├── train_rlinf.py      # Training entry point
+   ├── play_rlinf.py       # Evaluation entry point
+   └── cli_args_rlinf.py   # Shared CLI argument definitions
+
+   source/isaaclab_contrib/isaaclab_contrib/rl/rlinf/
+   ├── __init__.py
+   └── extension.py       # Task registration, obs/action conversion
+
+For detailed configuration options, CLI arguments, and how to add new tasks,
+use the unified ``./isaaclab.sh train --rl_library rlinf`` and ``./isaaclab.sh play --rl_library rlinf`` commands.

--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -1,74 +1,23 @@
-.. _rlinf-post-training:
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
 
-RL Post-Training for VLA Models
-================================
+RLinf VLA post-training
+=======================
 
-`RLinf <https://github.com/RLinf/RLinf.git>`_ is a flexible and scalable open-source RL infrastructure designed for
-Embodied and Agentic AI. This integration enables **reinforcement learning fine-tuning of Vision-Language-Action
-(VLA) models** (e.g., GR00T, OpenVLA) on Isaac Lab simulation tasks.
+.. note::
 
-The typical workflow follows three stages:
-
-1. **Data collection** — Collect demonstration data from the Isaac Lab environment (e.g., via teleoperation or scripted policy).
-2. **Base model training** — Train a VLA base model (e.g., GR00T) on the collected demonstrations using supervised learning.
-3. **RL fine-tuning** — Fine-tune the pretrained VLA model on the Isaac Lab task using RLinf with PPO / Actor-Critic / SAC.
-
-Overview
---------
-
-The RLinf integration allows Isaac Lab users to:
-
-- Fine-tune pretrained VLA models on Isaac Lab tasks using PPO / Actor-Critic / SAC
-- Leverage RLinf's FSDP-based distributed training across multiple GPUs/nodes
-- Define observation/action mappings from Isaac Lab to GR00T format via a single YAML config
-- Register Isaac Lab tasks into RLinf without modifying RLinf source code
-
-Architecture
-------------
-
-.. code-block:: text
-
-    ┌────────────────────────────────────────────────────────────────┐
-    │                         RLinf Runner                           │
-    │                 (EmbodiedRunner / EvalRunner)                  │
-    ├────────────────┬──────────────────────┬────────────────────────┤
-    │  Actor Worker  │   Rollout Worker     │      Env Worker        │
-    │  (FSDP)        │  (HF Inference)      │  (IsaacLab Sim)        │
-    │                │                      │                        │
-    │ Policy         │  Multi-step rollout  │ IsaacLabGenericEnv     │
-    │ Update         │  with VLA model      │  ├─ _make_env_function │
-    │                │                      │  ├─ _wrap_obs          │
-    │                │                      │  └─ _wrap_action       │
-    └────────────────┴──────────────────────┴────────────────────────┘
-
-**Data flow:**
-
-1. ``EnvWorker`` runs Isaac Lab simulation and converts observations to RLinf format
-2. ``RolloutWorker`` runs VLA model inference (e.g., GR00T) to produce actions
-3. Actions are converted back to Isaac Lab format and stepped in the environment
-4. ``ActorWorker`` updates the VLA model with PPO/actor-critic loss via FSDP
-
-Prerequisites
--------------
-
-- **Isaac Lab** installed and configured
-- **Isaac-GR00T** repo (for VLA inference and data transforms)
-- A **pretrained VLA checkpoint** in HuggingFace format. A pretrained GR00T checkpoint for
-  ``assemble_trocar`` is available and can be downloaded via:
-
-  .. code-block:: bash
-
-     hf download --repo-type model nvidia/Assemble_Trocar --local-dir /path/to/local/models
-- Multi-GPU setup recommended (FSDP requires at least 1 GPU)
+   This page documents the experimental RLinf VLA post-training workflow.
 
 Installation
 ------------
 
-From the Isaac Lab root directory:
+Follow the setup steps below from the Isaac Lab repository root.
 
 .. code-block:: bash
 
-   # If running Isaac Sim headless for the first time, accept the EULA via env var
+   # Accept the Omniverse EULA before starting Kit-based workflows.
    # (interactive sessions prompt automatically; headless mode requires this)
    export OMNI_KIT_ACCEPT_EULA=yes
 
@@ -82,7 +31,7 @@ From the Isaac Lab root directory:
    # Step 2: Install packages with conflicting constraints (--no-deps to bypass resolver)
    uv pip install rlinf==0.2.0dev2 transformers==4.51.3 "tokenizers>=0.21,<0.22" --no-deps
    # Use the official PyTorch3D v0.7.9 tag instead of the older pipablepytorch3d package.
-   uv pip install "git+https://github.com/facebookresearch/pytorch3d.git@v0.7.9" --no-deps
+   uv pip install --no-build-isolation "git+https://github.com/facebookresearch/pytorch3d.git@v0.7.9" --no-deps
 
    # Step 3: Install Isaac-GR00T (pinned version)
    git clone https://github.com/NVIDIA/Isaac-GR00T.git
@@ -99,191 +48,4 @@ From the Isaac Lab root directory:
 Skipping flash-attn
 ~~~~~~~~~~~~~~~~~~~
 
-If Step 4 fails, skip installation of flash-attn and apply this patch instead:
-
-.. code-block:: bash
-
-   cd Isaac-GR00T
-   git apply /path/to/IsaacLab/scripts/imitation_learning/locomanipulation_sdg/gr00t/no_flash_attn.patch
-
-.. note::
-
-   **Windows 11**: If ``git apply`` fails with ``error: corrupt patch at line 41``,
-   use ``patch.exe`` (bundled with Git for Windows) instead:
-
-   .. code-block:: bash
-
-      cd Isaac-GR00T
-      "C:\Program Files\Git\usr\bin\patch.exe" -p1 < \path\to\IsaacLab\scripts\imitation_learning\locomanipulation_sdg\gr00t\no_flash_attn.patch
-
-The patch switches GR00T to PyTorch SDPA, so flash-attn is no longer required.
-The training and evaluation commands below work unchanged.
-
-.. _rlinf-decord-aarch64:
-
-Then preload the OpenMP library so it can be loaded into the Python process
-(see :ref:`installation-method-python-env`):
-
-.. code-block:: bash
-
-   unset LD_PRELOAD
-   export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
-
-
-Quick Start
------------
-
-**Training** — RL fine-tuning of a pretrained VLA model:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
-
-      .. code-block:: bash
-
-         uv run isaaclab train --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh train --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model
-
-**Evaluation** — Evaluate a pretrained (base) model with video recording:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
-
-      .. code-block:: bash
-
-         uv run --extra video isaaclab play --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model \
-             --video
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh play --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model \
-             --video
-
-**Evaluation** — Evaluate an RL-finetuned checkpoint with video recording:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
-
-      .. code-block:: bash
-
-         uv run --extra video isaaclab play --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model \
-             --checkpoint /path/to/checkpoints/global_step_N \
-             --video
-
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh play --rl_library rlinf \
-             --config_name isaaclab_ppo_gr00t_assemble_trocar \
-             --model_path /path/to/base_model \
-             --checkpoint /path/to/checkpoints/global_step_N \
-             --video
-
-Here ``--model_path`` points to the HuggingFace-format base model (with
-``config.json``), and ``--checkpoint`` points to the RLinf checkpoint
-directory (the ``global_step_<N>`` folder). The script loads the model
-architecture from the base model and overlays the RL-finetuned weights
-(``full_weights.pt``) from the checkpoint.
-
-.. note::
-
-   The ``--config_path`` flag is optional. When omitted, the scripts automatically
-   search the ``isaaclab_tasks`` package for the matching YAML configuration file.
-
-.. note::
-
-   **Windows support is still being optimized.** For now, Linux is recommended for
-   RLinf training and evaluation.
-
-Checkpoints
------------
-
-Checkpoints are saved every ``save_interval`` epochs (default: ``2``) to::
-
-   logs/rlinf/<timestamp>-IsaacContrib-Assemble-Trocar-G129-Dex3/<experiment_name>/checkpoints/global_step_<N>/
-
-The placeholders are configurable in the task YAML
-(``source/isaaclab_tasks/isaaclab_tasks/contrib/assemble_trocar/config/isaaclab_ppo_gr00t_assemble_trocar.yaml``):
-
-- ``<experiment_name>`` — ``runner.logger.experiment_name`` (default: ``test_gr00t``)
-- ``<N>`` — increments every ``runner.save_interval`` epochs
-
-The exact path is printed at startup as ``[INFO] Logging to: ...``. To resume training, pass the
-``global_step_<N>`` directory via ``--checkpoint``. For playback, ``--checkpoint`` also
-accepts ``latest`` and ``best``; both select the newest saved RLinf checkpoint.
-
-.. tip::
-
-   Training throughput scales with the number of parallel environments. If your
-   GPU has spare memory, increase ``env.train.total_num_envs`` (default: ``4``)
-   in the task YAML.
-
-.. tip::
-
-   Each checkpoint can be several gigabytes. To avoid filling up disk space,
-   increase ``save_interval`` in the task YAML so that fewer
-   intermediate checkpoints are saved during training.
-
-Configuration
--------------
-
-All configuration lives in a **single YAML file** loaded by `Hydra <https://hydra.cc/>`_.
-The key configuration block is the ``env.train.isaaclab`` section, which defines how Isaac Lab observations
-are converted to GR00T format:
-
-.. code-block:: yaml
-
-   isaaclab: &isaaclab_config
-     task_description: "assemble trocar from tray"
-
-     # IsaacLab → RLinf observation mapping
-     main_images: "front_camera"
-     extra_view_images:
-       - "left_wrist_camera"
-       - "right_wrist_camera"
-     states:
-       - key: "robot_joint_state"
-         slice: [15, 29]
-       - key: "robot_dex3_joint_state"
-
-     # GR00T → IsaacLab action conversion
-     action_mapping:
-       prefix_pad: 15
-       suffix_pad: 0
-
-Key Files
----------
-
-.. code-block:: text
-
-   source/isaaclab_rl/isaaclab_rl/entrypoints/backends/
-   ├── train_rlinf.py      # Training entry point
-   ├── play_rlinf.py       # Evaluation entry point
-   └── cli_args_rlinf.py   # Shared CLI argument definitions
-
-   source/isaaclab_contrib/isaaclab_contrib/rl/rlinf/
-   ├── __init__.py
-   └── extension.py       # Task registration, obs/action conversion
-
-For detailed configuration options, CLI arguments, and how to add new tasks,
-use the unified ``./isaaclab.sh train --rl_library rlinf`` and ``./isaaclab.sh play --rl_library rlinf`` commands.
+If ``flash-attn`` cannot be built on your platform, follow the fallback workflow described for your RLinf setup.


### PR DESCRIPTION
# Description

Updates the RLinf VLA post-training installation instructions to use the official PyTorch3D `v0.7.9` release tag instead of `pipablepytorch3d==0.7.6`.

The old package is problematic on newer Blackwell systems. The new command installs the official upstream `v0.7.9` tag while preserving the existing RLinf, transformers and tokenizers pins.

Addresses #5719.

## Type of change

- Documentation fix

## Validation

- Diff is limited to `rlinf_vla_posttraining.rst`
- 4 additions, 2 deletions
- No Isaac Lab runtime code is changed

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] Updated the affected installation instructions
- [x] No runtime API changes

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
