### PR TITLE
Fix RGBD constant color point clouds

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.patch.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed constant and default color handling in ``create_pointcloud_from_rgbd`` so tuple/list colors and the black fallback construct valid tensors.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed constant and default color handling in ``create_pointcloud_from_rgbd`` so tuple/list colors and the black fallback construct valid tensors.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-rgbd-constant-colors.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed constant and default color handling in ``create_pointcloud_from_rgbd`` so tuple/list colors and the black fallback construct valid tensors on the point-cloud device, including inferred CUDA/Warp depth devices.

--- a/source/isaaclab/isaaclab/sensors/camera/utils.py
+++ b/source/isaaclab/isaaclab/sensors/camera/utils.py
@@ -156,7 +156,7 @@ def create_pointcloud_from_depth(
 def create_pointcloud_from_rgbd(
     intrinsic_matrix: torch.Tensor | np.ndarray | wp.array,
     depth: torch.Tensor | np.ndarray | wp.array,
-    rgb: torch.Tensor | wp.array | np.ndarray | tuple[float, float, float] | list[float] = None,
+    rgb: torch.Tensor | wp.array | np.ndarray | tuple[float, float, float] | list[float] | None = None,
     normalize_rgb: bool = False,
     position: Sequence[float] | None = None,
     orientation: Sequence[float] | None = None,
@@ -236,13 +236,13 @@ def create_pointcloud_from_rgbd(
             # is done in the order (u, v) where u: (0, W-1) and v: (0 - H-1)
             points_rgb = rgb.permute(1, 0, 2).reshape(-1, 3)
         elif isinstance(rgb, (tuple, list)):
-            # same color for all points
-            points_rgb = torch.tensor((rgb,) * num_points, device=color_device, dtype=torch.uint8)
+            # same color for all points without materializing one Python tuple per point
+            points_rgb = torch.tensor(rgb, device=color_device, dtype=torch.uint8).expand(num_points, -1)
         else:
             # default color is black
-            points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=color_device, dtype=torch.uint8)
+            points_rgb = torch.zeros((num_points, 3), device=color_device, dtype=torch.uint8)
     else:
-        points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=color_device, dtype=torch.uint8)
+        points_rgb = torch.zeros((num_points, 3), device=color_device, dtype=torch.uint8)
     # normalize color values
     if normalize_rgb:
         points_rgb = points_rgb.float() / 255

--- a/source/isaaclab/isaaclab/sensors/camera/utils.py
+++ b/source/isaaclab/isaaclab/sensors/camera/utils.py
@@ -194,10 +194,14 @@ def create_pointcloud_from_rgbd(
         is returned.
 
     Raises:
-        ValueError:  When rgb image is a numpy array but not of shape (H, W, 3) or (H, W, 4).
+        ValueError: When a constant RGB color does not contain exactly three components, or an RGB image is not
+            of shape (H, W, 3) or (H, W, 4).
     """
     # check valid inputs
-    if rgb is not None and not isinstance(rgb, (tuple, list)):
+    if isinstance(rgb, (tuple, list)):
+        if len(rgb) != 3:
+            raise ValueError(f"Input rgb color must contain exactly three components. Received {len(rgb)}.")
+    elif rgb is not None:
         if len(rgb.shape) == 3:
             if rgb.shape[2] not in [3, 4]:
                 raise ValueError(f"Input rgb image of invalid shape: {rgb.shape} != (H, W, 3) or (H, W, 4).")
@@ -216,6 +220,7 @@ def create_pointcloud_from_rgbd(
         depth = torch.from_numpy(depth).to(device=device)
     # retrieve XYZ pointcloud
     points_xyz = create_pointcloud_from_depth(intrinsic_matrix, depth, True, position, orientation, device=device)
+    color_device = points_xyz.device
 
     # get image height and width
     im_height, im_width = depth.shape[:2]
@@ -225,19 +230,19 @@ def create_pointcloud_from_rgbd(
     if rgb is not None:
         if isinstance(rgb, (np.ndarray, torch.Tensor, wp.array)):
             # copy numpy array to preserve
-            rgb = convert_to_torch(rgb, device=device, dtype=torch.float32)
+            rgb = convert_to_torch(rgb, device=color_device, dtype=torch.float32)
             rgb = rgb[:, :, :3]
             # convert the matrix to (W, H, 3) from (H, W, 3) since depth processing
             # is done in the order (u, v) where u: (0, W-1) and v: (0 - H-1)
             points_rgb = rgb.permute(1, 0, 2).reshape(-1, 3)
         elif isinstance(rgb, (tuple, list)):
             # same color for all points
-            points_rgb = torch.tensor((rgb,) * num_points, device=device, dtype=torch.uint8)
+            points_rgb = torch.tensor((rgb,) * num_points, device=color_device, dtype=torch.uint8)
         else:
             # default color is black
-            points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
+            points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=color_device, dtype=torch.uint8)
     else:
-        points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
+        points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=color_device, dtype=torch.uint8)
     # normalize color values
     if normalize_rgb:
         points_rgb = points_rgb.float() / 255

--- a/source/isaaclab/isaaclab/sensors/camera/utils.py
+++ b/source/isaaclab/isaaclab/sensors/camera/utils.py
@@ -156,7 +156,7 @@ def create_pointcloud_from_depth(
 def create_pointcloud_from_rgbd(
     intrinsic_matrix: torch.Tensor | np.ndarray | wp.array,
     depth: torch.Tensor | np.ndarray | wp.array,
-    rgb: torch.Tensor | wp.array | np.ndarray | tuple[float, float, float] = None,
+    rgb: torch.Tensor | wp.array | np.ndarray | tuple[float, float, float] | list[float] = None,
     normalize_rgb: bool = False,
     position: Sequence[float] | None = None,
     orientation: Sequence[float] | None = None,
@@ -172,8 +172,8 @@ def create_pointcloud_from_rgbd(
 
     - If a ``np.array``/``wp.array``/``torch.tensor`` of shape (H, W, 3), then the corresponding channels
       encode the RGB values.
-    - If a tuple, then the point cloud has a single color specified by the values (r, g, b).
-    - If None, then default color is white, i.e. (0, 0, 0).
+    - If a tuple or list, then the point cloud has a single color specified by the values (r, g, b).
+    - If None, then default color is black, i.e. (0, 0, 0).
 
     If the input ``normalize_rgb`` is set to :obj:`True`, then the RGB values are normalized to be in the range [0, 1].
 
@@ -197,7 +197,7 @@ def create_pointcloud_from_rgbd(
         ValueError:  When rgb image is a numpy array but not of shape (H, W, 3) or (H, W, 4).
     """
     # check valid inputs
-    if rgb is not None and not isinstance(rgb, tuple):
+    if rgb is not None and not isinstance(rgb, (tuple, list)):
         if len(rgb.shape) == 3:
             if rgb.shape[2] not in [3, 4]:
                 raise ValueError(f"Input rgb image of invalid shape: {rgb.shape} != (H, W, 3) or (H, W, 4).")
@@ -232,12 +232,12 @@ def create_pointcloud_from_rgbd(
             points_rgb = rgb.permute(1, 0, 2).reshape(-1, 3)
         elif isinstance(rgb, (tuple, list)):
             # same color for all points
-            points_rgb = torch.Tensor((rgb,) * num_points, device=device, dtype=torch.uint8)
+            points_rgb = torch.tensor((rgb,) * num_points, device=device, dtype=torch.uint8)
         else:
-            # default color is white
-            points_rgb = torch.Tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
+            # default color is black
+            points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
     else:
-        points_rgb = torch.Tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
+        points_rgb = torch.tensor(((0, 0, 0),) * num_points, device=device, dtype=torch.uint8)
     # normalize color values
     if normalize_rgb:
         points_rgb = points_rgb.float() / 255

--- a/source/isaaclab/test/sensors/test_camera_utils.py
+++ b/source/isaaclab/test/sensors/test_camera_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from isaaclab.sensors.camera.utils import create_pointcloud_from_rgbd
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("rgb", [(255, 0, 0), [0, 255, 0]])
+def test_create_pointcloud_from_rgbd_constant_color(rgb):
+    """Constant tuple/list colors should be expanded across every point."""
+    depth = torch.ones((2, 2), dtype=torch.float32)
+    intrinsic_matrix = torch.eye(3, dtype=torch.float32)
+
+    points, colors = create_pointcloud_from_rgbd(intrinsic_matrix, depth, rgb=rgb, device="cpu")
+
+    assert points.shape == (4, 3)
+    expected = torch.tensor(rgb, dtype=torch.uint8).expand(4, -1)
+    assert torch.equal(colors, expected)
+
+
+def test_create_pointcloud_from_rgbd_default_color():
+    """Missing RGB data should use the documented black fallback without raising."""
+    depth = torch.ones((2, 2), dtype=torch.float32)
+    intrinsic_matrix = torch.eye(3, dtype=torch.float32)
+
+    points, colors = create_pointcloud_from_rgbd(intrinsic_matrix, depth, rgb=None, device="cpu")
+
+    assert points.shape == (4, 3)
+    assert torch.equal(colors, torch.zeros((4, 3), dtype=torch.uint8))

--- a/source/isaaclab/test/sensors/test_camera_utils.py
+++ b/source/isaaclab/test/sensors/test_camera_utils.py
@@ -24,6 +24,15 @@ def test_create_pointcloud_from_rgbd_constant_color(rgb):
     assert torch.equal(colors, expected)
 
 
+def test_create_pointcloud_from_rgbd_rejects_invalid_constant_color_width():
+    """Constant colors must contain exactly RGB components."""
+    depth = torch.ones((2, 2), dtype=torch.float32)
+    intrinsic_matrix = torch.eye(3, dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="exactly three components"):
+        create_pointcloud_from_rgbd(intrinsic_matrix, depth, rgb=[255, 0], device="cpu")
+
+
 def test_create_pointcloud_from_rgbd_default_color():
     """Missing RGB data should use the documented black fallback without raising."""
     depth = torch.ones((2, 2), dtype=torch.float32)


### PR DESCRIPTION
# Description

Fixes the constant-color paths in `create_pointcloud_from_rgbd()`.

The tuple/list and no-RGB branches currently construct colors with `torch.Tensor(..., device=..., dtype=...)`, which is not a valid PyTorch constructor call and raises `TypeError`. This replaces those calls with `torch.tensor(...)`, aligns list validation/type hints with the implementation, and corrects the documented default color from white to black `(0, 0, 0)`.

Regression tests cover tuple colors, list colors, and the `rgb=None` fallback.

## Type of change

- Bug fix

## Validation

- Verified the failing constructor with PyTorch 2.10.0.
- Added `pytest.mark.unit` regression tests in `test_camera_utils.py`.
- Diff is limited to the camera utility, its tests, and the `isaaclab` changelog fragment.
- Full Isaac Lab test suite was not run locally.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added regression tests for the fix
- [x] I have added the required changelog fragment
- [x] No new dependencies
