### PR TITLE
Align camera output guide with current tutorial

### DIFF
--- a/docs/source/how-to/save_camera_output.rst
+++ b/docs/source/how-to/save_camera_output.rst
@@ -93,7 +93,7 @@ To run the accompanying script, execute the following command:
 .. code-block:: bash
 
    # Usage with saving and drawing
-   uv run python scripts/tutorials/04_sensors/run_usd_camera.py --save --draw
+   uv run python scripts/tutorials/04_sensors/run_usd_camera.py --save --draw --viz kit
 
    # Usage with saving only (no visualizer)
    uv run python scripts/tutorials/04_sensors/run_usd_camera.py --save

--- a/docs/source/how-to/save_camera_output.rst
+++ b/docs/source/how-to/save_camera_output.rst
@@ -75,8 +75,9 @@ to create a point cloud from the depth image and transform it to the world frame
    :start-at: # Derive pointcloud from camera at camera_index
    :end-before: # In the first few steps, things are still being instanced and Camera.data
 
-The resulting point cloud can be visualized using the :mod:`isaacsim.util.debug_draw` extension from Isaac Sim.
-This makes it easy to visualize the point cloud in the 3D space.
+The resulting point cloud can be visualized with Isaac Lab's :class:`~isaaclab.markers.VisualizationMarkers`.
+The accompanying tutorial uses :data:`~isaaclab.markers.config.RAY_CASTER_MARKER_CFG` and calls
+:meth:`~isaaclab.markers.VisualizationMarkers.visualize` to draw the points in the viewport.
 
 .. literalinclude:: ../../../scripts/tutorials/04_sensors/run_usd_camera.py
    :language: python
@@ -92,10 +93,10 @@ To run the accompanying script, execute the following command:
 .. code-block:: bash
 
    # Usage with saving and drawing
-   python scripts/tutorials/04_sensors/run_usd_camera.py --save --draw
+   uv run python scripts/tutorials/04_sensors/run_usd_camera.py --save --draw
 
    # Usage with saving only (no visualizer)
-   python scripts/tutorials/04_sensors/run_usd_camera.py --save
+   uv run python scripts/tutorials/04_sensors/run_usd_camera.py --save
 
 
 The simulation should start, and you can observe different objects falling down. An output folder will be created

--- a/docs/source/how-to/save_camera_output.rst
+++ b/docs/source/how-to/save_camera_output.rst
@@ -76,7 +76,7 @@ to create a point cloud from the depth image and transform it to the world frame
    :end-before: # In the first few steps, things are still being instanced and Camera.data
 
 The resulting point cloud can be visualized with Isaac Lab's :class:`~isaaclab.markers.VisualizationMarkers`.
-The accompanying tutorial uses :data:`~isaaclab.markers.config.RAY_CASTER_MARKER_CFG` and calls
+The accompanying tutorial uses ``RAY_CASTER_MARKER_CFG`` and calls
 :meth:`~isaaclab.markers.VisualizationMarkers.visualize` to draw the points in the viewport.
 
 .. literalinclude:: ../../../scripts/tutorials/04_sensors/run_usd_camera.py


### PR DESCRIPTION
# Description

Updates the camera output guide to match the current `run_usd_camera.py` tutorial.

The guide still says point clouds are drawn through Isaac Sim's `isaacsim.util.debug_draw`, but the current tutorial uses Isaac Lab `VisualizationMarkers` with `RAY_CASTER_MARKER_CFG`. The text now documents the actual implementation.

The execution examples are also updated to use the repository's current `uv run python` invocation style.

## Type of change

- Documentation fix

## Validation

- Diff is limited to `docs/source/how-to/save_camera_output.rst`.
- Documentation now matches the imports and visualization calls in the current tutorial.
- No runtime code or dependencies are changed.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] Documentation-only change
- [x] No runtime behavior changes
