### PR TITLE
Fix deprecated viewer camera path warning

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Emit the deprecated ``ViewerCfg.cam_prim_path`` migration warning when the camera prim path is the only legacy viewer setting that changed.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-* Emitted the deprecated ``ViewerCfg.cam_prim_path`` migration warning when the camera prim path is the only legacy viewer setting that changed.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.patch.rst
@@ -1,4 +1,4 @@
 Fixed
 -----
 
-* Emit the deprecated ``ViewerCfg.cam_prim_path`` migration warning when the camera prim path is the only legacy viewer setting that changed.
+* Emitted the deprecated ``ViewerCfg.cam_prim_path`` migration warning when the camera prim path is the only legacy viewer setting that changed.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-viewer-cam-prim-warning.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Emitted the deprecated ``ViewerCfg.cam_prim_path`` migration warning when the camera prim path is the only legacy viewer setting that changed.

--- a/source/isaaclab/isaaclab/envs/common.py
+++ b/source/isaaclab/isaaclab/envs/common.py
@@ -226,7 +226,7 @@ The tuple contains batched information for each sub-environment. The information
 2. **Rewards**: The rewards from the environment.
 3. **Terminated Dones**: Whether the environment reached a terminal state, such as task success or robot falling etc.
 4. **Timeout Dones**: Whether the environment reached a timeout state, such as end of max episode length.
-5. **Extras**: A dictionary containing additional information about the environment.
+5. **Extras**: A dictionary containing additional information from the environment.
 """
 
 AgentID = TypeVar("AgentID")
@@ -263,5 +263,5 @@ The information is stored in the following order:
 2. **Rewards**: The rewards from the environment.
 3. **Terminated Dones**: Whether the environment reached a terminal state, such as task success or robot falling etc.
 4. **Timeout Dones**: Whether the environment reached a timeout state, such as end of max episode length.
-5. **Extras**: A dictionary containing additional information about the environment.
+5. **Extras**: A dictionary containing additional information from the environment.
 """

--- a/source/isaaclab/isaaclab/envs/common.py
+++ b/source/isaaclab/isaaclab/envs/common.py
@@ -124,9 +124,6 @@ def _apply_deprecated_viewer_cfg(env_cfg: object) -> None:
     )
     cam_prim_path_changed = getattr(viewer, "cam_prim_path", _defaults.cam_prim_path) != _defaults.cam_prim_path
 
-    if not (eye_changed or lookat_changed or origin_changed or resolution_changed or cam_prim_path_changed):
-        return
-
     if cam_prim_path_changed:
         _logging.getLogger(__name__).warning(
             "env_cfg.viewer.cam_prim_path=%r cannot be automatically forwarded to KitVisualizerCfg "
@@ -134,6 +131,9 @@ def _apply_deprecated_viewer_cfg(env_cfg: object) -> None:
             "a custom KitVisualizerCfg in env_cfg.sim.visualizer_cfgs.",
             viewer.cam_prim_path,
         )
+
+    if not (eye_changed or lookat_changed or origin_changed or resolution_changed):
+        return
 
     _logging.getLogger(__name__).warning(
         "env_cfg.viewer is deprecated. Set env_cfg.sim.default_visualizer_cfg = "
@@ -226,7 +226,7 @@ The tuple contains batched information for each sub-environment. The information
 2. **Rewards**: The rewards from the environment.
 3. **Terminated Dones**: Whether the environment reached a terminal state, such as task success or robot falling etc.
 4. **Timeout Dones**: Whether the environment reached a timeout state, such as end of max episode length.
-5. **Extras**: A dictionary containing additional information from the environment.
+5. **Extras**: A dictionary containing additional information about the environment.
 """
 
 AgentID = TypeVar("AgentID")
@@ -263,5 +263,5 @@ The information is stored in the following order:
 2. **Rewards**: The rewards from the environment.
 3. **Terminated Dones**: Whether the environment reached a terminal state, such as task success or robot falling etc.
 4. **Timeout Dones**: Whether the environment reached a timeout state, such as end of max episode length.
-5. **Extras**: A dictionary containing additional information from the environment.
+5. **Extras**: A dictionary containing additional information about the environment.
 """

--- a/source/isaaclab/isaaclab/envs/common.py
+++ b/source/isaaclab/isaaclab/envs/common.py
@@ -256,7 +256,8 @@ EnvStepReturn = tuple[
 ]
 """The environment signals processed at the end of each step.
 
-The tuple contains batched information for each sub-environment (keyed by the agent ID). The information is stored in the following order:
+The tuple contains batched information for each sub-environment (keyed by the agent ID).
+The information is stored in the following order:
 
 1. **Observations**: The observations from the environment.
 2. **Rewards**: The rewards from the environment.

--- a/source/isaaclab/isaaclab/envs/common.py
+++ b/source/isaaclab/isaaclab/envs/common.py
@@ -124,7 +124,7 @@ def _apply_deprecated_viewer_cfg(env_cfg: object) -> None:
     )
     cam_prim_path_changed = getattr(viewer, "cam_prim_path", _defaults.cam_prim_path) != _defaults.cam_prim_path
 
-    if not (eye_changed or lookat_changed or origin_changed or resolution_changed):
+    if not (eye_changed or lookat_changed or origin_changed or resolution_changed or cam_prim_path_changed):
         return
 
     if cam_prim_path_changed:
@@ -256,8 +256,7 @@ EnvStepReturn = tuple[
 ]
 """The environment signals processed at the end of each step.
 
-The tuple contains batched information for each sub-environment (keyed by the agent ID).
-The information is stored in the following order:
+The tuple contains batched information for each sub-environment (keyed by the agent ID). The information is stored in the following order:
 
 1. **Observations**: The observations from the environment.
 2. **Rewards**: The rewards from the environment.

--- a/source/isaaclab/test/envs/test_viewer_cfg_deprecation.py
+++ b/source/isaaclab/test/envs/test_viewer_cfg_deprecation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from types import SimpleNamespace
 
 import pytest
 
@@ -66,10 +67,10 @@ def test_viewer_cfg_warning_is_deprecation_warning_subclass():
 
 
 def test_viewer_cfg_cam_prim_path_only_change_emits_migration_warning(caplog):
-    """A legacy camera-path override must not be silently ignored during migration."""
+    """A legacy camera-path override should warn without forwarding unrelated viewer defaults."""
 
     class EnvCfg:
-        sim = None
+        sim = SimpleNamespace(default_visualizer_cfg=None)
 
     env_cfg = EnvCfg()
     with warnings.catch_warnings():
@@ -80,3 +81,5 @@ def test_viewer_cfg_cam_prim_path_only_change_emits_migration_warning(caplog):
         _apply_deprecated_viewer_cfg(env_cfg)
 
     assert "cam_prim_path='/World/CustomCamera' cannot be automatically forwarded" in caplog.text
+    assert "viewer values have been automatically forwarded" not in caplog.text
+    assert env_cfg.sim.default_visualizer_cfg is None

--- a/source/isaaclab/test/envs/test_viewer_cfg_deprecation.py
+++ b/source/isaaclab/test/envs/test_viewer_cfg_deprecation.py
@@ -10,11 +10,12 @@ No simulation context or Kit app required — pure Python.
 
 from __future__ import annotations
 
+import logging
 import warnings
 
 import pytest
 
-from isaaclab.envs.common import ViewerCfg
+from isaaclab.envs.common import ViewerCfg, _apply_deprecated_viewer_cfg
 
 
 def test_viewer_cfg_default_no_warning():
@@ -62,3 +63,20 @@ def test_viewer_cfg_warning_is_deprecation_warning_subclass():
         ViewerCfg(eye=(0.0, 0.0, 1.0))
 
     assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_viewer_cfg_cam_prim_path_only_change_emits_migration_warning(caplog):
+    """A legacy camera-path override must not be silently ignored during migration."""
+
+    class EnvCfg:
+        sim = None
+
+    env_cfg = EnvCfg()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        env_cfg.viewer = ViewerCfg(cam_prim_path="/World/CustomCamera")
+
+    with caplog.at_level(logging.WARNING, logger="isaaclab.envs.common"):
+        _apply_deprecated_viewer_cfg(env_cfg)
+
+    assert "cam_prim_path='/World/CustomCamera' cannot be automatically forwarded" in caplog.text


### PR DESCRIPTION
# Description

Fixes a silent migration edge case in the deprecated `ViewerCfg` compatibility shim.

_apply_deprecated_viewer_cfg() already detects a non-default cam_prim_path and contains a warning explaining that the value cannot be forwarded to KitVisualizerCfg. The warning is now emitted before the existing early-return guard for forwardable viewer settings, so a camera-path-only override is reported without entering the unrelated viewer-migration path or modifying sim.default_visualizer_cfg.
## Type of change

- Bug fix

## Validation

- Extended the existing `test_viewer_cfg_deprecation.py` unit coverage.
- Regression test configures only `ViewerCfg.cam_prim_path` and verifies the migration warning is emitted.
- Source change is one condition only; no behavior changes for default ViewerCfg or other migrated viewer fields.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
