### PR TITLE
Support non-contiguous LinearInterpolation queries

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Allow :class:`LinearInterpolation` to evaluate non-contiguous query tensors while preserving their original shape.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
@@ -1,4 +1,4 @@
 Fixed
 -----
 
-* Allow :class:`LinearInterpolation` to evaluate non-contiguous query tensors while preserving their original shape.
+* Allowed :class:`LinearInterpolation` to evaluate non-contiguous query tensors while preserving their original shape.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.patch.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-* Allowed :class:`LinearInterpolation` to evaluate non-contiguous query tensors while preserving their original shape.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-linear-interpolation-reshape.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Allowed :class:`LinearInterpolation` to evaluate non-contiguous query tensors while preserving their original shape.

--- a/source/isaaclab/isaaclab/utils/interpolation/linear_interpolation.py
+++ b/source/isaaclab/isaaclab/utils/interpolation/linear_interpolation.py
@@ -60,8 +60,8 @@ class LinearInterpolation:
         Returns:
             The interpolated values at query points. It has the same shape as the input tensor.
         """
-        # serialized q
-        q_1d = q.view(-1)
+        # serialize q; reshape also supports non-contiguous query tensors
+        q_1d = q.reshape(-1)
         # Number of elements in the x that are strictly smaller than query points (use int32 instead of int64)
         num_smaller_elements = torch.sum(self._x.unsqueeze(1) < q_1d.unsqueeze(0), dim=0, dtype=torch.int)
 
@@ -80,6 +80,6 @@ class LinearInterpolation:
         # Perform linear interpolation
         fq = self._y[lower_bound] + weight * (self._y[upper_bound] - self._y[lower_bound])
 
-        # deserialized fq
-        fq = fq.view(q.shape)
+        # deserialize fq
+        fq = fq.reshape(q.shape)
         return fq

--- a/source/isaaclab/test/utils/test_linear_interpolation.py
+++ b/source/isaaclab/test/utils/test_linear_interpolation.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from isaaclab.utils.interpolation import LinearInterpolation
+
+pytestmark = pytest.mark.unit
+
+
+def test_compute_accepts_noncontiguous_query_tensor():
+    """Arbitrarily shaped query tensors should not need contiguous storage."""
+    interpolation = LinearInterpolation(
+        x=torch.tensor([0.0, 1.0, 2.0, 3.0]),
+        y=torch.tensor([0.0, 10.0, 20.0, 30.0]),
+        device="cpu",
+    )
+    query = torch.tensor([[0.5, 1.5, 2.5], [3.0, 2.0, 1.0]]).T
+    assert not query.is_contiguous()
+
+    output = interpolation.compute(query)
+
+    assert output.shape == query.shape
+    torch.testing.assert_close(output, query * 10.0)


### PR DESCRIPTION
# Description

Allows `LinearInterpolation.compute()` to accept non-contiguous query tensors.

The method documents that query points may have an arbitrary shape, but it currently flattens them with `q.view(-1)`. `view()` requires a compatible contiguous layout, so valid tensors produced by operations such as transpose can raise a runtime error.

Using `reshape()` preserves the existing zero-copy behavior when possible and transparently handles non-contiguous inputs when a copy is required. The result is reshaped back to the original query shape in the same way.

## Type of change

- Bug fix

## Validation

- Added a unit regression test using a transposed, explicitly non-contiguous query tensor.
- Test verifies output values and preservation of the original query shape.
- Contiguous-query behavior and interpolation math are unchanged.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
