### PR TITLE
Fix JointPositionToLimitsAction IO descriptor

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.patch.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-* Fixed ``JointPositionToLimitsAction.IO_descriptor`` raising when reporting its implicit zero offset.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed ``JointPositionToLimitsAction.IO_descriptor`` raising when reporting its implicit zero offset.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-joint-limits-io-offset.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed ``JointPositionToLimitsAction.IO_descriptor`` raising when reporting its implicit zero offset.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions_to_limits.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions_to_limits.py
@@ -137,11 +137,7 @@ class JointPositionToLimitsAction(ActionTerm):
         self._IO_descriptor.action_type = "JointAction"
         self._IO_descriptor.joint_names = self._joint_names
         self._IO_descriptor.scale = self._scale
-        # This seems to be always [4xNum_joints] IDK why. Need to check.
-        if isinstance(self._offset, torch.Tensor):
-            self._IO_descriptor.offset = self._offset[0].detach().cpu().numpy().tolist()
-        else:
-            self._IO_descriptor.offset = self._offset
+        self._IO_descriptor.offset = 0.0
         if self.cfg.clip is not None:
             self._IO_descriptor.clip = self._clip
         else:

--- a/source/isaaclab/test/envs/test_joint_limits_action_io_descriptor.py
+++ b/source/isaaclab/test/envs/test_joint_limits_action_io_descriptor.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from isaaclab.envs.mdp.actions.actions_cfg import JointPositionToLimitsActionCfg
+from isaaclab.envs.mdp.actions.joint_actions_to_limits import JointPositionToLimitsAction
+
+pytestmark = pytest.mark.unit
+
+
+class _JointIds:
+    def __init__(self, count: int):
+        self.torch = torch.arange(count, dtype=torch.int64)
+
+    def __len__(self) -> int:
+        return len(self.torch)
+
+
+class _FakeAsset:
+    num_joints = 2
+
+    def find_joints(self, *_args, **_kwargs):
+        return _JointIds(2), ["joint_left", "joint_right"]
+
+
+class _FakeEnv:
+    num_envs = 2
+    device = "cpu"
+
+    def __init__(self):
+        self.scene = {"robot": _FakeAsset()}
+
+
+def test_joint_position_to_limits_io_descriptor_has_zero_offset():
+    """The descriptor should report the term's implicit zero offset without accessing a missing attribute."""
+    cfg = JointPositionToLimitsActionCfg(
+        asset_name="robot",
+        joint_names=["joint_.*"],
+        rescale_to_limits=False,
+    )
+
+    action = JointPositionToLimitsAction(cfg, _FakeEnv())
+    descriptor = action.IO_descriptor
+
+    assert descriptor.offset == 0.0
+    assert descriptor.joint_names == ["joint_left", "joint_right"]
+    assert descriptor.shape == (2,)


### PR DESCRIPTION
# Description

Fixes `JointPositionToLimitsAction.IO_descriptor` raising `AttributeError`.

The descriptor implementation references `self._offset`, copied from the generic joint-action descriptor path. `JointPositionToLimitsAction` does not define an offset and its configuration has no offset field, so descriptor export can fail even though the action term itself is valid.

The descriptor now reports `offset = 0.0`, matching the action term's actual processing (`processed = raw * scale` before optional clipping and limit rescaling).

## Type of change

- Bug fix

## Validation

- Added a unit regression test that constructs the action term and reads its IO descriptor.
- Verifies the descriptor reports zero offset, resolved joint names, and action shape.
- Before the fix, descriptor access raises `AttributeError`.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
