### PR TITLE
Fix NonHolonomicAction IO descriptor without clipping

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.patch.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-* Fixed ``NonHolonomicAction.IO_descriptor`` when clipping is left at its default ``None`` value.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed ``NonHolonomicAction.IO_descriptor`` when clipping is left at its default ``None`` value.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-nonholonomic-io-clip.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed ``NonHolonomicAction.IO_descriptor`` when clipping is left at its default ``None`` value.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/non_holonomic_actions.py
@@ -161,7 +161,7 @@ class NonHolonomicAction(ActionTerm):
         self._IO_descriptor.action_type = "non holonomic actions"
         self._IO_descriptor.scale = self._scale
         self._IO_descriptor.offset = self._offset
-        self._IO_descriptor.clip = self._clip
+        self._IO_descriptor.clip = self._clip if self.cfg.clip is not None else None
         self._IO_descriptor.body_name = self._body_name
         self._IO_descriptor.x_joint_name = self._joint_names[0]
         self._IO_descriptor.y_joint_name = self._joint_names[1]

--- a/source/isaaclab/test/envs/test_nonholonomic_action_io_descriptor.py
+++ b/source/isaaclab/test/envs/test_nonholonomic_action_io_descriptor.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import pytest
+
+from isaaclab.envs.mdp.actions.actions_cfg import NonHolonomicActionCfg
+from isaaclab.envs.mdp.actions.non_holonomic_actions import NonHolonomicAction
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeAsset:
+    def find_joints(self, name):
+        mapping = {
+            "base_x": ([0], ["base_x"]),
+            "base_y": ([1], ["base_y"]),
+            "base_yaw": ([2], ["base_yaw"]),
+        }
+        return mapping[name]
+
+    def find_bodies(self, _name):
+        return [0], ["base"]
+
+
+class _FakeEnv:
+    num_envs = 2
+    device = "cpu"
+
+    def __init__(self):
+        self.scene = {"robot": _FakeAsset()}
+
+
+def test_nonholonomic_io_descriptor_without_clip():
+    """Default clip=None must produce a descriptor instead of reading an uninitialized _clip attribute."""
+    cfg = NonHolonomicActionCfg(
+        asset_name="robot",
+        body_name="base",
+        x_joint_name="base_x",
+        y_joint_name="base_y",
+        yaw_joint_name="base_yaw",
+    )
+
+    action = NonHolonomicAction(cfg, _FakeEnv())
+    descriptor = action.IO_descriptor
+
+    assert descriptor.clip is None
+    assert descriptor.shape == (2,)
+    assert descriptor.x_joint_name == "base_x"
+    assert descriptor.y_joint_name == "base_y"
+    assert descriptor.yaw_joint_name == "base_yaw"


### PR DESCRIPTION
# Description

Fixes `NonHolonomicAction.IO_descriptor` for the default `clip=None` configuration.

`_clip` is only allocated when a clip dictionary is configured, but the descriptor previously accessed `self._clip` unconditionally. As a result, exporting or inspecting the action descriptor could raise `AttributeError` for an otherwise valid default action configuration.

The descriptor now reports `clip = None` when clipping is disabled and retains the existing tensor value when clipping is configured.

## Type of change

- Bug fix

## Validation

- Added a unit regression test using the default no-clip configuration.
- Verifies descriptor shape, resolved joint names, and `clip is None`.
- Before the fix, descriptor access raises `AttributeError`.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
