### PR TITLE
Fix multi-joint clipping for binary joint actions

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed per-joint clipping for binary joint actions when one binary input controls multiple joints.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.patch.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-* Fixed per-joint clipping for binary joint actions when one binary input controls multiple joints.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-binary-joint-clip.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed per-joint clipping for binary joint actions when one binary input controls multiple joints.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/binary_joint_actions.py
@@ -93,7 +93,7 @@ class BinaryJointAction(ActionTerm):
         if self.cfg.clip is not None:
             if isinstance(cfg.clip, dict):
                 self._clip = torch.tensor([[-float("inf"), float("inf")]], device=self.device).repeat(
-                    self.num_envs, self.action_dim, 1
+                    self.num_envs, self._num_joints, 1
                 )
                 index_list, _, value_list = string_utils.resolve_matching_names_values(self.cfg.clip, self._joint_names)
                 self._clip[:, index_list] = torch.tensor(value_list, device=self.device)

--- a/source/isaaclab/test/envs/test_binary_joint_action_clip.py
+++ b/source/isaaclab/test/envs/test_binary_joint_action_clip.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.envs.mdp.actions.actions_cfg import BinaryJointPositionActionCfg
+from isaaclab.envs.mdp.actions.binary_joint_actions import BinaryJointPositionAction
+
+
+class _JointIds:
+    def __init__(self, count: int):
+        self.warp = torch.arange(count, dtype=torch.int32)
+
+    def __len__(self) -> int:
+        return len(self.warp)
+
+
+class _FakeAsset:
+    num_joints = 2
+
+    def find_joints(self, *_args, **_kwargs):
+        return _JointIds(2), ["finger_left", "finger_right"]
+
+
+class _FakeEnv:
+    num_envs = 2
+    device = "cpu"
+
+    def __init__(self):
+        self.scene = {"robot": _FakeAsset()}
+
+
+def test_binary_joint_action_clip_uses_processed_joint_dimension():
+    """Per-joint clipping must cover every processed gripper joint, not the 1-D binary input."""
+    cfg = BinaryJointPositionActionCfg(
+        asset_name="robot",
+        joint_names=["finger_.*"],
+        open_command_expr={"finger_left": 1.0, "finger_right": 2.0},
+        close_command_expr={"finger_left": -1.0, "finger_right": -2.0},
+        clip={"finger_left": (-0.5, 0.5), "finger_right": (-1.5, 1.5)},
+    )
+
+    action = BinaryJointPositionAction(cfg, _FakeEnv())
+    action.process_actions(torch.ones((2, 1), dtype=torch.float32))
+
+    expected = torch.tensor([[0.5, 1.5], [0.5, 1.5]])
+    torch.testing.assert_close(action.processed_actions, expected)

--- a/source/isaaclab/test/envs/test_binary_joint_action_clip.py
+++ b/source/isaaclab/test/envs/test_binary_joint_action_clip.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from isaaclab.envs.mdp.actions.actions_cfg import BinaryJointPositionActionCfg
 from isaaclab.envs.mdp.actions.binary_joint_actions import BinaryJointPositionAction
+
+pytestmark = pytest.mark.unit
 
 
 class _JointIds:


### PR DESCRIPTION
# Description

Fixes per-joint clipping for binary joint actions when one binary input controls multiple joints.

`BinaryJointAction` has a one-dimensional raw action, but maps that value to one processed command per resolved joint. Clip ranges are resolved against those joint names and applied to `processed_actions`, yet the clip tensor was allocated with `action_dim == 1`. A multi-joint gripper therefore fails when a clip entry resolves to joint index 1 or later.

The clip tensor now uses the processed joint count (`_num_joints`), matching the command it clamps.

## Type of change

- Bug fix

## Validation

- Added a unit regression test with a two-joint gripper and separate clip ranges.
- The test verifies both joints are clipped correctly.
- Before the fix, assigning the second joint's clip range fails.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
