### PR TITLE
Allow IO descriptors on functions without docstrings

### DIFF
--- a/docs/source/policy_deployment/01_io_descriptors/io_descriptors_101.rst
+++ b/docs/source/policy_deployment/01_io_descriptors/io_descriptors_101.rst
@@ -141,7 +141,8 @@ We are also attaching an IO descriptor to this term. The IO descriptor is define
 
 The ``@generic_io_descriptor`` decorator is a special decorator that is used to attach an IO descriptor to a custom observation term.
 It takes arbitrary arguments that are used to describe the observation term, in this case we provide extra information that could be
-useful for the end user:
+useful for the end user. If ``description`` is omitted, the decorator uses the function docstring when one is present; if the
+function has no docstring, the descriptor's ``description`` remains ``None``.
 
 - ``units``: The units of the observation term.
 - ``axes``: The axes of the observation term.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.patch.rst
@@ -1,0 +1,3 @@
+Bug Fixes
+---------
+* Allowed generic IO descriptors to decorate functions without docstrings when no explicit description is provided.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.patch.rst
@@ -1,3 +1,0 @@
-Bug Fixes
----------
-* Allowed generic IO descriptors to decorate functions without docstrings when no explicit description is provided.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-io-descriptor-docstring.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Allowed generic IO descriptors to decorate functions without docstrings when no explicit description is provided.

--- a/source/isaaclab/isaaclab/envs/utils/io_descriptors.py
+++ b/source/isaaclab/isaaclab/envs/utils/io_descriptors.py
@@ -232,7 +232,7 @@ def generic_io_descriptor(
         descriptor.full_path = f"{func.__module__}.{func.__name__}"
         descriptor.dtype = str(descriptor.dtype)
         # Check if description is set in the descriptor
-        if descriptor.description is None:
+        if descriptor.description is None and func.__doc__ is not None:
             descriptor.description = " ".join(func.__doc__.split())
 
         # Adds the descriptor to the wrapped function as an attribute

--- a/source/isaaclab/test/envs/test_io_descriptor_missing_docstring.py
+++ b/source/isaaclab/test/envs/test_io_descriptor_missing_docstring.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from isaaclab.envs.utils.io_descriptors import generic_io_descriptor
+
+pytestmark = pytest.mark.unit
+
+
+def test_generic_io_descriptor_accepts_function_without_docstring():
+    def observation(env):
+        return env
+
+    assert observation.__doc__ is None
+
+    decorated = generic_io_descriptor()(observation)
+
+    assert decorated._descriptor.description is None
+    marker = object()
+    assert decorated(marker) is marker


### PR DESCRIPTION
# Description

Allows `@generic_io_descriptor` to decorate functions that do not have a docstring when no explicit descriptor description is supplied.

The decorator currently tries to populate a missing description with `" ".join(func.__doc__.split())`. For a valid Python function without a docstring, `func.__doc__` is `None`, so decoration raises `AttributeError` before the function can be used.

The descriptor schema already permits `description=None`. The decorator now copies the function docstring only when one exists, otherwise leaving the description unset.

## Type of change

- Bug fix

## Validation

- Added a `pytest.mark.unit` regression test using a function with no docstring.
- Verifies decoration succeeds, `description` remains `None`, and the wrapped function still executes normally.
- Existing behavior for functions with docstrings or explicit descriptions is unchanged.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
