### PR TITLE
Remove stray ActionManager descriptor output

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.patch.rst
@@ -1,0 +1,3 @@
+Bug Fixes
+---------
+* Removed stray debug output from action IO descriptor export.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.patch.rst
@@ -1,3 +1,0 @@
-Bug Fixes
----------
-* Removed stray debug output from action IO descriptor export.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-action-descriptor-stdout.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Removed stray debug output from action IO descriptor export.

--- a/source/isaaclab/isaaclab/managers/action_manager.py
+++ b/source/isaaclab/isaaclab/managers/action_manager.py
@@ -292,7 +292,6 @@ class ActionManager(ManagerBase):
         for item in data:
             name = item.pop("name")
             formatted_item = {"name": name, "extras": item.pop("extras")}
-            print(item["export"])
             if not item.pop("export"):
                 continue
             for k, v in item.items():

--- a/source/isaaclab/test/managers/test_action_manager_io_descriptor_output.py
+++ b/source/isaaclab/test/managers/test_action_manager_io_descriptor_output.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab.envs.utils.io_descriptors import GenericActionIODescriptor
+from isaaclab.managers.action_manager import ActionManager
+
+pytestmark = pytest.mark.unit
+
+
+def test_action_descriptor_export_does_not_write_to_stdout(capsys):
+    """Exporting valid action descriptors should not emit debug output."""
+    descriptor = GenericActionIODescriptor(
+        name="test_action",
+        full_path="tests.TestAction",
+        description="Test action",
+        shape=(1,),
+        dtype="torch.float32",
+        export=True,
+    )
+    manager = ActionManager.__new__(ActionManager)
+    manager._terms = {"test": SimpleNamespace(IO_descriptor=descriptor)}
+
+    exported = manager.get_IO_descriptors
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert len(exported) == 1
+    assert exported[0]["name"] == "test_action"

--- a/source/isaaclab/test/managers/test_action_manager_io_descriptor_output.py
+++ b/source/isaaclab/test/managers/test_action_manager_io_descriptor_output.py
@@ -24,6 +24,7 @@ def test_action_descriptor_export_does_not_write_to_stdout(capsys):
         export=True,
     )
     manager = ActionManager.__new__(ActionManager)
+    manager._resolve_terms_handle = None
     manager._terms = {"test": SimpleNamespace(IO_descriptor=descriptor)}
 
     exported = manager.get_IO_descriptors


### PR DESCRIPTION
# Description

Removes stray debug output from `ActionManager.get_IO_descriptors`.

Successful descriptor export currently executes `print(item["export"])` for every action term, so normal export writes unrelated `True` / `False` lines to stdout. The export flag is already consumed immediately afterwards and does not need to be printed.

This removes only that debug print. The existing error message for descriptors that actually fail to build is unchanged.

## Type of change

- Bug fix

## Validation

- Added a `pytest.mark.unit` regression test using a valid action descriptor.
- The test captures stdout and verifies successful descriptor export is silent.
- The exported descriptor content is still checked.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
