### PR TITLE
Reset deterministic algorithms when configure_seed disables them

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.patch.rst
@@ -1,0 +1,1 @@
+Fixed ``configure_seed`` so disabling deterministic mode also disables PyTorch deterministic algorithms enabled by an earlier call.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.patch.rst
@@ -1,1 +1,0 @@
-Fixed ``configure_seed`` so disabling deterministic mode also disables PyTorch deterministic algorithms enabled by an earlier call.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+* Fixed ``configure_seed`` so ``torch_deterministic=False`` actively disables PyTorch deterministic algorithms enabled by an earlier call.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-seed-deterministic-reset.rst
@@ -1,4 +1,4 @@
 Fixed
------
+^^^^^
 
 * Fixed ``configure_seed`` so ``torch_deterministic=False`` actively disables PyTorch deterministic algorithms enabled by an earlier call.

--- a/source/isaaclab/isaaclab/utils/seed.py
+++ b/source/isaaclab/isaaclab/utils/seed.py
@@ -16,7 +16,8 @@ def configure_seed(seed: int | None, torch_deterministic: bool = False) -> int:
 
     Args:
         seed: The random seed value. If None, generates a random seed.
-        torch_deterministic: If True, enables deterministic mode for torch operations.
+        torch_deterministic: Whether torch operations should use deterministic mode. ``True`` enables PyTorch
+            deterministic algorithms; ``False`` actively disables them, including a mode enabled by an earlier call.
 
     Returns:
         The seed value that was set.

--- a/source/isaaclab/isaaclab/utils/seed.py
+++ b/source/isaaclab/isaaclab/utils/seed.py
@@ -41,5 +41,6 @@ def configure_seed(seed: int | None, torch_deterministic: bool = False) -> int:
     else:
         torch.backends.cudnn.benchmark = True
         torch.backends.cudnn.deterministic = False
+        torch.use_deterministic_algorithms(False)
 
     return seed

--- a/source/isaaclab/test/utils/test_seed.py
+++ b/source/isaaclab/test/utils/test_seed.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import pytest
+import torch
+
+from isaaclab.utils.seed import configure_seed
+
+pytestmark = pytest.mark.unit
+
+
+def test_configure_seed_disables_deterministic_algorithms_when_requested():
+    """A non-deterministic call must undo deterministic-algorithm mode enabled by an earlier call."""
+    previous_algorithms = torch.are_deterministic_algorithms_enabled()
+    previous_benchmark = torch.backends.cudnn.benchmark
+    previous_cudnn_deterministic = torch.backends.cudnn.deterministic
+    previous_cublas_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+
+    try:
+        configure_seed(123, torch_deterministic=True)
+        assert torch.are_deterministic_algorithms_enabled()
+
+        configure_seed(123, torch_deterministic=False)
+        assert not torch.are_deterministic_algorithms_enabled()
+    finally:
+        torch.use_deterministic_algorithms(previous_algorithms)
+        torch.backends.cudnn.benchmark = previous_benchmark
+        torch.backends.cudnn.deterministic = previous_cudnn_deterministic
+        if previous_cublas_config is None:
+            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        else:
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = previous_cublas_config

--- a/source/isaaclab/test/utils/test_seed.py
+++ b/source/isaaclab/test/utils/test_seed.py
@@ -8,23 +8,33 @@ import os
 import pytest
 import torch
 
-from isaaclab.utils.seed import configure_seed
+import isaaclab.utils.seed as seed_utils
 
 pytestmark = pytest.mark.unit
 
 
-def test_configure_seed_disables_deterministic_algorithms_when_requested():
+def test_configure_seed_disables_deterministic_algorithms_when_requested(monkeypatch):
     """A non-deterministic call must undo deterministic-algorithm mode enabled by an earlier call."""
     previous_algorithms = torch.are_deterministic_algorithms_enabled()
     previous_benchmark = torch.backends.cudnn.benchmark
     previous_cudnn_deterministic = torch.backends.cudnn.deterministic
     previous_cublas_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    previous_pythonhashseed = os.environ.get("PYTHONHASHSEED")
+
+    # This regression only exercises the deterministic-algorithm transition. Avoid
+    # mutating unrelated process-global RNG states while calling configure_seed().
+    monkeypatch.setattr(seed_utils.random, "seed", lambda _seed: None)
+    monkeypatch.setattr(seed_utils.np.random, "seed", lambda _seed: None)
+    monkeypatch.setattr(seed_utils.torch, "manual_seed", lambda _seed: None)
+    monkeypatch.setattr(seed_utils.torch.cuda, "manual_seed", lambda _seed: None)
+    monkeypatch.setattr(seed_utils.torch.cuda, "manual_seed_all", lambda _seed: None)
+    monkeypatch.setattr(seed_utils.wp, "rand_init", lambda _seed: None)
 
     try:
-        configure_seed(123, torch_deterministic=True)
+        seed_utils.configure_seed(123, torch_deterministic=True)
         assert torch.are_deterministic_algorithms_enabled()
 
-        configure_seed(123, torch_deterministic=False)
+        seed_utils.configure_seed(123, torch_deterministic=False)
         assert not torch.are_deterministic_algorithms_enabled()
     finally:
         torch.use_deterministic_algorithms(previous_algorithms)
@@ -34,3 +44,7 @@ def test_configure_seed_disables_deterministic_algorithms_when_requested():
             os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
         else:
             os.environ["CUBLAS_WORKSPACE_CONFIG"] = previous_cublas_config
+        if previous_pythonhashseed is None:
+            os.environ.pop("PYTHONHASHSEED", None)
+        else:
+            os.environ["PYTHONHASHSEED"] = previous_pythonhashseed

--- a/source/isaaclab/test/utils/test_seed.py
+++ b/source/isaaclab/test/utils/test_seed.py
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import random
 
+import numpy as np
 import pytest
 import torch
 
@@ -20,25 +22,26 @@ def test_configure_seed_disables_deterministic_algorithms_when_requested(monkeyp
     previous_benchmark = torch.backends.cudnn.benchmark
     previous_cudnn_deterministic = torch.backends.cudnn.deterministic
     previous_env = {key: os.environ.get(key) for key in ("CUBLAS_WORKSPACE_CONFIG", "PYTHONHASHSEED")}
-
-    # Keep the regression focused on deterministic-mode state rather than RNG state.
-    monkeypatch.setattr(seed_utils.random, "seed", lambda _seed: None)
-    monkeypatch.setattr(seed_utils.np.random, "seed", lambda _seed: None)
-    monkeypatch.setattr(seed_utils.torch, "manual_seed", lambda _seed: None)
-    monkeypatch.setattr(seed_utils.torch.cuda, "manual_seed", lambda _seed: None)
-    monkeypatch.setattr(seed_utils.torch.cuda, "manual_seed_all", lambda _seed: None)
+    previous_random_state = random.getstate()
+    previous_numpy_state = np.random.get_state()
+    previous_torch_state = torch.get_rng_state()
+    previous_cuda_states = torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
     monkeypatch.setattr(seed_utils.wp, "rand_init", lambda _seed: None)
 
     try:
         seed_utils.configure_seed(123, torch_deterministic=True)
         assert torch.are_deterministic_algorithms_enabled()
-
         seed_utils.configure_seed(123, torch_deterministic=False)
         assert not torch.are_deterministic_algorithms_enabled()
     finally:
         torch.use_deterministic_algorithms(previous_algorithms, warn_only=previous_warn_only)
         torch.backends.cudnn.benchmark = previous_benchmark
         torch.backends.cudnn.deterministic = previous_cudnn_deterministic
+        random.setstate(previous_random_state)
+        np.random.set_state(previous_numpy_state)
+        torch.set_rng_state(previous_torch_state)
+        if previous_cuda_states is not None:
+            torch.cuda.set_rng_state_all(previous_cuda_states)
         for key, value in previous_env.items():
             if value is None:
                 os.environ.pop(key, None)

--- a/source/isaaclab/test/utils/test_seed.py
+++ b/source/isaaclab/test/utils/test_seed.py
@@ -16,13 +16,12 @@ pytestmark = pytest.mark.unit
 def test_configure_seed_disables_deterministic_algorithms_when_requested(monkeypatch):
     """A non-deterministic call must undo deterministic-algorithm mode enabled by an earlier call."""
     previous_algorithms = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
     previous_benchmark = torch.backends.cudnn.benchmark
     previous_cudnn_deterministic = torch.backends.cudnn.deterministic
-    previous_cublas_config = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
-    previous_pythonhashseed = os.environ.get("PYTHONHASHSEED")
+    previous_env = {key: os.environ.get(key) for key in ("CUBLAS_WORKSPACE_CONFIG", "PYTHONHASHSEED")}
 
-    # This regression only exercises the deterministic-algorithm transition. Avoid
-    # mutating unrelated process-global RNG states while calling configure_seed().
+    # Keep the regression focused on deterministic-mode state rather than RNG state.
     monkeypatch.setattr(seed_utils.random, "seed", lambda _seed: None)
     monkeypatch.setattr(seed_utils.np.random, "seed", lambda _seed: None)
     monkeypatch.setattr(seed_utils.torch, "manual_seed", lambda _seed: None)
@@ -37,14 +36,11 @@ def test_configure_seed_disables_deterministic_algorithms_when_requested(monkeyp
         seed_utils.configure_seed(123, torch_deterministic=False)
         assert not torch.are_deterministic_algorithms_enabled()
     finally:
-        torch.use_deterministic_algorithms(previous_algorithms)
+        torch.use_deterministic_algorithms(previous_algorithms, warn_only=previous_warn_only)
         torch.backends.cudnn.benchmark = previous_benchmark
         torch.backends.cudnn.deterministic = previous_cudnn_deterministic
-        if previous_cublas_config is None:
-            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
-        else:
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = previous_cublas_config
-        if previous_pythonhashseed is None:
-            os.environ.pop("PYTHONHASHSEED", None)
-        else:
-            os.environ["PYTHONHASHSEED"] = previous_pythonhashseed
+        for key, value in previous_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value


### PR DESCRIPTION
# Description

Fixes `configure_seed()` leaving PyTorch deterministic-algorithm mode enabled after deterministic mode is turned off.

Calling `configure_seed(..., torch_deterministic=True)` enables `torch.use_deterministic_algorithms(True)`. A later call with `torch_deterministic=False` resets the cuDNN benchmark/deterministic flags, but does not reset PyTorch's global deterministic-algorithm flag. The process therefore remains in deterministic mode despite the later configuration request.

This adds the matching `torch.use_deterministic_algorithms(False)` call to the non-deterministic branch.

## Type of change

- Bug fix

## Validation

- Added a `pytest.mark.unit` regression test covering the transition from deterministic `True` to `False` in one process.
- The test restores global PyTorch/cuDNN/environment state after execution.
- Source change is one line.
- Added the required `isaaclab` changelog fragment.
- Full Isaac Lab test suite was not run locally.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
