### PR TITLE
Fix raycast_mesh auxiliary output shapes

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.patch.rst
@@ -1,0 +1,1 @@
+Fixed ``raycast_mesh`` distance and face-id outputs to preserve the leading shape of the input rays.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.patch.rst
@@ -1,1 +1,0 @@
-Fixed ``raycast_mesh`` distance and face-id outputs to preserve the leading shape of the input rays.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-raycast-mesh-output-shapes.rst
@@ -1,0 +1,1 @@
+Fixed ``raycast_mesh`` distance and face-id outputs to preserve the leading shape of the input rays.

--- a/source/isaaclab/isaaclab/utils/warp/ops.py
+++ b/source/isaaclab/isaaclab/utils/warp/ops.py
@@ -175,11 +175,11 @@ def raycast_mesh(
     wp.synchronize()
 
     if return_distance:
-        ray_distance = ray_distance.to(device).view(shape[0], shape[1])
+        ray_distance = ray_distance.to(device).view(shape[:-1])
     if return_normal:
         ray_normal = ray_normal.to(device).view(shape)
     if return_face_id:
-        ray_face_id = ray_face_id.to(device).view(shape[0], shape[1])
+        ray_face_id = ray_face_id.to(device).view(shape[:-1])
 
     return ray_hits.to(device).view(shape), ray_distance, ray_normal, ray_face_id
 

--- a/source/isaaclab/test/utils/warp/test_raycast_mesh.py
+++ b/source/isaaclab/test/utils/warp/test_raycast_mesh.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+import torch
+
+from isaaclab.utils.warp.ops import convert_to_warp_mesh, raycast_mesh
+
+pytestmark = pytest.mark.unit
+
+
+def test_raycast_mesh_auxiliary_outputs_match_unbatched_ray_shape():
+    """Distance and face-id outputs should use the leading shape of documented ``(N, 3)`` ray inputs."""
+    mesh = convert_to_warp_mesh(
+        points=np.array([[-1.0, -1.0, 0.0], [1.0, -1.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+        indices=np.array([[0, 1, 2]], dtype=np.int32),
+        device="cpu",
+    )
+    ray_starts = torch.tensor([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]], dtype=torch.float32)
+    ray_directions = torch.tensor([[0.0, 0.0, -1.0], [0.0, 0.0, -1.0]], dtype=torch.float32)
+
+    ray_hits, ray_distance, ray_normal, ray_face_id = raycast_mesh(
+        ray_starts,
+        ray_directions,
+        mesh,
+        return_distance=True,
+        return_normal=True,
+        return_face_id=True,
+    )
+
+    assert ray_hits.shape == (2, 3)
+    assert ray_distance.shape == (2,)
+    assert ray_normal.shape == (2, 3)
+    assert ray_face_id.shape == (2,)
+    torch.testing.assert_close(ray_distance, torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(ray_face_id, torch.tensor([0, 0], dtype=torch.int32))


### PR DESCRIPTION
# Description

Fixes auxiliary output shapes from `raycast_mesh()` for the documented `(N, 3)` ray input.

`raycast_mesh()` allocates one distance and one face id per ray, but currently reshapes those N-element outputs with `(shape[0], shape[1])`. For an `(N, 3)` input that attempts to reshape N values into `(N, 3)` and raises at return time whenever `return_distance=True` or `return_face_id=True`.

The outputs now use `ray_starts.shape[:-1]`, which correctly produces `(N,)` for the documented input and also preserves arbitrary leading/batched ray dimensions.

## Type of change

- Bug fix

## Validation

- Added a `pytest.mark.unit` regression test using a real CPU Warp triangle mesh.
- The test casts two rays and verifies hit, normal, distance, and face-id shapes.
- It also verifies the returned distances and face ids.
- Runtime change is limited to two reshape targets.
- Added the required `isaaclab` changelog fragment.
- Full Isaac Lab test suite was not run locally.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
