### PR TITLE
Fix camera aperture offset warning for negative offsets

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.patch.rst
@@ -1,1 +1,0 @@
-Fixed ``convert_camera_intrinsics_to_usd`` so unsupported camera aperture offsets are detected on either side of the image center.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.patch.rst
@@ -1,0 +1,1 @@
+Fixed ``convert_camera_intrinsics_to_usd`` so unsupported camera aperture offsets are detected on either side of the image center.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-camera-aperture-offset-warning.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``convert_camera_intrinsics_to_usd`` so unsupported camera aperture offsets are detected on either side of the image center.

--- a/source/isaaclab/isaaclab/utils/sensors.py
+++ b/source/isaaclab/isaaclab/utils/sensors.py
@@ -37,7 +37,7 @@ def convert_camera_intrinsics_to_usd(
         logger.warning("Camera non square pixels are not supported by Omniverse. The average of f_x and f_y are used.")
 
     # warn about aperture offsets
-    if abs((c_x - float(width) / 2) > 1e-4 or (c_y - float(height) / 2) > 1e-4):
+    if abs(c_x - float(width) / 2) > 1e-4 or abs(c_y - float(height) / 2) > 1e-4:
         logger.warning(
             "Camera aperture offsets are not supported by Omniverse. c_x and c_y will be half of width and height"
         )

--- a/source/isaaclab/test/utils/test_sensor_utils.py
+++ b/source/isaaclab/test/utils/test_sensor_utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+
+import pytest
+
+from isaaclab.utils.sensors import convert_camera_intrinsics_to_usd
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(("c_x", "c_y"), [(40.0, 40.0), (50.0, 30.0)])
+def test_camera_intrinsics_warn_for_negative_aperture_offsets(caplog, c_x, c_y):
+    """Principal-point offsets on either side of image center should emit the unsupported-offset warning."""
+    intrinsic_matrix = [100.0, 0.0, c_x, 0.0, 100.0, c_y, 0.0, 0.0, 1.0]
+
+    with caplog.at_level(logging.WARNING, logger="isaaclab.utils.sensors"):
+        convert_camera_intrinsics_to_usd(intrinsic_matrix, width=100, height=80)
+
+    assert "Camera aperture offsets are not supported by Omniverse" in caplog.text
+
+
+def test_camera_intrinsics_centered_principal_point_does_not_warn(caplog):
+    """A centered principal point should not emit an aperture-offset warning."""
+    intrinsic_matrix = [100.0, 0.0, 50.0, 0.0, 100.0, 40.0, 0.0, 0.0, 1.0]
+
+    with caplog.at_level(logging.WARNING, logger="isaaclab.utils.sensors"):
+        convert_camera_intrinsics_to_usd(intrinsic_matrix, width=100, height=80)
+
+    assert "Camera aperture offsets are not supported by Omniverse" not in caplog.text


### PR DESCRIPTION
# Description

Fixes the unsupported camera aperture-offset warning in `convert_camera_intrinsics_to_usd()`.

The current condition applies `abs()` to the result of a boolean expression rather than to the signed principal-point offsets themselves. As a result, positive deviations of `c_x` / `c_y` from image center trigger the warning, while equally valid negative deviations silently do not.

This change applies the absolute value to each offset before comparing it with the tolerance, so unsupported principal-point offsets are detected symmetrically on either side of image center.

## Type of change

- Bug fix

## Validation

- Added `pytest.mark.unit` regression coverage for negative horizontal and vertical principal-point offsets.
- Added a centered-principal-point case verifying that no warning is emitted.
- Source change is one condition only.
- Added the required `isaaclab` changelog fragment.
- Full Isaac Lab test suite was not run locally.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added regression tests
- [x] I have added the required changelog fragment
- [x] No new dependencies
