### PR TITLE
Keep partitioned environments visible in viewport and XR views

### DIFF
--- a/source/isaaclab/changelog.d/rwiltz-spectator-scene-partitioning.minor.rst
+++ b/source/isaaclab/changelog.d/rwiltz-spectator-scene-partitioning.minor.rst
@@ -1,0 +1,18 @@
+Fixed
+^^^^^
+
+* Fixed partitioned environments disappearing from the Kit viewport and the XR view. RTX culls
+  geometry carrying ``omni:scenePartition`` from cameras without a matching token, and the Kit
+  builds shipped with the pinned Isaac Sim do not implement
+  ``/rtx/scenePartitioning/showAllPartitionsByDefault``. Launches that render such a view now
+  default per-environment scene partitioning off. Set
+  ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1`` or
+  :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` to keep
+  partitioning for these launches.
+
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.renderers.set_isaac_rtx_per_env_scene_partition_default` to set the
+  Isaac RTX scene-partitioning default used when
+  ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` is unset.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -37,7 +37,10 @@ from isaaclab.app.loading_screen import report_activity
 from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
 from isaaclab.app.settings_manager import get_settings_manager, initialize_carb_settings
 from isaaclab.utils._device import set_cuda_device
-from isaaclab.utils.renderers import ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING
+from isaaclab.utils.renderers import (
+    ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING,
+    set_isaac_rtx_per_env_scene_partition_default,
+)
 
 # import logger
 logger = logging.getLogger(__name__)
@@ -1260,6 +1263,27 @@ class AppLauncher:
             or bool(getattr(self, "_xr", False))
         )
 
+    def _disable_per_env_scene_partitioning_default(self) -> None:
+        """Default per-environment RTX scene partitioning off for spectator launches.
+
+        RTX culls partitioned geometry from every camera whose ``omni:scenePartition`` token does
+        not match, and only Kit builds newer than the pinned Isaac Sim implement
+        :obj:`~isaaclab.utils.renderers.ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING`. Without
+        that setting the Kit viewport and the XR view, which carry no token, lose the partitioned
+        environments while environment-scoped cameras still render them. Partitioning only isolates
+        per-environment camera renders, which a spectator launch does not need.
+
+        An explicit ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` is left untouched, and an
+        explicit :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning`
+        still overrides this default.
+        """
+        set_isaac_rtx_per_env_scene_partition_default(False)
+        logger.info(
+            "Per-environment Isaac RTX scene partitioning defaulted off so partitioned environments"
+            " stay visible in views without a partition token. Set"
+            " ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=1 to keep partitioning."
+        )
+
     def _resolve_kit_args(self, launcher_args: dict):
         """Resolve additional arguments passed to Kit."""
         self._kit_args = launcher_args.get("kit_args", "").split()
@@ -1288,6 +1312,7 @@ class AppLauncher:
             setting = argument.partition("=")[0]
             if not any(arg.partition("=")[0] == setting for arg in sys.argv + self._kit_args):
                 self._kit_args.append(argument)
+            self._disable_per_env_scene_partitioning_default()
 
         # Select the renderer by CUDA index; the trailing comma keeps the setting string-typed.
         if launcher_args.get("multi_gpu") is False:

--- a/source/isaaclab/isaaclab/utils/renderers.py
+++ b/source/isaaclab/isaaclab/utils/renderers.py
@@ -12,13 +12,32 @@ ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING = "/rtx/scenePartitioning/showA
 
 _SCENE_PARTITION_ENV_VAR = "ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION"
 
+_scene_partition_default = True
+"""Fallback used by :func:`isaac_rtx_per_env_scene_partition_enabled` when the env var is unset."""
+
+
+def set_isaac_rtx_per_env_scene_partition_default(enabled: bool) -> None:
+    """Set the Isaac RTX scene-partitioning default used when the environment variable is unset.
+
+    :class:`~isaaclab.app.AppLauncher` calls this to turn partitioning off for launches that
+    render a view without a partition token, such as the Kit viewport and XR. An explicit
+    ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`` still wins over the value set here.
+
+    Args:
+        enabled: Whether per-environment scene partitioning is authored by default.
+    """
+    global _scene_partition_default
+    _scene_partition_default = enabled
+
 
 def isaac_rtx_per_env_scene_partition_enabled() -> bool:
     """Return the legacy environment-derived default for Isaac RTX scene partitioning.
 
     :class:`~isaaclab_physx.renderers.IsaacRtxRendererCfg` uses this helper as
-    the construction default for ``enable_scene_partitioning``. Partitioning
-    is enabled when the environment variable is absent. Set
+    the construction default for ``enable_scene_partitioning``. When the environment
+    variable is absent, the default set by
+    :func:`set_isaac_rtx_per_env_scene_partition_default` applies, which is partitioning
+    enabled unless a launcher turned it off. Set
     ``ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION=0`` to disable authoring of
     ``primvars:omni:scenePartition`` and ``omni:scenePartition`` on the USD stage.
     This setting does not affect OVRTX scene partitioning.
@@ -28,7 +47,7 @@ def isaac_rtx_per_env_scene_partition_enabled() -> bool:
     """
     value = os.environ.get(_SCENE_PARTITION_ENV_VAR)
     if value is None:
-        return True
+        return _scene_partition_default
     if value not in {"0", "1"}:
         raise ValueError(f"Invalid value for {_SCENE_PARTITION_ENV_VAR}: {value!r}. Expected '0' or '1'.")
     return value == "1"

--- a/source/isaaclab/test/app/test_app_launcher_argv.py
+++ b/source/isaaclab/test/app/test_app_launcher_argv.py
@@ -10,7 +10,15 @@ import sys
 import pytest
 
 from isaaclab.app.app_launcher import AppLauncher, _sanitize_sys_argv_for_kit
+from isaaclab.utils import renderers
 from isaaclab.utils.renderers import ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING
+
+
+@pytest.fixture(autouse=True)
+def _isolate_scene_partition_default(monkeypatch):
+    """Keep the process-wide scene-partitioning default from leaking between tests."""
+    monkeypatch.setattr(renderers, "_scene_partition_default", True)
+    monkeypatch.delenv("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", raising=False)
 
 
 def test_sanitize_sys_argv_removes_trailing_pytest_verbosity(monkeypatch):
@@ -125,6 +133,9 @@ def test_spectator_view_follows_visual_output_intent(launcher_state, expected_en
 
     spectator_arg = f"--{ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING}=true"
     assert (spectator_arg in launcher._kit_args) is expected_enabled
+    # The pinned Kit ignores the spectator setting, so a spectator launch must also stop authoring
+    # partitions; otherwise the untokened viewport and XR views lose the partitioned environments.
+    assert renderers.isaac_rtx_per_env_scene_partition_enabled() is not expected_enabled
 
 
 def test_explicit_spectator_setting_overrides_visualizer_default(monkeypatch):
@@ -139,3 +150,16 @@ def test_explicit_spectator_setting_overrides_visualizer_default(monkeypatch):
 
     assert explicit_arg in launcher._kit_args
     assert f"--{ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING}=true" not in launcher._kit_args
+
+
+def test_explicit_scene_partition_env_var_survives_spectator_launch(monkeypatch):
+    """An explicit partitioning opt-in should survive a spectator launch."""
+    monkeypatch.setattr(sys, "argv", ["script.py"])
+    monkeypatch.setenv("ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION", "1")
+    launcher = AppLauncher.__new__(AppLauncher)
+    launcher._cli_visualizer_explicit = True
+    launcher._cli_visualizer_types = ["kit"]
+
+    launcher._resolve_kit_args({})
+
+    assert renderers.isaac_rtx_per_env_scene_partition_enabled() is True

--- a/source/isaaclab/test/utils/test_renderers.py
+++ b/source/isaaclab/test/utils/test_renderers.py
@@ -7,6 +7,7 @@
 
 import pytest
 
+from isaaclab.utils import renderers
 from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled
 
 _ENV_VAR = "ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION"
@@ -36,3 +37,23 @@ def test_scene_partitioning_rejects_invalid_override(monkeypatch: pytest.MonkeyP
 
     with pytest.raises(ValueError, match=f"Invalid value for {_ENV_VAR}"):
         isaac_rtx_per_env_scene_partition_enabled()
+
+
+def test_scene_partitioning_default_follows_launcher_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A launcher-set default should apply when the environment variable is absent."""
+    monkeypatch.delenv(_ENV_VAR, raising=False)
+    monkeypatch.setattr(renderers, "_scene_partition_default", True)
+
+    renderers.set_isaac_rtx_per_env_scene_partition_default(False)
+
+    assert isaac_rtx_per_env_scene_partition_enabled() is False
+
+
+def test_scene_partitioning_env_var_overrides_launcher_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit environment value should win over a launcher-set default."""
+    monkeypatch.setenv(_ENV_VAR, "1")
+    monkeypatch.setattr(renderers, "_scene_partition_default", True)
+
+    renderers.set_isaac_rtx_per_env_scene_partition_default(False)
+
+    assert isaac_rtx_per_env_scene_partition_enabled() is True


### PR DESCRIPTION
  #Description
  
  `AppLauncher` enables the all-environment spectator view by passing
  `--/rtx/scenePartitioning/showAllPartitionsByDefault=true` whenever a Kit visualizer,
  viewport, recording, livestream, or XR is requested. The Kit builds shipped with the
  pinned Isaac Sim (6.0.1.0, Kit `110.1.2+production.326809`) do not implement that
  setting — it appears nowhere in the `omni.hydra.rtx` binaries.

  Since per-environment scene partitioning became the default in #7053, RTX therefore
  culls every prim carrying `omni:scenePartition` from cameras without a matching token.
  The Kit viewport and the XR view carry no token, so partitioned environments vanish from
  both while environment-scoped camera sensors still render them. RTX honors the token
  only for non-instanced geometry, so the failure looks selective: on
  `IsaacContrib-PickPlace-Locomanipulation-G1-Abs` the robot and packing table (USD
  instance proxies) render, while the steering wheel and bin (plain meshes) appear only in
  the XR picture-in-picture feed.

  `KitVisualizer._apply_viewport_camera_scene_partition()` has a working fallback that
  tags the viewport camera with `env_0`, but it is skipped because the ineffective setting
  reads back as `true`. Nothing tags the XR camera at all.

  This defaults per-environment scene partitioning off for launches that render a view
  without a partition token, in the same `AppLauncher` branch that already decides visual
  output intent. Partitioning only isolates per-environment camera renders, which a
  spectator launch does not need. The Kit argument is still passed, so relaxing the gate
  is a one-line change once the Isaac Sim bump #7053 assumed (alpha.50 / Kit 360924) lands.

  Precedence is unchanged: an explicit `ISAAC_LAB_ENABLE_ISAAC_RTX_PER_ENV_SCENE_PARTITION`
  or a task-set `IsaacRtxRendererCfg.enable_scene_partitioning` still wins.

  Reproducer:

      uv run --extra teleop isaaclab teleop run \
        --task IsaacContrib-PickPlace-Locomanipulation-G1-Abs --visualizer kit --xr

  ## Type of change

  - Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there