### PR TITLE
Make XR experiences show all scene partitions

### DIFF
--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -23,6 +23,7 @@ app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
 renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
+rtx.scenePartitioning.showAllPartitionsByDefault = true
 
 # xr optimizations
 xr.skipInputDeviceUSDWrites = true

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -35,6 +35,7 @@ app.useFabricSceneDelegate = true
 # Temporary, should be enabled by default in Kit soon
 rtx.hydra.readTransformsFromFabricInRenderDelegate = true
 renderer.scenePartitioning.enabled = true # Enable before RTX initialization so env-root partitions are honored
+rtx.scenePartitioning.showAllPartitionsByDefault = true
 
 # xr optimizations
 xr.skipInputDeviceUSDWrites = true

--- a/source/isaaclab/changelog.d/hougantc-xr-show-all-scene-partitions.rst
+++ b/source/isaaclab/changelog.d/hougantc-xr-show-all-scene-partitions.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed the OpenXR experiences to expose content from all Isaac RTX scene
+  partitions when launched directly.

--- a/source/isaaclab/test/app/test_experience_files.py
+++ b/source/isaaclab/test/app/test_experience_files.py
@@ -37,6 +37,25 @@ def _kit_dependencies(experience: str) -> set[str]:
     return dependencies
 
 
+def _kit_setting_values(experience: str, setting: str) -> list[str]:
+    """Collect values assigned to a setting in an experience file's settings sections."""
+    values: list[str] = []
+    in_settings = False
+
+    for line in (APPS_DIR / experience).read_text(encoding="utf-8").splitlines():
+        section = _SECTION_RE.match(line)
+        if section is not None:
+            in_settings = section.group("name").strip() == "settings"
+            continue
+        if not in_settings:
+            continue
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == setting:
+            values.append(value.partition("#")[0].strip())
+
+    return values
+
+
 @pytest.mark.parametrize("experience", ["isaaclab.python.kit", "isaaclab.python.headless.kit"])
 def test_base_experiences_enable_native_storage(experience: str):
     """Test the base experiences load the extension that applies ``ISAACSIM_ASSET_ROOT``."""
@@ -55,3 +74,12 @@ def test_base_experiences_enable_native_storage(experience: str):
 def test_derived_experiences_inherit_native_storage(experience: str, base: str):
     """Test the derived experiences inherit native storage from a base experience."""
     assert base in _kit_dependencies(experience)
+
+
+@pytest.mark.parametrize(
+    "experience",
+    ["isaaclab.python.xr.openxr.kit", "isaaclab.python.xr.openxr.headless.kit"],
+)
+def test_xr_experiences_show_all_scene_partitions(experience: str):
+    """Test each XR experience configures its spectator view before RTX starts."""
+    assert _kit_setting_values(experience, "rtx.scenePartitioning.showAllPartitionsByDefault") == ["true"]


### PR DESCRIPTION
# Description

Default-on per-environment Isaac RTX scene partitioning requires an unpartitioned spectator view for XR. This PR sets:

`rtx.scenePartitioning.showAllPartitionsByDefault = true`

in exactly the two standard OpenXR experiences, before RTX startup:

- `apps/isaaclab.python.xr.openxr.kit`
- `apps/isaaclab.python.xr.openxr.headless.kit`

It also adds a focused static contract test for both experience files and a changelog fragment. No dependencies are added.

## Baseline interpretation

Current `develop` already injects `--/rtx/scenePartitioning/showAllPartitionsByDefault=true` from `AppLauncher` whenever XR is requested (merged in #7053). Therefore the normal `uv run --extra teleop ... --xr` path is expected to be configured correctly before this PR.

This change does not claim to introduce the Isaac Sim 6.1 renderer fix or to make an already-failing `AppLauncher` path pass. It makes the shipped XR experience files self-contained and safe when launched directly or through a path that does not use `AppLauncher`.

## Type of change

- [x] Bug fix (non-breaking configuration fix)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

### Controlled static before/after

- Before, with the regression assertion added but both experience files unmodified: `2 failed, 6 passed`; both XR cases failed because the setting was absent.
- After adding the two settings: `8 passed`.
- Final focused suite, including current `AppLauncher` XR argument coverage: `23 passed`.
- `pre-commit run --all-files`: all hooks passed, including TOML, RST, changelog, spelling, formatting, and Git LFS pointer checks.
- IsaacLab reviewer risk scan and manual sibling-entry-point audit: no findings at `397685bada014f4911a4f3f05b80d4e464cb0b7c`.

### Isaac Sim / Kit target and runtime limitation

The `develop` CI pin is:

- Isaac Sim `6.1.0-alpha.50` (`b86cf6ce`)
- Kit `110.3.0-360924`
- Image digest `sha256:e7cd73cd7a9a6621274bd3a1bacddfd4ac1a15f92893e6a10cfb6b8100762a0c`

The exact image is on Isaac Lab's internal NGC mirror. The local Horde account was denied access to that manifest, and the only locally installed Kit oracle is Isaac Sim `6.0.1.0`, which does not contain `/rtx/scenePartitioning/showAllPartitionsByDefault`. I did not substitute 6.0.1 for the required 6.1 validation.

Consequently, this draft does **not** claim that the requested runtime command was exercised on 6.1, nor that the steering wheel, bin/environment geometry, or robot PiP were visually verified in IWER. The upstream PR workflow is configured to build and test against the exact pinned 6.1 image; visual IWER validation remains outstanding.

## Screenshots

Not available because the exact 6.1 XR/IWER runtime could not be launched from the local Horde account.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the all-files pre-commit checks.
- [x] No public API documentation change is required; the user-visible fix has a changelog fragment.
- [x] The static and focused tests generate no new warnings.
- [x] I have added a focused test that proves both shipped XR experiences carry the startup setting.
- [x] I have added an `isaaclab` changelog fragment.
- [x] Hougant Chen is already listed in `CONTRIBUTORS.md`.
