### PR TITLE
Fix gravity distributions for PhysX and OvPhysX

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-scene-gravity-distribution.rst
+++ b/source/isaaclab/changelog.d/antoiner-scene-gravity-distribution.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed scene gravity randomization to honor configured distributions with PhysX and OvPhysX.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1210,9 +1210,8 @@ class randomize_physics_scene_gravity(ManagerTermBase):
     - **Newton**: samples per-environment gravity vectors and writes them in-place to
       the Newton model's per-world gravity array on GPU.
 
-    The distribution parameters are tuples of two lists with three floats each for the x, y,
-    and z gravity components [m/s^2]. They represent lower and upper bounds for uniform and
-    log-uniform sampling, or mean and standard deviation for Gaussian sampling.
+    The distribution parameters are tuples of two lists with three floats each,
+    representing the lower and upper bounds for the x, y, and z gravity components [m/s^2].
 
     Args:
         cfg: The configuration of the event term.

--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -1210,8 +1210,9 @@ class randomize_physics_scene_gravity(ManagerTermBase):
     - **Newton**: samples per-environment gravity vectors and writes them in-place to
       the Newton model's per-world gravity array on GPU.
 
-    The distribution parameters are tuples of two lists with three floats each,
-    representing the lower and upper bounds for the x, y, and z gravity components [m/s^2].
+    The distribution parameters are tuples of two lists with three floats each for the x, y,
+    and z gravity components [m/s^2]. They represent lower and upper bounds for uniform and
+    log-uniform sampling, or mean and standard deviation for Gaussian sampling.
 
     Args:
         cfg: The configuration of the event term.
@@ -1234,6 +1235,7 @@ class randomize_physics_scene_gravity(ManagerTermBase):
             self._init_physx(env)
 
         distribution = cfg.params.get("distribution", "uniform")
+        self._distribution = distribution
         if distribution == "uniform":
             self._dist_fn = math_utils.sample_uniform
         elif distribution == "log_uniform":
@@ -1352,7 +1354,7 @@ class randomize_physics_scene_gravity(ManagerTermBase):
             None,
             slice(None),
             operation=operation,
-            distribution="uniform",
+            distribution=self._distribution,
         )
         gravity = gravity[0].tolist()
         self._physics_sim_view.set_gravity(self._carb.Float3(*gravity))
@@ -1370,7 +1372,7 @@ class randomize_physics_scene_gravity(ManagerTermBase):
             None,
             slice(None),
             operation=operation,
-            distribution="uniform",
+            distribution=self._distribution,
         )
         self._ovphysx_manager.set_gravity(tuple(gravity[0].tolist()))
 

--- a/source/isaaclab/test/envs/test_gravity_randomization.py
+++ b/source/isaaclab/test/envs/test_gravity_randomization.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for scene-wide gravity randomization."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from isaaclab.envs.mdp.events import randomize_physics_scene_gravity
+from isaaclab.managers import EventTermCfg
+from isaaclab.utils import math as math_utils
+
+
+@pytest.mark.parametrize("backend", ["physx", "ovphysx"])
+@pytest.mark.parametrize(("distribution", "expected"), [("uniform", 1.0), ("log_uniform", 2.0), ("gaussian", 3.0)])
+def test_scene_wide_backends_use_configured_distribution(
+    monkeypatch: pytest.MonkeyPatch, backend: str, distribution: str, expected: float
+) -> None:
+    """PhysX and OvPhysX should use the distribution configured at initialization."""
+
+    class OvPhysxManager:
+        gravity = None
+
+        @classmethod
+        def set_gravity(cls, gravity) -> None:
+            cls.gravity = gravity
+
+    class PhysxManager:
+        pass
+
+    monkeypatch.setattr(randomize_physics_scene_gravity, "_init_physx", lambda *_args: None)
+    env = SimpleNamespace(
+        device="cpu",
+        sim=SimpleNamespace(
+            cfg=SimpleNamespace(gravity=(0.0, 0.0, -9.81)),
+            physics_manager=PhysxManager if backend == "physx" else OvPhysxManager,
+        ),
+    )
+    for sampler_name, sampled_value in (
+        ("sample_uniform", 1.0),
+        ("sample_log_uniform", 2.0),
+        ("sample_gaussian", 3.0),
+    ):
+        monkeypatch.setattr(
+            math_utils,
+            sampler_name,
+            lambda _param_0, _param_1, size, device, value=sampled_value: torch.full(size, value, device=device),
+        )
+    cfg = EventTermCfg(
+        func=randomize_physics_scene_gravity,
+        params={
+            "gravity_distribution_params": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+            "operation": "abs",
+            "distribution": distribution,
+        },
+    )
+    gravity_event = randomize_physics_scene_gravity(cfg, env)
+
+    if backend == "physx":
+        physics_sim_view = SimpleNamespace(set_gravity=lambda gravity: setattr(physics_sim_view, "gravity", gravity))
+        gravity_event._carb = SimpleNamespace(Float3=lambda *values: values)
+        gravity_event._physics_sim_view = physics_sim_view
+
+    gravity_event(env, env_ids=None, **cfg.params)
+    actual = physics_sim_view.gravity if backend == "physx" else OvPhysxManager.gravity
+
+    assert actual == pytest.approx((expected, expected, expected))

--- a/source/isaaclab/test/envs/test_gravity_randomization.py
+++ b/source/isaaclab/test/envs/test_gravity_randomization.py
@@ -12,60 +12,36 @@ import torch
 
 from isaaclab.envs.mdp.events import randomize_physics_scene_gravity
 from isaaclab.managers import EventTermCfg
-from isaaclab.utils import math as math_utils
 
 
 @pytest.mark.parametrize("backend", ["physx", "ovphysx"])
-@pytest.mark.parametrize(("distribution", "expected"), [("uniform", 1.0), ("log_uniform", 2.0), ("gaussian", 3.0)])
-def test_scene_wide_backends_use_configured_distribution(
-    monkeypatch: pytest.MonkeyPatch, backend: str, distribution: str, expected: float
-) -> None:
+def test_scene_wide_backends_use_configured_distribution(monkeypatch: pytest.MonkeyPatch, backend: str) -> None:
     """PhysX and OvPhysX should use the distribution configured at initialization."""
-
-    class OvPhysxManager:
-        gravity = None
-
-        @classmethod
-        def set_gravity(cls, gravity) -> None:
-            cls.gravity = gravity
-
-    class PhysxManager:
-        pass
-
+    gravity_sink = SimpleNamespace()
+    physics_manager = type(
+        f"{backend}Manager",
+        (),
+        {"set_gravity": staticmethod(lambda gravity: setattr(gravity_sink, "value", gravity))},
+    )
     monkeypatch.setattr(randomize_physics_scene_gravity, "_init_physx", lambda *_args: None)
     env = SimpleNamespace(
         device="cpu",
         sim=SimpleNamespace(
             cfg=SimpleNamespace(gravity=(0.0, 0.0, -9.81)),
-            physics_manager=PhysxManager if backend == "physx" else OvPhysxManager,
+            physics_manager=physics_manager,
         ),
     )
-    for sampler_name, sampled_value in (
-        ("sample_uniform", 1.0),
-        ("sample_log_uniform", 2.0),
-        ("sample_gaussian", 3.0),
-    ):
-        monkeypatch.setattr(
-            math_utils,
-            sampler_name,
-            lambda _param_0, _param_1, size, device, value=sampled_value: torch.full(size, value, device=device),
-        )
     cfg = EventTermCfg(
         func=randomize_physics_scene_gravity,
         params={
-            "gravity_distribution_params": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+            "gravity_distribution_params": ((1.0, 2.0, 3.0), (0.0, 0.0, 0.0)),
             "operation": "abs",
-            "distribution": distribution,
+            "distribution": "gaussian",
         },
     )
     gravity_event = randomize_physics_scene_gravity(cfg, env)
-
-    if backend == "physx":
-        physics_sim_view = SimpleNamespace(set_gravity=lambda gravity: setattr(physics_sim_view, "gravity", gravity))
-        gravity_event._carb = SimpleNamespace(Float3=lambda *values: values)
-        gravity_event._physics_sim_view = physics_sim_view
-
+    gravity_event._carb = SimpleNamespace(Float3=lambda *values: values)
+    gravity_event._physics_sim_view = physics_manager
+    torch.manual_seed(0)
     gravity_event(env, env_ids=None, **cfg.params)
-    actual = physics_sim_view.gravity if backend == "physx" else OvPhysxManager.gravity
-
-    assert actual == pytest.approx((expected, expected, expected))
+    assert gravity_sink.value == pytest.approx((1.0, 2.0, 3.0))


### PR DESCRIPTION
# Description

Scene-wide gravity randomization accepted `uniform`, `log_uniform`, and `gaussian`, but the PhysX and OvPhysX paths always sampled uniformly. This change forwards the validated configured distribution to both scene-wide backend paths. Newton behavior is unchanged.

The focused regression exercises full event dispatch with deterministic Gaussian sampling on both affected backends.

Tested with:

- `uv run --extra test -m pytest source/isaaclab/test/envs/test_gravity_randomization.py source/isaaclab/test/envs/test_mdp_event_selectors.py -q` (7 passed)
- `uv run --extra test --extra ovphysx -m pytest source/isaaclab_ov/test/physics/test_ovphysx_gravity.py -q` (1 passed)
- `uv run isaaclab -f`
- `uv run python tools/changelog/cli.py check develop --include-worktree`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation (not applicable; no public API change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
