### PR TITLE
Preserve aliases in lazy_export absolute imports

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
@@ -1,0 +1,1 @@
+Fixed ``lazy_export()`` to preserve aliases on absolute named imports declared in ``.pyi`` stubs.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
@@ -1,1 +1,4 @@
-Fixed ``lazy_export()`` to preserve aliases on absolute named imports declared in ``.pyi`` stubs.
+Fixed
+^^^^^
+
+* Fixed ``lazy_export()`` to preserve aliases on absolute named imports declared in ``.pyi`` stubs.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.patch.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed ``lazy_export()`` to preserve aliases on absolute named imports declared in ``.pyi`` stubs.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-lazy-export-absolute-aliases.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``lazy_export()`` to preserve aliases on absolute named imports declared in ``.pyi`` stubs.

--- a/source/isaaclab/isaaclab/utils/module.py
+++ b/source/isaaclab/isaaclab/utils/module.py
@@ -20,7 +20,7 @@ import lazy_loader as lazy
 
 def _parse_stub(
     stub_file: str,
-) -> tuple[str | None, list[str], list[str], dict[str, list[str]]]:
+) -> tuple[str | None, list[str], list[str], dict[str, list[tuple[str, str]]]]:
     """Parse a ``.pyi`` stub in a single AST pass.
 
     Returns:
@@ -40,8 +40,8 @@ def _parse_stub(
         *relative_wildcards* lists submodule names extracted from relative
         wildcard imports (``from .mod import *``).
 
-        *absolute_named* maps fully-qualified package names to the list of
-        explicit names imported from them (``from pkg import a, b``).
+        *absolute_named* maps fully-qualified package names to ``(source_name,
+        export_name)`` pairs for explicit imports (``from pkg import a as b``).
     """
     with open(stub_file) as f:
         source = f.read()
@@ -50,7 +50,7 @@ def _parse_stub(
 
     fallback_packages: list[str] = []
     relative_wildcards: list[str] = []
-    absolute_named: dict[str, list[str]] = {}
+    absolute_named: dict[str, list[tuple[str, str]]] = {}
     filtered_body: list[ast.stmt] = []
     needs_filter = False
 
@@ -65,7 +65,7 @@ def _parse_stub(
             elif node.level == 1 and is_star and node.module:
                 relative_wildcards.append(node.module)
             elif node.level == 0 and not is_star and node.module:
-                names = [alias.name for alias in node.names]
+                names = [(alias.name, alias.asname or alias.name) for alias in node.names]
                 absolute_named.setdefault(node.module, []).extend(names)
             needs_filter = True
         else:
@@ -135,7 +135,7 @@ def lazy_export(
 
     fallback_packages: list[str] = list(packages) if packages else []
     relative_wildcards: list[str] = []
-    absolute_named: dict[str, list[str]] = {}
+    absolute_named: dict[str, list[tuple[str, str]]] = {}
 
     if has_stub:
         filtered_path, stub_fallbacks, relative_wildcards, absolute_named = _parse_stub(stub_file)
@@ -154,10 +154,10 @@ def lazy_export(
     # -- Eagerly resolve absolute named imports (from pkg import a, b) -----
     for abs_pkg, names in absolute_named.items():
         pkg_mod = importlib.import_module(abs_pkg)
-        for name in names:
-            mod.__dict__[name] = getattr(pkg_mod, name)
-            if name not in __all__:
-                __all__.append(name)
+        for source_name, export_name in names:
+            mod.__dict__[export_name] = getattr(pkg_mod, source_name)
+            if export_name not in __all__:
+                __all__.append(export_name)
 
     # -- Eagerly resolve relative wildcard imports (from .X import *) ------
     for rel_mod_name in relative_wildcards:

--- a/source/isaaclab/test/utils/test_module.py
+++ b/source/isaaclab/test/utils/test_module.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_lazy_export_preserves_absolute_import_alias(tmp_path, monkeypatch):
+    """Absolute named imports in stubs should be exported under their alias."""
+    package_name = "lazy_export_alias_test"
+    package_dir = tmp_path / package_name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(
+        "from isaaclab.utils.module import lazy_export\n\nlazy_export()\n",
+        encoding="utf-8",
+    )
+    (package_dir / "__init__.pyi").write_text("from math import sqrt as square_root\n", encoding="utf-8")
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop(package_name, None)
+    try:
+        module = importlib.import_module(package_name)
+        assert module.square_root(9.0) == 3.0
+        assert "square_root" in module.__all__
+        assert "sqrt" not in module.__all__
+    finally:
+        sys.modules.pop(package_name, None)

--- a/source/isaaclab_tasks/test/core/test_lazy_export_stubs.py
+++ b/source/isaaclab_tasks/test/core/test_lazy_export_stubs.py
@@ -107,7 +107,7 @@ def test_parse_stub_single_absolute_named_import():
         os.unlink(stub)
 
     assert "some.package" in absolute_named
-    assert absolute_named["some.package"] == ["alpha", "beta"]
+    assert absolute_named["some.package"] == [("alpha", "alpha"), ("beta", "beta")]
 
 
 def test_parse_stub_multiple_absolute_named_imports():
@@ -118,8 +118,8 @@ def test_parse_stub_multiple_absolute_named_imports():
     finally:
         os.unlink(stub)
 
-    assert absolute_named["pkg_a"] == ["foo"]
-    assert absolute_named["pkg_b"] == ["bar", "baz"]
+    assert absolute_named["pkg_a"] == [("foo", "foo")]
+    assert absolute_named["pkg_b"] == [("bar", "bar"), ("baz", "baz")]
 
 
 def test_parse_stub_same_package_multiple_lines_accumulates():
@@ -130,7 +130,7 @@ def test_parse_stub_same_package_multiple_lines_accumulates():
     finally:
         os.unlink(stub)
 
-    assert absolute_named["pkg"] == ["a", "b", "c"]
+    assert absolute_named["pkg"] == [("a", "a"), ("b", "b"), ("c", "c")]
 
 
 def test_parse_stub_absolute_wildcard_not_in_absolute_named():
@@ -170,7 +170,7 @@ def test_parse_stub_mixed_import_kinds():
 
     assert fallbacks == ["abs.pkg"]
     assert rel_wildcards == ["wildmod"]
-    assert absolute_named == {"abs.other": ["x", "y"]}
+    assert absolute_named == {"abs.other": [("x", "x"), ("y", "y")]}
     assert filtered_path is not None
 
 


### PR DESCRIPTION
# Description

Fixes alias handling for absolute named imports declared in `.pyi` stubs used by `lazy_export()`.

`_parse_stub()` currently records only `alias.name`. For a stub such as:

```python
from math import sqrt as square_root
```

the runtime export is created as `sqrt` instead of `square_root`, so the module does not match the public API described by its stub.

This change records both the source name and the exported name and installs the object under the alias when one is present. Non-aliased absolute imports keep their existing behavior.

## Type of change

- Bug fix

## Validation

- Added a unit regression test using a temporary package with an aliased absolute import in its `.pyi` stub.
- The test verifies the alias is callable and appears in `__all__`, while the original source name is not exported.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
