### PR TITLE
Keep DelayBuffer state unchanged after invalid lag updates

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-delay-buffer-invalid-lag-state.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-fix-delay-buffer-invalid-lag-state.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``DelayBuffer.set_time_lag`` leaving invalid lag values active after raising validation errors, so rejected
+  updates no longer alter subsequent delayed outputs.

--- a/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/delay_buffer.py
@@ -125,29 +125,34 @@ class DelayBuffer:
         if batch_ids is None:
             batch_ids = slice(None)
 
+        # Build the requested lag state separately so an invalid update never poisons
+        # the active buffer configuration.
+        requested_time_lags = self._time_lags.clone()
+
         # parse requested time_lag
         if isinstance(time_lag, int):
-            # set the time lags across provided batch indices
-            self._time_lags[batch_ids] = time_lag
+            requested_time_lags[batch_ids] = time_lag
         elif isinstance(time_lag, torch.Tensor):
             # check valid dtype for time_lag: must be int or long
             if time_lag.dtype not in [torch.int, torch.long]:
                 raise TypeError(f"Invalid dtype for time_lag: {time_lag.dtype}. Expected torch.int or torch.long.")
-            # set the time lags
-            self._time_lags[batch_ids] = time_lag.to(device=self.device)
+            requested_time_lags[batch_ids] = time_lag.to(device=self.device)
         else:
             raise TypeError(f"Invalid type for time_lag: {type(time_lag)}. Expected int or integer tensor.")
 
-        # compute the min and max time lag
-        self._min_time_lag = int(torch.min(self._time_lags).item())
-        self._max_time_lag = int(torch.max(self._time_lags).item())
-        # check that time_lag is feasible
-        if self._min_time_lag < 0:
-            raise ValueError(f"The minimum time lag cannot be negative. Received: {self._min_time_lag}")
-        if self._max_time_lag > self._history_length:
+        # Validate the complete requested state before committing it.
+        min_time_lag = int(torch.min(requested_time_lags).item())
+        max_time_lag = int(torch.max(requested_time_lags).item())
+        if min_time_lag < 0:
+            raise ValueError(f"The minimum time lag cannot be negative. Received: {min_time_lag}")
+        if max_time_lag > self._history_length:
             raise ValueError(
-                f"The maximum time lag cannot be larger than the history length. Received: {self._max_time_lag}"
+                f"The maximum time lag cannot be larger than the history length. Received: {max_time_lag}"
             )
+
+        self._time_lags.copy_(requested_time_lags)
+        self._min_time_lag = min_time_lag
+        self._max_time_lag = max_time_lag
 
     def reset(self, batch_ids: Sequence[int] | None = None):
         """Reset the data in the delay buffer at the specified batch indices.

--- a/source/isaaclab/test/utils/test_delay_buffer_invalid_lag_state.py
+++ b/source/isaaclab/test/utils/test_delay_buffer_invalid_lag_state.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from isaaclab.utils import DelayBuffer
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("invalid_lag", [-1, 4])
+def test_invalid_time_lag_does_not_mutate_active_state(invalid_lag):
+    buffer = DelayBuffer(history_length=3, batch_size=3, device="cpu")
+    buffer.set_time_lag(torch.tensor([0, 1, 2], dtype=torch.int))
+
+    previous_lags = buffer.time_lags.clone()
+    previous_min = buffer.min_time_lag
+    previous_max = buffer.max_time_lag
+
+    with pytest.raises(ValueError):
+        buffer.set_time_lag(invalid_lag, batch_ids=[1])
+
+    torch.testing.assert_close(buffer.time_lags, previous_lags)
+    assert buffer.min_time_lag == previous_min
+    assert buffer.max_time_lag == previous_max
+
+    # The rejected update must not change externally observable delayed output.
+    for step in range(3):
+        buffer.compute(torch.tensor([[step], [10 + step], [20 + step]], dtype=torch.float))
+    output = buffer.compute(torch.tensor([[3], [13], [23]], dtype=torch.float))
+
+    expected = torch.tensor([[3], [12], [21]], dtype=torch.float)
+    torch.testing.assert_close(output, expected)


### PR DESCRIPTION
# Description

Fixes `DelayBuffer.set_time_lag()` leaving an invalid lag configuration active after raising a validation error.

The method currently writes the requested lag values into `_time_lags` first and validates the resulting minimum and maximum afterwards. If the request is negative or larger than `history_length`, it raises `ValueError` but the invalid values remain in the live buffer state and can affect later `compute()` calls.

This change builds and validates the requested lag state on a clone first, then commits it with `copy_()` only after validation succeeds. Keeping `copy_()` also preserves the identity of the public `time_lags` tensor.

## Type of change

- Bug fix

## Validation

- Added regression coverage for both a negative lag and a lag above `history_length`.
- The test verifies rejected updates preserve `time_lags`, `min_time_lag`, and `max_time_lag`.
- It also verifies subsequent delayed output is unchanged by the rejected update.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
