### PR TITLE
Preserve .yml filenames in dump_yaml

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
@@ -1,5 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed ``dump_yaml()`` to preserve existing ``.yml`` and case-insensitive YAML file extensions instead of appending
-  ``.yaml``.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
@@ -1,0 +1,1 @@
+Fixed ``dump_yaml()`` to preserve existing ``.yml`` and case-insensitive YAML file extensions instead of appending ``.yaml``.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.patch.rst
@@ -1,1 +1,5 @@
-Fixed ``dump_yaml()`` to preserve existing ``.yml`` and case-insensitive YAML file extensions instead of appending ``.yaml``.
+Fixed
+^^^^^
+
+* Fixed ``dump_yaml()`` to preserve existing ``.yml`` and case-insensitive YAML file extensions instead of appending
+  ``.yaml``.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-dump-yaml-yml-extension.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``dump_yaml()`` to preserve existing ``.yml`` and case-insensitive YAML file extensions instead of appending
+  ``.yaml``.

--- a/source/isaaclab/isaaclab/utils/io/yaml.py
+++ b/source/isaaclab/isaaclab/utils/io/yaml.py
@@ -43,7 +43,7 @@ def dump_yaml(filename: str, data: dict | object, sort_keys: bool = False):
         sort_keys: Whether to sort the keys in the output file. Defaults to False.
     """
     # check ending
-    if not filename.endswith("yaml"):
+    if not filename.lower().endswith((".yaml", ".yml")):
         filename += ".yaml"
     # create directory
     directory = os.path.dirname(filename)

--- a/source/isaaclab/test/utils/test_yaml_io.py
+++ b/source/isaaclab/test/utils/test_yaml_io.py
@@ -27,11 +27,12 @@ def test_dump_yaml_adds_extension_in_current_working_directory(monkeypatch, tmp_
     assert (tmp_path / "config.yaml").is_file()
 
 
-def test_dump_yaml_preserves_yml_extension(monkeypatch, tmp_path):
+@pytest.mark.parametrize("filename", ["config.yml", "config.YML"])
+def test_dump_yaml_preserves_yml_extension(monkeypatch, tmp_path, filename):
     monkeypatch.chdir(tmp_path)
 
-    dump_yaml("config.yml", {"value": 42})
+    dump_yaml(filename, {"value": 42})
 
-    assert (tmp_path / "config.yml").is_file()
-    assert not (tmp_path / "config.yml.yaml").exists()
-    assert load_yaml("config.yml") == {"value": 42}
+    assert (tmp_path / filename).is_file()
+    assert not (tmp_path / f"{filename}.yaml").exists()
+    assert load_yaml(filename) == {"value": 42}

--- a/source/isaaclab/test/utils/test_yaml_io.py
+++ b/source/isaaclab/test/utils/test_yaml_io.py
@@ -25,3 +25,13 @@ def test_dump_yaml_adds_extension_in_current_working_directory(monkeypatch, tmp_
     dump_yaml("config", {"value": 42})
 
     assert (tmp_path / "config.yaml").is_file()
+
+
+def test_dump_yaml_preserves_yml_extension(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    dump_yaml("config.yml", {"value": 42})
+
+    assert (tmp_path / "config.yml").is_file()
+    assert not (tmp_path / "config.yml.yaml").exists()
+    assert load_yaml("config.yml") == {"value": 42}


### PR DESCRIPTION
# Description

Fixes `dump_yaml()` changing valid `.yml` filenames.

The helper currently checks only whether the filename ends with the literal string `yaml`. Passing a standard YAML filename such as `config.yml` therefore writes `config.yml.yaml` instead of the requested path.

The extension check now accepts both `.yaml` and `.yml` case-insensitively. Filenames without a YAML extension continue to receive the default `.yaml` suffix.

## Type of change

- Bug fix

## Validation

- Extended the existing YAML I/O unit tests.
- Added a regression test verifying `config.yml` is written unchanged and `config.yml.yaml` is not created.
- Existing coverage still verifies extensionless filenames receive `.yaml`.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
