### PR TITLE
Preserve HDF5 format version when merging datasets

### DIFF
--- a/scripts/tools/merge_hdf5_datasets.py
+++ b/scripts/tools/merge_hdf5_datasets.py
@@ -37,6 +37,8 @@ def merge_datasets():
                     episode_idx += 1
 
                 if copy_attributes:
+                    if "format_version" in input.attrs:
+                        output.attrs["format_version"] = input.attrs["format_version"]
                     output["data"].attrs["env_args"] = input["data"].attrs["env_args"]
                     copy_attributes = False
 

--- a/scripts/tools/merge_hdf5_datasets.py
+++ b/scripts/tools/merge_hdf5_datasets.py
@@ -37,7 +37,11 @@ def merge_datasets():
         versions = ", ".join(
             f"{filepath}={version}" for filepath, version in zip(args_cli.input_files, format_versions)
         )
-        raise ValueError(f"Cannot merge datasets with different format_version values: {versions}.")
+        raise ValueError(
+            f"Cannot merge datasets with different format_version values: {versions}. "
+            "Ensure all inputs use the same dataset format; regenerate augmented datasets from their source or "
+            "convert legacy datasets before merging."
+        )
 
     with h5py.File(args_cli.output_file, "w") as output:
         episode_idx = 0

--- a/scripts/tools/merge_hdf5_datasets.py
+++ b/scripts/tools/merge_hdf5_datasets.py
@@ -26,6 +26,19 @@ def merge_datasets():
         if not os.path.exists(filepath):
             raise FileNotFoundError(f"The dataset file {filepath} does not exist.")
 
+    # A single root-level format_version applies to every episode in the output.
+    # Treat a missing attribute as the legacy version 0 and reject heterogeneous
+    # inputs before creating the output file so episodes cannot be mislabeled.
+    format_versions = []
+    for filepath in args_cli.input_files:
+        with h5py.File(filepath, "r") as input:
+            format_versions.append(int(input.attrs.get("format_version", 0)))
+    if len(set(format_versions)) > 1:
+        versions = ", ".join(
+            f"{filepath}={version}" for filepath, version in zip(args_cli.input_files, format_versions)
+        )
+        raise ValueError(f"Cannot merge datasets with different format_version values: {versions}.")
+
     with h5py.File(args_cli.output_file, "w") as output:
         episode_idx = 0
         copy_attributes = True

--- a/scripts/tools/mp4_to_hdf5.py
+++ b/scripts/tools/mp4_to_hdf5.py
@@ -145,6 +145,11 @@ def main():
     os.makedirs(os.path.dirname(args.output_file), exist_ok=True)
 
     with h5py.File(args.input_file, "r") as f_in, h5py.File(args.output_file, "w") as f_out:
+        # Preserve the root dataset-format marker so augmented datasets retain the
+        # same quaternion interpretation as their source dataset.
+        if "format_version" in f_in.attrs:
+            f_out.attrs["format_version"] = f_in.attrs["format_version"]
+
         # Copy all data from input to output
         f_in.copy("data", f_out)
 

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed the HDF5 merge tool dropping the dataset ``format_version`` and causing current XYZW datasets to be treated as legacy WXYZ data after merging. Mixed legacy/current inputs are now rejected because one output file cannot safely represent multiple root-pose quaternion formats.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the HDF5 merge tool dropping the dataset ``format_version`` and causing current XYZW datasets to be treated as legacy WXYZ data after merging.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.patch.rst
@@ -1,4 +1,4 @@
 Fixed
 ^^^^^
 
-* Fixed the HDF5 merge tool dropping the dataset ``format_version`` and causing current XYZW datasets to be treated as legacy WXYZ data after merging.
+* Fixed the HDF5 merge tool dropping the dataset ``format_version`` and causing current XYZW datasets to be treated as legacy WXYZ data after merging. Mixed legacy/current inputs are now rejected because one output file cannot safely represent multiple root-pose quaternion formats.

--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-merge-hdf5-format-version.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the HDF5 merge and MP4 augmentation tools preserving the dataset ``format_version`` so current XYZW datasets remain correctly labeled through the documented augmentation-and-merge workflow. Mixed legacy/current inputs are rejected because one output file cannot safely represent multiple root-pose quaternion formats.

--- a/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
+++ b/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
@@ -14,24 +14,58 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def test_merge_preserves_dataset_format_version(tmp_path):
-    """Merged current-format datasets must not be reclassified as legacy datasets."""
-    input_path = tmp_path / "input.hdf5"
-    output_path = tmp_path / "merged.hdf5"
-
-    with h5py.File(input_path, "w") as file:
-        file.attrs["format_version"] = 1
+def _create_dataset(path: Path, format_version: int | None) -> None:
+    with h5py.File(path, "w") as file:
+        if format_version is not None:
+            file.attrs["format_version"] = format_version
         data = file.create_group("data")
         data.attrs["env_args"] = '{"env_name": "test"}'
         demo = data.create_group("demo_0")
         demo.create_dataset("actions", data=np.zeros((1, 1), dtype=np.float32))
 
-    repo_root = Path(__file__).resolve().parents[4]
-    script_path = repo_root / "scripts" / "tools" / "merge_hdf5_datasets.py"
+
+def _merge_script_path() -> Path:
+    return Path(__file__).resolve().parents[4] / "scripts" / "tools" / "merge_hdf5_datasets.py"
+
+
+def test_merge_preserves_dataset_format_version(tmp_path):
+    """Merged current-format datasets must not be reclassified as legacy datasets."""
+    input_path = tmp_path / "input.hdf5"
+    output_path = tmp_path / "merged.hdf5"
+    _create_dataset(input_path, format_version=1)
+
     subprocess.run(
-        [sys.executable, str(script_path), "--input_files", str(input_path), "--output_file", str(output_path)],
+        [sys.executable, str(_merge_script_path()), "--input_files", str(input_path), "--output_file", str(output_path)],
         check=True,
     )
 
     with h5py.File(output_path, "r") as file:
         assert file.attrs["format_version"] == 1
+
+
+def test_merge_rejects_mixed_dataset_format_versions(tmp_path):
+    """A merged file cannot safely represent episodes using different quaternion format versions."""
+    current_path = tmp_path / "current.hdf5"
+    legacy_path = tmp_path / "legacy.hdf5"
+    output_path = tmp_path / "merged.hdf5"
+    _create_dataset(current_path, format_version=1)
+    _create_dataset(legacy_path, format_version=None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_merge_script_path()),
+            "--input_files",
+            str(current_path),
+            str(legacy_path),
+            "--output_file",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "different format_version values" in result.stderr
+    assert not output_path.exists()

--- a/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
+++ b/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
@@ -24,8 +24,8 @@ def _create_dataset(path: Path, format_version: int | None) -> None:
         demo.create_dataset("actions", data=np.zeros((1, 1), dtype=np.float32))
 
 
-def _merge_script_path() -> Path:
-    return Path(__file__).resolve().parents[4] / "scripts" / "tools" / "merge_hdf5_datasets.py"
+def _tool_path(name: str) -> Path:
+    return Path(__file__).resolve().parents[4] / "scripts" / "tools" / name
 
 
 def test_merge_preserves_dataset_format_version(tmp_path):
@@ -35,7 +35,14 @@ def test_merge_preserves_dataset_format_version(tmp_path):
     _create_dataset(input_path, format_version=1)
 
     subprocess.run(
-        [sys.executable, str(_merge_script_path()), "--input_files", str(input_path), "--output_file", str(output_path)],
+        [
+            sys.executable,
+            str(_tool_path("merge_hdf5_datasets.py")),
+            "--input_files",
+            str(input_path),
+            "--output_file",
+            str(output_path),
+        ],
         check=True,
     )
 
@@ -43,29 +50,45 @@ def test_merge_preserves_dataset_format_version(tmp_path):
         assert file.attrs["format_version"] == 1
 
 
-def test_merge_rejects_mixed_dataset_format_versions(tmp_path):
-    """A merged file cannot safely represent episodes using different quaternion format versions."""
-    current_path = tmp_path / "current.hdf5"
-    legacy_path = tmp_path / "legacy.hdf5"
-    output_path = tmp_path / "merged.hdf5"
-    _create_dataset(current_path, format_version=1)
-    _create_dataset(legacy_path, format_version=None)
+def test_augmented_dataset_preserves_format_and_merges_with_source(tmp_path):
+    """The documented original-plus-augmented merge path must keep one consistent format version."""
+    source_path = tmp_path / "source.hdf5"
+    augmented_path = tmp_path / "augmented.hdf5"
+    merged_path = tmp_path / "merged.hdf5"
+    videos_dir = tmp_path / "videos"
+    videos_dir.mkdir()
+    _create_dataset(source_path, format_version=1)
 
-    result = subprocess.run(
+    subprocess.run(
         [
             sys.executable,
-            str(_merge_script_path()),
-            "--input_files",
-            str(current_path),
-            str(legacy_path),
+            str(_tool_path("mp4_to_hdf5.py")),
+            "--input_file",
+            str(source_path),
+            "--videos_dir",
+            str(videos_dir),
             "--output_file",
-            str(output_path),
+            str(augmented_path),
         ],
-        check=False,
-        capture_output=True,
-        text=True,
+        check=True,
     )
 
-    assert result.returncode != 0
-    assert "different format_version values" in result.stderr
-    assert not output_path.exists()
+    with h5py.File(augmented_path, "r") as file:
+        assert file.attrs["format_version"] == 1
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(_tool_path("merge_hdf5_datasets.py")),
+            "--input_files",
+            str(source_path),
+            str(augmented_path),
+            "--output_file",
+            str(merged_path),
+        ],
+        check=True,
+    )
+
+    with h5py.File(merged_path, "r") as file:
+        assert file.attrs["format_version"] == 1
+        assert len(file["data"]) == 2

--- a/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
+++ b/source/isaaclab/test/utils/test_merge_hdf5_datasets.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_merge_preserves_dataset_format_version(tmp_path):
+    """Merged current-format datasets must not be reclassified as legacy datasets."""
+    input_path = tmp_path / "input.hdf5"
+    output_path = tmp_path / "merged.hdf5"
+
+    with h5py.File(input_path, "w") as file:
+        file.attrs["format_version"] = 1
+        data = file.create_group("data")
+        data.attrs["env_args"] = '{"env_name": "test"}'
+        demo = data.create_group("demo_0")
+        demo.create_dataset("actions", data=np.zeros((1, 1), dtype=np.float32))
+
+    repo_root = Path(__file__).resolve().parents[4]
+    script_path = repo_root / "scripts" / "tools" / "merge_hdf5_datasets.py"
+    subprocess.run(
+        [sys.executable, str(script_path), "--input_files", str(input_path), "--output_file", str(output_path)],
+        check=True,
+    )
+
+    with h5py.File(output_path, "r") as file:
+        assert file.attrs["format_version"] == 1


### PR DESCRIPTION
# Description

Fixes `scripts/tools/merge_hdf5_datasets.py` dropping the dataset root `format_version` attribute.

Current Isaac Lab HDF5 datasets use `format_version=1` to mark root-pose quaternions as XYZW. The merge tool copied episode data and `env_args`, but not this root attribute. A merged current-format dataset therefore looked like a legacy version-0 dataset to `HDF5DatasetFileHandler`, which can trigger an unnecessary WXYZ-to-XYZW conversion when episodes are loaded.

The merge tool now preserves `format_version` when all inputs use the same effective dataset format. Before creating the output, it checks every input's effective `format_version` (treating a missing attribute as legacy version 0) and rejects mixed-version merges with a clear error, because one root-level format flag cannot safely represent multiple quaternion layouts. Legacy-only datasets without the attribute remain legacy.

## Type of change

- Bug fix

## Validation

- Added a unit regression test that creates a current-format HDF5 dataset, runs the merge tool, and verifies the merged file retains `format_version=1`.
- Added a regression for the documented augmentation workflow: `mp4_to_hdf5.py` preserves the source `format_version`, and the original plus augmented datasets merge successfully with the same version.
- Runtime change is limited to preserving and validating the existing root metadata attribute.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
