### PR TITLE
Fix HDF5 dataset creation in current directory

### DIFF
--- a/source/isaaclab/changelog.d/sylvesterkaczmarek-hdf5-current-directory.rst
+++ b/source/isaaclab/changelog.d/sylvesterkaczmarek-hdf5-current-directory.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed ``HDF5DatasetFileHandler.create()`` failing when a dataset filename is given in the current working directory.

--- a/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
+++ b/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
@@ -70,7 +70,7 @@ class HDF5DatasetFileHandler(DatasetFileHandlerBase):
         if not file_path.endswith(".hdf5"):
             file_path += ".hdf5"
         dir_path = os.path.dirname(file_path)
-        if not os.path.isdir(dir_path):
+        if dir_path and not os.path.isdir(dir_path):
             os.makedirs(dir_path)
         self._hdf5_file_stream = h5py.File(file_path, "w")
 

--- a/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
+++ b/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
@@ -67,6 +67,17 @@ def test_create_dataset_file(temp_dir):
     assert os.path.exists(dataset_file_path + ".hdf5")
 
 
+def test_create_dataset_file_in_current_directory(monkeypatch, tmp_path):
+    """Creating a dataset by basename should not try to create an empty directory path."""
+    monkeypatch.chdir(tmp_path)
+
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.create("dataset.hdf5", "test_env_name")
+    dataset_file_handler.close()
+
+    assert (tmp_path / "dataset.hdf5").is_file()
+
+
 def test_add_env_args_preserves_existing_args_after_reopen(temp_dir):
     """Test extending environment arguments after reopening a dataset."""
     dataset_file_path = os.path.join(temp_dir, f"{uuid.uuid4()}.hdf5")


### PR DESCRIPTION
# Description

Fixes `HDF5DatasetFileHandler.create()` when the requested dataset file is in the current working directory.

The handler derives the parent directory with `os.path.dirname(file_path)` and previously attempted to create it whenever `os.path.isdir()` returned false. For a basename such as `dataset.hdf5`, the parent path is the empty string, so `os.makedirs("")` raises instead of creating the dataset.

The handler now creates a parent directory only when the path actually contains one. Existing behavior for nested output paths and automatic `.hdf5` extension handling is unchanged.

## Type of change

- Bug fix

## Validation

- Added a unit regression test that changes into a temporary directory and creates `dataset.hdf5` by basename.
- The test verifies that the file is created successfully in the current directory.
- Runtime change is one condition only.
- Added the required `isaaclab` changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
