### PR TITLE
Return nested Mimic randomization controls

### DIFF
--- a/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.patch.rst
+++ b/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed nested randomizable parameters being omitted from the list returned by ``interactive_update_randomizable_params()``.

--- a/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.patch.rst
+++ b/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.patch.rst
@@ -1,4 +1,0 @@
-Fixed
-^^^^^
-
-* Fixed nested randomizable parameters being omitted from the list returned by ``interactive_update_randomizable_params()``.

--- a/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.rst
+++ b/source/isaaclab_mimic/changelog.d/sylvesterkaczmarek-nested-randomizable-inputs.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed nested randomizable parameters being omitted from the list returned by ``interactive_update_randomizable_params()``.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/utils.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/utils.py
@@ -150,7 +150,9 @@ def interactive_update_randomizable_params(
         keys = current_path.split(".")
 
         if isinstance(allowed_range, dict):
-            interactive_update_randomizable_params(event_term, event_term_name, allowed_range, current_path, env)
+            inputs.extend(
+                interactive_update_randomizable_params(event_term, event_term_name, allowed_range, current_path, env)
+            )
         else:
             try:
                 current_val = get_nested_value(event_term.params, keys)

--- a/source/isaaclab_mimic/test/test_datagen_utils.py
+++ b/source/isaaclab_mimic/test/test_datagen_utils.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2024-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_mimic.datagen import utils
+
+pytestmark = pytest.mark.unit
+
+
+def test_interactive_update_returns_nested_inputs(monkeypatch):
+    event_term = SimpleNamespace(params={"outer": {"inner": 1.0}, "top": 2.0})
+    param_config = {
+        "outer": {"inner": (0.0, 2.0, 0.1)},
+        "top": (0.0, 3.0, 0.1),
+    }
+    monkeypatch.setattr(utils, "get_parameter_input", lambda param_name, *args, **kwargs: param_name)
+
+    inputs = utils.interactive_update_randomizable_params(event_term, "randomize", param_config)
+
+    assert inputs == [
+        (["outer", "inner"], "outer.inner"),
+        (["top"], "top"),
+    ]


### PR DESCRIPTION
# Description

Fixes `interactive_update_randomizable_params()` omitting nested randomizable controls from its return value.

The function recursively creates controls for nested parameter dictionaries, but the recursive result was previously discarded. Nested controls were therefore displayed and remained functional, while callers received only top-level controls in the returned list.

The recursive result is now extended into the parent `inputs` list, preserving the documented complete list of generated controls at every nesting level.

## Type of change

- Bug fix

## Validation

- Added a unit regression test containing both a nested parameter and a top-level parameter.
- The test verifies the returned list contains both controls with the correct nested key path and order.
- Added the required `isaaclab_mimic` changelog fragment.
- No new dependencies.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added a regression test
- [x] I have added the required changelog fragment
- [x] No new dependencies
