### PR TITLE
Preserve Blender conversion paths and failures

### DIFF
--- a/scripts/tools/process_meshes_to_obj.py
+++ b/scripts/tools/process_meshes_to_obj.py
@@ -42,15 +42,16 @@ def run_blender_convert2obj(in_file: str, out_file: str):
         in_file: Input mesh file.
         out_file: Output obj file.
     """
+    if BLENDER_EXE_PATH is None:
+        raise FileNotFoundError("Unable to find the Blender executable on PATH.")
+
     # resolve for python file
     tools_dirname = os.path.dirname(os.path.abspath(__file__))
     script_file = os.path.join(tools_dirname, "blender_obj.py")
-    # complete command
-    command_exe = f"{BLENDER_EXE_PATH} --background --python {script_file} -- -i {in_file} -o {out_file}"
-    # break command into list
-    command_exe_list = command_exe.split(" ")
-    # run command
-    subprocess.run(command_exe_list)
+    # build the argument list directly so paths containing whitespace remain single arguments
+    command_exe = [BLENDER_EXE_PATH, "--background", "--python", script_file, "--", "-i", in_file, "-o", out_file]
+    # run command and surface conversion failures to the caller
+    subprocess.run(command_exe, check=True)
 
 
 def convert_meshes(source_folders: list[str], destination_folders: list[str]):

--- a/source/isaaclab/test/tools/test_process_meshes_to_obj.py
+++ b/source/isaaclab/test/tools/test_process_meshes_to_obj.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_process_meshes_module():
+    repo_root = Path(__file__).resolve().parents[4]
+    script_path = repo_root / "scripts" / "tools" / "process_meshes_to_obj.py"
+    spec = importlib.util.spec_from_file_location("test_process_meshes_to_obj_script", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_blender_command_preserves_paths_with_spaces(monkeypatch, tmp_path):
+    module = _load_process_meshes_module()
+    blender_path = str(tmp_path / "Blender App" / "blender")
+    input_path = str(tmp_path / "input meshes" / "robot part.stl")
+    output_path = str(tmp_path / "output meshes" / "robot part.obj")
+    run_mock = Mock()
+    monkeypatch.setattr(module, "BLENDER_EXE_PATH", blender_path)
+    monkeypatch.setattr(module.subprocess, "run", run_mock)
+
+    module.run_blender_convert2obj(input_path, output_path)
+
+    script_path = str(Path(module.__file__).resolve().parent / "blender_obj.py")
+    run_mock.assert_called_once_with(
+        [blender_path, "--background", "--python", script_path, "--", "-i", input_path, "-o", output_path],
+        check=True,
+    )
+
+
+def test_blender_conversion_requires_executable(monkeypatch):
+    module = _load_process_meshes_module()
+    monkeypatch.setattr(module, "BLENDER_EXE_PATH", None)
+
+    with pytest.raises(FileNotFoundError, match="Blender executable"):
+        module.run_blender_convert2obj("input.stl", "output.obj")


### PR DESCRIPTION
# Description

Fixes Blender subprocess invocation in `scripts/tools/process_meshes_to_obj.py`.

The helper previously constructed the command as one formatted string and then called `.split(" ")`. Any valid Blender, input, output, or script path containing whitespace was therefore split into multiple command-line arguments.

The subprocess was also launched without `check=True`, so a failed Blender conversion could be silently treated as success by the wrapper.

The helper now builds the subprocess argument list directly, preserves each path as one argument, requests `check=True`, and raises a clear error when Blender cannot be found on `PATH`.

## Type of change

- Bug fix

## Validation

- Added a unit regression test with Blender, input, and output paths containing spaces.
- The test verifies each path remains one subprocess argument and `check=True` is used.
- Added coverage for the missing-Blender error path.
- No Blender installation is required by the tests.
- No package changelog fragment is required because this changes a repository script, not a `source/<pkg>/` package.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added regression tests
- [x] No new dependencies
