### PR TITLE
Fix Blender OBJ output path handling

### DIFF
--- a/scripts/tools/blender_obj.py
+++ b/scripts/tools/blender_obj.py
@@ -67,8 +67,9 @@ def convert_to_obj(in_file: str, out_file: str, save_usd: bool = False):
     if not out_file.endswith(".obj"):
         out_file += ".obj"
     # create directory if it doesn't exist for destination file
-    if not os.path.exists(os.path.dirname(out_file)):
-        os.makedirs(os.path.dirname(out_file), exist_ok=True)
+    out_dir = os.path.dirname(out_file)
+    if out_dir and not os.path.exists(out_dir):
+        os.makedirs(out_dir, exist_ok=True)
     # reset scene to empty
     bpy.ops.wm.read_factory_settings(use_empty=True)
     # load object into scene
@@ -86,8 +87,8 @@ def convert_to_obj(in_file: str, out_file: str, save_usd: bool = False):
     )
     # save it as usd as well
     if save_usd:
-        out_file = out_file.replace("obj", "usd")
-        bpy.ops.wm.usd_export(filepath=out_file, check_existing=False)
+        usd_file = os.path.splitext(out_file)[0] + ".usd"
+        bpy.ops.wm.usd_export(filepath=usd_file, check_existing=False)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab/test/tools/test_blender_obj.py
+++ b/source/isaaclab/test/tools/test_blender_obj.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_blender_obj_module(monkeypatch):
+    fake_bpy = SimpleNamespace(
+        ops=SimpleNamespace(
+            wm=SimpleNamespace(read_factory_settings=Mock(), collada_import=Mock(), usd_export=Mock()),
+            import_mesh=SimpleNamespace(stl=Mock()),
+            export_scene=SimpleNamespace(obj=Mock()),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "bpy", fake_bpy)
+
+    repo_root = Path(__file__).resolve().parents[4]
+    script_path = repo_root / "scripts" / "tools" / "blender_obj.py"
+    spec = importlib.util.spec_from_file_location("test_blender_obj_script", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module, fake_bpy
+
+
+def test_convert_to_obj_supports_current_directory_output(monkeypatch, tmp_path):
+    module, fake_bpy = _load_blender_obj_module(monkeypatch)
+    input_path = tmp_path / "input.stl"
+    input_path.touch()
+    monkeypatch.chdir(tmp_path)
+
+    module.convert_to_obj(str(input_path), "robot.obj")
+
+    fake_bpy.ops.export_scene.obj.assert_called_once_with(
+        filepath="robot.obj",
+        check_existing=False,
+        axis_forward="Y",
+        axis_up="Z",
+        global_scale=1,
+        path_mode="RELATIVE",
+    )
+
+
+def test_save_usd_replaces_only_output_extension(monkeypatch, tmp_path):
+    module, fake_bpy = _load_blender_obj_module(monkeypatch)
+    input_path = tmp_path / "input.stl"
+    input_path.touch()
+    output_dir = tmp_path / "objects"
+    output_path = output_dir / "robot.obj"
+
+    module.convert_to_obj(str(input_path), str(output_path), save_usd=True)
+
+    fake_bpy.ops.wm.usd_export.assert_called_once_with(
+        filepath=str(output_dir / "robot.usd"), check_existing=False
+    )


### PR DESCRIPTION
# Description

Fixes two path-handling bugs in `scripts/tools/blender_obj.py`.

When the output is a basename such as `robot.obj`, `os.path.dirname()` returns an empty string. The converter previously tried to create that empty path with `os.makedirs("")`, so writing directly to the current working directory failed.

The optional USD export also used `out_file.replace("obj", "usd")`, which replaces every matching substring in the full path. A valid path such as `objects/robot.obj` could therefore be changed to `usdects/robot.usd`.

The converter now creates a parent directory only when one is present and derives the USD path by replacing only the file extension.

## Type of change

- Bug fix

## Validation

- Added a unit regression test for an OBJ basename in the current working directory.
- Added a regression test verifying `objects/robot.obj` maps to `objects/robot.usd` without changing directory names.
- Blender is mocked, so the tests do not require a Blender installation.
- Added the required `isaaclab` `.skip` changelog marker because managed package tests are touched.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have added regression tests
- [x] No new dependencies
