### PR TITLE
Cache pip and uv downloads in GitHub Actions

### DIFF
--- a/.github/actions/install-ci-run/action.yml
+++ b/.github/actions/install-ci-run/action.yml
@@ -29,6 +29,9 @@ runs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        # `auto` (the default) enables the cache only on GitHub-hosted runners;
+        # this action also runs on the self-hosted arm64 runner, so force it on.
+        enable-cache: true
     - name: Run Tests
       shell: bash
       env:

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -36,8 +36,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          # No `cache: pip` here: the pytest install below is conditional on the
+          # PR touching tools/changelog/, so on most runs pip never executes and
+          # ~/.cache/pip is never created. setup-python's post-job save treats a
+          # missing cache dir as an error and fails the job.
 
       - name: Resolve base ref
         id: base

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Resolve base ref
         id: base

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -64,6 +64,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        enable-cache: true
 
     - name: Install docs dependencies
       run: |
@@ -97,6 +98,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        enable-cache: true
 
     - name: Install docs dependencies
       run: |

--- a/.github/workflows/kitless-docker.yml
+++ b/.github/workflows/kitless-docker.yml
@@ -70,6 +70,8 @@ jobs:
     - name: Set up uv
       if: steps.detect.outputs.should_run == 'true'
       uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
 
     - name: Validate kit-less container profile
       if: steps.detect.outputs.should_run == 'true'

--- a/.github/workflows/skills-check.yml
+++ b/.github/workflows/skills-check.yml
@@ -35,10 +35,12 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          # Pin the cache key to the dependency source of truth. Without this the
-          # action keys off its `**/requirements.txt` default, which here matches
-          # only the unrelated tools/template/requirements.txt.
-          cache-dependency-path: pyproject.toml
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Hashing the workflow also ties
+          # invalidation to the install list below rather than to unrelated
+          # dependency churn.
+          cache-dependency-path: .github/workflows/skills-check.yml
 
       - name: Verify skills
         run: python3 tools/skills/cli.py check

--- a/.github/workflows/skills-check.yml
+++ b/.github/workflows/skills-check.yml
@@ -34,6 +34,11 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
+          cache: pip
+          # Pin the cache key to the dependency source of truth. Without this the
+          # action keys off its `**/requirements.txt` default, which here matches
+          # only the unrelated tools/template/requirements.txt.
+          cache-dependency-path: pyproject.toml
 
       - name: Verify skills
         run: python3 tools/skills/cli.py check

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -38,6 +38,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          # Pin the cache key to the dependency source of truth. Without this the
+          # action keys off its `**/requirements.txt` default, which here matches
+          # only the unrelated tools/template/requirements.txt.
+          cache-dependency-path: pyproject.toml
 
       # These tests only need pytest, junitparser (imported by tools/crash_journal.py) and
       # flaky, so they run without an Isaac Sim install or a full project sync. flaky drives the

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -39,10 +39,12 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          # Pin the cache key to the dependency source of truth. Without this the
-          # action keys off its `**/requirements.txt` default, which here matches
-          # only the unrelated tools/template/requirements.txt.
-          cache-dependency-path: pyproject.toml
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Hashing the workflow also ties
+          # invalidation to the install list below rather than to unrelated
+          # dependency churn.
+          cache-dependency-path: .github/workflows/tools-tests.yml
 
       # These tests only need pytest, junitparser (imported by tools/crash_journal.py) and
       # flaky, so they run without an Isaac Sim install or a full project sync. flaky drives the

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -150,6 +150,10 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          # Neither this job nor kitless-docker pins python-version, so both land
+          # on the same `-unknown-` cache key and only one can save. This job
+          # caches the wheel's full extras resolution; keep it separate.
+          cache-suffix: wheel-extras
 
       # Compose Docker-image-style metadata for the artifact. The artifact
       # name is what QA sees in `gh run download`, so we make it scannable:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -136,10 +136,20 @@ jobs:
           python-version: "3.12"
           architecture: x64
           cache: pip
-          # Pin the cache key to the dependency source of truth. Without this the
-          # action keys off its `**/requirements.txt` default, which here matches
-          # only the unrelated tools/template/requirements.txt.
-          cache-dependency-path: pyproject.toml
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Covers the `build` and `wheel`
+          # packages that tools/wheel_builder/build.sh installs with pip.
+          cache-dependency-path: .github/workflows/wheel.yml
+
+      # The extras-resolution step below drives uv, whose downloads land in
+      # ~/.cache/uv rather than pip's cache. Provisioning uv here caches that
+      # resolution work and drops the ~24 MB `pip install uv` bootstrap.
+      - name: Set up uv
+        if: steps.changes.outputs.run_build == 'true'
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       # Compose Docker-image-style metadata for the artifact. The artifact
       # name is what QA sees in `gh run download`, so we make it scannable:
@@ -181,9 +191,6 @@ jobs:
         if: steps.changes.outputs.run_build == 'true'
         run: |
           set -euo pipefail
-
-          bash "$GITHUB_WORKSPACE/.github/actions/_lib/with-python-package-retries.sh" python -m pip install --user uv
-          export PATH="$HOME/.local/bin:$PATH"
 
           overrides="$GITHUB_WORKSPACE/tools/wheel_builder/uv-overrides.txt"
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -135,6 +135,11 @@ jobs:
         with:
           python-version: "3.12"
           architecture: x64
+          cache: pip
+          # Pin the cache key to the dependency source of truth. Without this the
+          # action keys off its `**/requirements.txt` default, which here matches
+          # only the unrelated tools/template/requirements.txt.
+          cache-dependency-path: pyproject.toml
 
       # Compose Docker-image-style metadata for the artifact. The artifact
       # name is what QA sees in `gh run download`, so we make it scannable:

--- a/source/isaaclab/changelog.d/ci-cache-pip-uv.skip
+++ b/source/isaaclab/changelog.d/ci-cache-pip-uv.skip
@@ -1,0 +1,5 @@
+# No changelog entry / version bump: CI-only change. Enables the pip cache in
+# actions/setup-python and the uv cache in astral-sh/setup-uv across the
+# workflows that install Python packages, so an index outage no longer fails a
+# job once with-python-package-retries.sh exhausts its retries. No source
+# package or published wheel is affected.


### PR DESCRIPTION
# Description

Python packages were re-downloaded from PyPI on every CI run. Only `license-check.yaml` enabled a package cache; every other workflow that installs Python dependencies did so uncached.

**`astral-sh/setup-uv` — `enable-cache: true`**

| Location | Covers |
|---|---|
| `docs.yaml` (both jobs) | `uv sync --extra test` |
| `kitless-docker.yml` | `uv run --with pytest --with pyyaml` |
| `.github/actions/install-ci-run` | `uv venv --seed` + managed 3.12 |

The composite action sets this explicitly rather than relying on the default `auto`, which enables the cache only on GitHub-hosted runners — that action also runs on the self-hosted arm64 runner via `arm-ci.yml`.

**`actions/setup-python` — `cache: pip`**

Added to `changelog-check.yml`, `skills-check.yml`, `tools-tests.yml`, `wheel.yml`. Each pins `cache-dependency-path: pyproject.toml`; the action's `**/requirements.txt` default would otherwise key off `tools/template/requirements.txt`, which is unrelated to what these jobs install.

**Deliberately left uncached**

- `resolve-ov-pins` and `nightly-changelog` install nothing with pip (stdlib `tomllib` / `tools/changelog/cli.py` only), so a cache round-trip would be pure overhead.
- `test-multi-gpu.yaml` runs `./isaaclab.sh --install` on a self-hosted runner. Its pip cache would be multi-GB (torch, Isaac Sim wheels) and would compete with the Warp kernel cache for the 10 GB per-repository quota — the same quota `build.yaml` notes was exhausted once before.

Note that the Docker-side `--mount=type=cache` on pip in `docker/Dockerfile.base` does not persist across runs: `docker-build` creates a per-job `docker-container` builder and removes it in a trap, and BuildKit does not export `type=cache` mount contents through `--cache-to`. That is unchanged here; the deps-hash image short-circuit already covers that path.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<sub>CI-only change: no source package touched, so no changelog fragment is required (`tools/changelog/cli.py check` passes clean).</sub>