### PR TITLE
Create the Kit marker backend only when the Kit renderer is active

### DIFF
--- a/source/isaaclab/changelog.d/hehu-kit-marker-backend-requires-kit-renderer.rst
+++ b/source/isaaclab/changelog.d/hehu-kit-marker-backend-requires-kit-renderer.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed a GPU crash on the first environment step when the PhysX backend is combined with a non-Kit
+  visualizer, such as ``--viz newton_rtx physics=isaacsim_physx``. Such runs aborted with ``CUDA
+  error: unspecified launch failure`` after ``omni.physx.fabric`` reported "mismatched prototypes on
+  point instancer". Creating the Kit ``UsdGeom.PointInstancer`` marker backend was gated on
+  :attr:`~isaaclab.sim.SimulationContext.is_rendering`, which is ``True`` whenever any visualizer is
+  configured, so the instancer was created even though the Kit render pipeline never runs and never
+  populates it in Fabric. The Kit marker backend is now created only when the Kit render pipeline is
+  actually active. Runs using a Kit visualizer are unaffected.

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -261,7 +261,9 @@ class VisualizationMarkers:
         # Kit-pumping visualizer. Offscreen is excluded from ``is_rendering`` (see
         # :attr:`~isaaclab.sim.SimulationContext.is_rendering`), so it is checked explicitly here.
         needs_kit_backend = (
-            sim.is_rendering
+            sim.has_gui
+            or sim.get_setting("/isaaclab/render/rtx_sensors")
+            or sim.get_setting("/isaaclab/xr/enabled")
             or getattr(sim, "has_offscreen_render", False)
             or any(
                 viz.supports_markers() and viz.pumps_app_update() and viz.cfg.enable_markers for viz in sim.visualizers


### PR DESCRIPTION
# Description

`VisualizationMarkers` gated creation of the Kit `UsdGeom.PointInstancer` backend on
`SimulationContext.is_rendering`, which returns `True` whenever *any* visualizer is configured —
including non-Kit ones such as `newton_rtx`. The point instancer was therefore created against a
headless Kit whose render pipeline never runs and never populates it in Fabric. On the PhysX backend,
`omni.physx.fabric` then logged `mismatched prototypes on point instancer` and indexed the
unpopulated prototype data out of bounds, destroying the CUDA context. The first `env.step()` failed
with `CUDA error: unspecified launch failure`.

This gates the Kit marker backend on the Kit render pipeline actually being active. Real Kit
visualizers are already covered by the existing `pumps_app_update()` term, so `--viz kit` behaviour
is unchanged.

Fixes: https://nvbugspro.nvidia.com/bug/6605227

## Repro

```
uv run --extra ovrtx isaaclab train --rl_library rsl_rl --task Isaac-Velocity-Rough-G1 \
  --max_iterations 2 --viz newton_rtx physics=isaacsim_physx
```

| Config | Before | After |
| --- | --- | --- |
| `--viz newton_rtx physics=isaacsim_physx` | `CUDA error: unspecified launch failure` — exit 1 | no warning, trains to completion — exit 0 |
| `--viz kit physics=isaacsim_physx` | trains to completion — exit 0 | trains to completion — exit 0 |

Reproduced on RTX 5880 Ada, driver 580.159.03 / CUDA 13.0, Isaac Sim 6.0.1.0 — the failure does not
depend on a particular GPU, driver or Isaac Sim version.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
