### PR TITLE
[Newton] Avoid repeated model startup work

### DIFF
--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -86,6 +86,7 @@ class PhysicsManager(ABC):
     _sim_time: ClassVar[float] = 0.0
     _callbacks: ClassVar[dict[int, tuple[Any, Callable, int, str | None, Any]]] = {}
     _callback_id: ClassVar[int] = 0
+    views: ClassVar[dict[tuple[type, str], Any]] = {}
 
     @classmethod
     def _prepare_stage_creation(cls) -> None:
@@ -457,6 +458,7 @@ class PhysicsManager(ABC):
             cls.clear_callbacks()
         finally:
             if is_active_manager:
+                PhysicsManager.views.clear()
                 PhysicsManager._sim = None
                 PhysicsManager._cfg = None
                 PhysicsManager._sim_time = 0.0

--- a/source/isaaclab/test/sim/test_physics_manager_lifecycle.py
+++ b/source/isaaclab/test/sim/test_physics_manager_lifecycle.py
@@ -26,6 +26,7 @@ def test_close_runs_all_live_stop_listeners_and_aggregates_failures(monkeypatch)
     monkeypatch.setattr(PhysicsManager, "_sim", SimpleNamespace(physics_manager=TestManager))
     monkeypatch.setattr(PhysicsManager, "_cfg", object())
     monkeypatch.setattr(PhysicsManager, "_sim_time", 1.0)
+    monkeypatch.setattr(PhysicsManager, "views", {(TestManager, "/World/Robot"): object()})
 
     TestManager.register_callback(
         lambda _payload: events.append("first"),
@@ -71,6 +72,7 @@ def test_close_runs_all_live_stop_listeners_and_aggregates_failures(monkeypatch)
     assert PhysicsManager._sim is None
     assert PhysicsManager._cfg is None
     assert PhysicsManager._sim_time == 0.0
+    assert PhysicsManager.views == {}
 
 
 def test_close_surfaces_stop_errors_stored_by_safe_callback_invoke(monkeypatch):

--- a/source/isaaclab_contrib/changelog.d/ooctipus-newton-active-solver-attributes.rst
+++ b/source/isaaclab_contrib/changelog.d/ooctipus-newton-active-solver-attributes.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Registered every configured child solver's builder attributes for coupled Newton models.

--- a/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
@@ -188,17 +188,15 @@ class NewtonCouplerManager(NewtonVBDManager):
     def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
         """Register custom attributes required by nested coupled entries."""
         super()._register_builder_attributes(builder)
-        solver_cfg = getattr(PhysicsManager._cfg, "solver_cfg", None)
-        if any(isinstance(entry.solver_cfg, MPMSolverCfg) for entry in getattr(solver_cfg, "entries", ())):
-            NewtonMPMManager._register_builder_attributes(builder)
+        for entry in PhysicsManager._cfg.solver_cfg.entries:
+            entry.solver_cfg.class_type._register_builder_attributes(builder)
 
     @classmethod
     def _prepare_builder_for_finalize(cls, builder: ModelBuilder) -> None:
         """Normalize kinematic colliders when a coupled entry uses implicit MPM."""
         super()._prepare_builder_for_finalize(builder)
-        solver_cfg = getattr(PhysicsManager._cfg, "solver_cfg", None)
-        if any(isinstance(entry.solver_cfg, MPMSolverCfg) for entry in getattr(solver_cfg, "entries", ())):
-            NewtonMPMManager._prepare_builder_for_finalize(builder)
+        for entry in PhysicsManager._cfg.solver_cfg.entries:
+            entry.solver_cfg.class_type._prepare_builder_for_finalize(builder)
 
     @classmethod
     def _initialize_contacts(cls) -> None:

--- a/source/isaaclab_contrib/isaaclab_contrib/custom_coupling/coupled_mjwarp_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/custom_coupling/coupled_mjwarp_vbd_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import warp as wp
 from isaaclab_newton.physics.newton_manager import NewtonManager
 from isaaclab_newton.physics.vbd_manager import NewtonVBDManager
-from newton import Contacts, Control, Model, ModelBuilder, State
+from newton import Contacts, Control, Model, State
 from newton.solvers import SolverBase, SolverMuJoCo, SolverVBD
 
 from isaaclab.physics import PhysicsManager
@@ -29,12 +29,7 @@ class NewtonCoupledMJWarpVBDManager(NewtonVBDManager):
     _rigid_solver: SolverMuJoCo | None = None
     _soft_solver: SolverVBD | None = None
     _coupling_mode: str | None = None
-
-    @classmethod
-    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
-        """Register the custom attributes consumed by the nested rigid solver."""
-        super()._register_builder_attributes(builder)
-        PhysicsManager._cfg.solver_cfg.rigid_solver_cfg.class_type._register_builder_attributes(builder)
+    _builder_attribute_solvers = (SolverMuJoCo,)
 
     @classmethod
     def step(cls) -> None:

--- a/source/isaaclab_contrib/isaaclab_contrib/custom_coupling/coupled_mjwarp_vbd_manager.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/custom_coupling/coupled_mjwarp_vbd_manager.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import warp as wp
 from isaaclab_newton.physics.newton_manager import NewtonManager
 from isaaclab_newton.physics.vbd_manager import NewtonVBDManager
-from newton import Contacts, Control, Model, State
+from newton import Contacts, Control, Model, ModelBuilder, State
 from newton.solvers import SolverBase, SolverMuJoCo, SolverVBD
+
+from isaaclab.physics import PhysicsManager
 
 from .kernels import _kernel_body_particle_reaction
 from .newton_manager_cfg import CoupledMJWarpVBDSolverCfg
@@ -29,10 +31,14 @@ class NewtonCoupledMJWarpVBDManager(NewtonVBDManager):
     _coupling_mode: str | None = None
 
     @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register the custom attributes consumed by the nested rigid solver."""
+        super()._register_builder_attributes(builder)
+        PhysicsManager._cfg.solver_cfg.rigid_solver_cfg.class_type._register_builder_attributes(builder)
+
+    @classmethod
     def step(cls) -> None:
         """Step the physics simulation."""
-        from isaaclab.physics import PhysicsManager
-
         sim = PhysicsManager._sim
         if sim is None or not sim.is_playing():
             return

--- a/source/isaaclab_contrib/test/coupling/test_coupler.py
+++ b/source/isaaclab_contrib/test/coupling/test_coupler.py
@@ -30,7 +30,7 @@ from isaaclab_newton.physics import (
     XPBDSolverCfg,
 )
 from isaaclab_newton.physics.newton_manager import NewtonManager
-from newton import ShapeFlags
+from newton import ModelBuilder, ShapeFlags
 from newton.solvers.experimental.coupled import SolverCoupledADMM, SolverCoupledProxy
 
 from isaaclab_contrib.coupling import (
@@ -577,6 +577,23 @@ def test_mpm_entry_reuses_builder_lifecycle_hooks(monkeypatch):
     NewtonCouplerManager._prepare_builder_for_finalize(builder)
 
     assert events == [("register", builder), ("finalize", builder)]
+
+
+def test_nested_solvers_register_their_builder_attributes(monkeypatch):
+    """A coupled model declares the schemas consumed by each configured child solver."""
+    builder = ModelBuilder()
+    solver_cfg = CouplerProxyCfg(
+        entries=[
+            CouplerEntryCfg(name="rigid", solver_cfg=MJWarpSolverCfg()),
+            CouplerEntryCfg(name="media", solver_cfg=MPMSolverCfg()),
+        ]
+    )
+    monkeypatch.setattr(coupler.PhysicsManager, "_cfg", SimpleNamespace(solver_cfg=solver_cfg))
+
+    NewtonCouplerManager._register_builder_attributes(builder)
+
+    assert builder.has_custom_attribute("mujoco:condim")
+    assert builder.has_custom_attribute("mpm:young_modulus")
 
 
 def test_contact_initialization_prepares_coupled_solver_buffers(monkeypatch):

--- a/source/isaaclab_contrib/test/custom_coupling/test_manager.py
+++ b/source/isaaclab_contrib/test/custom_coupling/test_manager.py
@@ -5,14 +5,27 @@
 
 """Unit tests for the custom coupling manager."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from isaaclab_newton.physics import MJWarpSolverCfg, VBDSolverCfg
+from newton import ModelBuilder
 
 import isaaclab_contrib.custom_coupling.coupled_mjwarp_vbd_manager as manager_module
 from isaaclab_contrib.custom_coupling.coupled_mjwarp_vbd_manager import NewtonCoupledMJWarpVBDManager
 from isaaclab_contrib.custom_coupling.newton_manager_cfg import CoupledMJWarpVBDSolverCfg
+
+
+def test_register_builder_attributes_includes_nested_solvers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The custom coupled manager delegates builder setup to both configured children."""
+    cfg = CoupledMJWarpVBDSolverCfg()
+    monkeypatch.setattr(manager_module.PhysicsManager, "_cfg", SimpleNamespace(solver_cfg=cfg))
+    builder = ModelBuilder()
+
+    NewtonCoupledMJWarpVBDManager._register_builder_attributes(builder)
+
+    assert builder.has_custom_attribute("mujoco:condim")
 
 
 def test_reset_forwards_to_both_subsolvers(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/source/isaaclab_newton/changelog.d/ooctipus-newton-active-solver-attributes.rst
+++ b/source/isaaclab_newton/changelog.d/ooctipus-newton-active-solver-attributes.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Registered builder attributes only for the active Newton solver instead of importing and allocating inactive
+  solver data.

--- a/source/isaaclab_newton/changelog.d/ooctipus-newton-active-solver-attributes.rst
+++ b/source/isaaclab_newton/changelog.d/ooctipus-newton-active-solver-attributes.rst
@@ -3,3 +3,5 @@ Changed
 
 * Registered builder attributes only for the active Newton solver instead of importing and allocating inactive
   solver data.
+* Reused target-mode resolution across identical articulation clones and one canonical articulation view between
+  each articulation and its joint-wrench sensor.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
@@ -27,7 +28,7 @@ from isaaclab.actuators.actuator_base_cfg import _is_implicit_actuator_cfg
 from isaaclab.assets.articulation import ordering_kernels
 from isaaclab.assets.articulation.base_articulation import BaseArticulation
 from isaaclab.physics import PhysicsEvent
-from isaaclab.sim.utils.queries import path_expr_to_glob, resolve_matching_prims_from_source
+from isaaclab.sim.utils.queries import resolve_matching_prims_from_source
 from isaaclab.utils.string import resolve_matching_names, resolve_matching_names_values
 from isaaclab.utils.version import get_isaac_sim_version, has_kit
 from isaaclab.utils.warp import ProxyArray
@@ -84,10 +85,11 @@ def _resolve_articulation_root_prim_path_expr(cfg: ArticulationCfg) -> str:
 
 def _configure_builder_joint_target_modes(builder, cfg: ArticulationCfg) -> None:
     """Resolve configured actuator gains into Newton builder target modes before finalization."""
-    root_prim_path_regex = path_expr_to_glob(_resolve_articulation_root_prim_path_expr(cfg)).replace("*", ".*")
+    root_prim_path_regex = _resolve_articulation_root_prim_path_expr(cfg)
     articulation_ids, _ = resolve_matching_names(
         root_prim_path_regex, builder.articulation_label, raise_when_no_match=False
     )
+    source_dof_ids = None
     for articulation_id in articulation_ids:
         joint_start = builder.articulation_start[articulation_id]
         joint_end = builder.articulation_end[articulation_id]
@@ -106,6 +108,11 @@ def _configure_builder_joint_target_modes(builder, cfg: ArticulationCfg) -> None
             for axis_index, dof_id in enumerate(range(dof_start, dof_end)):
                 dof_ids.append(dof_id)
                 dof_names.append(joint_name if dof_end - dof_start == 1 else f"{joint_name}:{axis_index}")
+
+        if source_dof_ids is not None:
+            for source_dof_id, dof_id in zip(source_dof_ids, dof_ids, strict=True):
+                builder.joint_target_mode[dof_id] = builder.joint_target_mode[source_dof_id]
+            continue
 
         for actuator_cfg in cfg.actuators.values():
             matched_indices, matched_names = resolve_matching_names(
@@ -130,6 +137,7 @@ def _configure_builder_joint_target_modes(builder, cfg: ArticulationCfg) -> None
                     if _is_implicit_actuator_cfg(actuator_cfg)
                     else JointTargetMode.EFFORT
                 )
+        source_dof_ids = dof_ids
 
 
 class Articulation(BaseArticulation):
@@ -3279,19 +3287,14 @@ class Articulation(BaseArticulation):
     """
 
     def _initialize_impl(self):
-        # obtain global simulation view
-        self._physics_sim_view = SimulationManager.get_physics_sim_view()
-
         root_prim_path_expr = _resolve_articulation_root_prim_path_expr(self.cfg)
         # -- articulation
-        self._root_view = ArticulationView(
+        self._root_view = SimulationManager.views[SimulationManager, root_prim_path_expr] = ArticulationView(
             SimulationManager.get_model(),
-            path_expr_to_glob(root_prim_path_expr),
+            re.compile(root_prim_path_expr),
             verbose=False,
             exclude_joint_types=[JointType.FREE, JointType.FIXED],
         )
-        # Register view with Newton manager so sensors (e.g. FrameTransformer) can find it.
-        SimulationManager.get_physics_sim_view().append(self._root_view)
 
         # container for data access
         self._data = ArticulationData(self.root_view, self.device)

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -11,7 +11,7 @@ from typing import Any
 import numpy as np
 import torch
 import warp as wp
-from newton import GeoType, ModelBuilder, ShapeFlags, solvers
+from newton import GeoType, ModelBuilder, ShapeFlags
 
 from pxr import Usd, UsdGeom, UsdPhysics
 
@@ -133,8 +133,6 @@ def _build_source_builder(
 ) -> ModelBuilder:
     """Build one source builder."""
     builder = create_builder()
-    solvers.SolverMuJoCo.register_custom_attributes(builder)
-    solvers.SolverKamino.register_custom_attributes(builder)
     import_result = builder.add_usd(
         stage,
         root_path=source,

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, ModelBuilder, eval_fk
+from newton import Model, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -57,10 +57,7 @@ class NewtonKaminoManager(NewtonManager):
     # Annotate the concrete solver type.
     _solver: SolverKamino
 
-    @classmethod
-    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
-        """Register the custom attributes consumed by Kamino."""
-        SolverKamino.register_custom_attributes(builder)
+    _builder_attribute_solvers = (SolverKamino,)
 
     @classmethod
     def _get_kamino_solver_cfg(cls) -> _KaminoSolverCfgBase:

--- a/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/kamino_manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 import warp as wp
-from newton import Model, eval_fk
+from newton import Model, ModelBuilder, eval_fk
 from newton.solvers import SolverKamino
 
 from isaaclab.physics import PhysicsManager
@@ -56,6 +56,11 @@ class NewtonKaminoManager(NewtonManager):
 
     # Annotate the concrete solver type.
     _solver: SolverKamino
+
+    @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register the custom attributes consumed by Kamino."""
+        SolverKamino.register_custom_attributes(builder)
 
     @classmethod
     def _get_kamino_solver_cfg(cls) -> _KaminoSolverCfgBase:

--- a/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy as np
 import warp as wp
-from newton import Contacts, Model
+from newton import Contacts, Model, ModelBuilder
 from newton.solvers import SolverMuJoCo
 
 from isaaclab.physics import PhysicsManager
@@ -30,6 +30,11 @@ class NewtonMJWarpManager(NewtonManager):
     convergence logging emitted from :meth:`_log_solver_debug` when
     :attr:`NewtonCfg.debug_mode` is enabled.
     """
+
+    @classmethod
+    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
+        """Register the custom attributes consumed by MuJoCo Warp."""
+        SolverMuJoCo.register_custom_attributes(builder)
 
     @classmethod
     def _create_solver(cls, model: Model, solver_cfg: MJWarpSolverCfg) -> SolverMuJoCo:

--- a/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/mjwarp_manager.py
@@ -11,7 +11,7 @@ import logging
 
 import numpy as np
 import warp as wp
-from newton import Contacts, Model, ModelBuilder
+from newton import Contacts, Model
 from newton.solvers import SolverMuJoCo
 
 from isaaclab.physics import PhysicsManager
@@ -31,10 +31,7 @@ class NewtonMJWarpManager(NewtonManager):
     :attr:`NewtonCfg.debug_mode` is enabled.
     """
 
-    @classmethod
-    def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
-        """Register the custom attributes consumed by MuJoCo Warp."""
-        SolverMuJoCo.register_custom_attributes(builder)
+    _builder_attribute_solvers = (SolverMuJoCo,)
 
     @classmethod
     def _create_solver(cls, model: Model, solver_cfg: MJWarpSolverCfg) -> SolverMuJoCo:

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -485,8 +485,7 @@ class NewtonManager(PhysicsManager):
     _shadow_deformable_batch_sync_key: tuple | None = None
     _visualization_stop_callback: CallbackHandle | None = None
 
-    # Views list for assets to register their views
-    _views: list = []
+    _builder_attribute_solvers: tuple[type[SolverBase], ...] = ()
     _mpm_object_registry: list = []
 
     # CL: Cloning / Replication logic
@@ -1045,15 +1044,8 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def get_physics_sim_view(cls) -> list:
-        """Get the list of registered views.
-
-        Assets can append their views to this list, and sensors can access them.
-        Returns a list that callers can append to.
-
-        Returns:
-            List of registered views (e.g., NewtonArticulationView instances).
-        """
-        return cls._views
+        """Return the registered articulation views."""
+        return [view for (manager, _), view in cls.views.items() if manager is NewtonManager]
 
     @classmethod
     def is_fabric_enabled(cls) -> bool:
@@ -1143,7 +1135,8 @@ class NewtonManager(PhysicsManager):
         NewtonManager._cl_protos = {}
         NewtonManager._pending_extended_state_attributes = set()
         NewtonManager._pending_extended_contact_attributes = set()
-        NewtonManager._views = []
+        for key in [key for key in NewtonManager.views if key[0] is NewtonManager]:
+            del NewtonManager.views[key]
         cls._solver_specific_clear()
 
     @classmethod
@@ -1187,17 +1180,9 @@ class NewtonManager(PhysicsManager):
 
     @classmethod
     def _register_builder_attributes(cls, builder: ModelBuilder) -> None:
-        """Subclass hook to register solver-specific custom attributes on *builder*.
-
-        Override in solver subclasses (e.g. :class:`NewtonMPMManager`) that need
-        Newton-side particle, shape, or body custom attributes registered before
-        the builder is finalized. The default implementation is a no-op so
-        solvers without custom attributes do not need to override it.
-
-        Implementations should be **idempotent** — the same builder may be
-        passed multiple times across :meth:`create_builder`,
-        :meth:`instantiate_builder_from_stage`, and :meth:`start_simulation`.
-        """
+        """Register custom attributes required by the active solver."""
+        for solver_cls in cls._builder_attribute_solvers:
+            solver_cls.register_custom_attributes(builder)
 
     @classmethod
     def _prepare_builder_for_finalize(cls, builder: ModelBuilder) -> None:

--- a/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/joint_wrench/joint_wrench_sensor.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -16,7 +17,7 @@ from newton.selection import ArticulationView
 from pxr import UsdPhysics
 
 from isaaclab.sensors.joint_wrench import BaseJointWrenchSensor
-from isaaclab.sim.utils.queries import path_expr_to_glob, resolve_matching_prims_from_source
+from isaaclab.sim.utils.queries import resolve_matching_prims_from_source
 
 from isaaclab_newton.physics import NewtonManager
 
@@ -125,20 +126,21 @@ class JointWrenchSensor(BaseJointWrenchSensor):
         """PHYSICS_READY callback: builds the articulation view and binds model / state arrays."""
         super()._initialize_impl()
 
-        model = NewtonManager.get_model()
-        state_0 = NewtonManager.get_state_0()
+        model, state_0 = NewtonManager.get_model(), NewtonManager.get_state_0()
 
         def has_articulation_root_api(prim) -> bool:
             return bool(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
 
         resolve_kwargs = {"predicate": has_articulation_root_api, "expected_num_matches": 1}
         _, root_prim_path_expr = resolve_matching_prims_from_source(self.cfg.prim_path, **resolve_kwargs)[0]
-        self._root_view = ArticulationView(
-            model,
-            path_expr_to_glob(root_prim_path_expr),
-            verbose=False,
-            exclude_joint_types=[JointType.FREE, JointType.FIXED],
-        )
+        self._root_view = NewtonManager.views.get((NewtonManager, root_prim_path_expr))
+        if self._root_view is None:
+            self._root_view = NewtonManager.views[NewtonManager, root_prim_path_expr] = ArticulationView(
+                model,
+                re.compile(root_prim_path_expr),
+                verbose=False,
+                exclude_joint_types=[JointType.FREE, JointType.FIXED],
+            )
         self._num_joints = self._root_view.joint_count
         if self._num_joints == 0:
             raise RuntimeError(

--- a/source/isaaclab_newton/test/assets/test_articulation.py
+++ b/source/isaaclab_newton/test/assets/test_articulation.py
@@ -753,8 +753,8 @@ def test_actuator_cfg_matches_explicit_descendant_articulation_root(sim, device,
 
 @pytest.mark.parametrize("articulation_type", ["single_joint_implicit"])
 @pytest.mark.parametrize("device", test_devices())
-def test_actuator_cfg_matches_clone_plan_root_glob(sim, device, articulation_type, monkeypatch):
-    """Match builder labels when clone-plan root resolution returns a glob."""
+def test_actuator_cfg_matches_clone_plan_root_expr(sim, device, articulation_type, monkeypatch):
+    """Match builder labels against the clone slot spelling clone-plan root resolution returns."""
     articulation = Articulation(
         ArticulationCfg(
             prim_path="{ENV_REGEX_NS}/Robot",
@@ -763,7 +763,7 @@ def test_actuator_cfg_matches_clone_plan_root_glob(sim, device, articulation_typ
     )
     monkeypatch.setattr(
         "isaaclab_newton.assets.articulation.articulation.resolve_matching_prims_from_source",
-        lambda *_args, **_kwargs: [(None, "/World/envs/env_*/Robot/base")],
+        lambda *_args, **_kwargs: [(None, "/World/envs/env_[^/]+/Robot/base")],
     )
     builder = _make_target_mode_builder(["joint"], [JointTargetMode.NONE], [0.0], [0.0])
     builder.articulation_label = ["/World/envs/env_0/Robot/base"]

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -532,8 +532,6 @@ class TestVisualizationClonePlan(unittest.TestCase):
             mock.patch.object(newton_clone_utils_module, "ModelBuilder", _FakeVisualizationModelBuilder),
             mock.patch.object(visualization_builder_module, "SchemaResolverNewton", lambda: object()),
             mock.patch.object(visualization_builder_module, "SchemaResolverPhysx", lambda: object()),
-            mock.patch.object(newton_clone_utils_module.solvers.SolverMuJoCo, "register_custom_attributes"),
-            mock.patch.object(newton_clone_utils_module.solvers.SolverKamino, "register_custom_attributes"),
             mock.patch.object(visualization_builder_module, "import_builder_visual_material_paths"),
             mock.patch.object(newton_clone_utils_module, "import_builder_visual_material_paths"),
             mock.patch.object(newton_clone_utils_module, "replace_newton_builder_shape_colors"),

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -31,6 +31,7 @@ import isaaclab_newton.physics.newton_manager as newton_manager_module
 import numpy as np
 import pytest
 import warp as wp
+from isaaclab_newton.assets.articulation import articulation as articulation_module
 from isaaclab_newton.physics import (
     FeatherstoneSolverCfg,
     KaminoDVICfg,
@@ -55,9 +56,10 @@ from isaaclab_newton.physics import (
     XPBDSolverCfg,
 )
 from isaaclab_newton.physics.mpm_manager import _make_solver_config
-from newton import ModelBuilder
+from newton import JointTargetMode, JointType, ModelBuilder
 from newton.solvers import SolverFeatherstone, SolverImplicitMPM, SolverKamino, SolverMuJoCo, SolverVBD, SolverXPBD
 
+from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.physics import PhysicsManager
 from isaaclab.sim import SimulationCfg, build_simulation_context
 
@@ -1026,6 +1028,40 @@ def test_clear_resets_rigid_body_force_capability(monkeypatch):
         NewtonMPMManager,
     ):
         assert manager._supports_rigid_body_force_input is False
+
+
+def test_articulation_target_modes_are_resolved_once_for_replicas(monkeypatch):
+    """Resolve target modes once, then copy them to the replicated articulations."""
+    builder = SimpleNamespace(
+        articulation_label=["/World/Env_0/Robot", "/World/Env_1/Robot"],
+        articulation_start=[0, 1],
+        articulation_end=[1, 2],
+        joint_type=[JointType.REVOLUTE, JointType.REVOLUTE],
+        joint_qd_start=[0, 1],
+        joint_label=["/World/Env_0/Robot/joint", "/World/Env_1/Robot/joint"],
+        joint_target_mode=[int(JointTargetMode.NONE)] * 2,
+        joint_target_ke=[0.0] * 2,
+        joint_target_kd=[0.0] * 2,
+    )
+    cfg = SimpleNamespace(
+        prim_path="/World/Env_[^/]*/Robot",
+        articulation_root_prim_path="",
+        actuators={"joint": ImplicitActuatorCfg(joint_names_expr=[".*"], stiffness=10.0, damping=0.0)},
+    )
+    original = articulation_module.resolve_matching_names
+    actuator_resolutions = 0
+
+    def count_actuator_resolutions(name_keys, names, *args, **kwargs):
+        nonlocal actuator_resolutions
+        if names == ["joint"]:
+            actuator_resolutions += 1
+        return original(name_keys, names, *args, **kwargs)
+
+    monkeypatch.setattr(articulation_module, "resolve_matching_names", count_actuator_resolutions)
+    articulation_module._configure_builder_joint_target_modes(builder, cfg)
+
+    assert builder.joint_target_mode == [int(JointTargetMode.POSITION)] * 2
+    assert actuator_resolutions == 1
 
 
 @pytest.mark.parametrize(

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -55,6 +55,7 @@ from isaaclab_newton.physics import (
     XPBDSolverCfg,
 )
 from isaaclab_newton.physics.mpm_manager import _make_solver_config
+from newton import ModelBuilder
 from newton.solvers import SolverFeatherstone, SolverImplicitMPM, SolverKamino, SolverMuJoCo, SolverVBD, SolverXPBD
 
 from isaaclab.physics import PhysicsManager
@@ -561,6 +562,30 @@ def test_mpm_register_builder_attributes_is_idempotent():
     # Second call must be a no-op (no exceptions, attribute still present).
     NewtonMPMManager._register_builder_attributes(builder)
     assert builder.has_custom_attribute("mpm:young_modulus")
+
+
+@pytest.mark.parametrize(
+    ("manager", "active", "inactive"),
+    [
+        (NewtonMJWarpManager, "mujoco:condim", ("kamino:max_solver_iterations", "mpm:young_modulus")),
+        (NewtonKaminoManager, "kamino:max_solver_iterations", ("mujoco:condim", "mpm:young_modulus")),
+    ],
+)
+def test_rigid_solver_registers_only_its_builder_attributes(manager, active, inactive):
+    """A rigid solver declares its own builder schema and no inactive solver schema."""
+    builder = ModelBuilder()
+
+    manager._register_builder_attributes(builder)
+
+    assert builder.has_custom_attribute(active)
+    assert all(not builder.has_custom_attribute(name) for name in inactive)
+
+
+def test_clone_source_builder_has_no_solver_dependency():
+    """The active manager's builder factory, not the cloner, owns solver attributes."""
+    import isaaclab_newton.cloner.newton_clone_utils as clone_utils
+
+    assert not hasattr(clone_utils, "solvers")
 
 
 def test_mpm_prepare_builder_makes_kinematic_bodies_massless():

--- a/source/isaaclab_newton/test/sensors/test_joint_wrench_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_joint_wrench_sensor.py
@@ -153,6 +153,7 @@ def test_initialization_and_shapes(sim):
     scene = InteractiveScene(_SingleJointSceneCfg(num_envs=2))
     sim.reset()
 
+    robot: Articulation = scene["robot"]
     sensor: JointWrenchSensor = scene["wrench"]
     sim.step()
     scene.update(sim.get_physics_dt())
@@ -163,6 +164,7 @@ def test_initialization_and_shapes(sim):
     assert sensor.data.force.torch.shape == (num_envs, num_joints, 3)
     assert sensor.data.torque.torch.shape == (num_envs, num_joints, 3)
     assert sensor.body_names == ["Arm"]
+    assert sensor._root_view is robot.root_view  # noqa: SLF001
 
 
 def test_multi_body_articulation(sim):

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -3858,9 +3858,9 @@ class Articulation(BaseArticulation):
             resolve_kwargs = {"predicate": has_articulation_root_api, "expected_num_matches": 1}
             _, root_prim_path_expr = resolve_matching_prims_from_source(self.cfg.prim_path, **resolve_kwargs)[0]
         # -- articulation
-        self._root_view = self._physics_sim_view.create_articulation_view(path_expr_to_glob(root_prim_path_expr))
-
-        # check if the articulation was created
+        self._root_view = SimulationManager.views[SimulationManager, root_prim_path_expr] = (
+            self._physics_sim_view.create_articulation_view(path_expr_to_glob(root_prim_path_expr))
+        )
         if self.root_view._backend is None:
             raise RuntimeError(f"Failed to create articulation at: {root_prim_path_expr}. Please check PhysX logs.")
 

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -978,6 +978,8 @@ class PhysxManager(PhysicsManager):
     @classmethod
     def _invalidate_views(cls) -> None:
         """Invalidate and clear simulation views."""
+        for key in [key for key in cls.views if key[0] is cls]:
+            del cls.views[key]
         for view in (cls._view, cls._view_warp):
             if view:
                 view.invalidate()

--- a/source/isaaclab_physx/isaaclab_physx/sensors/joint_wrench/joint_wrench_sensor.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/joint_wrench/joint_wrench_sensor.py
@@ -60,7 +60,6 @@ class JointWrenchSensor(BaseJointWrenchSensor):
         super().__init__(cfg)
 
         self._data = JointWrenchSensorData()
-        self._physics_sim_view = None
         self._root_view: physx.ArticulationView | None = None
         self._joint_pos_b: wp.array | None = None
         self._joint_quat_b: wp.array | None = None
@@ -124,14 +123,18 @@ class JointWrenchSensor(BaseJointWrenchSensor):
         """PHYSICS_READY callback: builds the articulation view and allocates buffers."""
         super()._initialize_impl()
 
-        self._physics_sim_view = SimulationManager.get_physics_sim_view()
-
         def has_articulation_root_api(prim) -> bool:
             return bool(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
 
         resolve_kwargs = {"predicate": has_articulation_root_api, "expected_num_matches": 1}
         _, root_prim_path_expr = resolve_matching_prims_from_source(self.cfg.prim_path, **resolve_kwargs)[0]
-        self._root_view = self._physics_sim_view.create_articulation_view(path_expr_to_glob(root_prim_path_expr))
+        self._root_view = SimulationManager.views.get((SimulationManager, root_prim_path_expr))
+        if self._root_view is None:
+            self._root_view = SimulationManager.views[SimulationManager, root_prim_path_expr] = (
+                SimulationManager.get_physics_sim_view().create_articulation_view(
+                    path_expr_to_glob(root_prim_path_expr)
+                )
+            )
         if self._root_view._backend is None:
             raise RuntimeError(f"Failed to create articulation view at: {root_prim_path_expr}. Check PhysX logs.")
 
@@ -253,7 +256,6 @@ class JointWrenchSensor(BaseJointWrenchSensor):
             event: An invalidate event.
         """
         super()._invalidate_initialize_callback(event)
-        self._physics_sim_view = None
         self._root_view = None
         self._joint_pos_b = None
         self._joint_quat_b = None

--- a/source/isaaclab_physx/test/sensors/test_joint_wrench_sensor.py
+++ b/source/isaaclab_physx/test/sensors/test_joint_wrench_sensor.py
@@ -229,6 +229,7 @@ def test_initialization_and_shapes(sim):
     assert sensor.data.torque.torch.shape == (num_envs, num_bodies, 3)
     assert sensor.body_names == robot.body_names
     assert sensor.find_bodies("Arm") == ([robot.body_names.index("Arm")], ["Arm"])
+    assert sensor._root_view is robot.root_view  # noqa: SLF001
     _assert_sensor_matches_physx_tensor(sensor)
 
 


### PR DESCRIPTION
## Summary

This is the model/articulation part of the scoped Newton startup work. It keeps startup work with the component that owns it:

- each Newton manager declares only the custom builder schema used by its active solver;
- articulation target modes are resolved for the prototype and copied to its replicas;
- the base physics manager owns the articulation-view registry;
- articulations create and register their view, while joint-wrench sensors reuse it or create it when used independently;
- root expressions remain regular expressions instead of taking a lossy regex-to-glob round trip.

The active-solver and reusable-view findings originated in Chris's #7269. This PR isolates those model/articulation changes so #7269 can remain the contact/raycast change under Chris's PR.

This replaces the cloner's unconditional MuJoCo + Kamino registration and the duplicate joint-wrench view. There is no view scan, manager-specific cache API, compatibility fallback, or duplicate registry.

The production diff against the current base is `+57/-60` (net `-3`).

The explicit-global-ownership part is #7292. The contact/raycast part remains in #7269.

## Startup benchmark

RTX 5090, CUDA device 1, 4096 environments, three fresh processes per revision/task. Values are median end-to-end startup wall time; raw runs are included below. Base: `86cf66651bd`. PR: `947869af173`.

| Task | Base | PR | Change |
|---|---:|---:|---:|
| `Isaac-Cartpole` | 8.316 s | 7.655 s | -8.0% |
| `Isaac-Velocity-Rough-UnitreeGo2` | 17.525 s | 14.844 s | -15.3% |
| `Isaac-Lift-KukaAllegro-Camera` | 41.691 s | 36.832 s | -11.7% |

Raw totals:

- Cartpole base: 10.595, 8.190, 8.316 s; PR: 7.655, 7.674, 7.469 s.
- Go2 rough base: 17.568, 17.525, 16.426 s; PR: 14.852, 14.844, 14.724 s.
- Kuka camera base: 47.590, 41.691, 38.724 s; PR: 36.832, 36.666, 37.032 s.

The measured `env_creation` medians improve from 6.473 to 5.801 s for Cartpole, 15.558 to 12.863 s for Go2 rough, and 37.481 to 32.578 s for Kuka camera.

## Test plan

- `247 passed` across the physics-manager lifecycle, Newton cloner, manager abstraction, coupled-manager, and joint-wrench reuse tests.
- `test_rename_builder_labels.py`: `17 passed` after removing obsolete solver-registration mocks.
- Ruff check and format pass on all changed Python files.
- The three 4096-environment benchmark tasks provide end-to-end Newton MJWarp startup coverage.
