### PR TITLE
[Newton] Streamline contact and raycast sensor startup

### DIFF
--- a/source/isaaclab/changelog.d/contact-sensor-regex.skip
+++ b/source/isaaclab/changelog.d/contact-sensor-regex.skip
@@ -1,0 +1,1 @@
+Docstring-only clarification of the shape-expression convention; behaviour change lives in isaaclab_newton.

--- a/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/contact_sensor/contact_sensor_cfg.py
@@ -98,6 +98,9 @@ class ContactSensorCfg(SensorBaseCfg):
     **Newton backend only** (ignored by the PhysX and OvPhysX backends). A shape is an individual
     collision geometry attached to a body. If non-empty, :attr:`prim_path` is ignored for the
     sensing objects and these shape expressions are used instead.
+
+    Full-matched against shape paths, so an expression naming a body selects nothing:
+    write ``{ENV_REGEX_NS}/Box[^/]*/.*`` to reach the shapes below it.
     """
 
     filter_shape_prim_expr: list[str] = []
@@ -106,6 +109,8 @@ class ContactSensorCfg(SensorBaseCfg):
 
     **Newton backend only** (ignored by the PhysX and OvPhysX backends). If provided, the force
     matrix reports per-shape contact forces; mutually exclusive with :attr:`filter_prim_paths_expr`.
+
+    Matched against shape paths on the same terms as :attr:`sensor_shape_prim_expr`.
     """
 
     visualizer_cfg: VisualizationMarkersCfg = CONTACT_SENSOR_MARKER_CFG.replace(prim_path="/Visuals/ContactSensor")

--- a/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
+++ b/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
@@ -1,0 +1,15 @@
+Fixed
+^^^^^
+
+* **Breaking:** Fixed Newton contact sensors matching their body and shape expressions as globs
+  instead of regular expressions, which silently dropped alternation and let the segment-safe
+  ``[^/]*`` cross path separators. Expressions are now compiled and full-matched, as
+  :func:`~isaaclab.utils.string.resolve_matching_names` already does elsewhere. An expression that
+  relied on the widened wildcard to reach the shapes below a body now selects nothing and fails at
+  sensor initialization; spell the descendant segments explicitly to migrate, so
+  ``sensor_shape_prim_expr=["{ENV_REGEX_NS}/Object[^/]*"]`` becomes
+  ``["{ENV_REGEX_NS}/Object[^/]*/.*"]``. The same applies to ``filter_shape_prim_expr``.
+* **Breaking:** Removed the contact sensor's bare-label fallback, which rewrote a path expression
+  down to its final segment when no model label contained a separator. It dated from Newton's
+  pre-hierarchical label API. Spell body and shape expressions as full paths to migrate, so
+  ``["fingertip_.*"]`` becomes ``["{ENV_REGEX_NS}/Robot/fingertip_[^/]*/.*"]``.

--- a/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
+++ b/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
@@ -13,3 +13,5 @@ Fixed
   down to its final segment when no model label contained a separator. It dated from Newton's
   pre-hierarchical label API. Spell body and shape expressions as full paths to migrate, so
   ``["fingertip_.*"]`` becomes ``["{ENV_REGEX_NS}/Robot/fingertip_[^/]*/.*"]``.
+* Migrated the Newton contact sensor off the deprecated ``sensing_obj_*`` names onto the
+  replacements Newton 1.4 introduced.

--- a/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
+++ b/source/isaaclab_newton/changelog.d/contact-sensor-regex.rst
@@ -15,3 +15,9 @@ Fixed
   ``["fingertip_.*"]`` becomes ``["{ENV_REGEX_NS}/Robot/fingertip_[^/]*/.*"]``.
 * Migrated the Newton contact sensor off the deprecated ``sensing_obj_*`` names onto the
   replacements Newton 1.4 introduced.
+
+Changed
+^^^^^^^
+
+* Built the shared shape BVH with collision geometry during model finalization when a raycast sensor is present,
+  instead of rebuilding the BVH when the sensor task initializes.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -121,22 +121,11 @@ if TYPE_CHECKING:
     from isaaclab_newton.physics.newton_collision_cfg import NewtonCollisionPipelineCfg
 
 
-def _compile_label_pattern(expr: str | list[str] | None, field: str) -> re.Pattern[str] | None:
-    """Compile a selector expression into the regex Newton full-matches against model labels.
-
-    ``None`` when nothing is requested. Newton reads a plain string as a glob but a compiled
-    pattern as a regex.
-    """
-    if expr is None:
+def _compile_label_pattern(expr: str | list[str] | None) -> re.Pattern[str] | None:
+    """Compile selector expressions for Newton's full label matching."""
+    if not expr:
         return None
-    items = [expr] if isinstance(expr, str) else list(expr)
-    if not items:
-        return None
-    joined = "|".join(items)
-    try:
-        return re.compile(joined)
-    except re.error as err:
-        raise ValueError(f"{field} is not a valid regular expression: {expr!r} ({err})") from err
+    return re.compile("|".join((expr,) if isinstance(expr, str) else expr))
 
 
 logger = logging.getLogger(__name__)
@@ -454,7 +443,7 @@ class NewtonManager(PhysicsManager):
     _sensor_state: State | None = None
     _sensor_state_dirty: bool = True
     _sensor_graph_capture_failed: bool = False
-    _sensor_bvh_has_collision_shapes: bool = False  # set once a ray-cast sensor widens the shape BVH
+    _sensor_bvh_shape_flags: ShapeFlags = ShapeFlags.VISIBLE
 
     # USD/Fabric sync
     _newton_stage_path = None
@@ -1128,7 +1117,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._sensor_state = None
         NewtonManager._sensor_state_dirty = True
         NewtonManager._sensor_graph_capture_failed = False
-        NewtonManager._sensor_bvh_has_collision_shapes = False
+        NewtonManager._sensor_bvh_shape_flags = ShapeFlags.VISIBLE
         NewtonManager._newton_stage_path = None
         NewtonManager._usdrt_stage = None
         NewtonManager._transforms_dirty = False
@@ -1197,6 +1186,7 @@ class NewtonManager(PhysicsManager):
             mesh_constructor=cfg.bvh_constructor_geometry if isinstance(cfg, NewtonCfg) else None,
             gaussian_constructor=cfg.bvh_constructor_gaussian if isinstance(cfg, NewtonCfg) else None,
             shape_constructor=cfg.bvh_constructor_scene if isinstance(cfg, NewtonCfg) else None,
+            shape_flags=cls._sensor_bvh_shape_flags,
         )
 
         cls._register_builder_attributes(builder)
@@ -2593,19 +2583,12 @@ class NewtonManager(PhysicsManager):
         return cls._contacts
 
     @classmethod
-    def _register_sensor_task(
-        cls, name: str, update_fn: Callable[[], None], *, include_collision_shapes: bool = False
-    ) -> None:
+    def _register_sensor_task(cls, name: str, update_fn: Callable[[], None]) -> None:
         """Register a graph-capturable scene-query task.
 
         Args:
             name: Unique task name.
             update_fn: Graph-capturable callable run by :meth:`_update_sensor_tasks`.
-            include_collision_shapes: Whether the task must see collision-only
-                geometry. Newton builds the shape BVH over visible shapes, which is
-                what renderers want; the first ray-cast sensor rebuilds it with
-                collision shapes added, since those must be hit even when they carry
-                no visual representation.
         """
         if name in cls._sensor_tasks:
             raise ValueError(f"Newton sensor task '{name}' is already registered.")
@@ -2613,12 +2596,8 @@ class NewtonManager(PhysicsManager):
         state = cls.get_state_0()
         if model is None or state is None:
             raise RuntimeError("Registering a Newton sensor task requires an initialized model and state.")
-        if model.shape_count > 0:
-            if include_collision_shapes and not cls._sensor_bvh_has_collision_shapes:
-                model.bvh_build_shapes(state, shape_flags=ShapeFlags.VISIBLE | ShapeFlags.COLLIDE_SHAPES)
-                NewtonManager._sensor_bvh_has_collision_shapes = True
-            elif model.bvh_shapes is None:
-                model.bvh_build_shapes(state)
+        if model.shape_count > 0 and model.bvh_shapes is None:
+            model.bvh_build_shapes(state)
         if model.particle_count > 0 and model.bvh_particles is None:
             model.bvh_build_particles(state)
         cls._sensor_tasks[name] = update_fn
@@ -3413,10 +3392,10 @@ class NewtonManager(PhysicsManager):
         with Timer(name="newton_contact_sensor", msg="Contact sensor construction took:"):
             sensor = NewtonContactSensor(
                 cls._model,
-                sensing_bodies=_compile_label_pattern(body_names_expr, "body_names_expr"),
-                sensing_shapes=_compile_label_pattern(shape_names_expr, "shape_names_expr"),
-                counterpart_bodies=_compile_label_pattern(contact_partners_body_expr, "contact_partners_body_expr"),
-                counterpart_shapes=_compile_label_pattern(contact_partners_shape_expr, "contact_partners_shape_expr"),
+                sensing_bodies=_compile_label_pattern(body_names_expr),
+                sensing_shapes=_compile_label_pattern(shape_names_expr),
+                counterpart_bodies=_compile_label_pattern(contact_partners_body_expr),
+                counterpart_shapes=_compile_label_pattern(contact_partners_shape_expr),
                 measure_total=True,
                 verbose=verbose,
             )

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -3413,8 +3413,8 @@ class NewtonManager(PhysicsManager):
         with Timer(name="newton_contact_sensor", msg="Contact sensor construction took:"):
             sensor = NewtonContactSensor(
                 cls._model,
-                sensing_obj_bodies=_compile_label_pattern(body_names_expr, "body_names_expr"),
-                sensing_obj_shapes=_compile_label_pattern(shape_names_expr, "shape_names_expr"),
+                sensing_bodies=_compile_label_pattern(body_names_expr, "body_names_expr"),
+                sensing_shapes=_compile_label_pattern(shape_names_expr, "shape_names_expr"),
                 counterpart_bodies=_compile_label_pattern(contact_partners_body_expr, "contact_partners_body_expr"),
                 counterpart_shapes=_compile_label_pattern(contact_partners_shape_expr, "contact_partners_shape_expr"),
                 measure_total=True,

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -89,7 +89,7 @@ from isaaclab.scene_data.deformable_vis_remap import (
 )
 from isaaclab.sim import SimulationContext
 from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
-from isaaclab.sim.utils.queries import has_deformable_curve_api, path_expr_to_glob
+from isaaclab.sim.utils.queries import has_deformable_curve_api
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils import checked_apply
 from isaaclab.utils.string import resolve_matching_names
@@ -119,6 +119,25 @@ if TYPE_CHECKING:
     from isaaclab.renderers.base_renderer import VisualMaterialBatch
 
     from isaaclab_newton.physics.newton_collision_cfg import NewtonCollisionPipelineCfg
+
+
+def _compile_label_pattern(expr: str | list[str] | None, field: str) -> re.Pattern[str] | None:
+    """Compile a selector expression into the regex Newton full-matches against model labels.
+
+    ``None`` when nothing is requested. Newton reads a plain string as a glob but a compiled
+    pattern as a regex.
+    """
+    if expr is None:
+        return None
+    items = [expr] if isinstance(expr, str) else list(expr)
+    if not items:
+        return None
+    joined = "|".join(items)
+    try:
+        return re.compile(joined)
+    except re.error as err:
+        raise ValueError(f"{field} is not a valid regular expression: {expr!r} ({err})") from err
+
 
 logger = logging.getLogger(__name__)
 
@@ -3354,8 +3373,9 @@ class NewtonManager(PhysicsManager):
     ) -> tuple[str | list[str] | None, str | list[str] | None, str | list[str] | None, str | list[str] | None]:
         """Add a contact sensor for reporting contacts between bodies/shapes.
 
-        Converts Isaac Lab pattern conventions (``.*`` regex, full USD paths) to
-        fnmatch globs and delegates to :class:`newton.sensors.SensorContact`.
+        Compiles the Isaac Lab regular expressions and delegates to
+        :class:`newton.sensors.SensorContact`, which full-matches compiled patterns
+        against model labels.
 
         Args:
             body_names_expr: Expression for body names to sense.
@@ -3383,31 +3403,6 @@ class NewtonManager(PhysicsManager):
         def _hashable_key(x):
             return tuple(x) if isinstance(x, list) else x
 
-        def _to_fnmatch(expr: str | list[str] | None) -> str | list[str] | None:
-            """Convert Isaac Lab regex expressions (``.*``) to fnmatch glob (``*``)."""
-            if expr is None:
-                return None
-            if isinstance(expr, str):
-                return path_expr_to_glob(expr)
-            return [path_expr_to_glob(p) for p in expr]
-
-        def _normalize_for_labels(expr: str | list[str] | None, labels: list[str]) -> str | list[str] | None:
-            """Strip leading path components from *expr* when labels are bare names.
-
-            Model labels may be full USD paths (``/World/envs/env_0/Robot/base``) or bare
-            names (``base``).  When the labels are bare names but the user expression
-            contains slashes, we strip everything up to the last ``/``.
-            """
-            if expr is None or not labels:
-                return expr
-            label_has_paths = any("/" in lbl for lbl in labels)
-            items = [expr] if isinstance(expr, str) else list(expr)
-            expr_uses_paths = any("/" in p for p in items)
-            if label_has_paths or not expr_uses_paths:
-                return expr
-            normalized = [p.rsplit("/", 1)[-1] for p in items]
-            return normalized[0] if isinstance(expr, str) else normalized
-
         sensor_key = (
             _hashable_key(body_names_expr),
             _hashable_key(shape_names_expr),
@@ -3415,16 +3410,13 @@ class NewtonManager(PhysicsManager):
             _hashable_key(contact_partners_shape_expr),
         )
 
-        body_labels = list(cls._model.body_label)
-        shape_labels = list(cls._model.shape_label)
-
         with Timer(name="newton_contact_sensor", msg="Contact sensor construction took:"):
             sensor = NewtonContactSensor(
                 cls._model,
-                sensing_obj_bodies=_normalize_for_labels(_to_fnmatch(body_names_expr), body_labels),
-                sensing_obj_shapes=_normalize_for_labels(_to_fnmatch(shape_names_expr), shape_labels),
-                counterpart_bodies=_normalize_for_labels(_to_fnmatch(contact_partners_body_expr), body_labels),
-                counterpart_shapes=_normalize_for_labels(_to_fnmatch(contact_partners_shape_expr), shape_labels),
+                sensing_obj_bodies=_compile_label_pattern(body_names_expr, "body_names_expr"),
+                sensing_obj_shapes=_compile_label_pattern(shape_names_expr, "shape_names_expr"),
+                counterpart_bodies=_compile_label_pattern(contact_partners_body_expr, "contact_partners_body_expr"),
+                counterpart_shapes=_compile_label_pattern(contact_partners_shape_expr, "contact_partners_shape_expr"),
                 measure_total=True,
                 verbose=verbose,
             )

--- a/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor.py
@@ -329,14 +329,14 @@ class ContactSensor(BaseContactSensor):
         body_labels = self._get_model_labels("body")
         shape_labels = self._get_model_labels("shape")
 
-        s_kind = self.contact_view.sensing_obj_type
+        s_kind = self.contact_view.sensing_type
         if s_kind == "body":
             s_labels = body_labels
         elif s_kind == "shape":
             s_labels = shape_labels
         else:
-            raise RuntimeError(f"Unexpected Newton sensing_obj_type {s_kind!r}; expected 'body' or 'shape'.")
-        self._sensor_names = [s_labels[i].split("/")[-1] for i in self.contact_view.sensing_obj_idx]
+            raise RuntimeError(f"Unexpected Newton sensing_type {s_kind!r}; expected 'body' or 'shape'.")
+        self._sensor_names = [s_labels[i].split("/")[-1] for i in self.contact_view.sensing_indices]
         # Assumes the environments are processed in order.
         self._sensor_names = self._sensor_names[: self._num_sensors]
 

--- a/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor_cfg.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/contact_sensor/contact_sensor_cfg.py
@@ -60,7 +60,8 @@ class ContactSensorCfg(BaseContactSensorCfg):
 
         Args:
             base_cfg: The base contact sensor configuration to copy from.
-            **kwargs: Newton-specific fields, e.g. ``filter_shape_prim_expr=["fingertip_.*"]``.
+            **kwargs: Newton-specific fields, e.g.
+                ``filter_shape_prim_expr=["{ENV_REGEX_NS}/Robot/fingertip_[^/]*/.*"]``.
 
         Returns:
             A new :class:`ContactSensorCfg` instance.

--- a/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/newton_raycast_sensor.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/newton_raycast_sensor.py
@@ -273,6 +273,7 @@ class NewtonRaycastSensor(_NewtonRayCasterPoseMixin, BaseRayCaster):
     def __init__(self, cfg: NewtonRaycastSensorCfg):
         if cfg.max_distance <= 0.0:
             raise ValueError(f"max_distance must be positive, received {cfg.max_distance}.")
+        NewtonManager._sensor_bvh_shape_flags |= newton.ShapeFlags.COLLIDE_SHAPES
         super().__init__(cfg)
         self._data = NewtonRaycastSensorData()
         self._sensor_task_name: str | None = None
@@ -326,7 +327,7 @@ class NewtonRaycastSensor(_NewtonRayCasterPoseMixin, BaseRayCaster):
         self._hit_normal = wp.empty(ray_count, dtype=wp.vec3f, device=self._device)
 
         self._sensor_task_name = f"newton_raycast:{self.cfg.prim_path}:{id(self)}"
-        NewtonManager._register_sensor_task(self._sensor_task_name, self._launch_raycast, include_collision_shapes=True)
+        NewtonManager._register_sensor_task(self._sensor_task_name, self._launch_raycast)
 
     def _launch_raycast(self) -> None:
         """Sensor pose + ray transform + BVH query + hit resolve (graph-capturable)."""

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -25,6 +25,7 @@ Covers:
 
 from __future__ import annotations
 
+from inspect import signature
 from types import SimpleNamespace
 
 import isaaclab_newton.physics.newton_manager as newton_manager_module
@@ -55,6 +56,7 @@ from isaaclab_newton.physics import (
     XPBDSolverCfg,
 )
 from isaaclab_newton.physics.mpm_manager import _make_solver_config
+from newton import ShapeFlags
 from newton.solvers import SolverFeatherstone, SolverImplicitMPM, SolverKamino, SolverMuJoCo, SolverVBD, SolverXPBD
 
 from isaaclab.physics import PhysicsManager
@@ -337,6 +339,30 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     NewtonManager._update_sensor_tasks("render")
 
     assert status["rendered"]
+
+
+def test_sensor_bvh_shape_flags_are_fixed_before_builder_creation(monkeypatch):
+    """Builder finalization includes collision-only shapes without a later BVH rebuild."""
+    import newton
+
+    flags = ShapeFlags.VISIBLE | ShapeFlags.COLLIDE_SHAPES
+    monkeypatch.setattr(NewtonManager, "_sensor_bvh_shape_flags", flags)
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg())
+    builder = NewtonManager.create_builder()
+    body = builder.add_body()
+    builder.add_shape_sphere(body, cfg=newton.ModelBuilder.ShapeConfig(is_visible=False))
+
+    model = builder.finalize(device="cpu")
+
+    assert builder.default_bvh_cfg.shape_flags == flags
+    assert model.bvh_shape_count_enabled == 1
+    assert model.bvh_shapes is not None
+
+
+def test_sensor_task_registration_has_no_raycast_bvh_fallback():
+    """Raycast BVH requirements belong to builder creation, not task registration."""
+    assert "include_collision_shapes" not in signature(NewtonManager._register_sensor_task).parameters
+    assert not hasattr(NewtonManager, "_sensor_bvh_has_collision_shapes")
 
 
 def test_newton_shape_cfg_defaults_match_newton_shape_config():
@@ -988,10 +1014,12 @@ def test_subclass_of_newton_manager(manager):
 def test_clear_resets_rigid_body_force_capability(monkeypatch):
     """Teardown clears the canonical solver capability without subclass shadowing."""
     monkeypatch.setattr(NewtonManager, "_supports_rigid_body_force_input", True)
+    monkeypatch.setattr(NewtonManager, "_sensor_bvh_shape_flags", ShapeFlags.COLLIDE_SHAPES)
 
     NewtonManager.clear()
 
     assert NewtonManager._supports_rigid_body_force_input is False
+    assert NewtonManager._sensor_bvh_shape_flags == ShapeFlags.VISIBLE
     for manager in (
         NewtonMJWarpManager,
         NewtonXPBDManager,

--- a/source/isaaclab_newton/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_contact_sensor.py
@@ -29,7 +29,9 @@ import math
 import pytest
 import torch
 from flaky import flaky
+from isaaclab_newton.physics.newton_manager import _compile_label_pattern
 from isaaclab_newton.sensors.contact_sensor import ContactSensorCfg as NewtonContactSensorCfg
+from newton._src.utils.selection import match_labels
 from physics.physics_test_utils import (
     COLLISION_PIPELINES,
     STABLE_SHAPES,
@@ -44,6 +46,7 @@ from physics.physics_test_utils import (
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import Articulation, RigidObject, RigidObjectCfg
+from isaaclab.cloner.cloner_cfg import DEFAULT_ENV_TEMPLATE
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors import ContactSensor, ContactSensorCfg
 from isaaclab.sim import build_simulation_context
@@ -1020,13 +1023,15 @@ def test_sensor_metadata(device: str):
 
     # (3) Shape-mode, no filter: pattern matches shapes (not bodies).
     # `sensor_shape_prim_expr` is a Newton-only extension, so this block uses the
-    # backend-specific NewtonContactSensorCfg subclass.
+    # backend-specific NewtonContactSensorCfg subclass. Shape expressions are full-matched
+    # against shape paths, exactly as body expressions are against body paths, so the
+    # expression has to reach the shapes below the body (here ``BoxA/geometry/mesh``).
     with build_simulation_context(sim_cfg=sim_cfg, auto_add_lighting=True, add_ground_plane=True) as sim:
         sim._app_control_on_stop_handle = None
         scene_cfg = _make_two_box_scene_cfg(num_envs)
         scene_cfg.contact_sensor_a = NewtonContactSensorCfg(
             prim_path="{ENV_REGEX_NS}/Box[^/]*",
-            sensor_shape_prim_expr=["{ENV_REGEX_NS}/Box[^/]*"],
+            sensor_shape_prim_expr=["{ENV_REGEX_NS}/Box[^/]*/.*"],
             update_period=0.0,
             history_length=1,
         )
@@ -1145,3 +1150,77 @@ def test_no_stale_data_after_scene_reset(device: str):
         assert torch.isnan(post_reset_contact_pos).all(), (
             f"contact_pos_w should reset to NaN after scene.reset(); got {post_reset_contact_pos.tolist()}"
         )
+
+
+# ===================================================================
+# Selector patterns
+# ===================================================================
+
+_NS = DEFAULT_ENV_TEMPLATE.format("[^/]+")
+"""The expansion of ``{ENV_REGEX_NS}``, as ``expand_env_regex_ns`` produces it."""
+
+_LABELS = [
+    "/World/envs/env_0/Robot/base",
+    "/World/envs/env_0/Robot/LF_FOOT",
+    "/World/envs/env_0/Robot/RF_FOOT",
+    "/World/envs/env_0/Robot/R_index_distal",
+    "/World/envs/env_0/Robot/Geometry/panda_link0",
+    "/World/envs/env_1/Robot/LF_FOOT",
+]
+
+_SHAPE_LABELS = ["/World/envs/env_0/BoxA/geometry/mesh", "/World/envs/env_0/BoxB/mesh"]
+
+
+def _select(expr, labels, field="body_names_expr"):
+    """Labels Newton selects for ``expr``."""
+    pattern = _compile_label_pattern(expr, field)
+    return [labels[index] for index in match_labels(labels, pattern)]
+
+
+def test_alternation_resolves():
+    """A group selects its branches instead of matching literally."""
+    assert _select(f"{_NS}/Robot/[^/]*R_(index|middle|pinky)_distal", _LABELS) == [
+        "/World/envs/env_0/Robot/R_index_distal"
+    ]
+
+
+def test_segment_wildcard_does_not_cross_path_separators():
+    """``[^/]*`` selects one segment, so nested links stay out."""
+    selected = _select(f"{_NS}/Robot/[^/]*", _LABELS)
+
+    assert "/World/envs/env_0/Robot/base" in selected
+    assert "/World/envs/env_0/Robot/Geometry/panda_link0" not in selected
+
+
+def test_expression_list_selects_the_union():
+    """A list of expressions selects everything any one of them matches."""
+    feet = ["/World/envs/env_0/Robot/LF_FOOT", "/World/envs/env_0/Robot/RF_FOOT"]
+
+    # A single-element list is the shape every config takes, and carries alternation of its own.
+    assert _select([f"{_NS}/Robot/LF_FOOT|{_NS}/Robot/RF_FOOT"], _LABELS) == [
+        *feet,
+        "/World/envs/env_1/Robot/LF_FOOT",
+    ]
+    assert _select([f"{_NS}/Robot/base", f"{_NS}/Robot/LF_FOOT|{_NS}/Robot/RF_FOOT"], _LABELS) == [
+        "/World/envs/env_0/Robot/base",
+        *feet,
+        "/World/envs/env_1/Robot/LF_FOOT",
+    ]
+
+
+def test_shape_expressions_match_on_the_same_terms_as_body_expressions():
+    """Shape selectors carry no rule of their own."""
+    assert _select(f"{_NS}/Box[^/]*", _SHAPE_LABELS, "shape_names_expr") == []
+    assert _select(f"{_NS}/Box[^/]*/.*", _SHAPE_LABELS, "shape_names_expr") == _SHAPE_LABELS
+
+
+@pytest.mark.parametrize("expr", [None, []])
+def test_absent_selector_compiles_to_no_pattern(expr):
+    """Nothing requested means unfiltered, not empty."""
+    assert _compile_label_pattern(expr, "body_names_expr") is None
+
+
+def test_invalid_expression_names_the_offending_field():
+    """A malformed expression says which parameter carried it."""
+    with pytest.raises(ValueError, match="contact_partners_body_expr"):
+        _compile_label_pattern("foo(", "contact_partners_body_expr")

--- a/source/isaaclab_newton/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_contact_sensor.py
@@ -25,6 +25,7 @@ from isaaclab.test.utils import test_devices
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import math
+import re
 
 import pytest
 import torch
@@ -1171,9 +1172,9 @@ _LABELS = [
 _SHAPE_LABELS = ["/World/envs/env_0/BoxA/geometry/mesh", "/World/envs/env_0/BoxB/mesh"]
 
 
-def _select(expr, labels, field="body_names_expr"):
+def _select(expr, labels):
     """Labels Newton selects for ``expr``."""
-    pattern = _compile_label_pattern(expr, field)
+    pattern = _compile_label_pattern(expr)
     return [labels[index] for index in match_labels(labels, pattern)]
 
 
@@ -1210,17 +1211,17 @@ def test_expression_list_selects_the_union():
 
 def test_shape_expressions_match_on_the_same_terms_as_body_expressions():
     """Shape selectors carry no rule of their own."""
-    assert _select(f"{_NS}/Box[^/]*", _SHAPE_LABELS, "shape_names_expr") == []
-    assert _select(f"{_NS}/Box[^/]*/.*", _SHAPE_LABELS, "shape_names_expr") == _SHAPE_LABELS
+    assert _select(f"{_NS}/Box[^/]*", _SHAPE_LABELS) == []
+    assert _select(f"{_NS}/Box[^/]*/.*", _SHAPE_LABELS) == _SHAPE_LABELS
 
 
 @pytest.mark.parametrize("expr", [None, []])
 def test_absent_selector_compiles_to_no_pattern(expr):
     """Nothing requested means unfiltered, not empty."""
-    assert _compile_label_pattern(expr, "body_names_expr") is None
+    assert _compile_label_pattern(expr) is None
 
 
-def test_invalid_expression_names_the_offending_field():
-    """A malformed expression says which parameter carried it."""
-    with pytest.raises(ValueError, match="contact_partners_body_expr"):
-        _compile_label_pattern("foo(", "contact_partners_body_expr")
+def test_invalid_expression_raises_regex_error():
+    """Reject malformed selector expressions at contact sensor construction."""
+    with pytest.raises(re.error):
+        _compile_label_pattern("foo(")

--- a/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
@@ -21,6 +21,7 @@ from isaaclab_newton.sensors import (
     NewtonRaycastSensor,
     NewtonRaycastSensorCfg,
 )
+from newton import ShapeFlags
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObject, RigidObjectCfg
@@ -122,6 +123,9 @@ def test_rays_hit_ground_plane(sim, global_world_only):
     scene_cfg = RaycastTestSceneCfg(num_envs=2)
     scene_cfg.raycast.global_world_only = global_world_only
     scene = InteractiveScene(scene_cfg)
+    expected_bvh_flags = ShapeFlags.VISIBLE | ShapeFlags.COLLIDE_SHAPES
+    assert NewtonManager._sensor_bvh_shape_flags == expected_bvh_flags
+    assert NewtonManager._builder.default_bvh_cfg.shape_flags == expected_bvh_flags
     sim.reset()
     sensor = _step_and_read(sim, scene)
 


### PR DESCRIPTION
## Summary

This is the third and final scoped startup PR. It keeps sensor selection and shared scene-query resources explicit:

- contact body/shape selectors are compiled once as regular expressions and full-matched by Newton;
- the obsolete bare-label and regex-to-glob rewrites are removed;
- contact access uses Newton 1.4's non-deprecated `sensing_*` names;
- a raycast sensor declares `COLLIDE_SHAPES` before clone builders are created, so model finalization builds the shared shape BVH once;
- generic sensor-task registration no longer carries a raycast-only flag, late rebuild fallback, or duplicate “has collision shapes” state.

The production diff against the pinned base is `+34/-56` (net `-22`).

This carries forward the contact-regex work from #7269 and replaces its BVH fallback path with the deterministic scene lifecycle above. The other two PRs in the series are #7292 and #7295.

## Startup benchmark

RTX 5090, CUDA device 1, 4096 environments, three fresh processes per revision/task. Values are median end-to-end startup wall time; raw runs are included below. Base: `7666bd8369a`. PR: `2bb0293da19`.

| Task | Base | PR | Change |
|---|---:|---:|---:|
| `Isaac-Cartpole` | 8.103 s | 8.111 s | +0.1% (neutral) |
| `Isaac-Velocity-Rough-UnitreeGo2` | 18.154 s | 15.454 s | -14.9% |
| `Isaac-Lift-KukaAllegro-Camera` | 41.030 s | 37.087 s | -9.6% |

Raw totals:

- Cartpole base: 8.101, 8.152, 8.103 s; PR: 8.111, 8.183, 8.063 s.
- Go2 rough base: 18.406, 18.154, 17.765 s; PR: 15.471, 15.454, 15.378 s.
- Kuka-camera base: 44.868, 41.030, 40.101 s; PR: 37.470, 37.087, 36.946 s.

Phase medians explain the sensor-heavy gains:

- Go2 contact construction: 0.11 -> 0.04 s; simulation start: 8.35 -> 5.85 s.
- Kuka contact construction: 1.32 -> 0.24 s; scene creation: 21.70 -> 19.24 s; simulation start: 11.35 -> 10.21 s.

## Test plan

- `261 passed, 8 xpassed` across the full Newton manager, contact-sensor, and raycast-sensor modules (CPU/CUDA, eager/CUDA graph).
- Repository formatting and pre-commit checks pass.
- Contact and BVH regressions were applied to `7666bd8369a`: the contact contract fails during collection and both BVH architecture gates fail; all pass on this branch.
- The three 4096-environment benchmark tasks pass on all three branch runs.
