### PR TITLE
[Test] Disable Warp autodiff in test suite

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,6 +103,7 @@ jobs:
           ^apps/ :: Standalone apps
           ^scripts/ :: Standalone scripts
           ^\.dockerignore$ :: Docker build context filter
+          ^conftest\.py$ :: Root pytest configuration
           ^pyproject\.toml$ :: Root Python project (Docker copy)
           ^environment\.yml$ :: Conda env (Docker copy)
           ^isaaclab\. :: isaaclab.sh/.bat entrypoints (Docker copy)

--- a/conftest.py
+++ b/conftest.py
@@ -27,14 +27,18 @@ from __future__ import annotations
 import json
 import os
 
-import warp as wp
-
-# Warp captures ``enable_backward`` when a module is created, which can happen
-# while pytest collects a test module. Isaac Lab's tests do not use Warp
-# autodiff, so skip adjoint code generation before collection to reduce cold
-# kernel compilation time. This also applies to the Warp cache-warming job,
-# which uses the shared test runner.
-wp.config.enable_backward = False
+try:
+    import warp as wp
+except ModuleNotFoundError as exc:
+    if exc.name != "warp":
+        raise
+else:
+    # Warp captures ``enable_backward`` when a module is created, which can happen
+    # while pytest collects a test module. Isaac Lab's tests do not use Warp
+    # autodiff, so skip adjoint code generation before collection to reduce cold
+    # kernel compilation time. This also applies to the Warp cache-warming job,
+    # which uses the shared test runner.
+    wp.config.enable_backward = False
 
 pytest_plugins = ["tools.ovrtx_log"]
 

--- a/conftest.py
+++ b/conftest.py
@@ -33,11 +33,6 @@ except ModuleNotFoundError as exc:
     if exc.name != "warp":
         raise
 else:
-    # Warp captures ``enable_backward`` when a module is created, which can happen
-    # while pytest collects a test module. Isaac Lab's tests do not use Warp
-    # autodiff, so skip adjoint code generation before collection to reduce cold
-    # kernel compilation time. This also applies to the Warp cache-warming job,
-    # which uses the shared test runner.
     wp.config.enable_backward = False
 
 pytest_plugins = ["tools.ovrtx_log"]

--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,15 @@ from __future__ import annotations
 import json
 import os
 
+import warp as wp
+
+# Warp captures ``enable_backward`` when a module is created, which can happen
+# while pytest collects a test module. Isaac Lab's tests do not use Warp
+# autodiff, so skip adjoint code generation before collection to reduce cold
+# kernel compilation time. This also applies to the Warp cache-warming job,
+# which uses the shared test runner.
+wp.config.enable_backward = False
+
 pytest_plugins = ["tools.ovrtx_log"]
 
 JOURNAL_ENV_VAR = "ISAACLAB_TEST_JOURNAL"

--- a/source/isaaclab/test/test_scripts_warp_backward_ordering.py
+++ b/source/isaaclab/test/test_scripts_warp_backward_ordering.py
@@ -27,7 +27,6 @@ _ENTRY_SCRIPTS = [
 ]
 
 _SETTING = "wp.config.enable_backward = False"
-_TEST_CONFTEST = "conftest.py"
 
 
 @pytest.mark.unit
@@ -47,10 +46,3 @@ def test_entry_script_disables_warp_backward_before_isaaclab_imports(script: str
         f"{script} sets enable_backward on line {setting_at + 1}, after the Isaac Lab import on line"
         f" {first_isaaclab_import + 1}; Warp modules created by that import keep adjoint codegen."
     )
-
-
-@pytest.mark.unit
-def test_shared_pytest_configuration_disables_warp_backward():
-    contents = (_REPO_ROOT / _TEST_CONFTEST).read_text()
-
-    assert _SETTING in contents, f"{_TEST_CONFTEST} does not set '{_SETTING}'"

--- a/source/isaaclab/test/test_scripts_warp_backward_ordering.py
+++ b/source/isaaclab/test/test_scripts_warp_backward_ordering.py
@@ -27,6 +27,7 @@ _ENTRY_SCRIPTS = [
 ]
 
 _SETTING = "wp.config.enable_backward = False"
+_TEST_CONFTEST = "conftest.py"
 
 
 @pytest.mark.unit
@@ -46,3 +47,10 @@ def test_entry_script_disables_warp_backward_before_isaaclab_imports(script: str
         f"{script} sets enable_backward on line {setting_at + 1}, after the Isaac Lab import on line"
         f" {first_isaaclab_import + 1}; Warp modules created by that import keep adjoint codegen."
     )
+
+
+@pytest.mark.unit
+def test_shared_pytest_configuration_disables_warp_backward():
+    contents = (_REPO_ROOT / _TEST_CONFTEST).read_text()
+
+    assert _SETTING in contents, f"{_TEST_CONFTEST} does not set '{_SETTING}'"


### PR DESCRIPTION
## Summary

- Disable Warp backward code generation before pytest collection to reduce cold kernel compile times.
- Keep lightweight tooling compatible when Warp is not installed.
- Run the test matrix when the root pytest configuration changes; the cache warmer uses the same configuration.

## Validation

- Warp-free tools tests: 29 passed
- `uv run isaaclab -f`