### PR TITLE
Preserve HDF5 environment arguments across file lifecycles

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -202,6 +202,7 @@ Guidelines for modifications:
 * Vidur Vij
 * Virgilio Gómez Lambo
 * Vladimir Fokow
+* Wang Ke
 * Wei Yang
 * Weihua Zhang
 * Welf Rehberg

--- a/source/isaaclab/changelog.d/coffeedrivencoder-preserve-hdf5-env-args.rst
+++ b/source/isaaclab/changelog.d/coffeedrivencoder-preserve-hdf5-env-args.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed environment arguments being overwritten after reopening an HDF5 dataset and leaking between datasets when
+  reusing a file handler.

--- a/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
+++ b/source/isaaclab/isaaclab/utils/datasets/hdf5_dataset_file_handler.py
@@ -99,6 +99,8 @@ class HDF5DatasetFileHandler(DatasetFileHandlerBase):
     def add_env_args(self, env_args: dict):
         """Add environment arguments to the dataset."""
         self._raise_if_not_initialized()
+        stored_env_args = self._hdf5_data_group.attrs.get("env_args")
+        self._env_args = json.loads(stored_env_args) if stored_env_args is not None else {}
         self._env_args.update(env_args)
         self._hdf5_data_group.attrs["env_args"] = json.dumps(self._env_args)
 

--- a/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
+++ b/source/isaaclab/test/utils/test_hdf5_dataset_file_handler.py
@@ -2,11 +2,13 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
+import json
 import os
 import shutil
 import tempfile
 import uuid
 
+import h5py
 import pytest
 import torch
 
@@ -63,6 +65,42 @@ def test_create_dataset_file(temp_dir):
 
     # check if the dataset is created
     assert os.path.exists(dataset_file_path + ".hdf5")
+
+
+def test_add_env_args_preserves_existing_args_after_reopen(temp_dir):
+    """Test extending environment arguments after reopening a dataset."""
+    dataset_file_path = os.path.join(temp_dir, f"{uuid.uuid4()}.hdf5")
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.create(dataset_file_path, "test_env_name")
+    dataset_file_handler.close()
+
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.open(dataset_file_path, mode="r+")
+    dataset_file_handler.add_env_args({"custom_arg": "custom_value"})
+    dataset_file_handler.close()
+
+    with h5py.File(dataset_file_path, "r") as dataset_file:
+        env_args = json.loads(dataset_file["data"].attrs["env_args"])
+
+    assert env_args == {"env_name": "test_env_name", "type": 2, "custom_arg": "custom_value"}
+
+
+def test_create_resets_env_args_when_reusing_handler(temp_dir):
+    """Test environment arguments do not leak between datasets."""
+    first_dataset_path = os.path.join(temp_dir, f"{uuid.uuid4()}.hdf5")
+    second_dataset_path = os.path.join(temp_dir, f"{uuid.uuid4()}.hdf5")
+    dataset_file_handler = HDF5DatasetFileHandler()
+    dataset_file_handler.create(first_dataset_path, "first_env")
+    dataset_file_handler.add_env_args({"custom_arg": "custom_value"})
+    dataset_file_handler.close()
+
+    dataset_file_handler.create(second_dataset_path, "second_env")
+    dataset_file_handler.close()
+
+    with h5py.File(second_dataset_path, "r") as dataset_file:
+        env_args = json.loads(dataset_file["data"].attrs["env_args"])
+
+    assert env_args == {"env_name": "second_env", "type": 2}
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])


### PR DESCRIPTION
# Description

`HDF5DatasetFileHandler` previously treated its instance-level `_env_args` cache as the source of truth. A fresh
handler opened in `r+` mode therefore replaced the dataset's existing environment arguments when adding a field,
while a reused handler carried custom arguments from a closed dataset into a newly created one.

This change reads the `env_args` attribute from the active HDF5 data group before merging updates. Existing metadata
is preserved after reopening, and a new data group starts with an empty mapping regardless of handler history.

Fixes #7308

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Not applicable; this change affects dataset metadata serialization.


## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`


## Validation

- Verified both regression tests fail on the unmodified implementation:
  `2 failed, 3 deselected`.
- Ran the complete HDF5 dataset handler test file after the fix:
  `5 passed` (CPU and CUDA coverage included).
- Ran Ruff lint on both changed Python files: passed.
- Ran Ruff format check on both changed Python files: passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format` (focused Ruff lint and format checks pass; the full repository hook suite is left to CI)
- [x] I have made corresponding changes to the documentation (not applicable; no public API or usage changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
