### PR TITLE
Extend Core Lift and Reorient episode duration

### DIFF
--- a/source/isaaclab_tasks/changelog.d/zhengyuz-extend-reorient-episode-duration.rst
+++ b/source/isaaclab_tasks/changelog.d/zhengyuz-extend-reorient-episode-duration.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Extended Core Lift and Reorient task episodes to 12 seconds and their pose-command resampling range to 4--6 seconds.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
@@ -139,7 +139,7 @@ class CommandsCfg:
     object_pose = mdp.ObjectUniformPoseCommandCfg(
         asset_name="robot",
         object_name="object",
-        resampling_time_range=(3.0, 5.0),
+        resampling_time_range=(4.0, 6.0),
         debug_vis=False,
         ranges=mdp.ObjectUniformPoseCommandCfg.Ranges(
             pos_x=(-0.7, -0.3),
@@ -566,9 +566,8 @@ class ReorientEnvCfg(ManagerBasedRLEnvCfg):
         self.decimation = 4  # 30 Hz
 
         # *single-goal setup
-        self.commands.object_pose.resampling_time_range = (2.0, 3.0)
         self.commands.object_pose.position_only = False
-        self.episode_length_s = 6.0
+        self.episode_length_s = 12.0
         self.is_finite_horizon = False
 
         # simulation settings

--- a/source/isaaclab_tasks/test/core/test_lift_env_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_env_cfg.py
@@ -13,7 +13,6 @@ import torch
 from isaaclab.managers import CommandTerm
 
 from isaaclab_tasks.core.lift import mdp
-from isaaclab_tasks.core.lift.lift_env_cfg import ReorientEnvCfg
 from isaaclab_tasks.core.lift.mdp.commands.pose_commands import (
     CableUniformPoseCommand,
     DeformableUniformPoseCommand,
@@ -37,14 +36,6 @@ class _FakeScene(dict):
         super().__init__(assets)
         self._ALL_INDICES = environment_ids
         self.env_origins = torch.zeros((len(environment_ids), 3))
-
-
-def test_reorient_episode_and_command_timing() -> None:
-    """Reorientation episodes should retain the intended command timing."""
-    cfg = ReorientEnvCfg()
-
-    assert cfg.episode_length_s == 12.0
-    assert cfg.commands.object_pose.resampling_time_range == (4.0, 6.0)
 
 
 def test_camera_normalization_is_stationary() -> None:

--- a/source/isaaclab_tasks/test/core/test_lift_env_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_lift_env_cfg.py
@@ -13,6 +13,7 @@ import torch
 from isaaclab.managers import CommandTerm
 
 from isaaclab_tasks.core.lift import mdp
+from isaaclab_tasks.core.lift.lift_env_cfg import ReorientEnvCfg
 from isaaclab_tasks.core.lift.mdp.commands.pose_commands import (
     CableUniformPoseCommand,
     DeformableUniformPoseCommand,
@@ -36,6 +37,14 @@ class _FakeScene(dict):
         super().__init__(assets)
         self._ALL_INDICES = environment_ids
         self.env_origins = torch.zeros((len(environment_ids), 3))
+
+
+def test_reorient_episode_and_command_timing() -> None:
+    """Reorientation episodes should retain the intended command timing."""
+    cfg = ReorientEnvCfg()
+
+    assert cfg.episode_length_s == 12.0
+    assert cfg.commands.object_pose.resampling_time_range == (4.0, 6.0)
 
 
 def test_camera_normalization_is_stationary() -> None:


### PR DESCRIPTION
## Summary

- Changed the Core Lift and Reorient pose-command resampling range from 3–5 seconds to 4–6 seconds.
- Removed the ReorientEnvCfg 2–3 second post-init override so CommandsCfg remains the single source of truth.
- Extended the episode length from 6 to 12 seconds.

This gives policies more time to complete each commanded goal while retaining multiple goals per episode.

## Testing

- Focused lift config tests: 3 passed.
- Formatting and style hooks passed.
- The isaaclab_tasks changelog fragment passed validation against upstream/develop.