### PR TITLE
Open the asset server connection before the scene needs it

### DIFF
--- a/source/isaaclab/changelog.d/asset-server-prewarm.rst
+++ b/source/isaaclab/changelog.d/asset-server-prewarm.rst
@@ -1,7 +1,9 @@
 Changed
 ^^^^^^^
 
-* Changed :class:`~isaaclab.app.AppLauncher` to open the connection to a remote asset server on
-  a background thread once the extensions are loaded, so the DNS resolution and the TCP and TLS
-  handshakes overlap the rest of startup rather than the first asset lookup. A run whose
-  configured asset root is local does not open a connection.
+* Changed Isaac Lab to open the connection to a remote asset server on a background thread
+  before the first asset lookup, so the DNS resolution and the TCP and TLS handshakes overlap
+  the rest of startup rather than that lookup. :class:`~isaaclab.app.AppLauncher` opens it once
+  the extensions are loaded, and a kitless run, which never constructs one, opens it from
+  :func:`~isaaclab.app.launch_simulation` instead. A run whose configured asset root is local
+  does not open a connection.

--- a/source/isaaclab/changelog.d/asset-server-prewarm.rst
+++ b/source/isaaclab/changelog.d/asset-server-prewarm.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab.app.AppLauncher` to open the connection to a remote asset server on
+  a background thread once the extensions are loaded, so the DNS resolution and the TCP and TLS
+  handshakes overlap the rest of startup rather than the first asset lookup. A run whose
+  configured asset root is local does not open a connection.

--- a/source/isaaclab/changelog.d/asset-server-prewarm.rst
+++ b/source/isaaclab/changelog.d/asset-server-prewarm.rst
@@ -1,9 +1,10 @@
 Changed
 ^^^^^^^
 
-* Changed Isaac Lab to open the connection to a remote asset server on a background thread
-  before the first asset lookup, so the DNS resolution and the TCP and TLS handshakes overlap
+* Changed Isaac Lab to open the connection to a remote asset server with an asynchronous request
+  before normal scene construction, so the DNS resolution and the TCP and TLS handshakes overlap
   the rest of startup rather than that lookup. :class:`~isaaclab.app.AppLauncher` opens it once
   the extensions are loaded, and a kitless run, which never constructs one, opens it from
   :func:`~isaaclab.app.launch_simulation` instead. A run whose configured asset root is local
-  does not open a connection.
+  does not open a connection. Selected asset-region routing is applied before the request, and
+  a pending request is cancelled during normal launcher teardown.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -334,6 +334,13 @@ class AppLauncher:
         # Load IsaacSim extensions
         self._load_extensions()
 
+        # Nothing has asked for an asset yet, and the first thing that does -- building the
+        # scene -- would otherwise pay the connection handshake before its own lookup. Open
+        # it now instead, in the background.
+        from isaaclab.utils.assets import _prewarm_asset_server
+
+        _prewarm_asset_server()
+
         # Re-run path sanitization.  Kit and its extensions may have inserted
         # additional ``pip_prebundle`` or conflicting extension directories onto
         # ``sys.path`` during startup.  A second pass ensures pip-installed

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -334,13 +334,6 @@ class AppLauncher:
         # Load IsaacSim extensions
         self._load_extensions()
 
-        # Nothing has asked for an asset yet, and the first thing that does -- building the
-        # scene -- would otherwise pay the connection handshake before its own lookup. Open
-        # it now instead, in the background.
-        from isaaclab.utils.assets import _prewarm_asset_server
-
-        _prewarm_asset_server()
-
         # Re-run path sanitization.  Kit and its extensions may have inserted
         # additional ``pip_prebundle`` or conflicting extension directories onto
         # ``sys.path`` during startup.  A second pass ensures pip-installed
@@ -348,6 +341,13 @@ class AppLauncher:
         from isaaclab import _deprioritize_prebundle_paths
 
         _deprioritize_prebundle_paths()
+
+        # Nothing has asked for an asset yet, and the first thing that does -- building the
+        # scene -- would otherwise pay the connection handshake before its own lookup. Open
+        # it now instead, in the background.
+        from isaaclab.utils.assets import _prewarm_asset_server
+
+        _prewarm_asset_server()
 
         # Hide the stop button in the toolbar
         self._hide_stop_button()

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -342,12 +342,23 @@ class AppLauncher:
 
         _deprioritize_prebundle_paths()
 
-        # Nothing has asked for an asset yet, and the first thing that does -- building the
-        # scene -- would otherwise pay the connection handshake before its own lookup. Open
-        # it now instead, in the background.
-        from isaaclab.utils.assets import _prewarm_asset_server
+        # Prewarm the TLS connection in the background to speed up later asset loads.
+        import omni.kit.app
+        from carb.eventdispatcher import get_eventdispatcher
 
-        _prewarm_asset_server()
+        from isaaclab.utils.assets import _cancel_asset_server_prewarm, _prewarm_asset_server
+
+        # Stop the request before Kit unloads OmniClient. Covers direct close, signals, and atexit uniformly.
+        dispatcher = get_eventdispatcher()
+        asset_prewarm_shutdown_subscription = None
+        if dispatcher is not None:
+            asset_prewarm_shutdown_subscription = dispatcher.observe_event(
+                event_name=omni.kit.app.GLOBAL_EVENT_PRE_SHUTDOWN,
+                on_event=lambda _event: _cancel_asset_server_prewarm(),
+                observer_name="IsaacLab asset prewarm",
+                order=-100,
+            )
+            _prewarm_asset_server()
 
         # Hide the stop button in the toolbar
         self._hide_stop_button()
@@ -377,7 +388,7 @@ class AppLauncher:
         # the startup announcements, and distributed launchers/schedulers/CI read the exit
         # status. See the class docstring of :class:`_SimulationAppLifecycle` for the full
         # exit-path policy and its rationale.
-        self._lifecycle = AppLauncher._SimulationAppLifecycle(self._app)
+        self._lifecycle = AppLauncher._SimulationAppLifecycle(self._app, asset_prewarm_shutdown_subscription)
         self._lifecycle.announce_startup()
         self._lifecycle.install_exit_handlers()
 
@@ -1538,8 +1549,10 @@ class AppLauncher:
         Python's default handler for its own processes.
         """
 
-        def __init__(self, app: SimulationApp):
+        def __init__(self, app: SimulationApp, asset_prewarm_shutdown_subscription: object | None = None):
             self._app = app
+            # Retain the observer until process exit even if the AppLauncher is collected.
+            self._asset_prewarm_shutdown_subscription = asset_prewarm_shutdown_subscription
             # set once any close starts; later signals must not start a second teardown
             self._closing = False
 

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -542,6 +542,13 @@ def launch_simulation(
         launcher_args, "visualizer_explicit", False
     )
 
+    # AppLauncher.__init__ prewarms the asset server, but it runs on the Kit path only. The
+    # kitless elif below is not enough: a run that passes no visualizer argument skips both.
+    if not needs_kit:
+        from isaaclab.utils.assets import _prewarm_asset_server
+
+        _prewarm_asset_server()
+
     close_fn: Any = None
     if needs_kit:
         _ensure_isaac_sim_available()

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -574,10 +574,12 @@ def launch_simulation(
     try:
         # The import stays after the Kit launch decision. With no selected profile this is a
         # no-op; with one, it installs process-wide OmniClient routing before user code runs.
-        from isaaclab.utils.assets import _cancel_asset_server_prewarm, _prewarm_asset_server, configure_storage_profile
+        from isaaclab.utils.assets import configure_storage_profile
 
         configure_storage_profile()
         if not needs_kit:
+            from isaaclab.utils.assets import _cancel_asset_server_prewarm, _prewarm_asset_server
+
             cancel_asset_server_prewarm = _cancel_asset_server_prewarm
             _prewarm_asset_server()
         yield physics_cfg

--- a/source/isaaclab/isaaclab/app/sim_launcher.py
+++ b/source/isaaclab/isaaclab/app/sim_launcher.py
@@ -542,13 +542,6 @@ def launch_simulation(
         launcher_args, "visualizer_explicit", False
     )
 
-    # AppLauncher.__init__ prewarms the asset server, but it runs on the Kit path only. The
-    # kitless elif below is not enough: a run that passes no visualizer argument skips both.
-    if not needs_kit:
-        from isaaclab.utils.assets import _prewarm_asset_server
-
-        _prewarm_asset_server()
-
     close_fn: Any = None
     if needs_kit:
         _ensure_isaac_sim_available()
@@ -577,12 +570,16 @@ def launch_simulation(
             )
 
     exit_code = 0
+    cancel_asset_server_prewarm = None
     try:
         # The import stays after the Kit launch decision. With no selected profile this is a
         # no-op; with one, it installs process-wide OmniClient routing before user code runs.
-        from isaaclab.utils.assets import configure_storage_profile
+        from isaaclab.utils.assets import _cancel_asset_server_prewarm, _prewarm_asset_server, configure_storage_profile
 
         configure_storage_profile()
+        if not needs_kit:
+            cancel_asset_server_prewarm = _cancel_asset_server_prewarm
+            _prewarm_asset_server()
         yield physics_cfg
     except Exception:
         exit_code = 1
@@ -591,6 +588,8 @@ def launch_simulation(
         traceback.print_exc()
         raise
     finally:
+        if cancel_asset_server_prewarm is not None:
+            cancel_asset_server_prewarm()
         if close_fn is not None:
             if exit_code:
                 close_fn(exit_code=exit_code)

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -22,10 +22,9 @@ import posixpath
 import re
 import subprocess
 import tempfile
-import threading
 import uuid
 from types import ModuleType
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, Protocol, TypedDict
 from urllib.parse import urlparse
 
 from filelock import FileLock
@@ -250,13 +249,23 @@ _prewarm_started = False
 """Whether a prewarm has been started, so at most one is."""
 
 
+class _CancelableRequest(Protocol):
+    """Request that can be cancelled before OmniClient shuts down."""
+
+    def stop(self) -> None: ...
+
+
+_prewarm_request: _CancelableRequest | None = None
+"""Pending asset-server prewarm request, retained so launcher teardown can cancel it."""
+
+
 def _prewarm_asset_server() -> None:
     """Open the connection to the asset server ahead of the first asset lookup.
 
     Each lookup is one round trip on a kept-alive connection, but the first one also pays DNS
     resolution and the TCP and TLS handshakes -- several round trips that do not depend on
-    which asset is wanted. Running them on a background thread, before anything asks for an
-    asset, overlaps them with the rest of startup.
+    which asset is wanted. Starting an asynchronous request before anything asks for an asset
+    overlaps them with the rest of startup.
 
     Does nothing unless the asset root names a host, so a run configured against a local root
     never opens a connection, and nothing beyond the first call.
@@ -264,7 +273,7 @@ def _prewarm_asset_server() -> None:
     A failure here is not reported: the lookups that follow contact the same server and
     surface an unreachable one themselves.
     """
-    global _prewarm_started
+    global _prewarm_request, _prewarm_started
     parsed = urlparse(NUCLEUS_ASSET_ROOT_DIR)
     # A host is what distinguishes a remote URL from a Windows drive letter, which
     # ``urlparse`` also reports as a scheme.
@@ -272,15 +281,27 @@ def _prewarm_asset_server() -> None:
         return
     _prewarm_started = True
 
-    def open_connection() -> None:
-        try:
-            import omni.client  # noqa: PLC0415
+    try:
+        # Apply a selected storage profile before the first request so the connection uses
+        # the same endpoint and CDN routing as the asset lookups that follow.
+        omni_client = _get_omni_client()
+        _prewarm_request = omni_client.stat_with_callback(NUCLEUS_ASSET_ROOT_DIR, lambda _result, _entry: None)
+    except Exception as exc:  # noqa: BLE001 - a run must not fail because a prewarm did
+        _prewarm_request = None
+        logger.debug("Could not open the asset server connection ahead of use: %s", exc)
 
-            omni.client.stat(NUCLEUS_ASSET_ROOT_DIR)
-        except Exception as exc:  # noqa: BLE001 - a run must not fail because a prewarm did
-            logger.debug("Could not open the asset server connection ahead of use: %s", exc)
 
-    threading.Thread(target=open_connection, name="isaaclab-asset-prewarm", daemon=True).start()
+def _cancel_asset_server_prewarm() -> None:
+    """Cancel a pending asset-server prewarm before the runtime shuts down."""
+    global _prewarm_request
+    request, _prewarm_request = _prewarm_request, None
+    if request is None:
+        return
+
+    try:
+        request.stop()
+    except Exception as exc:  # noqa: BLE001 - cleanup must not prevent runtime shutdown
+        logger.debug("Could not cancel the asset server prewarm during shutdown: %s", exc)
 
 
 def retrieve_git_asset_path(

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -22,6 +22,7 @@ import posixpath
 import re
 import subprocess
 import tempfile
+import threading
 import uuid
 from types import ModuleType
 from typing import Literal, NotRequired, TypedDict
@@ -244,6 +245,42 @@ _MIRRORED_URLS: dict[str, str] = {}
 from its path, so a cache path is never inferred from a directory that merely looks like one."""
 
 _GIT_SSH_RE = re.compile(r"^[^@/:]+@[^:]+:.+")
+
+_prewarm_started = False
+"""Whether a prewarm has been started, so at most one is."""
+
+
+def _prewarm_asset_server() -> None:
+    """Open the connection to the asset server ahead of the first asset lookup.
+
+    Each lookup is one round trip on a kept-alive connection, but the first one also pays DNS
+    resolution and the TCP and TLS handshakes -- several round trips that do not depend on
+    which asset is wanted. Running them on a background thread, before anything asks for an
+    asset, overlaps them with the rest of startup.
+
+    Does nothing unless the asset root names a host, so a run configured against a local root
+    never opens a connection, and nothing beyond the first call.
+
+    A failure here is not reported: the lookups that follow contact the same server and
+    surface an unreachable one themselves.
+    """
+    global _prewarm_started
+    parsed = urlparse(NUCLEUS_ASSET_ROOT_DIR)
+    # A host is what distinguishes a remote URL from a Windows drive letter, which
+    # ``urlparse`` also reports as a scheme.
+    if _prewarm_started or not parsed.scheme or not parsed.netloc:
+        return
+    _prewarm_started = True
+
+    def open_connection() -> None:
+        try:
+            import omni.client  # noqa: PLC0415
+
+            omni.client.stat(NUCLEUS_ASSET_ROOT_DIR)
+        except Exception as exc:  # noqa: BLE001 - a run must not fail because a prewarm did
+            logger.debug("Could not open the asset server connection ahead of use: %s", exc)
+
+    threading.Thread(target=open_connection, name="isaaclab-asset-prewarm", daemon=True).start()
 
 
 def retrieve_git_asset_path(

--- a/source/isaaclab/test/app/test_launch_simulation_require_kit.py
+++ b/source/isaaclab/test/app/test_launch_simulation_require_kit.py
@@ -33,6 +33,8 @@ def kit_branch_taken(monkeypatch: pytest.MonkeyPatch):
     # pretend Kit is already running so the launcher skips constructing AppLauncher
     monkeypatch.setattr(isaaclab_utils, "has_kit", lambda: True)
     monkeypatch.setattr(sim_launcher, "_ensure_isaac_sim_available", lambda: taken.append(True))
+    monkeypatch.setattr(assets_utils, "_prewarm_asset_server", lambda: None)
+    monkeypatch.setattr(assets_utils, "_cancel_asset_server_prewarm", lambda: None)
     return taken
 
 
@@ -44,14 +46,16 @@ def test_default_stays_kitless_for_a_kitless_config(kit_branch_taken):
 
 
 def test_kitless_launch_configures_storage_before_user_code(kit_branch_taken, monkeypatch: pytest.MonkeyPatch):
-    """A direct OmniClient read inside a kitless runtime must see profile routing."""
+    """Profile routing must precede prewarming, which must be cancelled after user code."""
     events = []
     monkeypatch.setattr(assets_utils, "configure_storage_profile", lambda: events.append("configured"))
+    monkeypatch.setattr(assets_utils, "_prewarm_asset_server", lambda: events.append("prewarmed"))
+    monkeypatch.setattr(assets_utils, "_cancel_asset_server_prewarm", lambda: events.append("cancelled"))
 
     with launch_simulation(cfg=PhysicsCfg(), launcher_args={}):
         events.append("user-code")
 
-    assert events == ["configured", "user-code"]
+    assert events == ["configured", "prewarmed", "user-code", "cancelled"]
     assert kit_branch_taken == []
 
 

--- a/source/isaaclab/test/app/test_simulation_app_lifecycle.py
+++ b/source/isaaclab/test/app/test_simulation_app_lifecycle.py
@@ -5,16 +5,18 @@
 
 """Kitless unit tests for the AppLauncher process-lifecycle exit policy."""
 
+import gc
 import signal
 import sys
 import types
+import weakref
 
 from isaaclab.app.app_launcher import AppLauncher
 
 
-def _make_lifecycle(close_fn):
+def _make_lifecycle(close_fn, asset_prewarm_shutdown_subscription=None):
     app = types.SimpleNamespace(close=close_fn, config={"fast_shutdown": True})
-    return AppLauncher._SimulationAppLifecycle(app)
+    return AppLauncher._SimulationAppLifecycle(app, asset_prewarm_shutdown_subscription)
 
 
 def _capture_signal_actions(monkeypatch):
@@ -28,6 +30,27 @@ def _capture_signal_actions(monkeypatch):
         lambda signum: actions.append(("raise", signum)),
     )
     return actions
+
+
+def test_lifecycle_retains_asset_prewarm_shutdown_subscription():
+    """The shutdown observer survives when only the process lifecycle remains alive."""
+
+    class _Subscription:
+        pass
+
+    subscription = _Subscription()
+    subscription_ref = weakref.ref(subscription)
+    lifecycle = _make_lifecycle(lambda exit_code=0: None, subscription)
+
+    del subscription
+    gc.collect()
+
+    assert subscription_ref() is not None
+
+    del lifecycle
+    gc.collect()
+
+    assert subscription_ref() is None
 
 
 def test_abort_signal_closes_once_with_killed_by_signal_status(monkeypatch):

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -788,3 +788,61 @@ def test_newton_asset_dir_uses_environment_override(tmp_path, monkeypatch):
     finally:
         monkeypatch.delenv("NEWTON_ASSET_DIR", raising=False)
         importlib.reload(assets_utils)
+
+
+def _join_prewarm_thread(timeout: float = 10.0) -> None:
+    """Wait for a prewarm thread to finish, so a test never outlives the stub it installed."""
+    for thread in threading.enumerate():
+        if thread.name == "isaaclab-asset-prewarm":
+            thread.join(timeout=timeout)
+
+
+def test_prewarm_opens_the_remote_connection_once(monkeypatch):
+    """Test that a remote asset root is contacted, and only on the first call."""
+    import omni.client
+
+    root = "https://example.com/Assets/Isaac/6.0"
+    monkeypatch.setattr(assets_utils, "NUCLEUS_ASSET_ROOT_DIR", root)
+    monkeypatch.setattr(assets_utils, "_prewarm_started", False)
+    contacted: list[str] = []
+    opened = threading.Event()
+
+    def fake_stat(url, *args, **kwargs):
+        contacted.append(url)
+        opened.set()
+        return omni.client.Result.OK, SimpleNamespace(hash="", version="", size=0, modified_time="")
+
+    monkeypatch.setattr(omni.client, "stat", fake_stat)
+
+    assets_utils._prewarm_asset_server()
+    assert opened.wait(timeout=10.0)
+    # The flag is set on the calling thread before the connection opens, so a second call is
+    # turned away without waiting on the first to finish.
+    assert assets_utils._prewarm_started is True
+    assets_utils._prewarm_asset_server()
+
+    assert contacted == [root]
+
+
+@pytest.mark.parametrize("root", ["/tmp/isaacsim_assets/Assets/Isaac/6.0", "C:\\assets\\Assets\\Isaac\\6.0"])
+def test_prewarm_leaves_a_local_asset_root_alone(monkeypatch, root):
+    """Test that a run configured against local assets opens no connection."""
+    import omni.client
+
+    monkeypatch.setattr(assets_utils, "NUCLEUS_ASSET_ROOT_DIR", root)
+    monkeypatch.setattr(assets_utils, "_prewarm_started", False)
+    contacted: list[str] = []
+
+    # Recorded rather than raised: the prewarm runs on a background thread whose exceptions it
+    # swallows by design, so an exception here would never reach the test.
+    def record_stat(url, *args, **kwargs):
+        contacted.append(url)
+        return omni.client.Result.OK, SimpleNamespace(hash="", version="", size=0, modified_time="")
+
+    monkeypatch.setattr(omni.client, "stat", record_stat)
+
+    assets_utils._prewarm_asset_server()
+    _join_prewarm_thread()
+
+    assert contacted == []
+    assert assets_utils._prewarm_started is False

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -790,59 +790,54 @@ def test_newton_asset_dir_uses_environment_override(tmp_path, monkeypatch):
         importlib.reload(assets_utils)
 
 
-def _join_prewarm_thread(timeout: float = 10.0) -> None:
-    """Wait for a prewarm thread to finish, so a test never outlives the stub it installed."""
-    for thread in threading.enumerate():
-        if thread.name == "isaaclab-asset-prewarm":
-            thread.join(timeout=timeout)
-
-
 def test_prewarm_opens_the_remote_connection_once(monkeypatch):
-    """Test that a remote asset root is contacted, and only on the first call."""
-    import omni.client
-
+    """Test that routing precedes one cancellable request to a remote asset root."""
     root = "https://example.com/Assets/Isaac/6.0"
     monkeypatch.setattr(assets_utils, "NUCLEUS_ASSET_ROOT_DIR", root)
     monkeypatch.setattr(assets_utils, "_prewarm_started", False)
-    contacted: list[str] = []
-    opened = threading.Event()
+    monkeypatch.setattr(assets_utils, "_prewarm_request", None)
+    events = []
+    stop_calls = []
 
-    def fake_stat(url, *args, **kwargs):
-        contacted.append(url)
-        opened.set()
-        return omni.client.Result.OK, SimpleNamespace(hash="", version="", size=0, modified_time="")
+    request = SimpleNamespace(stop=lambda: stop_calls.append(True))
 
-    monkeypatch.setattr(omni.client, "stat", fake_stat)
+    def stat_with_callback(url, _callback):
+        events.append(("requested", url))
+        return request
+
+    def get_configured_client():
+        events.append(("configured", root))
+        return SimpleNamespace(stat_with_callback=stat_with_callback)
+
+    monkeypatch.setattr(assets_utils, "_get_omni_client", get_configured_client)
 
     assets_utils._prewarm_asset_server()
-    assert opened.wait(timeout=10.0)
-    # The flag is set on the calling thread before the connection opens, so a second call is
-    # turned away without waiting on the first to finish.
+    assets_utils._prewarm_asset_server()
+
+    assert events == [("configured", root), ("requested", root)]
     assert assets_utils._prewarm_started is True
-    assets_utils._prewarm_asset_server()
+    assert assets_utils._prewarm_request is request
 
-    assert contacted == [root]
+    assets_utils._cancel_asset_server_prewarm()
+    assets_utils._cancel_asset_server_prewarm()
+
+    assert stop_calls == [True]
+    assert assets_utils._prewarm_request is None
 
 
 @pytest.mark.parametrize("root", ["/tmp/isaacsim_assets/Assets/Isaac/6.0", "C:\\assets\\Assets\\Isaac\\6.0"])
 def test_prewarm_leaves_a_local_asset_root_alone(monkeypatch, root):
     """Test that a run configured against local assets opens no connection."""
-    import omni.client
-
     monkeypatch.setattr(assets_utils, "NUCLEUS_ASSET_ROOT_DIR", root)
     monkeypatch.setattr(assets_utils, "_prewarm_started", False)
-    contacted: list[str] = []
-
-    # Recorded rather than raised: the prewarm runs on a background thread whose exceptions it
-    # swallows by design, so an exception here would never reach the test.
-    def record_stat(url, *args, **kwargs):
-        contacted.append(url)
-        return omni.client.Result.OK, SimpleNamespace(hash="", version="", size=0, modified_time="")
-
-    monkeypatch.setattr(omni.client, "stat", record_stat)
+    monkeypatch.setattr(assets_utils, "_prewarm_request", None)
+    monkeypatch.setattr(
+        assets_utils,
+        "_get_omni_client",
+        lambda: pytest.fail("a local asset root must not initialize OmniClient"),
+    )
 
     assets_utils._prewarm_asset_server()
-    _join_prewarm_thread()
 
-    assert contacted == []
     assert assets_utils._prewarm_started is False
+    assert assets_utils._prewarm_request is None


### PR DESCRIPTION
# Description

Every remote asset lookup is one round trip on a kept-alive connection, but the first one also pays DNS resolution and the TCP and TLS handshakes. Instead, open the connection on a background thread once the extensions are loaded, so the handshake overlaps with the rest of startup. A run whose configured asset root is local opens no connection at all.

## Type of change

- (Startup performance enhancement)
- New feature (non-breaking change which adds functionality)


## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
