### PR TITLE
Vectorize clone plan queries

### DIFF
--- a/source/isaaclab/isaaclab/cloner/query.py
+++ b/source/isaaclab/isaaclab/cloner/query.py
@@ -37,10 +37,11 @@ if TYPE_CHECKING:
 
 def _row_env_ids(plan: ClonePlan, row: int) -> tuple[int, ...]:
     """Env ids populated from a plan row: the plan's env ids at the row's ``True`` columns."""
-    columns = plan.clone_mask[row].nonzero(as_tuple=False).flatten().tolist()
+    columns = plan.clone_mask[row].nonzero(as_tuple=False).flatten()
     if plan.env_ids is None:
-        return tuple(int(column) for column in columns)
-    return tuple(int(plan.env_ids[column]) for column in columns)
+        return tuple(columns.tolist())
+    columns = columns.to(plan.env_ids.device)
+    return tuple(plan.env_ids[columns].tolist())
 
 
 def _column_for_env_id(plan: ClonePlan, env_id: int) -> int | None:
@@ -82,7 +83,7 @@ def _clone_rows(plan: ClonePlan, path_expr: str, *, populated_only: bool) -> lis
     for row, template in enumerate(plan.destinations):
         if "{}" not in template:
             continue
-        if populated_only and not _row_env_ids(plan, row):
+        if populated_only and not plan.clone_mask[row].any():
             continue
         matched = pth.match(path_expr, template)
         if matched is None:

--- a/source/isaaclab/test/cloner/test_clone_plan_algebra.py
+++ b/source/isaaclab/test/cloner/test_clone_plan_algebra.py
@@ -334,8 +334,8 @@ def test_iter_sources_yields_nearest_owner():
     ]
 
 
-def test_iter_sources_skips_rows_without_envs():
-    """A row populating no env is not a source of anything."""
+def test_iter_sources_reports_only_the_envs_a_row_populates():
+    """A row covering part of the envs is a source for those envs only."""
     plan = _plan(
         ("/World/envs/env_2/Object",),
         ("/World/envs/env_{}/Object",),
@@ -348,6 +348,24 @@ def test_iter_sources_skips_rows_without_envs():
             "/World/envs/env_{}/Object",
             "/World/envs/env_2/Object/Body/Camera",
             (2, 3),
+        )
+    ]
+
+
+def test_iter_sources_skips_rows_without_envs():
+    """A nearer template populating no env does not hide the populated ancestor owning the path."""
+    plan = _plan(
+        ("/World/envs/env_0/Robot", "/World/envs/env_0/Robot/wrist/Camera"),
+        ("/World/envs/env_{}/Robot", "/World/envs/env_{}/Robot/wrist/Camera"),
+        [[True, True, False, False], [False, False, False, False]],
+    )
+
+    assert list(cloner.query.iter_sources(plan, "/World/envs/env_[^/]+/Robot/wrist/Camera")) == [
+        (
+            "/World/envs/env_0/Robot",
+            "/World/envs/env_{}/Robot",
+            "/World/envs/env_0/Robot/wrist/Camera",
+            (0, 1),
         )
     ]
 
@@ -492,6 +510,21 @@ def test_query_translates_env_ids_through_the_plan():
 
     source, _glob, suffix = cloner.query.path_to_source(plan, "/World/envs/env_5/Robot/base")
     assert source + suffix == path
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_query_gathers_env_ids_across_devices():
+    """Environment ids can remain on CPU when the clone mask is on CUDA."""
+    plan = ClonePlan(
+        sources=("/World/envs/env_2/Robot",),
+        destinations=("/World/envs/env_{}/Robot",),
+        clone_mask=torch.tensor([[True, False, True]], dtype=torch.bool, device="cuda"),
+        env_ids=torch.tensor([2, 5, 8], dtype=torch.long),
+    )
+    path = "/World/envs/env_2/Robot/base"
+
+    assert cloner.query.path_env_ids(plan, path) == (2, 8)
+    assert next(iter(cloner.query.iter_sources(plan, "/World/envs/env_[^/]+/Robot")))[3] == (2, 8)
 
 
 @pytest.mark.parametrize("env_id", [-1, 4, 99])


### PR DESCRIPTION
# Description
Gather clone-plan env ids in one indexing step

This replaces some Python loops with vectorized numpy calls and improves startup performance.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- (Startup performance enhancement)

## Checklist

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
