### PR TITLE
Add ADR guidance to domain randomization skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -15,7 +15,7 @@ User skills:
 - `user/install-isaac-lab/`: install Isaac Lab following the current install docs — automatic uv setup, downloaded Isaac Sim package, source build, Isaac Lab wheel, legacy isaaclab.sh installer, or Docker — across Linux (x86_64, aarch64) and Windows 11.
 - `user/migrate-from-isaac-gym/`: migrate Isaac Gym tasks, assets, and training workflows to Isaac Lab.
 - `user/migrate-2x-to-3x/`: migrate Isaac Lab 2.x projects to Isaac Lab 3.0 using the official migration guide.
-- `user/domain-randomization-events/`: implement domain randomization through Isaac Lab event terms.
+- `user/domain-randomization-events/`: implement fixed and adaptive domain randomization through event and curriculum terms.
 - `user/create-environments/`: create manager-based Isaac Lab environments by default, with direct environments for special cases.
 - `user/convert-direct-to-manager/`: convert validated direct Isaac Lab environments into manager-based task configurations.
 - `user/train-rl-agents/`: configure and run Isaac Lab reinforcement learning workflows.

--- a/skills/user/domain-randomization-events/SKILL.md
+++ b/skills/user/domain-randomization-events/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: isaaclab-randomizing-with-events
-description: Implements fixed and adaptive Isaac Lab domain randomization with event and curriculum terms. Use when randomizing physics, observations, or resets; configuring Automatic or Adaptive Domain Randomization (ADR); expanding ranges from policy success; or porting randomization into direct or manager-based tasks.
+description: Implements Isaac Lab domain randomization with event terms and success-driven ADR curricula. Use when randomizing physics or observations, porting reset randomization, or configuring Automatic or Adaptive Domain Randomization (ADR).
 audience: user
 status: stable
 owners:
@@ -11,41 +11,40 @@ owners:
 
 ## When To Use
 
-Use this skill for fixed event-based randomization or success-driven Automatic/Adaptive Domain Randomization (ADR).
+Use this skill when a user wants to add domain randomization to an Isaac Lab task through event terms. Use ADR when policy success should change the randomization range.
 
-Do not use this skill for unrelated curricula, command sampling, or reward shaping.
+Do not use this skill for unrelated curriculum, command sampling, or reward shaping unless those changes interact with randomization.
 
 ## Workflow
 
-1. Identify the property, scene entity, physical units, and target backend.
-2. Choose the default:
-   - Use a fixed event range when training should sample the same distribution throughout.
-   - Use ADR when the range should grow or shrink from a stable policy-success signal.
-3. Identify the workflow. Direct and manager-based tasks both support event terms, but the maintained `CurriculumManager` ADR pattern is manager-based.
-4. Choose the event mode:
+1. Identify what should vary: assets, physics properties, observations, initial state, external disturbances, or rendering.
+2. Identify the task workflow: direct (`DirectRLEnv` or `DirectMARLEnv`) or manager-based. Both can use `EventManager` through an `events` config.
+3. Identify the active target backend: PhysX, Newton, or both through `PresetCfg`.
+4. Check whether the randomization function has backend-specific behavior or unsupported backends in `source/isaaclab/isaaclab/envs/mdp/events.py`.
+5. Choose the event mode:
    - Use prestartup events for USD-level properties that must be authored before simulation starts.
    - Use startup events for one-time setup randomization after simulation starts.
    - Use reset events for per-episode randomization.
    - Use interval events for repeated disturbances during an episode.
-5. Read the event implementation before editing. Check backend behavior and whether the property can change after startup.
-6. Implement and validate the intended final range as a fixed event first. Use backend-specific `PresetCfg` terms when PhysX and Newton differ.
-7. For ADR, follow the [gravity example](examples.md#success-driven-adr):
-   - Keep the randomization in its event term.
-   - Add a task-owned difficulty scheduler driven by terminal success; do not import another task's private scheduler.
-   - Put the scheduler before dependent terms in `CurriculumCfg`.
-   - Use `mdp.modify_term_cfg` to interpolate each event or manager-term parameter from an easy initial value to the validated final value.
-   - Assign both `events` and `curriculum` on the manager-based environment config.
-8. Validate with a small number of environments and repeated resets before scaling.
+6. Check timing limitations before editing. Some USD-stage or topology-level changes are prestartup-only and cannot be safely moved to reset or interval events.
+7. Define event terms in the environment configuration. In direct workflows, assign the event config to the task config's `events` field. In manager-based workflows, assign it to the manager-based env config's `events` field.
+8. Use backend-specific `PresetCfg` event configs when PhysX and Newton need different terms.
+9. Scope each term to the correct scene entities.
+10. Use one clear distribution and range for each randomized quantity.
+11. Validate with a small number of environments and repeated resets on each backend.
+12. Expand ranges only after the baseline randomized task is stable.
+13. For manager-based ADR, validate the final range as a fixed event, then use a task-owned scheduler and `modify_term_cfg` to interpolate it; see the [gravity example](examples.md#success-driven-adr).
 
 ## Validation
 
 Use the plan-validate-execute loop:
 
-1. Confirm the final fixed randomization range resets and rolls out cleanly on every target backend.
-2. For ADR, check initial and maximum difficulty produce the exact initial and final parameter values.
-3. Check success promotes difficulty, failure follows the chosen demotion policy, and difficulty remains clamped.
-4. Confirm the scheduler runs before interpolation terms and the updated range is consumed by the following reset event.
-5. Log difficulty and current bounds; fix shape, device, backend, and entity-name errors before scaling.
+1. List each randomized property, target entity, backend, event mode, distribution, range, and timing limitation.
+2. Check the list against the environment config before editing.
+3. Check CPU/GPU expectations in the implementation. Some PhysX paths use CPU tensors while Newton paths may operate on the environment device.
+4. Run a small reset or rollout smoke test for every targeted backend.
+5. Fix shape, device, backend, and entity-name errors before scaling.
+6. For ADR, test the exact endpoints and confirm policy success changes the next reset's range within its bounds.
 
 For skill changes, run:
 
@@ -55,7 +54,7 @@ uv run --no-project python tools/skills/cli.py check
 
 ## Maintenance
 
-Keep this skill synchronized with the event and curriculum managers, the curriculum guide, the direct and manager-based environment tutorials, and the Core Lift ADR example. Update maintained docs or source examples before copying new API details into this skill.
+Keep this skill synchronized with `source/isaaclab/isaaclab/managers/event_manager.py`, `source/isaaclab/isaaclab/envs/direct_rl_env.py`, `source/isaaclab/isaaclab/envs/direct_marl_env.py`, the direct and manager-based environment tutorials, and the managers API docs. For ADR, follow the curriculum guide and Core Lift example.
 
 ## References
 
@@ -67,5 +66,4 @@ Keep this skill synchronized with the event and curriculum managers, the curricu
 - [Manager-based event terms tutorial](../../../docs/source/tutorials/03_envs/create_manager_base_env.rst)
 - [Curriculum utilities guide](../../../docs/source/how-to/curriculums.rst)
 - [Core Lift ADR config](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/adr_curriculum.py)
-- [Core Lift ADR terms](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py)
 - [Managers API](../../../docs/source/api/lab/isaaclab.managers.rst)

--- a/skills/user/domain-randomization-events/SKILL.md
+++ b/skills/user/domain-randomization-events/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: isaaclab-randomizing-with-events
-description: Implements Isaac Lab domain randomization with event terms in direct and manager-based workflows. Use when adding domain randomization, randomizing physics or observations, porting reset randomization, or configuring event-based variation.
+description: Implements fixed and adaptive Isaac Lab domain randomization with event and curriculum terms. Use when randomizing physics, observations, or resets; configuring Automatic or Adaptive Domain Randomization (ADR); expanding ranges from policy success; or porting randomization into direct or manager-based tasks.
 audience: user
 status: stable
 owners:
@@ -11,38 +11,41 @@ owners:
 
 ## When To Use
 
-Use this skill when a user wants to add domain randomization to an Isaac Lab task through event terms.
+Use this skill for fixed event-based randomization or success-driven Automatic/Adaptive Domain Randomization (ADR).
 
-Do not use this skill for unrelated curriculum, command sampling, or reward shaping unless those changes interact with randomization.
+Do not use this skill for unrelated curricula, command sampling, or reward shaping.
 
 ## Workflow
 
-1. Identify what should vary: assets, physics properties, observations, initial state, external disturbances, or rendering.
-2. Identify the task workflow: direct (`DirectRLEnv` or `DirectMARLEnv`) or manager-based. Both can use `EventManager` through an `events` config.
-3. Identify the active target backend: PhysX, Newton, or both through `PresetCfg`.
-4. Check whether the randomization function has backend-specific behavior or unsupported backends in `source/isaaclab/isaaclab/envs/mdp/events.py`.
-5. Choose the event mode:
+1. Identify the property, scene entity, physical units, and target backend.
+2. Choose the default:
+   - Use a fixed event range when training should sample the same distribution throughout.
+   - Use ADR when the range should grow or shrink from a stable policy-success signal.
+3. Identify the workflow. Direct and manager-based tasks both support event terms, but the maintained `CurriculumManager` ADR pattern is manager-based.
+4. Choose the event mode:
    - Use prestartup events for USD-level properties that must be authored before simulation starts.
    - Use startup events for one-time setup randomization after simulation starts.
    - Use reset events for per-episode randomization.
    - Use interval events for repeated disturbances during an episode.
-6. Check timing limitations before editing. Some USD-stage or topology-level changes are prestartup-only and cannot be safely moved to reset or interval events.
-7. Define event terms in the environment configuration. In direct workflows, assign the event config to the task config's `events` field. In manager-based workflows, assign it to the manager-based env config's `events` field.
-8. Use backend-specific `PresetCfg` event configs when PhysX and Newton need different terms.
-9. Scope each term to the correct scene entities.
-10. Use one clear distribution and range for each randomized quantity.
-11. Validate with a small number of environments and repeated resets on each backend.
-12. Expand ranges only after the baseline randomized task is stable.
+5. Read the event implementation before editing. Check backend behavior and whether the property can change after startup.
+6. Implement and validate the intended final range as a fixed event first. Use backend-specific `PresetCfg` terms when PhysX and Newton differ.
+7. For ADR, follow the [gravity example](examples.md#success-driven-adr):
+   - Keep the randomization in its event term.
+   - Add a task-owned difficulty scheduler driven by terminal success; do not import another task's private scheduler.
+   - Put the scheduler before dependent terms in `CurriculumCfg`.
+   - Use `mdp.modify_term_cfg` to interpolate each event or manager-term parameter from an easy initial value to the validated final value.
+   - Assign both `events` and `curriculum` on the manager-based environment config.
+8. Validate with a small number of environments and repeated resets before scaling.
 
 ## Validation
 
 Use the plan-validate-execute loop:
 
-1. List each randomized property, target entity, backend, event mode, distribution, range, and timing limitation.
-2. Check the list against the environment config before editing.
-3. Check CPU/GPU expectations in the implementation. Some PhysX paths use CPU tensors while Newton paths may operate on the environment device.
-4. Run a small reset or rollout smoke test for every targeted backend.
-5. Fix shape, device, backend, and entity-name errors before scaling.
+1. Confirm the final fixed randomization range resets and rolls out cleanly on every target backend.
+2. For ADR, check initial and maximum difficulty produce the exact initial and final parameter values.
+3. Check success promotes difficulty, failure follows the chosen demotion policy, and difficulty remains clamped.
+4. Confirm the scheduler runs before interpolation terms and the updated range is consumed by the following reset event.
+5. Log difficulty and current bounds; fix shape, device, backend, and entity-name errors before scaling.
 
 For skill changes, run:
 
@@ -52,7 +55,7 @@ uv run --no-project python tools/skills/cli.py check
 
 ## Maintenance
 
-Keep this skill synchronized with `source/isaaclab/isaaclab/managers/event_manager.py`, `source/isaaclab/isaaclab/envs/direct_rl_env.py`, `source/isaaclab/isaaclab/envs/direct_marl_env.py`, the direct and manager-based environment tutorials, and the managers API docs. If event-term behavior or mode semantics change, update the official docs or examples first and keep this skill focused on selecting the right workflow.
+Keep this skill synchronized with the event and curriculum managers, the curriculum guide, the direct and manager-based environment tutorials, and the Core Lift ADR example. Update maintained docs or source examples before copying new API details into this skill.
 
 ## References
 
@@ -62,4 +65,7 @@ Keep this skill synchronized with `source/isaaclab/isaaclab/managers/event_manag
 - [Event manager source](../../../source/isaaclab/isaaclab/managers/event_manager.py)
 - [Direct workflow randomization tutorial](../../../docs/source/tutorials/03_envs/create_direct_rl_env.rst)
 - [Manager-based event terms tutorial](../../../docs/source/tutorials/03_envs/create_manager_base_env.rst)
+- [Curriculum utilities guide](../../../docs/source/how-to/curriculums.rst)
+- [Core Lift ADR config](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/adr_curriculum.py)
+- [Core Lift ADR terms](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py)
 - [Managers API](../../../docs/source/api/lab/isaaclab.managers.rst)

--- a/skills/user/domain-randomization-events/evaluations.md
+++ b/skills/user/domain-randomization-events/evaluations.md
@@ -93,14 +93,9 @@ Query: "Start gravity at zero and automatically ramp it to -9.81 as my lift poli
 Expected behavior:
 
 - Keeps gravity application in a reset event.
-- Uses a task-owned success-driven scheduler and `modify_term_cfg` interpolation in a manager-based curriculum.
-- Places the scheduler before the gravity interpolation term.
-- Validates the fixed final range, both interpolation endpoints, promotion/demotion behavior, and clamping.
-- References the curriculum guide and Core Lift ADR example.
+- Uses a manager-based curriculum to interpolate from zero to full gravity as policy success changes.
+- Uses a task-owned scheduler and validates both endpoint values.
 
-Known failure modes:
+Pass/fail criteria:
 
-- Treats ADR as an event mode or modifies gravity in the training loop.
-- Adds a `curriculum` field to a direct environment and assumes it will execute.
-- Imports Core Lift's private scheduler into an unrelated task.
-- Expands an unvalidated final range or omits endpoint checks.
+- Links the curriculum guide and Core Lift ADR example.

--- a/skills/user/domain-randomization-events/evaluations.md
+++ b/skills/user/domain-randomization-events/evaluations.md
@@ -7,6 +7,7 @@
 - Scenario 3: interval disturbance
 - Scenario 4: PhysX and Newton material randomization
 - Scenario 5: direct workflow events
+- Scenario 6: success-driven ADR
 
 ## Scenario 1: Reset Randomization
 
@@ -84,3 +85,22 @@ Known failure modes:
 
 - Claims event terms are only for manager-based environments.
 - Converts the task to manager-based solely to use randomization events.
+
+## Scenario 6: Success-Driven ADR
+
+Query: "Start gravity at zero and automatically ramp it to -9.81 as my lift policy succeeds."
+
+Expected behavior:
+
+- Keeps gravity application in a reset event.
+- Uses a task-owned success-driven scheduler and `modify_term_cfg` interpolation in a manager-based curriculum.
+- Places the scheduler before the gravity interpolation term.
+- Validates the fixed final range, both interpolation endpoints, promotion/demotion behavior, and clamping.
+- References the curriculum guide and Core Lift ADR example.
+
+Known failure modes:
+
+- Treats ADR as an event mode or modifies gravity in the training loop.
+- Adds a `curriculum` field to a direct environment and assumes it will execute.
+- Imports Core Lift's private scheduler into an unrelated task.
+- Expands an unvalidated final range or omits endpoint checks.

--- a/skills/user/domain-randomization-events/examples.md
+++ b/skills/user/domain-randomization-events/examples.md
@@ -4,6 +4,7 @@
 
 - Reset state randomization
 - Direct workflow event config
+- Success-driven ADR
 - Prestartup USD randomization
 - Startup property randomization
 - Backend-specific material randomization
@@ -30,6 +31,57 @@ Expected setup:
 - Assign `events: EventCfg = EventCfg()` on the direct task config.
 - Keep reward and observation logic in direct methods.
 - Validate that `prestartup`, `startup`, `reset`, and `interval` modes fire at the expected times for direct workflows.
+
+## Success-Driven ADR
+
+Input: start a manager-based lift task at zero gravity, then approach full gravity as the policy succeeds.
+
+Keep the scheduler and interpolation function in the task's own `mdp/curriculums.py`. The maintained implementations are in the [Core Lift ADR terms](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py); adapt their success signal instead of importing Core Lift internals into another task.
+
+```python
+import isaaclab.envs.mdp as base_mdp
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.utils.configclass import configclass
+
+from . import mdp as task_mdp
+
+
+@configclass
+class EventCfg:
+    variable_gravity = EventTerm(
+        func=base_mdp.randomize_physics_scene_gravity,
+        mode="reset",
+        params={
+            "gravity_distribution_params": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+            "operation": "abs",
+        },
+    )
+
+
+@configclass
+class CurriculumCfg:
+    difficulty = CurrTerm(
+        func=task_mdp.DifficultyScheduler,
+        params={"init_difficulty": 0, "min_difficulty": 0, "max_difficulty": 10},
+    )
+    gravity_adr = CurrTerm(
+        func=base_mdp.modify_term_cfg,
+        params={
+            "address": "events.variable_gravity.params.gravity_distribution_params",
+            "modify_fn": task_mdp.initial_final_interpolate_fn,
+            "modify_params": {
+                "initial_value": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
+                "final_value": ((0.0, 0.0, -9.81), (0.0, 0.0, -9.81)),
+                "difficulty_term_str": "difficulty",
+            },
+        },
+    )
+```
+
+Assign `events: EventCfg = EventCfg()` and `curriculum: CurriculumCfg = CurriculumCfg()` on the environment config. At reset, `CurriculumManager` updates the range before `EventManager` applies `variable_gravity`.
+
+Validate difficulty fractions `0.0` and `1.0` first, then confirm real successes promote the scheduler without exceeding its bounds.
 
 ## Startup Property Randomization
 

--- a/skills/user/domain-randomization-events/examples.md
+++ b/skills/user/domain-randomization-events/examples.md
@@ -36,52 +36,33 @@ Expected setup:
 
 Input: start a manager-based lift task at zero gravity, then approach full gravity as the policy succeeds.
 
-Keep the scheduler and interpolation function in the task's own `mdp/curriculums.py`. The maintained implementations are in the [Core Lift ADR terms](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py); adapt their success signal instead of importing Core Lift internals into another task.
+Given a reset event named `variable_gravity`, add a task-owned scheduler and interpolation term:
 
 ```python
-import isaaclab.envs.mdp as base_mdp
 from isaaclab.managers import CurriculumTermCfg as CurrTerm
-from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.utils.configclass import configclass
 
-from . import mdp as task_mdp
-
-
-@configclass
-class EventCfg:
-    variable_gravity = EventTerm(
-        func=base_mdp.randomize_physics_scene_gravity,
-        mode="reset",
-        params={
-            "gravity_distribution_params": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
-            "operation": "abs",
-        },
-    )
+from . import mdp
 
 
 @configclass
 class CurriculumCfg:
-    difficulty = CurrTerm(
-        func=task_mdp.DifficultyScheduler,
-        params={"init_difficulty": 0, "min_difficulty": 0, "max_difficulty": 10},
-    )
+    adr = CurrTerm(func=mdp.DifficultyScheduler, params={"init_difficulty": 0, "min_difficulty": 0, "max_difficulty": 10})
     gravity_adr = CurrTerm(
-        func=base_mdp.modify_term_cfg,
+        func=mdp.modify_term_cfg,
         params={
             "address": "events.variable_gravity.params.gravity_distribution_params",
-            "modify_fn": task_mdp.initial_final_interpolate_fn,
+            "modify_fn": mdp.initial_final_interpolate_fn,
             "modify_params": {
                 "initial_value": ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0)),
                 "final_value": ((0.0, 0.0, -9.81), (0.0, 0.0, -9.81)),
-                "difficulty_term_str": "difficulty",
+                "difficulty_term_str": "adr",
             },
         },
     )
 ```
 
-Assign `events: EventCfg = EventCfg()` and `curriculum: CurriculumCfg = CurriculumCfg()` on the environment config. At reset, `CurriculumManager` updates the range before `EventManager` applies `variable_gravity`.
-
-Validate difficulty fractions `0.0` and `1.0` first, then confirm real successes promote the scheduler without exceeding its bounds.
+Assign `curriculum: CurriculumCfg = CurriculumCfg()` on the environment config. Adapt the [Core Lift ADR scheduler](../../../source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/curriculums.py) and test both endpoints.
 
 ## Startup Property Randomization
 

--- a/skills/user/domain-randomization-events/reference.md
+++ b/skills/user/domain-randomization-events/reference.md
@@ -3,7 +3,6 @@
 ## Contents
 
 - Direct and manager-based usage
-- Fixed randomization and ADR
 - Event mode selection
 - Backend compatibility
 - Timing limitations
@@ -24,16 +23,6 @@ Use the same event-term structure in both workflows:
 | Manager-based | Add an event config class to the manager-based env config's `events` field. |
 
 In direct workflows, observations and rewards remain direct methods; only randomization is routed through event terms.
-
-## Fixed Randomization and ADR
-
-Fixed domain randomization stores a stable distribution in an event term. ADR keeps the event as the owner of randomization and uses curriculum terms to adapt its configuration from policy performance.
-
-The maintained ADR pattern is manager-based: `ManagerBasedRLEnv` computes curriculum terms before applying reset events. Put the difficulty scheduler before interpolation terms in `CurriculumCfg`, then use `modify_term_cfg` addresses such as `events.variable_gravity.params.gravity_distribution_params`.
-
-Direct environments expose event terms but not `CurriculumManager`. Do not add a `curriculum` field and assume it will run; implement an explicit task-local schedule or migrate the curriculum ownership to a manager-based environment.
-
-ADR schedulers are task-owned because success semantics differ. Define which terminal signal promotes or demotes difficulty, clamp the range, and expose a normalized fraction for interpolation. Do not import a scheduler from an unrelated task package.
 
 ## Event Mode Selection
 

--- a/skills/user/domain-randomization-events/reference.md
+++ b/skills/user/domain-randomization-events/reference.md
@@ -3,6 +3,7 @@
 ## Contents
 
 - Direct and manager-based usage
+- Fixed randomization and ADR
 - Event mode selection
 - Backend compatibility
 - Timing limitations
@@ -23,6 +24,16 @@ Use the same event-term structure in both workflows:
 | Manager-based | Add an event config class to the manager-based env config's `events` field. |
 
 In direct workflows, observations and rewards remain direct methods; only randomization is routed through event terms.
+
+## Fixed Randomization and ADR
+
+Fixed domain randomization stores a stable distribution in an event term. ADR keeps the event as the owner of randomization and uses curriculum terms to adapt its configuration from policy performance.
+
+The maintained ADR pattern is manager-based: `ManagerBasedRLEnv` computes curriculum terms before applying reset events. Put the difficulty scheduler before interpolation terms in `CurriculumCfg`, then use `modify_term_cfg` addresses such as `events.variable_gravity.params.gravity_distribution_params`.
+
+Direct environments expose event terms but not `CurriculumManager`. Do not add a `curriculum` field and assume it will run; implement an explicit task-local schedule or migrate the curriculum ownership to a manager-based environment.
+
+ADR schedulers are task-owned because success semantics differ. Define which terminal signal promotes or demotes difficulty, clamp the range, and expose a normalized fraction for interpolation. Do not import a scheduler from an unrelated task package.
 
 ## Event Mode Selection
 


### PR DESCRIPTION
## Summary

- Add success-driven ADR routing to the existing domain-randomization skill.
- Add one compact manager-based gravity example using a task-owned scheduler and modify_term_cfg.
- Validate exact endpoints and link the curriculum guide and Core Lift source.

## Testing

- Repository skill validator: 21 skills validated.
- Python example syntax: 2 examples validated.
- Full formatting and pre-commit checks passed.