### PR TITLE
[Backport release/3.0.0] Cache pip and uv downloads in GitHub Actions

### DIFF
--- a/.github/actions/install-ci-run/action.yml
+++ b/.github/actions/install-ci-run/action.yml
@@ -29,6 +29,9 @@ runs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        # `auto` (the default) enables the cache only on GitHub-hosted runners;
+        # this action also runs on the self-hosted arm64 runner, so force it on.
+        enable-cache: true
     - name: Run Tests
       shell: bash
       env:

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
+          # No `cache: pip` here: the pytest install below is conditional on the
+          # PR touching tools/changelog/, so on most runs pip never executes and
+          # ~/.cache/pip is never created. setup-python's post-job save treats a
+          # missing cache dir as an error and fails the job.
 
       - name: Resolve base ref
         id: base

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -64,6 +64,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        enable-cache: true
 
     - name: Install docs dependencies
       run: |
@@ -97,6 +98,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        enable-cache: true
 
     - name: Install docs dependencies
       run: |

--- a/.github/workflows/kitless-docker.yml
+++ b/.github/workflows/kitless-docker.yml
@@ -70,6 +70,8 @@ jobs:
     - name: Set up uv
       if: steps.detect.outputs.should_run == 'true'
       uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
 
     - name: Validate kit-less container profile
       if: steps.detect.outputs.should_run == 'true'

--- a/.github/workflows/skills-check.yml
+++ b/.github/workflows/skills-check.yml
@@ -34,6 +34,13 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.12"
+          cache: pip
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Hashing the workflow also ties
+          # invalidation to the install list below rather than to unrelated
+          # dependency churn.
+          cache-dependency-path: .github/workflows/skills-check.yml
 
       - name: Verify skills
         run: python3 tools/skills/cli.py check

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -38,6 +38,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Hashing the workflow also ties
+          # invalidation to the install list below rather than to unrelated
+          # dependency churn.
+          cache-dependency-path: .github/workflows/tools-tests.yml
 
       # These tests only need pytest, junitparser (imported by tools/crash_journal.py) and
       # flaky, so they run without an Isaac Sim install or a full project sync. flaky drives the

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -135,6 +135,25 @@ jobs:
         with:
           python-version: "3.12"
           architecture: x64
+          cache: pip
+          # Keyed on this workflow file, not pyproject.toml: the pip cache key is
+          # otherwise identical across every 3.12 ubuntu job here, so they collide
+          # and all but the first fail to save. Covers the `build` and `wheel`
+          # packages that tools/wheel_builder/build.sh installs with pip.
+          cache-dependency-path: .github/workflows/wheel.yml
+
+      # The extras-resolution step below drives uv, whose downloads land in
+      # ~/.cache/uv rather than pip's cache. Provisioning uv here caches that
+      # resolution work and drops the ~24 MB `pip install uv` bootstrap.
+      - name: Set up uv
+        if: steps.changes.outputs.run_build == 'true'
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          # Neither this job nor kitless-docker pins python-version, so both land
+          # on the same `-unknown-` cache key and only one can save. This job
+          # caches the wheel's full extras resolution; keep it separate.
+          cache-suffix: wheel-extras
 
       # Compose Docker-image-style metadata for the artifact. The artifact
       # name is what QA sees in `gh run download`, so we make it scannable:
@@ -176,9 +195,6 @@ jobs:
         if: steps.changes.outputs.run_build == 'true'
         run: |
           set -euo pipefail
-
-          bash "$GITHUB_WORKSPACE/.github/actions/_lib/with-python-package-retries.sh" python -m pip install --user uv
-          export PATH="$HOME/.local/bin:$PATH"
 
           overrides="$GITHUB_WORKSPACE/tools/wheel_builder/uv-overrides.txt"
 

--- a/source/isaaclab/changelog.d/ci-cache-pip-uv.skip
+++ b/source/isaaclab/changelog.d/ci-cache-pip-uv.skip
@@ -1,0 +1,5 @@
+# No changelog entry / version bump: CI-only change. Enables the pip cache in
+# actions/setup-python and the uv cache in astral-sh/setup-uv across the
+# workflows that install Python packages, so an index outage no longer fails a
+# job once with-python-package-retries.sh exhausts its retries. No source
+# package or published wheel is affected.


### PR DESCRIPTION
## Summary

- Backport of #7287 (squash commit `d508d95`), cherry-picked with `-x`; applied with no conflicts and the diff is identical to develop.
- Enable `enable-cache: true` for `astral-sh/setup-uv` in `docs.yaml` (both jobs), `kitless-docker.yml`, and `.github/actions/install-ci-run`. The composite action sets it explicitly rather than relying on the default `auto`, which enables the cache only on GitHub-hosted runners.
- Enable `cache: pip` for `actions/setup-python` in `skills-check.yml`, `tools-tests.yml`, and `wheel.yml`, each keyed on its own workflow file so the jobs do not collide on one cache key.
- Provision uv in the wheel job through `setup-uv` under a `wheel-extras` cache suffix, replacing the `pip install --user uv` bootstrap.
- `resolve-ov-pins`, `nightly-changelog`, `changelog-check.yml`, and `test-multi-gpu.yaml` stay uncached; the inline comments explain why.

CI-only change: no source package touched, so the changelog fragment is a `.skip`.

## Test plan

- [x] `git diff` of this commit is byte-identical to the diff of `d508d95` on develop.
- [x] Verified the `wheel.yml` context this depends on exists on `release/3.0.0` (`steps.changes.outputs.run_build`, and the `uv pip install` calls that now rely on `setup-uv` for `uv`).
- [x] `uv run isaaclab -f` passes. `check-changelog-fragments` reports a pre-existing failure unrelated to this change (it defaults to `origin/develop`; with `ISAACLAB_CHANGELOG_BASE_REF=release/3.0.0` it reports all fragments valid).
- [ ] Cache hit/save behavior confirmed by the CI runs on this PR.

## Follow-up (not in this backport)

`install-ci-run`, both `docs.yaml` jobs, and the existing `license-check.yaml` all resolve to the same uv cache key (`setup-uv-1-x86_64-unknown-linux-gnu-3.12-pruned-<deps hash>`), since the hash covers the repo's dependency files rather than the job. Only one of them can save per ref; the others restore a mismatched payload and skip saving. That needs a `cache-suffix` fix on develop first, then a separate backport.