### PR TITLE
[Docs] Fix broken release documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Isaac Lab offers a comprehensive set of tools and environments designed to facil
 Our [documentation page](https://isaac-sim.github.io/IsaacLab) provides everything you need to get started, including
 detailed tutorials and step-by-step guides. Follow these links to learn more about:
 
-- [Installation steps](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/setup/installation/index.html#local-installation)
-- [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html)
-- [Tutorials](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/tutorials/index.html)
-- [Available environments](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/overview/environments.html)
+- [Installation steps](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/setup/installation/index.html#local-installation)
+- [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html)
+- [Tutorials](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/tutorials/index.html)
+- [Available environments](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/environments.html)
 
 ## Performance Dashboard
 
@@ -83,7 +83,7 @@ dependency versions for Isaac Sim.
 
 We wholeheartedly welcome contributions from the community to make this framework mature and useful for everyone.
 These may happen as bug reports, feature requests, or code contributions. For details, please check our
-[contribution guidelines](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/refs/contributing.html).
+[contribution guidelines](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/refs/contributing.html).
 
 ## Show & Tell: Share Your Inspiration
 
@@ -100,7 +100,7 @@ innovation in robotics and simulation.
 
 ## Troubleshooting
 
-Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/refs/troubleshooting.html) section for
+Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/refs/troubleshooting.html) section for
 common fixes or [submit an issue](https://github.com/isaac-sim/IsaacLab/issues).
 
 For issues related to Isaac Sim, we recommend checking its [documentation](https://docs.isaacsim.omniverse.nvidia.com/latest/index.html)

--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -118,8 +118,7 @@ The training and evaluation commands below work unchanged.
 .. _rlinf-decord-aarch64:
 
 Then preload the OpenMP library so it can be loaded into the Python process
-(see the IsaacLab `pip installation guide
-<https://isaac-sim.github.io/IsaacLab/release/3.0.0-beta2/source/setup/installation/pip_installation.html#installing-dependencies>`_):
+(see :ref:`isaaclab-pip-installing-dependencies`):
 
 .. code-block:: bash
 

--- a/docs/source/setup/installation/pip_installation.rst
+++ b/docs/source/setup/installation/pip_installation.rst
@@ -34,6 +34,8 @@ If you encounter any issues, please report them to the
 
 .. include:: include/pip_python_virtual_env.rst
 
+.. _isaaclab-pip-installing-dependencies:
+
 Installing dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp.rst
@@ -240,6 +240,6 @@ into deployment systems.
 .. note::
 
    Refer to the `LEAPP semantic annotation guide
-   <https://nvidia-isaac.github.io/leapp/guides/semantics.html>`_
+   <https://nvidia-isaac.github.io/leapp/semantics/usage.html>`_
    and `LEAPP API reference <https://nvidia-isaac.github.io/leapp/api/index.html>`_
    for details on authoring semantic annotations.


### PR DESCRIPTION
## Description

Fix broken links in the published 3.0.0-beta2 documentation and release README:

- replace the version-pinned RLinf installation URL with a stable Sphinx cross-reference
- update the LEAPP semantic annotation guide URL to its current location
- point all six README documentation links at the immutable v3.0.0-beta2 tag instead of the release/3.0.0-beta2 branch path

This pull request intentionally targets the frozen release snapshot because the stale links remain in that version. The RST source equivalents are already corrected on develop, while the README tag-prefix change is specific to this release branch. The LEAPP correction was previously proposed in #7190.

No dependencies are added.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

Not applicable; this pull request directly repairs release/3.0.0-beta2 documentation.

## Screenshots

Not applicable; these are documentation link corrections.

## Validation

- Full Sphinx documentation build completed with warnings treated as errors for the RST changes.
- Repository formatting and pre-commit checks passed after the README update.
- Verified the generated RLinf page uses a relative URL and the installation page contains the target anchor.
- Verified the old LEAPP URL returns 404 and the replacement URL returns 200.
- Verified all six v3.0.0-beta2 README targets resolve and no release/3.0.0-beta2 documentation URL remains in the repository.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The warning-as-error Sphinx build validates the changed cross-reference
- [x] Changelog fragments are not applicable because no source package was changed
- [x] My name is already present in CONTRIBUTORS.md