### PR TITLE
[Test] Remove Shadow Hand rendering flaky retry marker

### DIFF
--- a/source/isaaclab_tasks/changelog.d/esekkin-remove-marker.skip
+++ b/source/isaaclab_tasks/changelog.d/esekkin-remove-marker.skip
@@ -1,0 +1,1 @@
+Test-only: dropped the flaky retry marker from the Shadow Hand rendering correctness parameter.

--- a/source/isaaclab_tasks/test/core/test_rendering_registered_tasks.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_registered_tasks.py
@@ -79,15 +79,7 @@ _RENDER_CORRECTNESS_TASK_IDS = [
     ("Isaac-Cartpole-Camera-Direct", "simple_shading_constant_diffuse", "cartpole"),
     ("Isaac-Cartpole-Camera-Direct", "simple_shading_diffuse_mdl", "cartpole"),
     ("Isaac-Cartpole-Camera-Direct", "simple_shading_full_mdl", "cartpole"),
-    pytest.param(
-        "Isaac-Reorient-Cube-Shadow-Camera-Direct",
-        None,
-        "shadow_hand",
-        # The Shadow-Vision render is right at the SSIM/diff-pixel tolerance and intermittently
-        # exceeds the 3% diff threshold by a fraction of a percent. Allow up to 3 attempts and
-        # require at least one pass while we tighten the validation tolerances for this scene.
-        marks=pytest.mark.flaky(max_runs=3, min_passes=1),
-    ),
+    ("Isaac-Reorient-Cube-Shadow-Camera-Direct", None, "shadow_hand"),
 ]
 
 


### PR DESCRIPTION
# Description

Removes the `flaky(max_runs=3, min_passes=1)` marker from the `Isaac-Reorient-Cube-Shadow-Camera-Direct` rendering-correctness parameter, along with its stale comment referencing a 3% diff threshold that no longer exists.

The marker was added in #5401 as a stopgap while OVRTX render instability was outstanding. Across eight recent PR runs of the `rendering-correctness` job, this parameter passed on the first attempt every time without consuming a retry, so the marker now only serves to hide future regressions.

## Type of change

- Test cleanup

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there