### PR TITLE
Fixes CI base image pulls by not inheriting runner registry credentials

### DIFF
--- a/.github/actions/_lib/compute-deps-hash/action.yml
+++ b/.github/actions/_lib/compute-deps-hash/action.yml
@@ -63,15 +63,16 @@ runs:
 
         # Resolve the actual base image digest so a new push of a mutable tag
         # (e.g. latest-develop) invalidates the deps cache automatically.
-        base_image_digest=$(docker buildx imagetools inspect \
+        # Fail loudly: an unreadable manifest is an auth/registry problem, and
+        # silently falling back to the tag string stops the deps cache from
+        # tracking the base image at all.
+        if ! base_image_digest=$(docker buildx imagetools inspect \
           "${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}" \
-          --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)
-        if [ -n "${base_image_digest}" ]; then
-          base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}:${base_image_digest}"
-        else
-          echo "🟠 Could not resolve base image digest, falling back to tag string"
-          base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}"
+          --format '{{json .Manifest.Digest}}' 2>&1 | tr -d '"'); then
+          echo "::error::Cannot read manifest for ${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}: ${base_image_digest}"
+          exit 1
         fi
+        base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}:${base_image_digest}"
 
         mapfile -t manifest_files < <(git ls-files | grep -E "${deps_manifest_pattern}" || true)
         file_hash=$(git ls-files -s "${deps_files[@]}" "${manifest_files[@]}" 2>/dev/null \

--- a/.github/actions/_lib/setup-docker-config/action.yml
+++ b/.github/actions/_lib/setup-docker-config/action.yml
@@ -26,18 +26,19 @@ runs:
           exit 0
         fi
 
+        # Seed a CLEAN config - never inherit the runner's registry credentials.
+        # A persistent `docker login nvcr.io` on the runner is stored inline
+        # (the credential helper is broken), and inheriting it makes NGC refuse
+        # to mint a token for the PUBLIC nvidia/* catalog for that org identity
+        # ("denied: Access Denied") instead of falling back to anonymous.
         DOCKER_CONFIG_DIR=$(mktemp -d)
-        if [ -f "${HOME}/.docker/config.json" ]; then
-          python3 -c "import json; cfg=json.load(open('${HOME}/.docker/config.json')); cfg['credsStore']=''; cfg.pop('credHelpers',None); json.dump(cfg,open('${DOCKER_CONFIG_DIR}/config.json','w'))"
-        else
-          echo '{"credsStore":""}' > "${DOCKER_CONFIG_DIR}/config.json"
-        fi
+        echo '{"credsStore":"","auths":{}}' > "${DOCKER_CONFIG_DIR}/config.json"
         export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
         echo "DOCKER_CONFIG=${DOCKER_CONFIG_DIR}" >> "$GITHUB_ENV"
 
         if [ -n "${NGC_API_KEY:-}" ]; then
           echo "🔵 Logging into nvcr.io..."
-          docker login -u '$oauthtoken' -p "${NGC_API_KEY}" nvcr.io
+          printf '%s' "${NGC_API_KEY}" | docker login -u '$oauthtoken' --password-stdin nvcr.io
         else
           echo "🟠 NGC_API_KEY not set - skipping nvcr.io login (normal for fork PRs)"
         fi


### PR DESCRIPTION
# Description

CI docker builds intermittently fail to resolve `nvcr.io/nvidia/isaac-sim:6.0.1` with `denied: Access Denied`. `setup-docker-config` copies the runner's `~/.docker/config.json` into the job's temp `DOCKER_CONFIG`, and NGC denies an inherited org credential lacking a grant instead of falling back to anonymous. Now the temp config starts with empty `auths`, and `compute-deps-hash` surfaces resolve errors instead of silently dropping the base-image digest from the cache key. Verified by anonymous manifest fetch with a clean config.

| Before | After |
| ------ | ----- |
| On a runner with a persistent nvcr.io login, fork-PR builds that miss the deps cache fail at `FROM` with `denied: Access Denied`; digest-resolve failures are silently swallowed and drop the digest from the deps-cache key | Public base images pull anonymously regardless of runner state; a failed digest resolve fails the step with the underlying error |

## Reproduction

1. On a machine whose `~/.docker/config.json` holds a valid inline nvcr.io credential for an org with no grant on `nvidia/isaac-sim`, resolve the base image the same way the build does:

   ```
   docker buildx imagetools inspect nvcr.io/nvidia/isaac-sim:6.0.1
   ```

   Observed in CI: `ERROR: failed to authorize: failed to fetch oauth token: denied: Access Denied` (https://github.com/isaac-sim/IsaacLab/actions/runs/32741844858; fork PR with a deps-cache miss, and the job logged `NGC_API_KEY not set - skipping nvcr.io login`, so the only credential came from the runner's home config). The denial requires a valid credential from a non-granted org: a missing or invalid credential falls back to anonymous access and succeeds, which is why only some runners fail.

2. Repeat with a clean config, as the patched action now provides:

   ```
   DOCKER_CONFIG=$(mktemp -d) docker buildx imagetools inspect nvcr.io/nvidia/isaac-sim:6.0.1 --format '{{json .Manifest.Digest}}'
   ```

   Returns `"sha256:783444c706538aa76cf5126e911ddc5e618779e6105305ad4af4260362a30aa9"`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
