### PR TITLE
Enable Newton base COM randomization

### DIFF
--- a/source/isaaclab_tasks/changelog.d/antoiner-newton-base-com.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-newton-base-com.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Re-enabled base center-of-mass randomization for Newton MJWarp velocity environments.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -232,7 +232,6 @@ class EventsCfg:
                 "com_range": {"x": (-0.05, 0.05), "y": (-0.05, 0.05), "z": (-0.01, 0.01)},
             },
         ),
-        newton_mjwarp=None,
     )
 
     # reset

--- a/source/isaaclab_tasks/test/core/test_hydra.py
+++ b/source/isaaclab_tasks/test/core/test_hydra.py
@@ -880,6 +880,23 @@ def test_go2_rough_legacy_newton_alias_resolves_to_newton_mjwarp():
     assert env_cfg.scene.robot.actuators["base_legs"].armature == 0.02
 
 
+def test_velocity_events_newton_mjwarp_keeps_base_com_randomization():
+    """MJWarp velocity configs should retain base center-of-mass randomization."""
+    from isaaclab_tasks.core.velocity import mdp
+    from isaaclab_tasks.core.velocity.velocity_env_cfg import EventsCfg
+
+    events = resolve_presets(EventsCfg(), {"newton_mjwarp"})
+
+    assert events.base_com is not None
+    assert events.base_com.func is mdp.randomize_rigid_body_com
+    assert events.base_com.mode == "startup"
+    assert events.base_com.params["com_range"] == {
+        "x": (-0.05, 0.05),
+        "y": (-0.05, 0.05),
+        "z": (-0.01, 0.01),
+    }
+
+
 # =============================================================================
 # Tests: PresetCfg inside deeply nested dicts (e.g., event term params)
 # =============================================================================


### PR DESCRIPTION
## Description

Re-enable the shared startup base center-of-mass randomization event for Newton MJWarp velocity environments. Newton now inherits the existing default event, including the configured x/y/z ranges, while robot-specific preset customization remains unchanged.

Add a preset-resolution regression test and an `isaaclab_tasks` changelog fragment.

Fixes #7097 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Testing

- Confirmed the regression test fails before the fix because `base_com` resolves to `None`.
- `./isaaclab.sh -p -m pytest source/isaaclab_tasks/test/core/test_hydra.py source/isaaclab_tasks/test/core/test_velocity_newton_cfg.py -q` (89 passed)
- `./isaaclab.sh -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh -f`
- [x] Documentation changes are not required for this behavior restoration
- [x] My changes generate no new warnings
- [x] I have added a test that proves the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`