### PR TITLE
Serve the sim-to-sim transfer videos from S3 instead of LFS-backed mp4

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,8 +58,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        lfs: true
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
@@ -91,8 +89,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        lfs: true
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v6

--- a/docs/source/_static/how-to/sim2sim_allegro_transfer.mp4
+++ b/docs/source/_static/how-to/sim2sim_allegro_transfer.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72fb443c6ab18f0acc6774aa013d9a3bea57cf77db9064308aebcb89b0784f39
-size 769345

--- a/docs/source/_static/how-to/sim2sim_anymal_d_transfer.mp4
+++ b/docs/source/_static/how-to/sim2sim_anymal_d_transfer.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a386e8aeb569296e125124bf353188a5c42cd8d7244da5581299a6b75c78f340
-size 3226579

--- a/docs/source/how-to/transfer_policies_between_physx_and_newton.rst
+++ b/docs/source/how-to/transfer_policies_between_physx_and_newton.rst
@@ -300,7 +300,7 @@ They do not represent full PP/PN/NN/NP validation. The backends are shown side b
 .. raw:: html
 
    <video controls preload="metadata" style="width:100%; max-width:960px; margin-bottom:1.5em;">
-     <source src="../../_static/sim2sim_anymal_d_transfer.mp4" type="video/mp4">
+     <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_anymal_d_transfer_10s_trimmed.mp4" type="video/mp4">
    </video>
 
 **Allegro hand cube reorientation** (``Isaac-Reorient-Cube-Allegro``, PhysX-to-Newton direction only)
@@ -308,7 +308,7 @@ They do not represent full PP/PN/NN/NP validation. The backends are shown side b
 .. raw:: html
 
    <video controls preload="metadata" style="width:100%; max-width:960px; margin-bottom:1.5em;">
-     <source src="../../_static/sim2sim_allegro_transfer.mp4" type="video/mp4">
+     <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_allegro_transfer_trimmed.mp4" type="video/mp4">
    </video>
 
 .. tip::


### PR DESCRIPTION
# Description

The two demonstration videos on
[Transferring policies between PhysX and Newton](https://isaac-sim.github.io/IsaacLab/develop/source/how-to/transfer_policies_between_physx_and_newton.html)
do not play. `.gitattributes` routes `*.mp4` through Git LFS, and the published site serves the
132-byte LFS pointer rather than the video:

```
$ curl -s https://isaac-sim.github.io/IsaacLab/develop/_static/sim2sim_anymal_d_transfer.mp4
version https://git-lfs.github.com/spec/v1
oid sha256:a386e8aeb569296e125124bf353188a5c42cd8d7244da5581299a6b75c78f340
size 3226579
```

Adding `lfs: true` to the docs workflow checkout (done in #6913) is not sufficient. The deploying
job builds with sphinx-multiversion, which re-checks-out each version into its own tree, and those
inner checkouts do not run the LFS smudge filter.

Per review, both clips are now **hosted on the Isaac Sim download server** — alongside the other
remote docs media under `isaaclab/images` — and the in-repo copies are removed:

- https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_anymal_d_transfer_10s_trimmed.mp4
- https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_allegro_transfer_trimmed.mp4

They stay `mp4`, and the embeds keep their existing `.. raw:: html` form so the player keeps its
`controls` attribute; only the source URL changes. The ANYmal-D clip is the 10 s excerpt of the
original 140 s recording.

With the mp4s gone, no docs asset is LFS-backed any more, so the `lfs: true` checkout options
added for them are reverted.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
