### PR TITLE
[CLI] Report the required extra when an optional dependency is missing

### DIFF
--- a/source/isaaclab/changelog.d/cli-missing-extra-hint.rst
+++ b/source/isaaclab/changelog.d/cli-missing-extra-hint.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :func:`~isaaclab.utils.extras.missing_extra_hint`, which turns a missing optional
+  dependency into a message naming the extra that provides it and the command to install it.
+  ``isaaclab`` commands now report ``rl_games is not installed. It is provided by the
+  'rl-games' extra`` instead of a bare ``ModuleNotFoundError``. The suggested command matches
+  the environment: ``uv run --extra ...`` under uv, ``pip install "isaaclab-dev[...]"`` otherwise.

--- a/source/isaaclab/isaaclab/cli/__init__.py
+++ b/source/isaaclab/isaaclab/cli/__init__.py
@@ -67,6 +67,7 @@ def random_agent(args: list[str] | None = None) -> None:
         args = sys.argv[1:]
     run_python_command(ISAACLAB_ROOT / "scripts" / "environments" / "random_agent.py", args, check=True)
 
+
 def teleop(args: list[str] | None = None) -> None:
     """Run a live teleoperation, demonstration recording, or demonstration replay workflow.
 
@@ -121,12 +122,20 @@ def cli() -> None:
         "zero_agent": zero_agent,
         "random_agent": random_agent,
     }
-    if len(sys.argv) > 1 and sys.argv[1] in subcommands:
-        subcommands[sys.argv[1]](sys.argv[2:])
-        return
-    if len(sys.argv) > 1 and sys.argv[1] == "teleop":
-        teleop(sys.argv[2:])
-        return
+    try:
+        if len(sys.argv) > 1 and sys.argv[1] in subcommands:
+            subcommands[sys.argv[1]](sys.argv[2:])
+            return
+        if len(sys.argv) > 1 and sys.argv[1] == "teleop":
+            teleop(sys.argv[2:])
+            return
+    except ModuleNotFoundError as exc:
+        from isaaclab.utils.extras import missing_extra_hint
+
+        hint = missing_extra_hint(exc.name)
+        if hint is None:
+            raise
+        raise SystemExit(hint) from exc
 
     executable_name = Path(sys.argv[0]).name
     default_prog = "isaaclab.bat" if is_windows() else "isaaclab.sh"

--- a/source/isaaclab/isaaclab/utils/extras.py
+++ b/source/isaaclab/isaaclab/utils/extras.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Map missing imports back to the optional extra that provides them."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+EXTRA_FOR_MODULE: dict[str, str] = {
+    "isaacsim": "isaacsim",
+    "leapp": "leapp",
+    "moviepy": "video",
+    "ovphysx": "ovphysx",
+    "ovrtx": "ovrtx",
+    "ovstage": "ov",
+    "pytetwild": "tetrahedralization",
+    "rerun": "rerun",
+    "rl_games": "rl-games",
+    "robomimic": "mimic",
+    "skrl": "skrl",
+    "stable_baselines3": "sb3",
+    "viser": "viser",
+}
+"""Top-level import name to the optional extra that provides it.
+
+Deliberate omissions: ``rsl_rl`` (``rsl-rl-lib`` is a base dependency, so it is never
+missing because an extra was skipped) and ``rlinf`` (the ``rlinf`` extra installs that
+framework's dependencies, not the framework itself, so the hint would point at the
+wrong remedy).
+"""
+
+
+def missing_extra_hint(module: str, command: str | None = None) -> str | None:
+    """Return an install hint when a module is provided by an optional extra.
+
+    Args:
+        module: Top-level module name that failed to import.
+        command: Command to suggest re-running, without the installer prefix. Defaults to
+            the current ``isaaclab`` invocation.
+
+    Returns:
+        An actionable message naming the extra and how to install it, or None when the
+        module is not provided by any extra.
+    """
+    extra = EXTRA_FOR_MODULE.get(module)
+    if extra is None:
+        return None
+    if command is None:
+        command = f"isaaclab {' '.join(sys.argv[1:])}".strip()
+    # uv run exports these; a conda or plain-pip install exports neither.
+    if os.environ.get("UV_RUN_RECURSION_DEPTH") or os.environ.get("UV"):
+        install = f"uv run --extra {extra} {command}"
+    else:
+        install = f'pip install "isaaclab-dev[{extra}]"'
+    return f"{module} is not installed. It is provided by the '{extra}' extra:\n  {install}"

--- a/source/isaaclab/test/utils/test_extras.py
+++ b/source/isaaclab/test/utils/test_extras.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the missing-extra install hint."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from isaaclab.utils.extras import EXTRA_FOR_MODULE, missing_extra_hint
+
+_PYPROJECT = Path(__file__).resolve().parents[4] / "pyproject.toml"
+
+
+def _extras() -> dict[str, set[str]]:
+    """Return each optional extra mapped to the distribution names it installs."""
+    data = tomllib.loads(_PYPROJECT.read_text())
+    extras = data["project"]["optional-dependencies"]
+    return {name: {re.split(r"[<>=!;\[ @]", req)[0].strip().lower() for req in reqs} for name, reqs in extras.items()}
+
+
+def test_every_mapped_extra_exists() -> None:
+    """A mapping must not name an extra that pyproject.toml does not declare."""
+    declared = set(_extras())
+    unknown = {extra for extra in EXTRA_FOR_MODULE.values() if extra not in declared}
+    assert not unknown, f"EXTRA_FOR_MODULE names undeclared extras: {sorted(unknown)}"
+
+
+def test_every_mapped_module_is_installed_by_its_extra() -> None:
+    """The extra must actually ship the module it is claimed to provide.
+
+    Distribution names normalize to import names by replacing ``-`` with ``_``. Entries
+    whose distribution differs from the import name are listed explicitly so a wrong
+    mapping cannot pass silently.
+    """
+    known_aliases = {"rerun": "rerun-sdk"}
+    extras = _extras()
+    for module, extra in EXTRA_FOR_MODULE.items():
+        dists = extras[extra]
+        candidates = {module.replace("_", "-"), module, known_aliases.get(module, module)}
+        assert candidates & dists, (
+            f"extra '{extra}' does not install anything providing '{module}' (has {sorted(dists)})"
+        )
+
+
+@pytest.mark.parametrize("module", ["rsl_rl", "rlinf"])
+def test_deliberate_omissions_stay_unmapped(module: str) -> None:
+    """rsl_rl is a base dependency; the rlinf extra ships deps, not the framework."""
+    assert module not in EXTRA_FOR_MODULE
+    assert missing_extra_hint(module) is None
+
+
+def test_unknown_module_yields_no_hint() -> None:
+    """An unrelated broken import must not be mislabelled as a missing extra."""
+    assert missing_extra_hint("numpy") is None
+
+
+def test_hint_names_module_extra_and_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under uv the hint repeats the invocation with the extra added."""
+    monkeypatch.setenv("UV_RUN_RECURSION_DEPTH", "1")
+    hint = missing_extra_hint("rl_games", command="isaaclab train --rl_library rl_games")
+    assert "rl_games is not installed" in hint
+    assert "uv run --extra rl-games isaaclab train --rl_library rl_games" in hint
+
+
+def test_hint_falls_back_to_pip_outside_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without uv markers the hint must not tell a pip/conda user to run uv."""
+    monkeypatch.delenv("UV_RUN_RECURSION_DEPTH", raising=False)
+    monkeypatch.delenv("UV", raising=False)
+    hint = missing_extra_hint("skrl", command="isaaclab train --rl_library skrl")
+    assert 'pip install "isaaclab-dev[skrl]"' in hint
+    assert "uv run" not in hint

--- a/source/isaaclab_rl/changelog.d/cli-missing-extra-hint.rst
+++ b/source/isaaclab_rl/changelog.d/cli-missing-extra-hint.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the RL entrypoint dispatcher to report a missing RL framework as an install hint
+  naming the required extra, instead of letting a bare ``ModuleNotFoundError`` escape. An
+  import failure from inside an installed framework is re-raised unchanged.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/dispatch.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/dispatch.py
@@ -116,7 +116,17 @@ def run_cli(action: str, argv: list[str] | None = None) -> int:
             return 0
         print(f"\n{action}: error: the following argument is required: --rl_library", file=sys.stderr)
         return 2
-    _run_backend(backends[selected.rl_library], backend_argv, run_as_script=action == "play")
+    try:
+        _run_backend(backends[selected.rl_library], backend_argv, run_as_script=action == "play")
+    except ModuleNotFoundError as exc:
+        # The backends import their RL library inside run(), so a skipped extra surfaces
+        # here rather than at module import. Name the extra instead of the bare error.
+        from isaaclab.utils.extras import missing_extra_hint
+
+        hint = missing_extra_hint(exc.name, command=f"isaaclab {action} {' '.join(argv)}")
+        if hint is None:
+            raise
+        raise SystemExit(hint) from exc
     return 0
 
 


### PR DESCRIPTION
# Description

Running an `isaaclab` command without the extra that provides its backend failed with a bare `ModuleNotFoundError` naming no remedy:

```
ModuleNotFoundError: No module named 'rl_games'
```

The extras are documented in the quickstart and installation guides, but nothing connected the failure to them, so every doc example had to repeat the flag to stay runnable. This maps the missing top-level module back to the extra that installs it:

```
rl_games is not installed. It is provided by the 'rl-games' extra:
  uv run --extra rl-games isaaclab train --rl_library rl_games --task Isaac-Cartpole
```

Covers every optional extra, not just RL frameworks — `isaacsim`, `ovphysx`, `ovrtx`, `viser`, `rerun`, `moviepy`, `robomimic`, `leapp`, `pytetwild`. The suggested command matches the environment: `uv run --extra ...` under uv, `pip install "isaaclab-dev[...]"` otherwise.

**Where the catch lives.** The RL backends import their framework inside `run()` deliberately, so `--help` works without it installed; the failure therefore surfaces in the dispatcher, not at module import. `isaaclab train` / `play` also run their script in a subprocess via `run_python_command`, so a handler in `cli()` alone never sees the child's exception. The catch is in `isaaclab_rl.entrypoints.dispatch` (inside the child) plus `isaaclab.cli` (for in-process subcommands).

**Deliberate omissions.** `rsl_rl` is unmapped because `rsl-rl-lib` is a base dependency, so it is never missing due to a skipped extra. `rlinf` is unmapped because its extra installs that framework's dependencies rather than the framework itself, so the hint would name the wrong remedy. An import error raised from inside an installed package is re-raised unchanged.

**Why the map is static.** No installed dist-info carries `Provides-Extra` (the extras live on the root `isaaclab-dev` project, which has no dist-info), and `packages_distributions()` only sees installed packages — precisely what a missing one is not. Reading `pyproject.toml` at error time would work only from a source checkout, not a wheel. The drift risk therefore moves into the test, which derives the expected mapping from `pyproject.toml`.

Relates to NVBug 6657697.

## Type of change

- New feature (non-breaking change which adds functionality)

## Validation

Verified end to end in an environment without the extras:

| Command | Result |
|---|---|
| `isaaclab train --rl_library rl_games` | names `rl-games` |
| `isaaclab train --rl_library skrl` | names `skrl` |
| `isaaclab train --rl_library sb3` | names `sb3` (maps `stable_baselines3`) |
| `isaaclab train --rl_library rsl_rl` | no hint, training starts (base dependency) |
| the suggested `uv run --extra rl-games ...` | `Training time: 0.67 seconds`, exit 0 |

The suggested remedy was executed, not just inspected. 7 unit tests pass; both drift guards were verified non-vacuous by poisoning the map (an undeclared extra, and a wrong `torch` -> `sb3` mapping) — each fails the suite.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (the extras are already documented in the quickstart; this connects the failure to them, so no doc change was needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
