### PR TITLE
Add scene entity selection utilities for heterogeneous views

### DIFF
--- a/docs/source/api/lab/isaaclab.cloner.rst
+++ b/docs/source/api/lab/isaaclab.cloner.rst
@@ -9,6 +9,7 @@
 
       path
       query
+      selection_utils
 
    .. Rubric:: Classes
 
@@ -52,6 +53,13 @@ Query
 
 .. automodule:: isaaclab.cloner.query
    :members:
+
+Selection utils
+~~~~~~~~~~~~~~~
+
+.. automodule:: isaaclab.cloner.selection_utils
+   :members:
+   :show-inheritance:
 
 Additional Public Classes
 -------------------------

--- a/source/isaaclab/changelog.d/reb-scene-entity-selection.minor.rst
+++ b/source/isaaclab/changelog.d/reb-scene-entity-selection.minor.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab.cloner.selection_utils.SceneEntitySelectionCfg`, a heterogeneous extension
+  of :class:`~isaaclab.managers.SceneEntityCfg` that maps global environment IDs to the instance rows
+  of a partially populated asset physics view and scatters view-ordered values back into global
+  environment order. Only PhysX is supported because the mapping is read from the view's ``prim_paths``
+  metadata.

--- a/source/isaaclab/isaaclab/cloner/__init__.pyi
+++ b/source/isaaclab/isaaclab/cloner/__init__.pyi
@@ -23,12 +23,13 @@ __all__ = [
     "REPLICATION_QUEUE",
     "replicate",
     "queue_replication",
+    "selection_utils",
     "sequential",
     "UsdReplicateContext",
     "usd_replicate",
 ]
 
-from . import path, query
+from . import path, query, selection_utils
 from ._fabric_notices import disabled_fabric_change_notifies
 from .clone_plan import (
     ClonePlan,

--- a/source/isaaclab/isaaclab/cloner/selection_utils.py
+++ b/source/isaaclab/isaaclab/cloner/selection_utils.py
@@ -50,15 +50,17 @@ class SceneEntitySelectionCfg(SceneEntityCfg):
         """Map global environment IDs to physics-view instance rows.
 
         Args:
-            env_ids: Global environment IDs to select.
+            env_ids: Global environment IDs to select. Moved to the resolved entity's device.
             strict: Whether to reject environments that do not contain the entity. Defaults to False.
 
         Returns:
-            A tuple containing selected instance rows and their aligned global environment IDs.
+            A tuple containing selected instance rows and their aligned global environment IDs on the
+            resolved entity's device.
 
         Raises:
             ValueError: If ``strict`` is enabled and an environment does not contain the entity.
         """
+        env_ids = env_ids.to(self.instance_ids.device)
         instance_ids = self.instance_ids[env_ids]
         selected = instance_ids >= 0
         if strict and not bool(selected.all()):
@@ -73,7 +75,7 @@ class SceneEntitySelectionCfg(SceneEntityCfg):
             fill_value: Value assigned to environments that do not contain the entity. Defaults to 0.
 
         Returns:
-            Values in global environment order.
+            Values in global environment order on the same device as ``values``.
 
         Raises:
             ValueError: If the values do not have an instance dimension or its length does not match
@@ -85,7 +87,7 @@ class SceneEntitySelectionCfg(SceneEntityCfg):
             raise ValueError(f"Expected {self.env_ids.numel()} values for '{self.name}', got {values.shape[0]}.")
 
         result = values.new_full((self.instance_ids.numel(), *values.shape[1:]), fill_value)
-        result[self.env_ids] = values
+        result[self.env_ids.to(values.device)] = values
         return result
 
 

--- a/source/isaaclab/isaaclab/cloner/selection_utils.py
+++ b/source/isaaclab/isaaclab/cloner/selection_utils.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Selection-aware scene entities for heterogeneous physics views."""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.managers.scene_entity_cfg import SceneEntityCfg
+from isaaclab.utils.configclass import configclass
+
+from .path import match
+
+if TYPE_CHECKING:
+    from isaaclab.assets import BaseArticulation, BaseRigidObject, BaseRigidObjectCollection
+    from isaaclab.scene import InteractiveScene
+
+
+@configclass
+class SceneEntitySelectionCfg(SceneEntityCfg):
+    """Scene entity resolved across a heterogeneous subset of environments.
+
+    In addition to resolving joints, bodies, tendons, and collection objects like
+    :class:`~isaaclab.managers.SceneEntityCfg`, this configuration maps global environment IDs to
+    the instance rows of the entity's physics view. Environments that do not contain the entity map
+    to ``-1``.
+    """
+
+    env_ids: torch.Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.long), init=False, repr=False)
+    """Global environment ID of each physics-view instance row, shape ``(num_instances,)``."""
+
+    instance_ids: torch.Tensor = field(default_factory=lambda: torch.empty(0, dtype=torch.long), init=False, repr=False)
+    """Physics-view instance row of each environment, or ``-1`` if absent, shape ``(num_envs,)``."""
+
+    def resolve(self, scene: InteractiveScene):
+        """Resolve entity members and its environment-to-instance mapping."""
+        super().resolve(scene)
+        entity: BaseArticulation | BaseRigidObject | BaseRigidObjectCollection = scene[self.name]
+        self.env_ids = _view_env_ids(entity, scene.cloner_cfg.clone_template)
+        self.instance_ids = torch.full((scene.num_envs,), -1, dtype=torch.long, device=entity.device)
+        self.instance_ids[self.env_ids] = torch.arange(entity.num_instances, dtype=torch.long, device=entity.device)
+
+    def select(self, env_ids: torch.Tensor, *, strict: bool = False) -> tuple[torch.Tensor, torch.Tensor]:
+        """Map global environment IDs to physics-view instance rows.
+
+        Args:
+            env_ids: Global environment IDs to select.
+            strict: Whether to reject environments that do not contain the entity. Defaults to False.
+
+        Returns:
+            A tuple containing selected instance rows and their aligned global environment IDs.
+
+        Raises:
+            ValueError: If ``strict`` is enabled and an environment does not contain the entity.
+        """
+        instance_ids = self.instance_ids[env_ids]
+        selected = instance_ids >= 0
+        if strict and not bool(selected.all()):
+            raise ValueError(f"Environments {env_ids[~selected].tolist()} contain no '{self.name}'.")
+        return instance_ids[selected], env_ids[selected]
+
+    def scatter_to_envs(self, values: torch.Tensor, *, fill_value: float | int | bool = 0) -> torch.Tensor:
+        """Scatter physics-view values into global environment order.
+
+        Args:
+            values: Values whose first dimension follows this entity's physics-view instance order.
+            fill_value: Value assigned to environments that do not contain the entity. Defaults to 0.
+
+        Returns:
+            Values in global environment order.
+
+        Raises:
+            ValueError: If the values do not have an instance dimension or its length does not match
+                the entity's physics view.
+        """
+        if values.ndim == 0:
+            raise ValueError("Expected values to have an instance dimension.")
+        if values.shape[0] != self.env_ids.numel():
+            raise ValueError(f"Expected {self.env_ids.numel()} values for '{self.name}', got {values.shape[0]}.")
+
+        result = values.new_full((self.instance_ids.numel(), *values.shape[1:]), fill_value)
+        result[self.env_ids] = values
+        return result
+
+
+def _view_env_ids(
+    entity: BaseArticulation | BaseRigidObject | BaseRigidObjectCollection, env_template: str
+) -> torch.Tensor:
+    """Read the global environment ID of every physics-view instance row."""
+    env_ids = []
+    for prim_path in entity.root_view.prim_paths[: entity.num_instances]:
+        matched = match(prim_path, env_template)
+        if matched is None:
+            raise ValueError(f"Prim path '{prim_path}' is not under the environment template '{env_template}'.")
+        env_ids.append(int(matched.instance))
+    return torch.tensor(env_ids, dtype=torch.long, device=entity.device)

--- a/source/isaaclab/test/cloner/test_selection_utils.py
+++ b/source/isaaclab/test/cloner/test_selection_utils.py
@@ -8,6 +8,7 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from isaaclab import cloner
 from isaaclab.cloner.selection_utils import SceneEntitySelectionCfg
@@ -24,11 +25,11 @@ class _View:
 class _Asset:
     """Scene-entity stand-in exposing the selection resolution contract."""
 
-    device = "cpu"
     joint_names = ["joint_0", "joint_1"]
     num_joints = 2
 
-    def __init__(self, prim_paths: list[str], num_bodies: int = 1):
+    def __init__(self, prim_paths: list[str], num_bodies: int = 1, device: str = "cpu"):
+        self.device = device
         self.root_view = _View(prim_paths)
         self.num_instances = len(prim_paths) // num_bodies
 
@@ -125,6 +126,22 @@ def test_select_maps_rows_and_reports_selected_env_ids() -> None:
         cfg.select(cfg.instance_ids.new_tensor([0, 1]), strict=True)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_select_accepts_cpu_env_ids_for_cuda_entity() -> None:
+    """CPU environment IDs should be selected on the resolved entity's CUDA device."""
+    cfg = SceneEntitySelectionCfg("robot")
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [0, 2, 3]), device="cuda"), num_envs=5))
+
+    rows, selected_env_ids = cfg.select(torch.tensor([0, 1, 3]))
+
+    assert rows.device.type == "cuda"
+    assert selected_env_ids.device.type == "cuda"
+    assert rows.tolist() == [0, 2]
+    assert selected_env_ids.tolist() == [0, 3]
+    with pytest.raises(ValueError, match=r"Environments \[1\] contain no 'robot'"):
+        cfg.select(torch.tensor([0, 1]), strict=True)
+
+
 def test_scatter_to_envs_restores_global_order() -> None:
     """Physics-view values should be scattered to global order with the requested fill value."""
     cfg = SceneEntitySelectionCfg("robot")
@@ -136,6 +153,19 @@ def test_scatter_to_envs_restores_global_order() -> None:
 
     assert result.tolist() == [[0, 1], [-1, -1], [20, 21], [30, 31], [-1, -1]]
     assert mask.tolist() == [False, False, True, True, False]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_scatter_to_envs_accepts_cpu_values_for_cuda_entity() -> None:
+    """Scattering should preserve the values device when selection indices are on CUDA."""
+    cfg = SceneEntitySelectionCfg("robot")
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [3, 0, 2]), device="cuda"), num_envs=5))
+    values = torch.tensor([[30, 31], [0, 1], [20, 21]])
+
+    result = cfg.scatter_to_envs(values, fill_value=-1)
+
+    assert result.device.type == "cpu"
+    assert result.tolist() == [[0, 1], [-1, -1], [20, 21], [30, 31], [-1, -1]]
 
 
 def test_scatter_to_envs_rejects_misaligned_values() -> None:

--- a/source/isaaclab/test/cloner/test_selection_utils.py
+++ b/source/isaaclab/test/cloner/test_selection_utils.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for selection-aware scene entity resolution."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab import cloner
+from isaaclab.cloner.selection_utils import SceneEntitySelectionCfg
+from isaaclab.managers import SceneEntityCfg
+
+
+class _View:
+    """Physics-view stand-in exposing concrete prim paths in view order."""
+
+    def __init__(self, prim_paths: list[str]):
+        self.prim_paths = prim_paths
+
+
+class _Asset:
+    """Scene-entity stand-in exposing the selection resolution contract."""
+
+    device = "cpu"
+    joint_names = ["joint_0", "joint_1"]
+    num_joints = 2
+
+    def __init__(self, prim_paths: list[str], num_bodies: int = 1):
+        self.root_view = _View(prim_paths)
+        self.num_instances = len(prim_paths) // num_bodies
+
+    def find_joints(self, joint_names: list[str], preserve_order: bool = False) -> tuple[list[int], list[str]]:
+        """Resolve exact joint names for inherited ``SceneEntityCfg`` coverage."""
+        joint_ids = [self.joint_names.index(name) for name in joint_names]
+        if not preserve_order:
+            joint_ids.sort()
+        return joint_ids, [self.joint_names[joint_id] for joint_id in joint_ids]
+
+
+class _Scene(dict):
+    """Interactive-scene stand-in used by ``SceneEntityCfg.resolve``."""
+
+    def __init__(self, asset: _Asset, num_envs: int, env_template: str = "/World/envs/env_{}"):
+        super().__init__(robot=asset)
+        self.num_envs = num_envs
+        self.cloner_cfg = SimpleNamespace(clone_template=env_template)
+
+
+def _slot_paths(slot: int, env_ids: list[int], env_prefix: str = "/World/envs/env_") -> list[str]:
+    """Return concrete clone paths for one asset slot."""
+    return [f"{env_prefix}{env_id}/Groceries/Grocery_{slot:02d}" for env_id in env_ids]
+
+
+def test_selection_cfg_extends_scene_entity_cfg() -> None:
+    """The heterogeneous entity should follow the existing manager resolution contract."""
+    cfg = SceneEntitySelectionCfg("robot")
+
+    assert isinstance(cfg, SceneEntityCfg)
+    assert cloner.selection_utils.SceneEntitySelectionCfg is SceneEntitySelectionCfg
+
+
+def test_resolve_retains_scene_entity_member_resolution() -> None:
+    """Joint-name resolution should run before physics-view selection resolution."""
+    cfg = SceneEntitySelectionCfg("robot", joint_names="joint_1")
+
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [0])), num_envs=1))
+
+    assert cfg.joint_names == ["joint_1"]
+    assert cfg.joint_ids == [1]
+
+
+def test_resolve_maps_both_directions_in_view_order() -> None:
+    """Resolution should preserve view order and mark absent environments with ``-1``."""
+    asset = _Asset(_slot_paths(0, [3, 0, 2]))
+    cfg = SceneEntitySelectionCfg("robot")
+
+    cfg.resolve(_Scene(asset, num_envs=5))
+
+    assert cfg.env_ids.tolist() == [3, 0, 2]
+    assert cfg.instance_ids.tolist() == [1, -1, 2, 0, -1]
+
+
+def test_resolve_reads_first_body_block() -> None:
+    """A multi-body view should report its environment order once per instance."""
+    env_ids = [0, 2, 3]
+    asset = _Asset(_slot_paths(0, env_ids) + _slot_paths(8, env_ids), num_bodies=2)
+    cfg = SceneEntitySelectionCfg("robot")
+
+    cfg.resolve(_Scene(asset, num_envs=5))
+
+    assert cfg.env_ids.tolist() == env_ids
+
+
+def test_resolve_honors_scene_clone_template() -> None:
+    """Resolution should use the active scene's clone template."""
+    asset = _Asset(_slot_paths(0, [1, 4], env_prefix="/World/scenes/scene_"))
+    cfg = SceneEntitySelectionCfg("robot")
+
+    cfg.resolve(_Scene(asset, num_envs=5, env_template="/World/scenes/scene_{}"))
+
+    assert cfg.env_ids.tolist() == [1, 4]
+
+
+def test_resolve_rejects_non_environment_paths() -> None:
+    """Every physics-view row should belong to a concrete replicated environment."""
+    cfg = SceneEntitySelectionCfg("robot")
+
+    with pytest.raises(ValueError, match="not under the environment template"):
+        cfg.resolve(_Scene(_Asset(["/World/Table/Object"]), num_envs=1))
+
+
+def test_select_maps_rows_and_reports_selected_env_ids() -> None:
+    """Selection should return aligned rows and environment IDs after dropping absent environments."""
+    cfg = SceneEntitySelectionCfg("robot")
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [0, 2, 3])), num_envs=5))
+
+    rows, selected_env_ids = cfg.select(cfg.instance_ids.new_tensor([0, 1, 3]))
+
+    assert rows.tolist() == [0, 2]
+    assert selected_env_ids.tolist() == [0, 3]
+    with pytest.raises(ValueError, match=r"Environments \[1\] contain no 'robot'"):
+        cfg.select(cfg.instance_ids.new_tensor([0, 1]), strict=True)
+
+
+def test_scatter_to_envs_restores_global_order() -> None:
+    """Physics-view values should be scattered to global order with the requested fill value."""
+    cfg = SceneEntitySelectionCfg("robot")
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [3, 0, 2])), num_envs=5))
+    values = cfg.instance_ids.new_tensor([[30, 31], [0, 1], [20, 21]])
+
+    result = cfg.scatter_to_envs(values, fill_value=-1)
+    mask = cfg.scatter_to_envs(cfg.instance_ids.new_tensor([True, False, True]).bool())
+
+    assert result.tolist() == [[0, 1], [-1, -1], [20, 21], [30, 31], [-1, -1]]
+    assert mask.tolist() == [False, False, True, True, False]
+
+
+def test_scatter_to_envs_rejects_misaligned_values() -> None:
+    """Scatter should reject values without exactly one row per physics-view instance."""
+    cfg = SceneEntitySelectionCfg("robot")
+    cfg.resolve(_Scene(_Asset(_slot_paths(0, [0, 2, 3])), num_envs=5))
+
+    with pytest.raises(ValueError, match="instance dimension"):
+        cfg.scatter_to_envs(cfg.instance_ids.new_tensor(1))
+    with pytest.raises(ValueError, match=r"Expected 3 values for 'robot', got 2"):
+        cfg.scatter_to_envs(cfg.instance_ids.new_tensor([1, 2]))


### PR DESCRIPTION
# Description

This PR adds `SceneEntitySelectionCfg`, a heterogeneous extension of `SceneEntityCfg` for assets whose physics views are only populated in a subset of cloned environments.

The new configuration:

- preserves the existing joint, body, tendon, and collection member resolution;
- maps physics-view rows to global environment IDs;
- maps global environment IDs back to compact physics-view rows;
- filters selections to environments containing the entity, with an optional strict mode;
- scatters compact view-ordered values back into global environment order.

The mapping is resolved from the asset view prim paths and the scene clone template. The current implementation supports PhysX views, which expose the required prim-path metadata.

The public API export, API documentation, changelog fragment, and focused unit tests are included. No new dependencies are introduced.

## Type of change

- New feature
- Documentation update

## Testing

- `uv run python -m pytest source/isaaclab/test/cloner/test_selection_utils.py`
  - 9 tests passed
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`
- `uv run --isolated --extra test -- make -C docs current-docs`
  - Documentation build succeeded without warnings or errors

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the new behavior
- [x] I have added a changelog fragment for the `isaaclab` package
- [x] My name already exists in `CONTRIBUTORS.md`