### PR TITLE
[CI] Check links to our own docs pages against the source tree

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -63,4 +63,6 @@ jobs:
         # --noconftest keeps tools/conftest.py out of the session. That file is the CI test
         # orchestrator - its pytest_sessionstart scans source/ and scripts/ and runs the whole
         # suite, so loading it here would ignore the files named below.
-        run: python3 -m pytest tools/test_crash_journal.py tools/test_device_split.py -v --noconftest
+        run: >-
+          python3 -m pytest tools/test_crash_journal.py tools/test_device_split.py
+          tools/docs/test/test_check_self_doc_links.py -v --noconftest

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -14,6 +14,10 @@ on:
       # Top-level tools modules and their tests. Deliberately not "tools/**": the
       # subpackages (changelog/, skills/, wheel_builder/) have their own gates.
       - "tools/*.py"
+      # tools/docs/ has no gate of its own, so its tests are gated here. media/ is left out
+      # deliberately - this job does not exercise it.
+      - "tools/docs/*.py"
+      - "tools/docs/test/**"
       - ".github/workflows/tools-tests.yml"
   workflow_dispatch:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,12 @@ repos:
         language: python
         always_run: true
         pass_filenames: false
+      - id: check-self-doc-links
+        name: check links to our own docs pages
+        entry: python tools/docs/check_self_doc_links.py
+        language: python
+        always_run: true
+        pass_filenames: false
       - id: check-git-lfs-pointers
         name: check Git LFS pointers
         entry: tools/pre_commit/check_git_lfs_pointers.sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ detailed tutorials and step-by-step guides. Follow these links to learn more abo
 - [Installation steps](https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#local-installation)
 - [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/develop/source/overview/reinforcement-learning/rl_existing_scripts.html)
 - [Tutorials](https://isaac-sim.github.io/IsaacLab/develop/source/tutorials/index.html)
-- [Available environments](https://isaac-sim.github.io/IsaacLab/develop/source/overview/environments.html)
+- [Available environments](https://isaac-sim.github.io/IsaacLab/develop/source/setup/environments.html)
 
 ## Performance Dashboard
 

--- a/tools/docs/check_self_doc_links.py
+++ b/tools/docs/check_self_doc_links.py
@@ -38,12 +38,14 @@ def _source_candidates(doc_path: str) -> list[Path]:
     Both suffixes are accepted because ``docs/conf.py`` registers ``.rst`` and ``.md``
     (myst-parser). The tree is almost entirely reStructuredText today, so the Markdown
     forms exist to avoid reporting a MyST page as missing.
+
+    ``<path>/index.rst`` is deliberately not a candidate: the default ``html`` builder
+    publishes it at ``<path>/index.html``, not ``<path>.html``, so accepting it here would
+    pass a link that 404s. Links written against ``.../index.html`` match directly.
     """
     return [
         DOCS_ROOT / f"{doc_path}.rst",
         DOCS_ROOT / f"{doc_path}.md",
-        DOCS_ROOT / doc_path / "index.rst",
-        DOCS_ROOT / doc_path / "index.md",
     ]
 
 

--- a/tools/docs/check_self_doc_links.py
+++ b/tools/docs/check_self_doc_links.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Check links that point at our own published documentation against the source tree.
+
+The external link checker resolves URLs against the deployed site, which still serves the
+previous build while a pull request is open. A change that deletes or moves a page therefore
+passes its own run and breaks every later pull request instead. This check resolves the same
+URLs against ``docs/`` in the working tree, so the page and the reference to it are compared
+in one state.
+
+Run directly, or via the ``check-self-doc-links`` pre-commit hook::
+
+    python tools/docs/check_self_doc_links.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "docs"
+SKIP_DIRS = {"_build", ".venv", ".git", "node_modules", "_isaac_sim"}
+
+# Published page URLs, e.g. https://isaac-sim.github.io/IsaacLab/develop/source/setup/index.html
+SELF_DOC_URL = re.compile(
+    r"https://isaac-sim\.github\.io/IsaacLab/(?:develop|main|release/[^/]+)/(source/[^)\s\"'>#]+?)\.html"
+)
+
+
+def _source_candidates(doc_path: str) -> list[Path]:
+    """Return the source files that would build the given documentation path.
+
+    Both suffixes are accepted because ``docs/conf.py`` registers ``.rst`` and ``.md``
+    (myst-parser). The tree is almost entirely reStructuredText today, so the Markdown
+    forms exist to avoid reporting a MyST page as missing.
+    """
+    return [
+        DOCS_ROOT / f"{doc_path}.rst",
+        DOCS_ROOT / f"{doc_path}.md",
+        DOCS_ROOT / doc_path / "index.rst",
+        DOCS_ROOT / doc_path / "index.md",
+    ]
+
+
+def _iter_text_files() -> list[Path]:
+    """Return every Markdown and reStructuredText file that may carry a link."""
+    files: list[Path] = []
+    for pattern in ("*.md", "*.rst"):
+        for path in REPO_ROOT.rglob(pattern):
+            if not SKIP_DIRS.intersection(path.parts):
+                files.append(path)
+    return files
+
+
+def find_broken_links() -> list[tuple[Path, int, str]]:
+    """Return every self-referencing documentation link with no matching source file."""
+    broken: list[tuple[Path, int, str]] = []
+    for path in _iter_text_files():
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for number, line in enumerate(lines, start=1):
+            for match in SELF_DOC_URL.finditer(line):
+                doc_path = match.group(1)
+                if not any(candidate.exists() for candidate in _source_candidates(doc_path)):
+                    broken.append((path, number, doc_path))
+    return broken
+
+
+def main() -> int:
+    """Report self-referencing documentation links whose page no longer exists."""
+    broken = find_broken_links()
+    if not broken:
+        return 0
+    print("Links point at documentation pages that do not exist in docs/:", file=sys.stderr)
+    for path, number, doc_path in broken:
+        relative = path.relative_to(REPO_ROOT)
+        print(f"  {relative}:{number} -> docs/{doc_path}.rst (not found)", file=sys.stderr)
+    print(
+        "\nThe page was renamed, moved, or removed. Update the link to the new location,"
+        "\nor restore the page. Searching docs/ for the page title usually finds it.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/docs/check_self_doc_links.py
+++ b/tools/docs/check_self_doc_links.py
@@ -7,9 +7,10 @@
 
 The external link checker resolves URLs against the deployed site, which still serves the
 previous build while a pull request is open. A change that deletes or moves a page therefore
-passes its own run and breaks every later pull request instead. This check resolves the same
-URLs against ``docs/`` in the working tree, so the page and the reference to it are compared
-in one state.
+passes its own run and breaks every later pull request instead. This check resolves the
+``develop`` URLs -- the build this tree produces -- against ``docs/`` in the working tree, so
+the page and the reference to it are compared in one state. Links to other refs stay with the
+live checker; see ``SELF_DOC_URL``.
 
 Run directly, or via the ``check-self-doc-links`` pre-commit hook::
 
@@ -27,9 +28,11 @@ DOCS_ROOT = REPO_ROOT / "docs"
 SKIP_DIRS = {"_build", ".venv", ".git", "node_modules", "_isaac_sim"}
 
 # Published page URLs, e.g. https://isaac-sim.github.io/IsaacLab/develop/source/setup/index.html
-SELF_DOC_URL = re.compile(
-    r"https://isaac-sim\.github\.io/IsaacLab/(?:develop|main|release/[^/]+)/(source/[^)\s\"'>#]+?)\.html"
-)
+#
+# Only develop is matched: main, release/* and the vX.Y.Z tag builds are made from a different
+# source state, so this tree cannot judge them. The lychee run in check-links.yml resolves those
+# against the live site, which is the correct oracle for a build this tree does not produce.
+SELF_DOC_URL = re.compile(r"https://isaac-sim\.github\.io/IsaacLab/develop/(source/[^)\s\"'>#]+?)\.html")
 
 
 def _source_candidates(doc_path: str) -> list[Path]:

--- a/tools/docs/test/test_check_self_doc_links.py
+++ b/tools/docs/test/test_check_self_doc_links.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Test that the self-referencing documentation link check detects a missing page.
+"""Test the self-referencing documentation link check's mapping from URLs to source files.
 
 The repository-wide guard is the ``check-self-doc-links`` pre-commit hook, which runs on
-every pull request. This test covers the one thing the hook cannot: that the check still
+every pull request. These tests cover the one thing the hook cannot: that the check still
 reports a break rather than silently passing, so a pattern change cannot make it a no-op.
 """
 
@@ -30,3 +30,29 @@ def test_missing_page_is_reported_ignoring_anchors(tmp_path, monkeypatch) -> Non
         "- [Envs](https://isaac-sim.github.io/IsaacLab/develop/source/overview/gone.html#usage)\n"
     )
     assert [(p.name, n, d) for p, n, d in checker.find_broken_links()] == [("README.md", 1, "source/overview/gone")]
+
+
+def test_directory_index_source_does_not_satisfy_a_flat_page_url(tmp_path, monkeypatch) -> None:
+    """``docs/<path>/index.rst`` publishes at ``<path>/index.html``, so ``<path>.html`` is broken."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "DOCS_ROOT", tmp_path / "docs")
+    index = tmp_path / "docs" / "source" / "overview" / "environments" / "index.rst"
+    index.parent.mkdir(parents=True)
+    index.write_text("Environments\n============\n")
+    (tmp_path / "README.md").write_text(
+        "- [Envs](https://isaac-sim.github.io/IsaacLab/develop/source/overview/environments.html)\n"
+    )
+    assert [doc_path for _, _, doc_path in checker.find_broken_links()] == ["source/overview/environments"]
+
+
+def test_links_to_refs_built_elsewhere_are_left_to_the_live_link_checker(tmp_path, monkeypatch) -> None:
+    """Only develop is built from this tree; main, release and tag URLs are checked by lychee."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "DOCS_ROOT", tmp_path / "docs")
+    (tmp_path / "README.md").write_text(
+        "".join(
+            f"- [Gone](https://isaac-sim.github.io/IsaacLab/{ref}/source/overview/gone.html)\n"
+            for ref in ("main", "release/3.0.0", "v3.0.0-beta2")
+        )
+    )
+    assert checker.find_broken_links() == []

--- a/tools/docs/test/test_check_self_doc_links.py
+++ b/tools/docs/test/test_check_self_doc_links.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test that the self-referencing documentation link check detects a missing page.
+
+The repository-wide guard is the ``check-self-doc-links`` pre-commit hook, which runs on
+every pull request. This test covers the one thing the hook cannot: that the check still
+reports a break rather than silently passing, so a pattern change cannot make it a no-op.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "check_self_doc_links.py"
+_spec = importlib.util.spec_from_file_location("check_self_doc_links", _MODULE_PATH)
+checker = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(checker)
+
+
+def test_missing_page_is_reported_ignoring_anchors(tmp_path, monkeypatch) -> None:
+    """A link whose page is absent is reported at its location, anchor excluded."""
+    monkeypatch.setattr(checker, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(checker, "DOCS_ROOT", tmp_path / "docs")
+    (tmp_path / "README.md").write_text(
+        "- [Envs](https://isaac-sim.github.io/IsaacLab/develop/source/overview/gone.html#usage)\n"
+    )
+    assert [(p.name, n, d) for p, n, d in checker.find_broken_links()] == [("README.md", 1, "source/overview/gone")]


### PR DESCRIPTION
# Description

`README.md` linked to `source/overview/environments.html`, which #7183 deleted when it consolidated that page into `source/setup/environments.html`. The link 404s and failed **Check for Broken Links on every open PR in the repository**. That link has since been corrected on `develop` by #7328, so this PR no longer touches `README.md` — what remains is the guard that stops the next one.

That job could not have caught it. `lychee` resolves URLs against the deployed site, and `Deploy Docs` only runs after merge, so while #7183 was open the old page was still published and its own run passed (15s, green). The breakage lands on whoever opens a PR next. Sphinx cannot catch it either: `README.md` is not part of the documentation build and no `include` pulls it in.

| | Would it have caught `README.md:62`? |
|---|---|
| lychee against the deployed site | No — the page was still published at check time |
| Sphinx build / `nitpicky` | No — `README.md` is outside the docs tree |
| This check | Yes |

`tools/docs/check_self_doc_links.py` scans `*.md` and `*.rst` repo-wide, extracts URLs of the form `isaac-sim.github.io/IsaacLab/develop/source/<path>.html`, and requires a matching source file under `docs/`. Both suffixes registered in `docs/conf.py` (`.rst`, and `.md` via myst-parser) are accepted.

The two checks partition the problem rather than overlap:

| Link target | Correct oracle | Checked by |
|---|---|---|
| `develop/…` | this working tree — the build it produces | this check |
| `main/`, `release/*`, `vX.Y.Z` tags | the live site — builds made from another source state | `lychee` in `check-links.yml` |

Judging a `main` URL against this tree is wrong in both directions: a page this branch deletes is still served there, and a page it adds is not. A directory-index source is likewise not a candidate for a flat page URL — the default `html` builder publishes `docs/<path>/index.rst` at `<path>/index.html`, never `<path>.html`, so accepting it would pass a link that 404s.

It runs as a pre-commit hook. The `pre-commit` workflow already executes local hooks on every PR — only `check-changelog-fragments` is skipped there — so this needs no new workflow. `always_run: true` matters, because the PR that deletes a page does not touch the file holding the link.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

Against the whole repo: 8 `develop` URLs scanned, all resolve, no false positives. The other 8 self-referencing URLs target `main` and are left to `lychee`.

Validated before the README fix landed on `develop`, while the breakage was still present:

```
link broken -> check links to our own docs pages......Failed
                 README.md:62 -> docs/source/overview/environments.rst (not found)
link fixed  -> check links to our own docs pages......Passed
```

Three unit tests cover the one thing the hook cannot — that the check still reports a break rather than failing open if the pattern regresses:

- a missing page is reported, anchor excluded
- `docs/<path>/index.rst` does not satisfy `<path>.html`
- `main`, `release/*` and tag URLs are skipped

`tools/docs/` is added to the `tools-tests.yml` path filter: `tools/*.py` does not cross a directory separator, so without it a change to the checker never ran the test that guards it. The job runs with `--noconftest` (`tools/conftest.py` is the CI test orchestrator and would otherwise take over the session).

`pre-commit run --all-files` passes; `pytest tools/docs/test/test_check_self_doc_links.py` reports 3 passed.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (no source package is touched, so none is required — the fragment check passes)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
