### PR TITLE
Document additional NCCL troubleshooting options

### DIFF
--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -183,6 +183,17 @@ If the issue persists, additional NCCL fallbacks that may help are:
     export NCCL_IB_DISABLE=1
     export NCCL_ALGO=Ring
 
+When the failure only occurs with RTX rendering enabled (for example, for camera-based tasks),
+CUDA and the renderer may enumerate the same GPUs in different orders. Make CUDA enumerate GPUs
+by ascending PCI bus ID before launching training:
+
+.. code-block:: shell
+
+    export CUDA_DEVICE_ORDER=PCI_BUS_ID
+
+This changes the CUDA device ordinals, but not which GPUs are visible. The PCI bus IDs and their
+corresponding GPUs can be inspected with ``nvidia-smi --query-gpu=name,pci.bus_id``.
+
 On some multi-GPU systems, distributed training with RTX rendering enabled (for example,
 camera-based tasks) fails when the participating GPUs span
 multiple NUMA nodes, while the same training runs fine on GPUs attached to a single PCIe
@@ -218,6 +229,15 @@ systems, disabling NCCL's P2P transport resolves the hang:
 
     export NCCL_P2P_DISABLE=1
 
+The same restriction can be expressed with NCCL's topology cutoff:
+
+.. code-block:: shell
+
+    export NCCL_P2P_LEVEL=LOC
+
+In NCCL, ``LOC`` means that P2P is never used between GPUs, so set either
+``NCCL_P2P_DISABLE=1`` or ``NCCL_P2P_LEVEL=LOC`` rather than both.
+
 Then relaunch the distributed training command as usual.
 
 To confirm the problem is NCCL rather than Isaac Lab, reproduce it without Isaac Lab in the loop.
@@ -251,9 +271,10 @@ applying it to training.
 
     These variables are NCCL-level workarounds intended for affected systems. They are not
     required on all machines, and may change communication behavior or performance depending
-    on the hardware topology. In particular, ``NCCL_P2P_DISABLE=1`` routes inter-GPU traffic
-    through host/shared memory instead of a direct P2P link, which can reduce communication
-    bandwidth, so only set it after confirming it resolves an observed hang.
+    on the hardware topology. In particular, ``NCCL_P2P_DISABLE=1`` and
+    ``NCCL_P2P_LEVEL=LOC`` prevent direct P2P communication and force NCCL to select another
+    transport, which can reduce communication bandwidth, so only set one after confirming it
+    resolves an observed hang.
 
 Multi-Node Training
 -------------------

--- a/source/isaaclab/changelog.d/nccl-device-order.rst
+++ b/source/isaaclab/changelog.d/nccl-device-order.rst
@@ -1,0 +1,4 @@
+Added
+^^^^^
+
+* Added multi-GPU troubleshooting guidance for CUDA device ordering and NCCL P2P topology.


### PR DESCRIPTION
# Description

Documents the remaining multi-GPU troubleshooting mitigations reported in #4011:

- Use `CUDA_DEVICE_ORDER=PCI_BUS_ID` when CUDA and the renderer enumerate GPUs differently.
- Use `NCCL_P2P_LEVEL=LOC` as an alternative to `NCCL_P2P_DISABLE=1`.

The guide also clarifies that both P2P settings disable direct peer-to-peer communication and make NCCL select another transport. No new dependencies are required.

Related to #4011.

## Type of change

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this is a text-only documentation update.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (documentation-only; verified with a warning-as-error Sphinx build)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there