### PR TITLE
[Docs] List registered XR camera PiP tasks

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -1294,16 +1294,19 @@ XR Camera Feedback
 An ordered list of :class:`~isaaclab_teleop.XrCameraFeedCfg` objects selects existing task scene
 cameras. The manager publishes each new RGBA frame after rendering, while
 :class:`~isaaclab_teleop.XrCameraFeedLayoutCfg` places the panels manually or in horizontal,
-vertical, and grid layouts. ``IsaacContrib-PickPlace-GR1T2-Abs`` and
-``IsaacContrib-PickPlace-Locomanipulation-G1-Abs`` are the primary reference examples.
+vertical, and grid layouts. The following registered tasks enable PiP by default:
+
+* ``IsaacContrib-PickPlace-Locomanipulation-G1-Abs``
+* ``IsaacContrib-PickPlace-GR1T2-Abs``
+* ``IsaacContrib-NutPour-GR1T2-Pink-IK-Abs``
+* ``IsaacContrib-ExhaustPipe-GR1T2-Pink-IK-Abs``
 
 ``teleop_se3_agent.py`` and ``record_demos.py`` show every enabled feed when an IsaacTeleop-enabled
 environment runs with ``--xr``. PiP is absent unless the task explicitly selects an existing
-``CameraCfg`` through ``xr_camera_feeds``. In the reference examples, the selected
+``CameraCfg`` through ``xr_camera_feeds``. In the registered tasks above, the selected
 ``robot_pov_cam`` is also a policy image observation, so the normal demonstration recorder stores
-the same view shown to the operator. Both reference cameras are parented to a physical robot body
-link, so the recorded view follows robot motion. The NutPour and ExhaustPipe GR1T2 teleoperation
-tasks also present their existing recorded ``robot_pov_cam``:
+the same view shown to the operator. Each camera is parented to a physical robot body link, so the
+recorded view follows robot motion:
 
 .. figure:: ../_static/teleop/xr-camera-pip.jpg
    :width: 80%


### PR DESCRIPTION
# Description

List the exact registered Isaac Teleop tasks that enable XR camera picture-in-picture (PiP) feedback by default. This replaces reference-only wording with copyable task IDs and clarifies that all four tasks use their recorded `robot_pov_cam` view.

This is a documentation-only change; runtime behavior is unchanged.

Related: [NVBug 6655989](https://nvbugspro.nvidia.com/bug/6655989)

## Type of change

- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this is a text-only documentation clarification.

## Validation

- `git diff --check`
- File-applicable pre-commit checks, including codespell and the RST syntax checks
- Verified every documented task ID against its current Gym registration and `xr_camera_feeds` configuration

The full Sphinx build was not available locally because `sphinx-build` is not installed; CI will perform the repository documentation checks.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the relevant pre-commit checks
- [x] I have made the requested documentation change
- [x] Tests are not applicable to this documentation-only change
- [x] A changelog fragment is not applicable because no source package is changed
- [x] My name already exists in `CONTRIBUTORS.md`
