### PR TITLE
Pin the OVRTX render product to the renderer's CUDA device

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovrtx-render-product-device-ids.rst
+++ b/source/isaaclab_ov/changelog.d/ovrtx-render-product-device-ids.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed an illegal memory access (CUDA error 700) when rendering with OVRTX on a device other than
+  ``cuda:0``. The OVRTX render product is now pinned to the renderer's CUDA device through its
+  ``deviceIds`` attribute, so its render var buffers are allocated on the same device as the Warp
+  kernels that extract camera tiles from them. Previously OVRTX chose the device itself, which on a
+  multi-GPU machine placed the buffers on ``cuda:0`` while the extraction kernels ran on the
+  simulation device.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -22,8 +22,11 @@ from typing import Any
 import warp as wp
 
 
-def _cuda_device_id(device: str) -> int:
+def cuda_device_id(device: str) -> int:
     """CUDA device index parsed from a Warp device string, e.g. ``"cuda:1"`` -> ``1``.
+
+    Shared by the attribute mappings below and by the render product's ``deviceIds``, so both
+    resolve the renderer's device the same way.
 
     TODO: A bare ``"cuda"`` parses to ``0`` while Warp enqueues fill work on its *current* CUDA
     device, so the mapping and the fill can target different GPUs on multi-GPU processes. The
@@ -64,7 +67,7 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     # already imported by the time this runs.
     from ovrtx import Device  # noqa: PLC0415
 
-    attr_mapping = binding.map(device=Device.CUDA, device_id=_cuda_device_id(device))
+    attr_mapping = binding.map(device=Device.CUDA, device_id=cuda_device_id(device))
     try:
         yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
     finally:

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -85,6 +85,7 @@ from .ovrtx_annotator_utils import (
     decode_stable_id_map,
     decode_stable_id_semantic_id_map,
 )
+from .ovrtx_mapping import cuda_device_id
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     compute_cable_points_world_kernel,
@@ -517,6 +518,7 @@ class OVRTXRenderer(BaseRenderer):
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
             camera_rel_path=self._camera_rel_path,
             background_color=getattr(spec.cfg, "background_color", None),
+            device_id=cuda_device_id(self._device),
         )
         self._render_product_paths.append(render_product_path)
 
@@ -1363,10 +1365,10 @@ class OVRTXRenderer(BaseRenderer):
         if str(tiled_data.device) == output_device:
             return tiled_data
 
-        # FIXME: OVRTX render var mapping can select a different CUDA device
-        # than the camera/output buffers on MGPU systems. Keep this PPISP-only
-        # bridge until render var mapping can be constrained like transform
-        # bindings, whose maps pin ``device_id`` (see ``ovrtx_mapping``).
+        # The render product pins ``deviceIds`` to this renderer's CUDA device, so the mapping
+        # normally lands on the output device already. This stays as a fallback for the case OVRTX
+        # reports as "deviceIds ... not in the active device set" and falls back to automatic
+        # assignment.
         return wp.clone(tiled_data, device=output_device)
 
     def _process_render_frame(self, render_data: OVRTXRenderData, frame, output_buffers: dict) -> None:
@@ -1760,6 +1762,7 @@ class OVRTXRenderer(BaseRenderer):
             data_types=data_types,
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
             camera_rel_path=self._camera_rel_path,
+            device_id=cuda_device_id(self._device),
         )
         self._render_product_paths.append(render_product_path)
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -151,6 +151,7 @@ def build_render_scope_usd(
     minimal_mode: int | None = None,
     render_var_configs: list[tuple[str, str, str]] | None = None,
     background_color: tuple[float, float, float] | None = None,
+    device_id: int | None = None,
 ) -> str:
     """Build the Render scope USD string (def Scope Render, RenderProduct, Vars).
 
@@ -167,11 +168,17 @@ def build_render_scope_usd(
         background_color: Solid background color as normalized RGB floats ``(r, g, b)`` in ``[0, 1]``.
             When set, the render product uses a solid color background instead of the dome light.
             When ``None``, the default dome-light background is used.
+        device_id: CUDA device index the render product is pinned to via ``deviceIds``. When ``None``,
+            OVRTX assigns the device automatically.
 
     Returns:
         The USD string for the render scope.
     """
     camera_rel_list = ", ".join([f"<{p}>" for p in camera_paths])
+    # OVRTX reads ``deviceIds`` as CUDA indices and returns render var buffers on that device. Left
+    # unauthored it picks its own device, which on a multi-GPU machine can differ from the device the
+    # consuming Warp kernels run on -- an illegal access without peer access, silent garbage with it.
+    device_ids_line = "" if device_id is None else f"\n        uint[] deviceIds = [{device_id}]"
 
     if background_color is None:
         bg_type_line = 'token omni:rtx:background:source:type = "domeLight"'
@@ -208,7 +215,7 @@ def Scope "Render"
     def RenderProduct "{render_product_name}" (
         prepend apiSchemas = ["OmniRtxSettingsCommonAdvancedAPI_1"]
     ) {{
-        rel camera = [{camera_rel_list}]
+        rel camera = [{camera_rel_list}]{device_ids_line}
         {bg_type_line}
         float omni:rtx:rt:ambientLight:intensity = 1.0
         {render_mode_block}
@@ -240,6 +247,7 @@ def build_render_product_as_string(
     minimal_mode: int | None = None,
     camera_rel_path: str = "Camera",
     background_color: tuple[float, float, float] | None = None,
+    device_id: int | None = None,
 ) -> tuple[str, str]:
     """Build the render product USD snippet as a string.
 
@@ -258,6 +266,9 @@ def build_render_product_as_string(
         background_color: Solid background color as normalized RGB floats ``(r, g, b)`` in ``[0, 1]``.
             When set, the render product uses a solid color background instead of the dome light.
             When ``None``, the default dome-light background is used.
+        device_id: CUDA device index the render product is pinned to, so its render var buffers are
+            allocated on the same device as the Warp kernels that read them. When ``None``, OVRTX
+            assigns the device automatically.
 
     Returns:
         Tuple of (render product USD snippet as a string, absolute render product prim path).
@@ -283,6 +294,7 @@ def build_render_product_as_string(
         minimal_mode,
         render_var_configs,
         background_color,
+        device_id,
     )
     return camera_content, render_product_path
 

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -100,6 +100,7 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
         write_attribute=lambda *args, **kwargs: None,
     )
     renderer._clone_plan = None
+    renderer._device = "cuda:0"  # __init__'s default, replaced by create_render_data(spec)
     renderer._camera_rel_path = "Camera"
     renderer._render_product_paths = []
     renderer._exported_usd_string = None
@@ -110,7 +111,7 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     return renderer
 
 
-def _make_camera_render_spec(num_envs: int = 1) -> CameraRenderSpec:
+def _make_camera_render_spec(num_envs: int = 1, device: str = "cpu") -> CameraRenderSpec:
     spawn = PinholeCameraCfg(
         focal_length=24.0,
         focus_distance=400.0,
@@ -127,7 +128,7 @@ def _make_camera_render_spec(num_envs: int = 1) -> CameraRenderSpec:
     camera_paths = tuple(f"/World/envs/env_{env_idx}/Camera" for env_idx in range(num_envs))
     return CameraRenderSpec(
         cfg=cfg,
-        device="cpu",
+        device=device,
         num_instances=num_envs,
         camera_prim_paths=camera_paths,
         view_count=num_envs,
@@ -448,6 +449,26 @@ def test_initialize_from_spec_writes_combined_stage_dump(tmp_path: Path):
     assert 'def RenderProduct "RenderProduct"' in combined_text
     assert open_calls == [combined_text]
     assert renderer._exported_usd_string is None
+
+
+def test_create_render_data_pins_the_render_product_to_the_spec_device(tmp_path: Path):
+    """The render product is pinned to the CUDA device whose Warp kernels read its render vars.
+
+    Without this, OVRTX picks the device itself and hands back buffers on ``cuda:0`` while the tile
+    extraction kernels launch on the simulation device.
+    """
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer.cfg.temp_usd_dir = str(tmp_path)
+    renderer._exported_usd_string = "#usda 1.0\n"
+
+    renderer._renderer.open_usd_from_string = lambda _usd_string: None
+    renderer._renderer.bind_attribute = lambda **kwargs: object()
+    renderer._renderer.write_attribute = lambda **kwargs: None
+
+    renderer.create_render_data(_make_camera_render_spec(num_envs=1, device="cuda:1"))
+
+    combined_text = (tmp_path / _OVRTX_STAGE_FILE).read_text(encoding="utf-8")
+    assert "uint[] deviceIds = [1]" in combined_text
 
 
 def test_initialize_from_spec_refreshes_camera_relationship_after_cloning():

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -498,9 +498,9 @@ def test_cuda_device_id_parses_the_device_string(device, expected):
     """The mapping device index is parsed from the string; a bare ``"cuda"`` parses to 0.
 
     The bare-``"cuda"`` case intentionally preserves pre-existing behavior even though Warp
-    resolves it to its current CUDA device -- see the TODO on ``_cuda_device_id``.
+    resolves it to its current CUDA device -- see the TODO on ``cuda_device_id``.
     """
-    assert ovrtx_mapping._cuda_device_id(device) == expected
+    assert ovrtx_mapping.cuda_device_id(device) == expected
 
 
 def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatch):

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -251,6 +251,31 @@ def test_render_product_initially_targets_only_the_resolvable_source_camera():
     assert "uniform int2 resolution = (32, 16)" in render_product
 
 
+def test_render_product_pins_device_ids_to_the_requested_cuda_device():
+    """``device_id`` is authored as ``deviceIds`` so OVRTX allocates buffers on the reader's device."""
+    render_product, render_product_path = build_render_product_as_string(
+        width=16,
+        height=8,
+        num_envs=4,
+        data_types=["rgb"],
+        device_id=1,
+    )
+
+    layer = Sdf.Layer.CreateAnonymous(".usda")
+    assert layer.ImportFromString("#usda 1.0\n" + render_product)
+    device_ids = layer.GetAttributeAtPath(f"{render_product_path}.deviceIds")
+    assert device_ids is not None
+    assert device_ids.typeName == Sdf.ValueTypeNames.UIntArray
+    assert list(device_ids.default) == [1]
+
+
+def test_render_product_omits_device_ids_when_no_device_is_given():
+    """Without a device index the render product keeps OVRTX's automatic device assignment."""
+    render_product, _ = build_render_product_as_string(width=16, height=8, num_envs=4, data_types=["rgb"])
+
+    assert "deviceIds" not in render_product
+
+
 def test_ovrtx_rgb_and_rgb_hdr_author_both_render_vars():
     """Requesting LDR RGB and RGB_HDR keeps both OVRTX render variables."""
     render_var_configs = get_render_var_configs(["rgb", "rgb_hdr"])


### PR DESCRIPTION
# Description

IsaacLab creates its OVRTX `RenderProduct` without authoring `deviceIds`. OVRTX therefore picks the render device itself, places the render product on CUDA 0, and correctly returns a CUDA-0 DLPack buffer from `render_var.map(device=Device.CUDA)`. The camera tile extraction kernels, however, launch with `device=self._device` — the simulation device. On a multi-GPU machine running with `--device cuda:1`, `extract_all_tiles_kernel` then reads a CUDA-0 buffer from CUDA 1. On a machine without peer access between the two GPUs that is an illegal memory access and the run aborts with CUDA error 700; where peer access is available it silently reads across the link instead of failing.

This authors `uint[] deviceIds = [<cuda index>]` on the render product, resolving the index with the same helper the attribute mappings use (`ovrtx_mapping.cuda_device_id`, promoted from `_cuda_device_id` so both callers share one parser). Both initialization paths — legacy and ovstage — pass it, so every OVRTX buffer the renderer reads is allocated on the device its kernels launch on. The generated prim matches the form OVRTX documents in its own `doc-pin-render-product-to-gpu-0-usda` snippet:

```
def RenderProduct "RenderProduct" ( ... ) {
    rel camera = [</World/envs/env_0/Camera>]
    uint[] deviceIds = [1]
    ...
```

`device_id=None` keeps OVRTX's automatic assignment, so the USD builders behave exactly as before for any caller that does not pass a device.

This also resolves the `FIXME` in `_prepare_ppisp_hdr_source`, whose stated precondition ("until render var mapping can be constrained like transform bindings") is now met. Its `wp.clone` stays as a fallback for the case OVRTX logs as *"deviceIds ... not in the active device set"* and reverts to automatic assignment; the comment is updated to say so.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

```
uv run python -m pytest source/isaaclab_ov/test/test_ovrtx_usd.py \
  source/isaaclab_ov/test/test_ovrtx_renderer_kernels.py \
  source/isaaclab_ov/test/test_ovrtx_renderer_contract.py \
  source/isaaclab_ov/test/test_ovrtx_clone_plan.py \
  source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
# 107 passed

uv run python -m pytest source/isaaclab/test/renderers/test_renderer_factory.py
# 4 passed
```

Three tests added, each verified to fail on the unfixed sources and pass with the fix:

* `test_render_product_pins_device_ids_to_the_requested_cuda_device` — parses the authored snippet through `Sdf.Layer` and asserts `deviceIds` is a `UIntArray` equal to `[1]`.
* `test_render_product_omits_device_ids_when_no_device_is_given` — nothing authored when no device is given.
* `test_create_render_data_pins_the_render_product_to_the_spec_device` — covers the wiring: a spec on `cuda:1` produces a render product pinned to device 1.

`_make_ovrtx_renderer_without_backend` bypasses `__init__`, so it now sets `_device` to the same default `__init__` uses.

Not verified here: the multi-GPU, no-peer-access machine from the report. The change is validated at the USD authoring and renderer wiring level only.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

