### PR TITLE
Fix task preset selection in teleop workflows

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -1596,6 +1596,31 @@ uses ``create_isaac_teleop_device()`` -- no ``--teleop_device`` flag is needed:
              --visualizer kit \
              --xr
 
+The ``run``, ``record``, and ``replay`` workflows accept task configuration selectors using
+Hydra-style ``key=value`` syntax (with no leading ``--``). For example, record the Franka reach
+task with the PhysX and differential IK presets as follows:
+
+.. code-block:: bash
+
+   uv run --extra teleop isaaclab teleop record \
+       --task Isaac-Reach-Franka \
+       --visualizer kit \
+       --dataset_file ./datasets/dataset.hdf5 \
+       --num_demos 1 \
+       --teleop_device keyboard \
+       physics=isaacsim_physx presets=diffik
+
+When replaying a preset-configured dataset, pass the same selectors again. The HDF5 metadata stores
+the registered task ID, but not the command-line selector values:
+
+.. code-block:: bash
+
+   uv run --extra teleop isaaclab teleop replay \
+       --task Isaac-Reach-Franka \
+       --visualizer kit \
+       --dataset_file ./datasets/dataset.hdf5 \
+       physics=isaacsim_physx presets=diffik
+
 Some environments use the legacy ``teleop_devices`` configuration instead of ``isaac_teleop``
 (e.g. the Galbot RmpFlow relative-mode tasks). For these, pass ``--teleop_device`` to select
 the input device:
@@ -1624,7 +1649,8 @@ The workflow is:
 
 #. Configure your environment with ``IsaacTeleopCfg`` (see :ref:`isaac-teleop-env-config`)
    or ``teleop_devices`` for legacy devices (keyboard, spacemouse).
-#. Run ``record_demos.py`` with the task name.
+#. Run ``record_demos.py`` with the task name and any ``physics=``, ``renderer=``, or ``presets=``
+   selectors required by the task.
 #. For XR tasks: start AR, connect your XR device, and teleoperate.
    For legacy tasks: use the configured input device directly.
 #. Demonstrations are recorded to HDF5 files.

--- a/scripts/environments/teleoperation/teleop_se3_agent.py
+++ b/scripts/environments/teleoperation/teleop_se3_agent.py
@@ -25,10 +25,13 @@ import warp as wp
 wp.config.enable_backward = False
 
 import argparse
+import sys
 from collections.abc import Callable
 
 from isaaclab.app import AppLauncher
 from isaaclab.utils.string import list_intersection, string_to_callable
+
+from isaaclab_tasks.utils import setup_preset_cli
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Teleoperation for Isaac Lab environments.")
@@ -86,7 +89,7 @@ parser.add_argument(
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
-args_cli, remaining_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 
 app_launcher_args = vars(args_cli)
 
@@ -103,10 +106,9 @@ if args_cli.external_callback:
     external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
     remaining_args_env_registration = external_callback_function()
 
-# Error on unrecognized arguments.
-unrecognized_args = list_intersection(remaining_args, remaining_args_env_registration)
-if unrecognized_args:
-    parser.error(f"unrecognized arguments: {' '.join(unrecognized_args)}")
+# Hand arguments consumed by neither this parser nor the callback over to Hydra.
+hydra_args = list_intersection(hydra_args, remaining_args_env_registration)
+sys.argv = [sys.argv[0]] + hydra_args
 
 """Rest everything follows."""
 
@@ -128,7 +130,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.core.lift import mdp
-from isaaclab_tasks.utils import parse_env_cfg
+from isaaclab_tasks.utils import resolve_task_config
 
 logger = logging.getLogger(__name__)
 
@@ -255,8 +257,10 @@ def main() -> None:  # noqa: C901
     Returns:
         None
     """
-    # parse configuration
-    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
+    # Resolve the task configuration through Hydra so CLI presets are applied.
+    env_cfg, _ = resolve_task_config(args_cli.task, "")
+    env_cfg.sim.device = args_cli.device
+    env_cfg.scene.num_envs = args_cli.num_envs
     env_cfg.env_name = args_cli.task
     if not isinstance(env_cfg, ManagerBasedRLEnvCfg):
         raise ValueError(

--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -40,11 +40,14 @@ wp.config.enable_backward = False
 # Standard library imports
 import argparse
 import contextlib
+import sys
 from typing import TYPE_CHECKING
 
 # Isaac Lab AppLauncher
 from isaaclab.app import AppLauncher
 from isaaclab.utils.string import list_intersection, string_to_callable
+
+from isaaclab_tasks.utils import setup_preset_cli
 
 if TYPE_CHECKING:
     from isaaclab_teleop import XrCameraFeedSession
@@ -133,7 +136,7 @@ parser.add_argument(
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
-args_cli, remaining_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 
 # Validate required arguments
 if args_cli.task is None:
@@ -155,10 +158,9 @@ if args_cli.external_callback:
     external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
     remaining_args_env_registration = external_callback_function()
 
-# Error on unrecognized arguments.
-unrecognized_args = list_intersection(remaining_args, remaining_args_env_registration)
-if unrecognized_args:
-    parser.error(f"unrecognized arguments: {' '.join(unrecognized_args)}")
+# Hand arguments consumed by neither this parser nor the callback over to Hydra.
+hydra_args = list_intersection(hydra_args, remaining_args_env_registration)
+sys.argv = [sys.argv[0]] + hydra_args
 
 """Rest everything follows."""
 
@@ -190,7 +192,8 @@ import isaaclab_mimic.envs  # noqa: F401
 from isaaclab_mimic.ui.instruction_display import InstructionDisplay, show_subtask_instructions
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry, parse_env_cfg
+from isaaclab_tasks.utils import resolve_task_config
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
 logger = logging.getLogger(__name__)
 
@@ -326,9 +329,11 @@ def create_environment_config(
     Raises:
         Exception: If parsing the environment configuration fails
     """
-    # parse configuration
+    # Resolve the task configuration through Hydra so CLI presets are applied.
     try:
-        env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=1)
+        env_cfg, _ = resolve_task_config(args_cli.task, "")
+        env_cfg.sim.device = args_cli.device
+        env_cfg.scene.num_envs = 1
         env_cfg.env_name = args_cli.task.split(":")[-1]
     except Exception as e:
         logger.error(f"Failed to parse environment configuration: {e}")
@@ -390,7 +395,7 @@ def create_environment(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg) -> gym.En
 
     Args:
         env_cfg: The environment configuration object that defines the environment properties.
-            This should be an instance of EnvCfg created by parse_env_cfg().
+            This should be an instance of EnvCfg created by resolve_task_config().
 
     Returns:
         gym.Env: A Gymnasium environment instance for the specified task.

--- a/scripts/tools/replay_demos.py
+++ b/scripts/tools/replay_demos.py
@@ -14,9 +14,12 @@ import warp as wp
 wp.config.enable_backward = False
 
 import argparse
+import sys
 
 from isaaclab.app import AppLauncher
 from isaaclab.utils.string import list_intersection, string_to_callable
+
+from isaaclab_tasks.utils import setup_preset_cli
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Replay demonstrations in Isaac Lab environments.")
@@ -59,7 +62,7 @@ parser.add_argument("--external_callback", default=None, help="Fully qualified p
 # append AppLauncher cli args
 AppLauncher.add_app_launcher_args(parser)
 # parse the arguments
-args_cli, remaining_args = parser.parse_known_args()
+args_cli, hydra_args = setup_preset_cli(parser)
 # args_cli.headless = True
 
 # launch the simulator
@@ -72,10 +75,9 @@ if args_cli.external_callback:
     external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
     remaining_args_env_registration = external_callback_function()
 
-# Error on unrecognized arguments.
-unrecognized_args = list_intersection(remaining_args, remaining_args_env_registration)
-if unrecognized_args:
-    parser.error(f"unrecognized arguments: {' '.join(unrecognized_args)}")
+# Hand arguments consumed by neither this parser nor the callback over to Hydra.
+hydra_args = list_intersection(hydra_args, remaining_args_env_registration)
+sys.argv = [sys.argv[0]] + hydra_args
 
 """Rest everything follows."""
 
@@ -89,7 +91,7 @@ from isaaclab.devices import Se3Keyboard, Se3KeyboardCfg
 from isaaclab.utils.datasets import EpisodeData, HDF5DatasetFileHandler
 
 import isaaclab_tasks  # noqa: F401
-from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
+from isaaclab_tasks.utils import resolve_task_config
 
 is_paused = False
 
@@ -283,7 +285,9 @@ def main():
             f"Got num_envs={num_envs}. Use --num_envs 1 or disable --reset_sim_buffer_each_episode."
         )
 
-    env_cfg = parse_env_cfg(env_name, device=args_cli.device, num_envs=num_envs)
+    env_cfg, _ = resolve_task_config(env_name, "")
+    env_cfg.sim.device = args_cli.device
+    env_cfg.scene.num_envs = num_envs
 
     # extract success checking function to invoke in the main loop
     success_term = None

--- a/source/isaaclab/test/cli/test_teleop_entrypoints.py
+++ b/source/isaaclab/test/cli/test_teleop_entrypoints.py
@@ -6,6 +6,7 @@
 """Tests for the unified teleoperation console entry point."""
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 from unittest import mock
@@ -23,6 +24,26 @@ TELEOP_WORKFLOWS = {
     "record": ("scripts", "tools", "record_demos.py"),
     "replay": ("scripts", "tools", "replay_demos.py"),
 }
+
+
+@pytest.mark.parametrize(("command", "script_parts"), TELEOP_WORKFLOWS.items())
+def test_teleop_workflow_help_exposes_task_preset_selectors(command, script_parts):
+    """Every teleop workflow accepts the task preset selectors documented for teleoperation."""
+    script = cli.ISAACLAB_ROOT.joinpath(*script_parts)
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=cli.ISAACLAB_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "preset selection:" in result.stdout
+    assert "physics=NAME" in result.stdout
+    assert "renderer=NAME" in result.stdout
+    assert "presets=NAME[,NAME,...]" in result.stdout
 
 
 @pytest.mark.parametrize(("command", "script_parts"), TELEOP_WORKFLOWS.items())

--- a/source/isaaclab_teleop/changelog.d/maximiliank-fix-teleop-preset-cli.rst
+++ b/source/isaaclab_teleop/changelog.d/maximiliank-fix-teleop-preset-cli.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed the ``isaaclab teleop run``, ``record``, and ``replay`` workflows rejecting Hydra-style
+  task selectors such as ``physics=isaacsim_physx presets=diffik``. The workflows now resolve task
+  configurations through the shared preset-aware path and expose the selector syntax in ``--help``.

--- a/source/isaaclab_teleop/test/test_teleop_scripts_smoke.py
+++ b/source/isaaclab_teleop/test/test_teleop_scripts_smoke.py
@@ -173,6 +173,7 @@ def test_teleop_se3_agent_starts(tmp_path):
         "scripts/environments/teleoperation/teleop_se3_agent.py",
         "--task",
         _ISAAC_TELEOP_TASK,
+        "physics=isaacsim_physx",
         *_NO_CLOUDXR,
     ]
     output = _launch_until_marker(argv, [_ISAAC_TELEOP_MARKER], tmp_path / "se3_agent.log")
@@ -189,6 +190,7 @@ def test_record_demos_starts(tmp_path):
         "scripts/tools/record_demos.py",
         "--task",
         _ISAAC_TELEOP_TASK,
+        "physics=isaacsim_physx",
         "--dataset_file",
         str(tmp_path / "dataset.hdf5"),
         *_NO_CLOUDXR,


### PR DESCRIPTION
# Description

The unified `isaaclab teleop run`, `record`, and `replay` entrypoints parsed unknown arguments with `argparse` and then rejected task preset selectors such as `physics=isaacsim_physx` and `presets=diffik`. The documented Franka recording command therefore failed before task configuration was resolved.

This change:

- connects all three teleop workflows to the canonical preset CLI setup and task-config resolver;
- preserves external callback argument filtering before forwarding remaining selectors;
- reapplies command-line device and environment-count overrides after preset resolution;
- documents the exact record and replay syntax, including why HDF5 replay must repeat selectors;
- adds focused CLI coverage and extends the simulator smoke-test arguments.

No new dependencies are required. The patch changes 8 files with 93 additions and 25 deletions (68 net lines).

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this is a command-line workflow fix.

## Validation

- 57 targeted preset-resolution, CLI, and replay-loop tests passed.
- 3 simulator-backed teleop recording smoke tests passed.
- The reported Franka record command reached environment creation with `PhysxCfg` and relative `DifferentialInverseKinematicsActionCfg`.
- Formatting, RST, diff, and changelog-fragment validation passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there