### PR TITLE
Add temporary UV mapping fallbacks for Newton visualizers

### DIFF
--- a/docs/source/_static/quickstart/agent-comparison.gif
+++ b/docs/source/_static/quickstart/agent-comparison.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45d9a0b1dc7f202765eeec21dad92d92eeb5861bbd5dbca5a8597451ac6ae835
-size 1105959
+oid sha256:3c17753d59b46ac372eedcb9d065cb442e8d2ae34f4a310e4a9fdf3dc63c2d64
+size 1408723

--- a/docs/source/_static/quickstart/task-sampler.gif
+++ b/docs/source/_static/quickstart/task-sampler.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fde0ba58ff8f2937177f0d566e5f6181c604c3ad491386a5bad5db5f334c951f
-size 651499
+oid sha256:1868b2fd7b0c94d0ccdea3aa14677bca9c8cdef8044256f9b4c2670f3d4cecd6
+size 803578

--- a/source/isaaclab/changelog.d/esekkin-newton-uv-patch.rst
+++ b/source/isaaclab/changelog.d/esekkin-newton-uv-patch.rst
@@ -2,3 +2,4 @@ Fixed
 ^^^^^
 
 * Fixed stretched default ground textures in Newton visualizers by authoring fallback world-projected UVs.
+* Fixed lost OmniPBR scale, translation, and rotation for existing UVs in Newton visualizers.

--- a/source/isaaclab/changelog.d/esekkin-newton-uv-patch.rst
+++ b/source/isaaclab/changelog.d/esekkin-newton-uv-patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed stretched default ground textures in Newton visualizers by authoring fallback world-projected UVs.

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -236,6 +236,7 @@ def spawn_ground_plane(
         scale = (cfg.size[0] / 100.0, cfg.size[1] / 100.0, 1.0)
         # apply scale to the mesh
         environment_prim.GetAttribute("xformOp:scale").Set(scale)
+        # TODO: Remove this fallback after adopting the Newton fix tracked by OMPE-107347.
         # Preserve the projected grid density for renderers that consume only authored UVs.
         if cfg.usd_path == f"{ISAAC_NUCLEUS_DIR}/Environments/Grid/default_environment.usd":
             _author_ground_plane_fallback_uvs(prim_path, stage)

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import tempfile
 from contextlib import nullcontext
@@ -30,7 +31,7 @@ from isaaclab.sim.utils import (
     select_usd_variants,
     set_prim_visibility,
 )
-from isaaclab.utils.assets import check_file_path, retrieve_file_path
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, check_file_path, retrieve_file_path
 from isaaclab.utils.version import has_kit
 
 if TYPE_CHECKING:
@@ -235,6 +236,9 @@ def spawn_ground_plane(
         scale = (cfg.size[0] / 100.0, cfg.size[1] / 100.0, 1.0)
         # apply scale to the mesh
         environment_prim.GetAttribute("xformOp:scale").Set(scale)
+        # Preserve the projected grid density for renderers that consume only authored UVs.
+        if cfg.usd_path == f"{ISAAC_NUCLEUS_DIR}/Environments/Grid/default_environment.usd":
+            _author_ground_plane_fallback_uvs(prim_path, stage)
 
     # Change the color of the plane
     # Warning: This is specific to the default grid plane asset.
@@ -278,6 +282,50 @@ def spawn_ground_plane(
 """
 Helper functions.
 """
+
+
+def _author_ground_plane_fallback_uvs(prim_path: str, stage: Usd.Stage) -> None:
+    """Bake the default grid's world-space projection into fallback UV coordinates."""
+    from pxr import Gf, Sdf, UsdGeom, UsdShade  # noqa: PLC0415
+
+    mesh = UsdGeom.Mesh(stage.GetPrimAtPath(f"{prim_path}/Environment/Geometry"))
+    shader = UsdShade.Shader(stage.GetPrimAtPath(f"{prim_path}/Looks/theGrid/Shader"))
+    if not mesh or not shader:
+        return
+
+    project_uvw = shader.GetInput("project_uvw")
+    world_or_object = shader.GetInput("world_or_object")
+    if not project_uvw or not bool(project_uvw.Get()) or not world_or_object or not bool(world_or_object.Get()):
+        return
+
+    texture_scale_input = shader.GetInput("texture_scale")
+    texture_scale = texture_scale_input.Get() if texture_scale_input else Gf.Vec2f(1.0, 1.0)
+    scale_u, scale_v = float(texture_scale[0]), float(texture_scale[1])
+    if not math.isfinite(scale_u) or not math.isfinite(scale_v):
+        return
+
+    points = mesh.GetPointsAttr().Get()
+    face_vertex_indices = mesh.GetFaceVertexIndicesAttr().Get()
+    if not points or not face_vertex_indices:
+        return
+
+    world_xform = UsdGeom.XformCache().GetLocalToWorldTransform(mesh.GetPrim())
+    world_points = [world_xform.Transform(point) for point in points]
+    z_coordinates = [float(point[2]) for point in world_points]
+    if max(z_coordinates) - min(z_coordinates) > 1.0e-6:
+        return
+
+    projected_uvs = [
+        Gf.Vec2f(float(world_points[index][0]) * scale_u, float(world_points[index][1]) * scale_v)
+        for index in face_vertex_indices
+    ]
+    st_primvar = UsdGeom.PrimvarsAPI(mesh).GetPrimvar("st")
+    if not st_primvar:
+        st_primvar = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+        )
+    st_primvar.Set(projected_uvs)
+    st_primvar.SetInterpolation(UsdGeom.Tokens.faceVarying)
 
 
 def _spawn_from_usd_file(

--- a/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
+++ b/source/isaaclab/isaaclab/sim/utils/newton_model_utils.py
@@ -12,6 +12,7 @@ to be deprecated and removed.
 
 from __future__ import annotations
 
+import copy
 import logging
 import warnings
 from typing import Any
@@ -20,7 +21,7 @@ import numpy as np
 
 from pxr import Usd, UsdGeom, UsdShade
 
-__all__ = ["replace_newton_builder_shape_colors"]
+__all__ = ["replace_newton_builder_shape_colors", "replace_newton_builder_shape_uv_transforms"]
 
 logger = logging.getLogger(__name__)
 
@@ -94,15 +95,25 @@ def _get_bound_material_prim(shape_prim: Usd.Prim) -> Usd.Prim:
     return Usd.Prim()
 
 
-def _get_input_value(shader: UsdShade.Shader, name: str) -> tuple[float, float, float] | None:
-    """Fetch the effective input value from a shader, following connections."""
+def _get_shader_input_value(shader: UsdShade.Shader, name: str) -> Any:
+    """Fetch an effective shader input value, following connections."""
     inp = shader.GetInput(name)
     if inp is not None:
         attrs = UsdShade.Utils.GetValueProducingAttributes(inp)
         if attrs and len(attrs) > 0:
             value = attrs[0].Get()
             if value is not None:
-                return _coerce_color(value)
+                return value
+        return inp.Get()
+
+    return None
+
+
+def _get_input_value(shader: UsdShade.Shader, name: str) -> tuple[float, float, float] | None:
+    """Fetch an effective color input value, following connections."""
+    value = _get_shader_input_value(shader, name)
+    if value is not None:
+        return _coerce_color(value)
 
     return None
 
@@ -203,6 +214,148 @@ def _resolve_shape_color(
 
     material_color_cache[material_key] = material_color
     return material_color
+
+
+def _coerce_texture_vec2(value: Any, default: tuple[float, float]) -> np.ndarray | None:
+    """Coerce a finite texture transform input to a two-component array."""
+    if value is None:
+        return np.asarray(default, dtype=np.float32)
+    try:
+        vector = np.asarray(value, dtype=np.float32).reshape(-1)
+    except (TypeError, ValueError):
+        return None
+    if vector.size < 2 or not np.all(np.isfinite(vector[:2])):
+        return None
+    return vector[:2]
+
+
+def _resolve_omnipbr_uv_transform(material_prim: Usd.Prim) -> tuple[np.ndarray, np.ndarray, float] | None:
+    """Resolve a non-identity affine transform for authored OmniPBR UV coordinates."""
+    shader_prim = _get_surface_shader(material_prim)
+    if not _is_omnipbr_shader(shader_prim):
+        return None
+
+    shader = UsdShade.Shader(shader_prim)
+    if bool(_get_shader_input_value(shader, "project_uvw")):
+        return None
+
+    scale = _coerce_texture_vec2(_get_shader_input_value(shader, "texture_scale"), (1.0, 1.0))
+    translate = _coerce_texture_vec2(_get_shader_input_value(shader, "texture_translate"), (0.0, 0.0))
+    rotate_value = _get_shader_input_value(shader, "texture_rotate")
+    try:
+        rotate = 0.0 if rotate_value is None else float(rotate_value)
+    except (TypeError, ValueError):
+        return None
+    if scale is None or translate is None or not np.isfinite(rotate):
+        return None
+    if np.array_equal(scale, (1.0, 1.0)) and np.array_equal(translate, (0.0, 0.0)) and rotate == 0.0:
+        return None
+    return scale, translate, rotate
+
+
+def _apply_uv_transform(
+    uvs: Any,
+    scale: np.ndarray,
+    translate: np.ndarray,
+    rotate: float,
+) -> np.ndarray | None:
+    """Apply OmniPBR's rotate-scale-translate transform to existing UV coordinates."""
+    try:
+        coordinates = np.asarray(uvs, dtype=np.float32)
+    except (TypeError, ValueError):
+        return None
+    if coordinates.ndim != 2 or coordinates.shape[1] != 2:
+        return None
+
+    angle = np.deg2rad(rotate)
+    cosine = np.float32(np.cos(angle))
+    sine = np.float32(np.sin(angle))
+    rotated = np.empty_like(coordinates)
+    rotated[:, 0] = cosine * coordinates[:, 0] + sine * coordinates[:, 1]
+    rotated[:, 1] = -sine * coordinates[:, 0] + cosine * coordinates[:, 1]
+    return rotated * scale + translate
+
+
+# TODO: Remove this compatibility pass after OMPE-107347 provides equivalent Newton ViewerRTX support.
+def replace_newton_builder_shape_uv_transforms(builder: Any, stage: Usd.Stage) -> int:
+    """Bake authored OmniPBR affine UV transforms into Newton visual mesh sources.
+
+    Newton imports textures and authored ``primvars:st`` but currently drops OmniPBR ``texture_scale``,
+    ``texture_translate``, and ``texture_rotate``. This stopgap copies only affected mesh wrappers and UV arrays;
+    vertices, indices, textures, and simulation mesh identity remain shared. Projected mappings are deliberately
+    excluded because object/world cubic projection cannot be represented by one affine transform of existing UVs.
+    The pass runs once immediately after each USD import; runtime material-transform updates are not supported.
+
+    Args:
+        builder: Object with ``shape_label`` and ``shape_source`` lists, typically a Newton ``ModelBuilder`` before
+            finalization.
+        stage: USD stage used to resolve effective visual material bindings.
+
+    Returns:
+        Number of shape sources whose UV coordinates were transformed.
+    """
+    shape_labels = getattr(builder, "shape_label", None)
+    shape_sources = getattr(builder, "shape_source", None)
+    if not isinstance(shape_labels, list) or not isinstance(shape_sources, list):
+        return 0
+    if len(shape_labels) != len(shape_sources):
+        raise ValueError(
+            f"Mismatching length of shape_label and shape_source: {len(shape_labels)} != {len(shape_sources)}"
+        )
+
+    material_transform_cache: dict[str, tuple[np.ndarray, np.ndarray, float] | None] = {}
+    transformed_source_cache: dict[tuple[int, tuple[float, ...]], Any] = {}
+    num_uv_updates = 0
+
+    for shape_index, label in enumerate(shape_labels):
+        source = shape_sources[shape_index]
+        source_uvs = getattr(source, "uvs", None)
+        if getattr(source, "texture", None) is None or source_uvs is None:
+            continue
+
+        shape_prim = stage.GetPrimAtPath(label)
+        if not shape_prim.IsValid():
+            continue
+        imageable = UsdGeom.Imageable(shape_prim)
+        if bool(imageable) and imageable.ComputePurpose() == UsdGeom.Tokens.guide:
+            continue
+
+        material_prim = _get_bound_material_prim(shape_prim)
+        if not material_prim.IsValid():
+            continue
+        material_key = _canonical_prim_lookup_key(material_prim)
+        if material_key not in material_transform_cache:
+            material_transform_cache[material_key] = _resolve_omnipbr_uv_transform(material_prim)
+        transform = material_transform_cache[material_key]
+        if transform is None:
+            continue
+
+        scale, translate, rotate = transform
+        transform_key = (*scale.tolist(), *translate.tolist(), rotate)
+        if getattr(source, "_isaaclab_uv_transform", None) == transform_key:
+            continue
+        source_key = (id(source), transform_key)
+        if source_key in transformed_source_cache:
+            shape_sources[shape_index] = transformed_source_cache[source_key]
+            num_uv_updates += 1
+            continue
+
+        transformed_uvs = _apply_uv_transform(source_uvs, scale, translate, rotate)
+        if transformed_uvs is None:
+            continue
+
+        source_copy = copy.copy(source)
+        if not hasattr(source_copy, "_uvs"):
+            logger.debug("Shape source %s does not expose Newton mesh UV storage.", type(source).__name__)
+            continue
+        setattr(source_copy, "_uvs", transformed_uvs)
+        setattr(source_copy, "_isaaclab_uv_transform", transform_key)
+        shape_sources[shape_index] = source_copy
+        transformed_source_cache[source_key] = source_copy
+        num_uv_updates += 1
+
+    logger.debug("Transformed builder UVs for %d / %d shapes", num_uv_updates, len(shape_labels))
+    return num_uv_updates
 
 
 def replace_newton_builder_shape_colors(builder: Any, stage: Usd.Stage) -> int:

--- a/source/isaaclab/test/sim/test_newton_model_utils.py
+++ b/source/isaaclab/test/sim/test_newton_model_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import warnings
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import warp as wp
 
@@ -23,6 +24,7 @@ from isaaclab.sim.utils.newton_model_utils import (
     _get_omnipbr_albedo,
     _resolve_shape_color,
     replace_newton_builder_shape_colors,
+    replace_newton_builder_shape_uv_transforms,
 )
 
 pytestmark = pytest.mark.integration
@@ -35,6 +37,20 @@ def _replace_newton_builder_shape_colors_wrapper(builder: object, stage: Usd.Sta
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=_WARNING_MESSAGE, category=FutureWarning)
         return replace_newton_builder_shape_colors(builder, stage)
+
+
+class _FakeNewtonMesh:
+    """Minimal Newton mesh surface used to verify payload sharing."""
+
+    def __init__(self):
+        self.vertices = object()
+        self.indices = object()
+        self.texture = object()
+        self._uvs = np.asarray(((0.0, 0.0), (1.0, 0.0), (1.0, 1.0)), dtype=np.float32)
+
+    @property
+    def uvs(self) -> np.ndarray:
+        return self._uvs
 
 
 _OMNIPBR_ALBEDO_INPUT_CASES = [
@@ -236,6 +252,32 @@ def test_resolve_shape_color_neutral_material_binding():
     """Bound ``UsdPreviewSurface`` material: not OmniPBR, so resolution is ``None`` (Newton row unchanged)."""
     stage, mesh_path = _make_preview_surface_bound_mesh_stage()
     assert _resolve_shape_color(stage, mesh_path, {}) is None
+
+
+def test_replace_newton_builder_shape_uv_transforms_shares_mesh_payload():
+    """The stopgap copies transformed UVs without duplicating geometry or textures."""
+    stage, shader, mesh_path = _make_mesh_bound_to_omnipbr_test_material(None, None)
+    shader.CreateInput("project_uvw", Sdf.ValueTypeNames.Bool).Set(False)
+    shader.CreateInput("texture_scale", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(2.0, 3.0))
+    shader.CreateInput("texture_translate", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(0.25, -0.5))
+    shader.CreateInput("texture_rotate", Sdf.ValueTypeNames.Float).Set(90.0)
+    source = _FakeNewtonMesh()
+    builder = SimpleNamespace(shape_label=[mesh_path], shape_source=[source])
+
+    assert replace_newton_builder_shape_uv_transforms(builder, stage) == 1
+    transformed = builder.shape_source[0]
+    assert transformed is not source
+    assert transformed.vertices is source.vertices
+    assert transformed.indices is source.indices
+    assert transformed.texture is source.texture
+    assert transformed.uvs is not source.uvs
+    np.testing.assert_allclose(
+        transformed.uvs,
+        ((0.25, -0.5), (0.25, -3.5), (2.25, -3.5)),
+        atol=1.0e-6,
+    )
+    np.testing.assert_array_equal(source.uvs, ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0)))
+    assert replace_newton_builder_shape_uv_transforms(builder, stage) == 0
 
 
 def test_replace_newton_builder_shape_colors_warning():

--- a/source/isaaclab/test/sim/test_spawn_from_files.py
+++ b/source/isaaclab/test/sim/test_spawn_from_files.py
@@ -12,6 +12,8 @@ simulation_app = AppLauncher(headless=True).app
 
 """Rest everything follows."""
 
+import math
+
 import pytest
 
 import omni.kit.app
@@ -133,12 +135,34 @@ def test_spawn_urdf(sim):
 def test_spawn_ground_plane(sim):
     """Test loading prim for the ground plane from grid world USD."""
     # Spawn ground plane
-    cfg = sim_utils.GroundPlaneCfg(color=(0.1, 0.1, 0.1), size=(10.0, 10.0))
-    prim = cfg.func("/World/ground_plane", cfg)
+    cfg = sim_utils.GroundPlaneCfg(color=(0.1, 0.1, 0.1), size=(10.0, 20.0))
+    prim = cfg.func(
+        "/World/ground_plane",
+        cfg,
+        translation=(1.0, 2.0, 0.0),
+        orientation=(0.0, 0.0, math.sqrt(0.5), math.sqrt(0.5)),
+    )
     # Check validity
     assert prim.IsValid()
     assert sim.stage.GetPrimAtPath("/World/ground_plane").IsValid()
     assert prim.GetPrimTypeInfo().GetTypeName() == "Xform"
+
+    mesh = UsdGeom.Mesh(sim.stage.GetPrimAtPath("/World/ground_plane/Environment/Geometry"))
+    shader = UsdShade.Shader(sim.stage.GetPrimAtPath("/World/ground_plane/Looks/theGrid/Shader"))
+    texture_scale = shader.GetInput("texture_scale").Get()
+    uvs = UsdGeom.PrimvarsAPI(mesh).GetPrimvar("st").Get()
+    points = mesh.GetPointsAttr().Get()
+    face_vertex_indices = mesh.GetFaceVertexIndicesAttr().Get()
+    world_xform = UsdGeom.XformCache().GetLocalToWorldTransform(mesh.GetPrim())
+    expected_uvs = [
+        (
+            world_xform.Transform(points[index])[0] * texture_scale[0],
+            world_xform.Transform(points[index])[1] * texture_scale[1],
+        )
+        for index in face_vertex_indices
+    ]
+    for uv, expected_uv in zip(uvs, expected_uvs, strict=True):
+        assert tuple(uv) == pytest.approx(expected_uv)
 
 
 @pytest.mark.isaacsim_ci

--- a/source/isaaclab_newton/changelog.d/esekkin-newton-uv-patch.rst
+++ b/source/isaaclab_newton/changelog.d/esekkin-newton-uv-patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Applied the temporary affine UV compatibility pass across Newton USD import paths.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -16,7 +16,10 @@ from newton import GeoType, ModelBuilder, ShapeFlags
 from pxr import Usd, UsdGeom, UsdPhysics
 
 from isaaclab.cloner import path as clone_path
-from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
+from isaaclab.sim.utils.newton_model_utils import (
+    replace_newton_builder_shape_colors,
+    replace_newton_builder_shape_uv_transforms,
+)
 
 from isaaclab_newton.renderers.visual_material import import_builder_visual_material_paths
 
@@ -146,6 +149,7 @@ def _build_source_builder(
         builder, stage, import_result["path_shape_map"], load_visual_shapes
     )
     replace_newton_builder_shape_colors(builder, stage)
+    replace_newton_builder_shape_uv_transforms(builder, stage)
     if load_visual_shapes:
         import_builder_visual_material_paths(builder, stage)
     return builder

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -19,7 +19,10 @@ from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 from pxr import Usd
 
 from isaaclab.physics import PhysicsManager
-from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
+from isaaclab.sim.utils.newton_model_utils import (
+    replace_newton_builder_shape_colors,
+    replace_newton_builder_shape_uv_transforms,
+)
 
 from isaaclab_newton.cloner.newton_clone_utils import (
     _restore_visible_colliders_without_visual_shapes,
@@ -140,6 +143,7 @@ def _build_newton_builder_from_mapping(
         import_results.append(import_result)
     stage_info = import_results[0]
     replace_newton_builder_shape_colors(builder, stage)
+    replace_newton_builder_shape_uv_transforms(builder, stage)
     if load_visual_shapes:
         import_builder_visual_material_paths(builder, stage)
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -88,7 +88,10 @@ from isaaclab.scene_data.deformable_vis_remap import (
     launch_batch_volume_vis_remap,
 )
 from isaaclab.sim import SimulationContext
-from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_colors
+from isaaclab.sim.utils.newton_model_utils import (
+    replace_newton_builder_shape_colors,
+    replace_newton_builder_shape_uv_transforms,
+)
 from isaaclab.sim.utils.queries import has_deformable_curve_api
 from isaaclab.sim.utils.stage import get_current_stage
 from isaaclab.utils import checked_apply
@@ -1897,6 +1900,7 @@ class NewtonManager(PhysicsManager):
             )
             _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
             replace_newton_builder_shape_colors(builder, stage)
+            replace_newton_builder_shape_uv_transforms(builder, stage)
             import_builder_visual_material_paths(builder, stage)
             NewtonManager._world_xforms = [wp.transform()]
             for hook in cls._per_world_builder_hooks:
@@ -1908,6 +1912,7 @@ class NewtonManager(PhysicsManager):
             import_result = builder.add_usd(stage, ignore_paths=ignore_paths, schema_resolvers=schema_resolvers)
             _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
             replace_newton_builder_shape_colors(builder, stage)
+            replace_newton_builder_shape_uv_transforms(builder, stage)
             import_builder_visual_material_paths(builder, stage)
 
             _, proto_path = env_paths[0]
@@ -1922,6 +1927,7 @@ class NewtonManager(PhysicsManager):
                 source_builders[proto_path], stage, import_result["path_shape_map"]
             )
             replace_newton_builder_shape_colors(source_builders[proto_path], stage)
+            replace_newton_builder_shape_uv_transforms(source_builders[proto_path], stage)
             import_builder_visual_material_paths(source_builders[proto_path], stage)
             cls._cl_protos = source_builders
 

--- a/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
@@ -15,6 +15,7 @@ from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 from pxr import Usd
 
 from isaaclab.scene_data.deformable_discovery import DeformableStageEntry, discover_deformables_on_stage
+from isaaclab.sim.utils.newton_model_utils import replace_newton_builder_shape_uv_transforms
 from isaaclab.sim.utils.transforms import resolve_prim_pose
 
 from isaaclab_newton.cloner.newton_clone_utils import (
@@ -110,6 +111,7 @@ def build_visualization_builder_from_stage_envs(
             ignore_paths=deformable_ignore_paths or None,
         )
         _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
+        replace_newton_builder_shape_uv_transforms(builder, stage)
         import_builder_visual_material_paths(builder, stage)
         shadow_entities, registry_groups = add_shadow_deformables_to_builder(
             builder, stage, env_paths, device=device, entries=deformable_entries, clone_plan=clone_plan
@@ -139,6 +141,7 @@ def build_visualization_builder_from_stage_envs(
         schema_resolvers=schema_resolvers,
     )
     _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
+    replace_newton_builder_shape_uv_transforms(builder, stage)
     import_builder_visual_material_paths(builder, stage)
     source_deformable_ignore_paths = _deformable_ignore_paths(stage, sources, entries=deformable_entries)
     source_builders = build_source_builders(

--- a/source/isaaclab_newton/test/cloner/test_visual_shape_import.py
+++ b/source/isaaclab_newton/test/cloner/test_visual_shape_import.py
@@ -6,12 +6,15 @@
 """Unit tests: the Newton cloner imports visual-only geometry only when it is drawn."""
 
 import newton
+import numpy as np
+import pytest
 from isaaclab_newton.cloner import newton_clone_utils
 from isaaclab_newton.cloner import replicate as replicate_module
 from isaaclab_newton.cloner.newton_clone_utils import build_source_builders
 from newton import ShapeFlags
+from PIL import Image
 
-from pxr import Usd, UsdGeom, UsdPhysics
+from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
 
 _SOURCE = "/World/Asset"
 
@@ -27,6 +30,44 @@ def _make_stage() -> Usd.Stage:
     collider = UsdGeom.Cube.Define(stage, f"{_SOURCE}/collision")
     UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
     UsdGeom.Cube.Define(stage, f"{_SOURCE}/visual")
+    return stage
+
+
+def _make_uv_transform_stage(texture_path: str, project_uvw: bool = False) -> Usd.Stage:
+    """Create a textured mesh with an authored OmniPBR UV transform."""
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    UsdGeom.Xform.Define(stage, _SOURCE)
+
+    mesh = UsdGeom.Mesh.Define(stage, f"{_SOURCE}/visual")
+    mesh.CreateFaceVertexCountsAttr([4])
+    mesh.CreateFaceVertexIndicesAttr([0, 1, 2, 3])
+    mesh.CreatePointsAttr(
+        [
+            Gf.Vec3f(-0.5, -0.5, 0.0),
+            Gf.Vec3f(0.5, -0.5, 0.0),
+            Gf.Vec3f(0.5, 0.5, 0.0),
+            Gf.Vec3f(-0.5, 0.5, 0.0),
+        ]
+    )
+    UsdGeom.PrimvarsAPI(mesh).CreatePrimvar("st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying).Set(
+        [Gf.Vec2f(0.0, 0.0), Gf.Vec2f(1.0, 0.0), Gf.Vec2f(1.0, 1.0), Gf.Vec2f(0.0, 1.0)]
+    )
+
+    material = UsdShade.Material.Define(stage, f"{_SOURCE}/material")
+    shader = UsdShade.Shader.Define(stage, f"{_SOURCE}/material/Shader")
+    shader.SetSourceAsset(Sdf.AssetPath("OmniPBR.mdl"), "mdl")
+    shader.SetSourceAssetSubIdentifier("OmniPBR", "mdl")
+    shader.CreateInput("diffuse_texture", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_path))
+    shader.CreateInput("project_uvw", Sdf.ValueTypeNames.Bool).Set(project_uvw)
+    shader.CreateInput("texture_scale", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(2.0, 3.0))
+    shader.CreateInput("texture_translate", Sdf.ValueTypeNames.Float2).Set(Gf.Vec2f(0.25, -0.5))
+    shader.CreateInput("texture_rotate", Sdf.ValueTypeNames.Float).Set(90.0)
+    output = shader.CreateOutput("out", Sdf.ValueTypeNames.Token)
+    output.SetRenderType("material")
+    material.CreateSurfaceOutput("mdl").ConnectToSource(output)
+    UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
     return stage
 
 
@@ -100,6 +141,30 @@ class TestClonerVisualShapeImport:
         assert rendering_stage.prim_lookups == 1
         # ...and the collider was visible either way, so skipping it changed nothing.
         assert list(builder.shape_flags) == flags_before
+
+    @pytest.mark.parametrize("project_uvw", [False, True])
+    def test_uv_transform_is_baked_only_for_authored_uvs(self, tmp_path, project_uvw):
+        """Affine texture transforms are baked without touching projected mappings or the source stage."""
+        texture_path = tmp_path / "grid.png"
+        Image.new("RGBA", (2, 2), "white").save(texture_path)
+        stage = _make_uv_transform_stage(str(texture_path), project_uvw)
+        builder = _build(stage, load_visual_shapes=True)
+
+        shape_index = builder.shape_label.index(f"{_SOURCE}/visual")
+        actual_uvs = builder.shape_source[shape_index].uvs
+        raw_uvs = np.asarray(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            dtype=np.float32,
+        )
+        transformed_uvs = np.asarray(
+            [[0.25, -0.5], [0.25, -3.5], [2.25, -3.5], [0.25, -0.5], [2.25, -3.5], [2.25, -0.5]],
+            dtype=np.float32,
+        )
+
+        assert actual_uvs is not None
+        np.testing.assert_allclose(actual_uvs, raw_uvs if project_uvw else transformed_uvs, atol=1.0e-6)
+        source_uvs = UsdGeom.PrimvarsAPI(stage.GetPrimAtPath(f"{_SOURCE}/visual")).GetPrimvar("st").Get()
+        np.testing.assert_allclose(source_uvs, raw_uvs[[0, 1, 2, 5]], atol=1.0e-6)
 
 
 class _StubSim:

--- a/source/isaaclab_visualizers/changelog.d/esekkin-newton-uv-patch.rst
+++ b/source/isaaclab_visualizers/changelog.d/esekkin-newton-uv-patch.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Newton viewer prototype reuse for textured meshes with distinct UV coordinates.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -12,7 +12,7 @@ import logging
 import math
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np  # noqa: F401 — used in type hints and colorization helpers
 import torch
@@ -134,6 +134,25 @@ def _eye_lookat_to_pitch_yaw(
     return pitch, yaw
 
 
+# TODO: Remove this cache extension after OMPE-107347 provides equivalent Newton viewer support.
+def _mesh_uv_hash(geo_src: Any) -> int | None:
+    """Return a cached hash of a textured Newton mesh's UV coordinates."""
+    if getattr(geo_src, "texture", None) is None:
+        return None
+    uvs = getattr(geo_src, "uvs", None)
+    if uvs is None:
+        return None
+
+    cached_hash = getattr(geo_src, "_isaaclab_uv_hash", None)
+    if cached_hash is not None:
+        return cached_hash
+
+    uv_array = np.ascontiguousarray(np.asarray(uvs))
+    uv_hash = hash((uv_array.dtype.str, uv_array.shape, uv_array.tobytes()))
+    setattr(geo_src, "_isaaclab_uv_hash", uv_hash)
+    return uv_hash
+
+
 # ---------------------------------------------------------------------------
 # Newton viewer wrappers (add IsaacLab ImGui controls to Newton's viewers)
 # ---------------------------------------------------------------------------
@@ -154,6 +173,12 @@ class _NewtonViewerUIMixin:
 
     CAMERA_SPEED_BOOST_MULTIPLIER = 2.0
     """Factor applied to :attr:`camera_speed` while the speed-boost modifier is held."""
+
+    def _hash_geometry(self, geo_type, geo_scale, thickness, is_solid, geo_src=None, mirror=False):
+        """Include textured-mesh UVs in Isaac Lab Newton viewer prototype keys."""
+        base_hash = super()._hash_geometry(geo_type, geo_scale, thickness, is_solid, geo_src, mirror)
+        uv_hash = _mesh_uv_hash(geo_src)
+        return base_hash if uv_hash is None else hash((base_hash, uv_hash))
 
     def _is_camera_speed_boost_active(self) -> bool:
         """Return whether the camera speed-boost modifier (Left/Right Shift) is held."""

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -22,7 +22,7 @@ from isaaclab_visualizers.newton import (
 )
 from isaaclab_visualizers.newton import newton_visualization_markers as newton_markers
 from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
-from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, _eye_lookat_to_pitch_yaw
+from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, NewtonViewerRTX, _eye_lookat_to_pitch_yaw
 from isaaclab_visualizers.newton_adapter import (
     VISUALIZER_INFINITE_PLANE_SIZE,
     apply_viewer_visible_worlds,
@@ -51,6 +51,28 @@ def test_expand_infinite_plane_scale_expands_non_positive_extents():
 
 def test_expand_infinite_plane_scale_preserves_finite_extents():
     assert expand_infinite_plane_scale((100.0, 50.0, 1.0)) == (100.0, 50.0, 1.0)
+
+
+@pytest.mark.parametrize("viewer_cls", [NewtonViewerGL, NewtonViewerRTX])
+def test_newton_viewer_geometry_hash_distinguishes_uvs(viewer_cls):
+    """Newton viewer wrappers must not reuse prototypes whose UV coordinates differ."""
+    import newton
+
+    vertices = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+    indices = (0, 1, 2)
+    texture = np.zeros((2, 2, 4), dtype=np.uint8)
+    mesh_a = newton.Mesh(
+        vertices, indices, uvs=((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)), texture=texture, compute_inertia=False
+    )
+    mesh_b = newton.Mesh(
+        vertices, indices, uvs=((0.0, 0.0), (2.0, 0.0), (0.0, 2.0)), texture=texture, compute_inertia=False
+    )
+    assert hash(mesh_a) == hash(mesh_b)
+
+    viewer = object.__new__(viewer_cls)
+    hash_a = viewer._hash_geometry(newton.GeoType.MESH, (1.0, 1.0, 1.0), 0.0, True, mesh_a)
+    hash_b = viewer._hash_geometry(newton.GeoType.MESH, (1.0, 1.0, 1.0), 0.0, True, mesh_b)
+    assert hash_a != hash_b
 
 
 def test_log_geo_with_expanded_plane_scale_delegates_with_adjusted_plane_scale():

--- a/tools/docs/media/capture_quickstart.py
+++ b/tools/docs/media/capture_quickstart.py
@@ -30,10 +30,10 @@ from isaaclab_tasks.core.velocity.config.g1.flat_env_cfg import G1FlatEnvCfg
 from isaaclab_tasks.utils import resolve_task_config, setup_preset_cli
 
 _TASK_CONFIGS = {
-    "Isaac-Cartpole": "capture:CartpoleCaptureCfg",
-    "Isaac-Lift-KukaAllegro": "capture:KukaAllegroCaptureCfg",
-    "Isaac-Open-Drawer-Franka": "capture:FrankaCabinetCaptureCfg",
-    "Isaac-Velocity-Flat-G1": "capture:G1FlatCaptureCfg",
+    "Isaac-Cartpole": "capture_quickstart:CartpoleCaptureCfg",
+    "Isaac-Lift-KukaAllegro": "capture_quickstart:KukaAllegroCaptureCfg",
+    "Isaac-Open-Drawer-Franka": "capture_quickstart:FrankaCabinetCaptureCfg",
+    "Isaac-Velocity-Flat-G1": "capture_quickstart:G1FlatCaptureCfg",
 }
 
 


### PR DESCRIPTION
## Description

Add temporary Isaac Lab UV-mapping fallbacks for Newton visualizers while the Newton changes tracked by OMPE-107347 are evaluated.

Newton currently imports textures and authored `primvars:st`, but its ViewerRTX path does not preserve OmniPBR texture-coordinate mapping. This stretches the canonical default grid and drops affine transforms from otherwise valid authored UVs.

This change:
- authors fallback face-varying UVs for the canonical horizontal default grid using its world transform and texture scale;
- bakes OmniPBR texture scale, translation, and rotation into existing UVs when `project_uvw` is disabled;
- applies the affine compatibility pass across Newton USD import paths;
- keeps vertices, indices, textures, and simulation mesh hashes shared;
- includes UVs in Isaac Lab Newton GL/RTX prototype cache keys;
- fixes the Quickstart capture configuration module name; and
- regenerates `agent-comparison.gif` and `task-sampler.gif`.

The workaround is import-time only. Runtime material-transform updates and general object/world projected mappings remain unsupported. Direct MDL rendering is unchanged.

[newton-physics/newton#4007](https://github.com/newton-physics/newton/pull/4007) preserves this metadata.

Addresses NVBug 6667468.


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

![Agent comparison](https://github.com/nvsekkin/IsaacLab/blob/a8e13c423668c26120fee0d1719aed11b9f54f99/docs/source/_static/quickstart/agent-comparison.gif?raw=1)

![Task sampler](https://github.com/nvsekkin/IsaacLab/blob/a8e13c423668c26120fee0d1719aed11b9f54f99/docs/source/_static/quickstart/task-sampler.gif?raw=1)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there