### PR TITLE
Fix PhysX scene data joint name collisions

### DIFF
--- a/source/isaaclab_physx/changelog.d/fix-scene-data-joint-name-collisions.rst
+++ b/source/isaaclab_physx/changelog.d/fix-scene-data-joint-name-collisions.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed PhysX scene-data rigid-body views resolving same-named USD joint prims
+  when synchronizing PhysX simulations with Newton visualizers.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -213,10 +213,8 @@ class PhysxSceneDataBackend(SceneDataBackend):
         rigid_body_paths: list[str] = []
         non_rigid_body_names: set[str] = set()
         for prim in stage.Traverse():
-            if prim.IsA(UsdPhysics.Joint):
-                continue
             prim_path = prim.GetPath().pathString
-            if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI) and not prim.IsA(UsdPhysics.Joint):
                 rigid_body_paths.append(prim_path)
             elif re.search(r"/World/envs/env_\d+/", prim_path):
                 non_rigid_body_names.add(prim_path.rsplit("/", 1)[-1])

--- a/source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py
+++ b/source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py
@@ -11,8 +11,9 @@ pytest.importorskip("pxr")
 pytest.importorskip("omni.physics.tensors")
 
 
-def test_scene_data_rigid_body_view_skips_joint_prims_with_rigid_body_api(monkeypatch):
-    """Joint prims must not be passed to PhysX tensor rigid-body views."""
+@pytest.mark.parametrize("joint_has_rigid_body_api", [False, True])
+def test_rigid_body_view_uses_exact_path_for_joint_name_collision(monkeypatch, joint_has_rigid_body_api):
+    """Joint names must keep same-named rigid bodies out of wildcard views."""
     from isaaclab_physx.physics import physx_manager
     from isaaclab_physx.physics.physx_manager import PhysxSceneDataBackend
 
@@ -21,8 +22,11 @@ def test_scene_data_rigid_body_view_skips_joint_prims_with_rigid_body_api(monkey
     stage = Usd.Stage.CreateInMemory()
     body_prim = UsdGeom.Xform.Define(stage, "/World/envs/env_0/Robot/robot0_forearm").GetPrim()
     UsdPhysics.RigidBodyAPI.Apply(body_prim)
+    unique_body_prim = UsdGeom.Xform.Define(stage, "/World/envs/env_0/Robot/torso").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(unique_body_prim)
     joint_prim = UsdPhysics.FixedJoint.Define(stage, "/World/envs/env_0/Robot/joints/robot0_forearm").GetPrim()
-    UsdPhysics.RigidBodyAPI.Apply(joint_prim)
+    if joint_has_rigid_body_api:
+        UsdPhysics.RigidBodyAPI.Apply(joint_prim)
 
     captured_paths = []
 
@@ -41,7 +45,10 @@ def test_scene_data_rigid_body_view_skips_joint_prims_with_rigid_body_api(monkey
     backend.simulation_view = _SimulationView()
     backend.get_rigid_body_view()
 
-    assert captured_paths == ["/World/envs/env_*/Robot/robot0_forearm"]
+    assert captured_paths == [
+        "/World/envs/env_*/Robot/torso",
+        "/World/envs/env_0/Robot/robot0_forearm",
+    ]
 
 
 def test_discover_deformable_geometry_publishes_discovered_roots(monkeypatch):


### PR DESCRIPTION
# Description

Fix repeated `Failed to find rigid body` warnings when a PhysX simulation is synchronized to a Newton visualizer and rigid-body prims share leaf names with USD joint prims.

`PhysxSceneDataBackend.get_rigid_body_view()` previously skipped joint prims before collecting non-rigid name collisions. This allowed same-named rigid bodies, such as the Ant leg and foot bodies, to be compressed into PhysX wildcard expressions that could also resolve the corresponding prims under `Robot/joints`.

Joint prims are now excluded from the rigid-body candidates while still participating in collision detection. Same-named bodies therefore use exact paths, while bodies without collisions retain wildcard compaction.

The regression test covers both ordinary joints and joints with `RigidBodyAPI`, and verifies that an unrelated body still uses a wildcard.

Reported with Isaac Sim 6.1.0-rc9 and Isaac Lab `release/3.0.0` at `bb0c8e1` using:

```bash
uv run --extra isaacsim,all,rlinf,mimic,teleop,tetrahedralization,video,leapp \
  python scripts/environments/zero_agent.py --task Isaac-Ant --num_envs 128 \
  presets=physx --visualizer newton
```

Related to #5935 and #6041.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- Relevant pre-commit formatting, lint, spelling, license, and RST hooks passed.
- `isaaclab_physx` changelog compilation dry-run passed.
- A direct red/green path-selection check confirmed that the baseline emits the unsafe wildcard and the patch emits the exact collision path for both joint variants while preserving safe wildcard compaction.
- The focused pytest module was collected but skipped locally because `omni.physics.tensors` requires Kit startup. Full Kit startup was not run because the isolated environment requested interactive NVIDIA EULA acceptance.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [ ] I have made corresponding changes to the documentation (not applicable; no public API or workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
