### PR TITLE
[Odin] Fix multi-agent play benchmark environment creation

### DIFF
--- a/source/isaaclab/changelog.d/fix-marl-play-benchmark.rst
+++ b/source/isaaclab/changelog.d/fix-marl-play-benchmark.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed play benchmarks failing on ``DirectMARLEnv`` tasks by creating and converting environments
+  with the same backend-specific rules as training.

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -84,6 +84,7 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
+    _common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
     _common.enable_cameras_for_video(args_cli)
@@ -105,7 +106,6 @@ def run(argv: list[str]) -> BenchmarkResult:
     import re
     import time
 
-    import gymnasium as gym
     from rl_games.common import env_configurations, vecenv
     from rl_games.common.player import BasePlayer
     from rl_games.torch_runner import Runner
@@ -193,7 +193,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             concate_obs_groups = agent_cfg["params"]["env"].get("concate_obs_groups", True)
 
             env_t0 = time.perf_counter_ns()
-            env = gym.make(args_cli.task, cfg=env_cfg)
+            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_play_rl_games.py
@@ -21,7 +21,7 @@ import sys
 
 from isaaclab.benchmark.entrypoints.backends.rl_games.registry import register_scoped_rl_games_environment
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _parse_args(argv: list[str]):
@@ -84,10 +84,10 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
-    _common.add_frontend_args(parser)
+    common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
-    _common.enable_cameras_for_video(args_cli)
+    common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -128,7 +128,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
-    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
+    common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -136,7 +136,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
-            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
+            common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -146,8 +146,8 @@ def run(argv: list[str]) -> BenchmarkResult:
 
             config_name = agent_cfg["params"]["config"]["name"]
             log_root_path = os.path.abspath(os.path.join("logs", "rl_games", config_name))
-            if args_cli.checkpoint in _common.CHECKPOINT_SELECTORS:
-                resume_path = _common.resolve_checkpoint_selector(
+            if args_cli.checkpoint in common.CHECKPOINT_SELECTORS:
+                resume_path = common.resolve_checkpoint_selector(
                     log_root_path,
                     args_cli.checkpoint,
                     library="rl_games",
@@ -158,7 +158,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                     metadata={"agent": args_cli.agent},
                 )
             else:
-                resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "rl_games", args_cli.task, env_cfg)
+                resume_path = common.resolve_play_checkpoint(args_cli.checkpoint, "rl_games", args_cli.task, env_cfg)
 
             cfg = capture.run_config_from_env_cfg(env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
@@ -193,7 +193,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             concate_obs_groups = agent_cfg["params"]["env"].get("concate_obs_groups", True)
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rl_games/benchmark_train_rl_games.py
@@ -18,7 +18,7 @@ import time
 from isaaclab.benchmark.entrypoints.backends.rl_games.registry import register_scoped_rl_games_environment
 from isaaclab.benchmark.entrypoints.training import _resolve_training_checkpoint_path
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _close_rl_games_writer(observer: Any) -> None:
@@ -51,8 +51,8 @@ def _parse_args(argv: list[str]):
 
     from isaaclab_tasks.utils import setup_preset_cli
 
-    add_common_train_args = _common.add_common_train_args
-    enable_cameras_for_video = _common.enable_cameras_for_video
+    add_common_train_args = common.add_common_train_args
+    enable_cameras_for_video = common.enable_cameras_for_video
 
     parser = argparse.ArgumentParser(description="Benchmark RL training with RL-Games.")
     add_common_train_args(
@@ -156,7 +156,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
 
     from isaaclab_tasks.utils import resolve_task_config
 
-    apply_env_overrides = _common.apply_env_overrides
+    apply_env_overrides = common.apply_env_overrides
     from isaaclab.benchmark.entrypoints.early_stop import (
         RlGamesEarlyStopObserver,
         build_success_kwargs,
@@ -179,7 +179,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             cleanup.enter_context(
-                _common.scoped_torch_backend_flags(
+                common.scoped_torch_backend_flags(
                     cuda_matmul_allow_tf32=True,
                     cudnn_allow_tf32=True,
                     cudnn_deterministic=False,
@@ -197,7 +197,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             if args_cli.max_iterations is not None:
                 agent_cfg["params"]["config"]["max_epochs"] = args_cli.max_iterations
 
-            _common.validate_distributed_device(args_cli)
+            common.validate_distributed_device(args_cli)
             if distributed.enabled:
                 # Mirror the regular training entrypoint: the launcher pinned this rank to its own
                 # device, and offsetting the seed by the rank decorrelates exploration across ranks.
@@ -247,18 +247,18 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             # RL-Games silences logging on every rank but global rank 0, so only that rank has a
             # populated run directory to describe.
             if distributed.is_main:
-                _common.write_run_manifest(
+                common.write_run_manifest(
                     run_log_dir, library="rl_games", task=args_cli.task, metadata={"agent": args_cli.agent}
                 )
             env_cfg.log_dir = run_log_dir
-            _common.apply_video_recording(env_cfg, run_log_dir, args_cli, subdir="benchmark")
+            common.apply_video_recording(env_cfg, run_log_dir, args_cli, subdir="benchmark")
 
             rl_device = agent_cfg["params"]["config"]["device"]
             clip_obs = agent_cfg["params"]["env"].get("clip_observations", math.inf)
             clip_actions = agent_cfg["params"]["env"].get("clip_actions", math.inf)
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -85,6 +85,7 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         ),
     )
     add_launcher_args(parser)
+    _common.add_frontend_args(parser)
 
     args, remaining = setup_preset_cli(parser, argv)
     _common.enable_cameras_for_video(args)
@@ -104,7 +105,6 @@ def run(argv: list[str]) -> BenchmarkResult:
     import os
     import time
 
-    import gymnasium as gym
     from rsl_rl.runners import DistillationRunner, OnPolicyRunner
 
     from isaaclab.app import launch_simulation
@@ -183,7 +183,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = gym.make(args.task, cfg=env_cfg)
+            env = _common.create_isaaclab_env(args.task, env_cfg, args, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_play_rsl_rl.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 import argparse
 import sys
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
@@ -85,10 +85,10 @@ def _parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         ),
     )
     add_launcher_args(parser)
-    _common.add_frontend_args(parser)
+    common.add_frontend_args(parser)
 
     args, remaining = setup_preset_cli(parser, argv)
-    _common.enable_cameras_for_video(args)
+    common.enable_cameras_for_video(args)
     sys.argv = [sys.argv[0]] + remaining
     return args, remaining
 
@@ -125,7 +125,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args, remaining = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args.task, args.agent)
-    _common.pre_launch_video_config(env_cfg, args_cli=args)
+    common.pre_launch_video_config(env_cfg, args_cli=args)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -133,7 +133,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
-            _common.apply_video_recording(env_cfg, args.output_path, args, subdir="play")
+            common.apply_video_recording(env_cfg, args.output_path, args, subdir="play")
 
             if args.num_envs is not None:
                 env_cfg.scene.num_envs = args.num_envs
@@ -145,8 +145,8 @@ def run(argv: list[str]) -> BenchmarkResult:
             agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, installed_rsl_rl)
 
             log_root_path = os.path.abspath(os.path.join("logs", "rsl_rl", agent_cfg.experiment_name))
-            if args.checkpoint in _common.CHECKPOINT_SELECTORS:
-                resume_path = _common.resolve_checkpoint_selector(
+            if args.checkpoint in common.CHECKPOINT_SELECTORS:
+                resume_path = common.resolve_checkpoint_selector(
                     log_root_path,
                     args.checkpoint,
                     library="rsl_rl",
@@ -155,7 +155,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                     metadata={"agent": args.agent},
                 )
             else:
-                resume_path = _common.resolve_play_checkpoint(args.checkpoint, "rsl_rl", args.task, env_cfg)
+                resume_path = common.resolve_play_checkpoint(args.checkpoint, "rsl_rl", args.task, env_cfg)
 
             cfg = capture.run_config_from_env_cfg(env_cfg)
             formatter_types = [value.strip() for value in args.benchmark_formatter.split(",") if value.strip()]
@@ -183,7 +183,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args.task, env_cfg, args, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args.task, env_cfg, args, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/rsl_rl/benchmark_train_rsl_rl.py
@@ -16,7 +16,7 @@ import sys
 import time
 from typing import Any
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _disable_code_state_capture(runner: Any) -> None:
@@ -42,8 +42,8 @@ def _parse_args(argv: list[str]):
 
     from isaaclab_tasks.utils import setup_preset_cli
 
-    add_common_train_args = _common.add_common_train_args
-    enable_cameras_for_video = _common.enable_cameras_for_video
+    add_common_train_args = common.add_common_train_args
+    enable_cameras_for_video = common.enable_cameras_for_video
     from isaaclab_rl.entrypoints.backends import cli_args_rsl_rl as cli_args
 
     parser = argparse.ArgumentParser(description="Benchmark RL training with RSL-RL.")
@@ -147,7 +147,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
 
     from isaaclab_tasks.utils import get_checkpoint_path, resolve_task_config
 
-    apply_env_overrides = _common.apply_env_overrides
+    apply_env_overrides = common.apply_env_overrides
     from isaaclab.benchmark.entrypoints.early_stop import (
         RslRlEarlyStopWrapper,
         build_success_kwargs,
@@ -170,7 +170,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             cleanup.enter_context(
-                _common.scoped_torch_backend_flags(
+                common.scoped_torch_backend_flags(
                     cuda_matmul_allow_tf32=True,
                     cudnn_allow_tf32=True,
                     cudnn_deterministic=False,
@@ -188,7 +188,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             agent_cfg = handle_deprecated_rsl_rl_cfg(agent_cfg, installed_rsl_rl)
             env_cfg.seed = agent_cfg.seed
 
-            _common.validate_distributed_device(args_cli)
+            common.validate_distributed_device(args_cli)
             if distributed.enabled:
                 # Mirror the regular training entrypoint: the launcher pinned this rank to its own
                 # device, and offsetting the seed by the rank decorrelates exploration across ranks.
@@ -237,14 +237,14 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             # RSL-RL silences logging on every rank but global rank 0, so only that rank has a
             # populated run directory to describe.
             if distributed.is_main:
-                _common.write_run_manifest(
+                common.write_run_manifest(
                     log_dir, library="rsl_rl", task=args_cli.task, metadata={"agent": args_cli.agent}
                 )
             env_cfg.log_dir = log_dir
-            _common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
+            common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -91,6 +91,7 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
+    _common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
     _common.enable_cameras_for_video(args_cli)
@@ -109,7 +110,6 @@ def run(argv: list[str]) -> BenchmarkResult:
     import contextlib
     import os
 
-    import gymnasium as gym
     from stable_baselines3 import PPO
     from stable_baselines3.common.vec_env import VecNormalize
 
@@ -186,7 +186,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = gym.make(args_cli.task, cfg=env_cfg)
+            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_play_sb3.py
@@ -22,7 +22,7 @@ import sys
 import time
 from pathlib import Path
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _parse_args(argv: list[str]):
@@ -91,10 +91,10 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
-    _common.add_frontend_args(parser)
+    common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
-    _common.enable_cameras_for_video(args_cli)
+    common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -131,7 +131,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     args_cli, remaining_args = _parse_args(argv)
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
-    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
+    common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -139,7 +139,7 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
-            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
+            common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.num_envs is not None:
                 env_cfg.scene.num_envs = args_cli.num_envs
@@ -147,8 +147,8 @@ def run(argv: list[str]) -> BenchmarkResult:
             env_cfg.seed = agent_cfg["seed"]
 
             log_root_path = os.path.abspath(os.path.join("logs", "sb3", args_cli.task))
-            if args_cli.checkpoint in _common.CHECKPOINT_SELECTORS:
-                resume_path = _common.resolve_checkpoint_selector(
+            if args_cli.checkpoint in common.CHECKPOINT_SELECTORS:
+                resume_path = common.resolve_checkpoint_selector(
                     log_root_path,
                     args_cli.checkpoint,
                     library="sb3",
@@ -158,7 +158,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                     metadata={"agent": args_cli.agent},
                 )
             else:
-                resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "sb3", args_cli.task, env_cfg)
+                resume_path = common.resolve_play_checkpoint(args_cli.checkpoint, "sb3", args_cli.task, env_cfg)
 
             cfg = capture.run_config_from_env_cfg(env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
@@ -186,7 +186,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_train_sb3.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/sb3/benchmark_train_sb3.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 import sys
 import time
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _build_benchmark_callback_class():
@@ -102,8 +102,8 @@ def _parse_args(argv: list[str]):
 
     from isaaclab_tasks.utils import setup_preset_cli
 
-    add_common_train_args = _common.add_common_train_args
-    enable_cameras_for_video = _common.enable_cameras_for_video
+    add_common_train_args = common.add_common_train_args
+    enable_cameras_for_video = common.enable_cameras_for_video
 
     parser = argparse.ArgumentParser(description="Benchmark RL training with Stable-Baselines3.")
     add_common_train_args(
@@ -210,7 +210,7 @@ def run(argv: list[str]) -> BenchmarkResult:
 
     from isaaclab_tasks.utils import resolve_task_config
 
-    apply_env_overrides = _common.apply_env_overrides
+    apply_env_overrides = common.apply_env_overrides
 
     from isaaclab.benchmark.entrypoints.early_stop import (
         SuccessRateTrackerWrapper,
@@ -275,16 +275,16 @@ def run(argv: list[str]) -> BenchmarkResult:
             run_info = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             log_root_path = os.path.abspath(os.path.join("logs", "sb3", args_cli.task))
             log_dir = os.path.join(log_root_path, run_info)
-            _common.write_run_manifest(log_dir, library="sb3", task=args_cli.task, metadata={"agent": args_cli.agent})
+            common.write_run_manifest(log_dir, library="sb3", task=args_cli.task, metadata={"agent": args_cli.agent})
             env_cfg.log_dir = log_dir
-            _common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
+            common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
 
             agent_cfg = process_sb3_cfg(agent_cfg, env_cfg.scene.num_envs)
             policy_arch = agent_cfg.pop("policy")
             n_timesteps = agent_cfg.pop("n_timesteps")
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
+            env = common.create_isaaclab_env(args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=True)
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
             success_kwargs = build_success_kwargs(args_cli)

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -100,6 +100,7 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
+    _common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
     _common.enable_cameras_for_video(args_cli)
@@ -117,8 +118,6 @@ def run(argv: list[str]) -> BenchmarkResult:
     """
     import contextlib
     import os
-
-    import gymnasium as gym
 
     from isaaclab.app import launch_simulation
     from isaaclab.benchmark import BaseIsaacLabBenchmark, BenchmarkMonitor, BenchmarkResult, builders, capture, stepping
@@ -207,7 +206,9 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = gym.make(args_cli.task, cfg=env_cfg)
+            env = _common.create_isaaclab_env(
+                args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=algorithm == "ppo"
+            )
             cleanup.callback(lambda: env.close())
             env_t1 = time.perf_counter_ns()
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_play_skrl.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 import sys
 import time
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _parse_args(argv: list[str]):
@@ -100,10 +100,10 @@ def _parse_args(argv: list[str]):
         ),
     )
     add_launcher_args(parser)
-    _common.add_frontend_args(parser)
+    common.add_frontend_args(parser)
 
     args_cli, remaining_args = setup_preset_cli(parser, argv)
-    _common.enable_cameras_for_video(args_cli)
+    common.enable_cameras_for_video(args_cli)
     sys.argv = [sys.argv[0]] + remaining_args
 
     return args_cli, remaining_args
@@ -140,7 +140,7 @@ def run(argv: list[str]) -> BenchmarkResult:
 
     env_cfg, agent_cfg = resolve_task_config(args_cli.task, agent_cfg_entry_point)
     algorithm = resolve_skrl_algorithm(agent_cfg, args_cli.algorithm)
-    _common.pre_launch_video_config(env_cfg, args_cli=args_cli)
+    common.pre_launch_video_config(env_cfg, args_cli=args_cli)
 
     start_utc = capture.now_utc_iso()
     app_t0 = time.perf_counter_ns()
@@ -148,12 +148,12 @@ def run(argv: list[str]) -> BenchmarkResult:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             app_t1 = time.perf_counter_ns()
-            _common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
+            common.apply_video_recording(env_cfg, args_cli.output_path, args_cli, subdir="play")
 
             if args_cli.ml_framework.startswith("jax"):
                 import skrl
 
-                cleanup.enter_context(_common.preserve_attribute(skrl.config.jax, "backend"))
+                cleanup.enter_context(common.preserve_attribute(skrl.config.jax, "backend"))
                 skrl.config.jax.backend = "jax" if args_cli.ml_framework == "jax" else "numpy"
 
             if args_cli.num_envs is not None:
@@ -162,8 +162,8 @@ def run(argv: list[str]) -> BenchmarkResult:
             env_cfg.seed = agent_cfg["seed"]
 
             log_root_path = os.path.abspath(os.path.join("logs", "skrl", agent_cfg["agent"]["experiment"]["directory"]))
-            if args_cli.checkpoint in _common.CHECKPOINT_SELECTORS:
-                resume_path = _common.resolve_checkpoint_selector(
+            if args_cli.checkpoint in common.CHECKPOINT_SELECTORS:
+                resume_path = common.resolve_checkpoint_selector(
                     log_root_path,
                     args_cli.checkpoint,
                     library="skrl",
@@ -177,7 +177,7 @@ def run(argv: list[str]) -> BenchmarkResult:
                     },
                 )
             else:
-                resume_path = _common.resolve_play_checkpoint(args_cli.checkpoint, "skrl", args_cli.task, env_cfg)
+                resume_path = common.resolve_play_checkpoint(args_cli.checkpoint, "skrl", args_cli.task, env_cfg)
 
             cfg = capture.run_config_from_env_cfg(env_cfg)
             formatter_types = [value.strip() for value in args_cli.benchmark_formatter.split(",") if value.strip()]
@@ -206,7 +206,7 @@ def run(argv: list[str]) -> BenchmarkResult:
             )
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(
+            env = common.create_isaaclab_env(
                 args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=algorithm == "ppo"
             )
             cleanup.callback(lambda: env.close())

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/backends/skrl/benchmark_train_skrl.py
@@ -17,7 +17,7 @@ import time
 
 from isaaclab.benchmark.entrypoints.training import _resolve_training_checkpoint_path
 
-from isaaclab_rl.entrypoints import common as _common
+from isaaclab_rl.entrypoints import common
 
 
 def _build_benchmark_trainer_class():
@@ -134,8 +134,8 @@ def _parse_args(argv: list[str]):
 
     from isaaclab_tasks.utils import setup_preset_cli
 
-    add_common_train_args = _common.add_common_train_args
-    enable_cameras_for_video = _common.enable_cameras_for_video
+    add_common_train_args = common.add_common_train_args
+    enable_cameras_for_video = common.enable_cameras_for_video
 
     parser = argparse.ArgumentParser(description="Benchmark RL training with SKRL.")
     add_common_train_args(
@@ -245,7 +245,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
 
     from isaaclab_tasks.utils import resolve_task_config
 
-    apply_env_overrides = _common.apply_env_overrides
+    apply_env_overrides = common.apply_env_overrides
     from isaaclab.benchmark.entrypoints.early_stop import (
         SuccessRateTrackerWrapper,
         build_success_kwargs,
@@ -271,7 +271,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
     with launch_simulation(env_cfg, args_cli):
         with contextlib.ExitStack() as cleanup:
             cleanup.enter_context(
-                _common.scoped_torch_backend_flags(
+                common.scoped_torch_backend_flags(
                     cuda_matmul_allow_tf32=True,
                     cudnn_allow_tf32=True,
                     cudnn_deterministic=False,
@@ -289,7 +289,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             agent_cfg["trainer"]["close_environment_at_exit"] = False
 
             agent_cfg["seed"] = args_cli.seed if args_cli.seed is not None else agent_cfg.get("seed", 0)
-            _common.validate_distributed_device(args_cli)
+            common.validate_distributed_device(args_cli)
             if distributed.enabled:
                 # skrl reads the rank environment itself and pins the device; offsetting the seed by
                 # the rank decorrelates exploration across ranks, as in regular skrl training.
@@ -309,7 +309,7 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             # skrl silences experiment logging on every rank but global rank 0, so only that rank
             # has a populated run directory to describe.
             if distributed.is_main:
-                _common.write_run_manifest(
+                common.write_run_manifest(
                     log_dir,
                     library="skrl",
                     task=args_cli.task,
@@ -349,10 +349,10 @@ def run(argv: list[str]) -> BenchmarkResult | None:
             )
 
             env_cfg.log_dir = log_dir
-            _common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
+            common.apply_video_recording(env_cfg, log_dir, args_cli, subdir="benchmark")
 
             env_t0 = time.perf_counter_ns()
-            env = _common.create_isaaclab_env(
+            env = common.create_isaaclab_env(
                 args_cli.task, env_cfg, args_cli, convert_marl_to_single_agent=algorithm == "ppo"
             )
             cleanup.callback(lambda: env.close())

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -151,6 +151,7 @@ def test_play_request_uses_backend_arguments(backend: str, monkeypatch) -> None:
     assert args.warmup_steps == 12
     assert args.video is True
     assert args.video_length == 37
+    assert args.frontend == "torch"
     assert args.enable_cameras is True
     assert remaining_args == []
 
@@ -201,6 +202,56 @@ def test_play_backend_configures_video_before_environment_creation(
                 "--video",
                 "--video_length",
                 "37",
+            ]
+        )
+
+
+def test_rsl_play_converts_direct_marl_task_before_wrapping(monkeypatch, tmp_path) -> None:
+    """RSL-RL play should convert a DirectMARLEnv task before constructing its wrapper."""
+
+    class MultiAgentConversionRequested(Exception):
+        pass
+
+    class FakeMultiAgentEnvironment:
+        def __init__(self, cfg):
+            self.cfg = cfg
+            self.unwrapped = self
+
+        def close(self) -> None:
+            pass
+
+    entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
+    monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
+
+    import gymnasium as gym
+
+    import isaaclab.app as app
+    import isaaclab.envs as envs
+
+    @contextlib.contextmanager
+    def launch_simulation(env_cfg, args):
+        yield
+
+    def make_environment(task, *, cfg):
+        assert task == "Isaac-Shadow-Handover-Direct"
+        return FakeMultiAgentEnvironment(cfg)
+
+    def convert_environment(env):
+        raise MultiAgentConversionRequested
+
+    monkeypatch.setattr(app, "launch_simulation", launch_simulation)
+    monkeypatch.setattr(gym, "make", make_environment)
+    monkeypatch.setattr(envs, "multi_agent_to_single_agent", convert_environment)
+
+    with pytest.raises(MultiAgentConversionRequested):
+        entrypoint.run(
+            [
+                "--task",
+                "Isaac-Shadow-Handover-Direct",
+                "--checkpoint",
+                "/tmp/checkpoint",
+                "--output_path",
+                str(tmp_path),
             ]
         )
 

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -166,8 +166,6 @@ def test_play_backend_configures_video_before_environment_creation(
     entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
     monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
 
-    import gymnasium as gym
-
     import isaaclab.app as app
 
     @contextlib.contextmanager
@@ -180,7 +178,8 @@ def test_play_backend_configures_video_before_environment_creation(
             env_cfg.video_recorders = [VideoRecorderCfg(output_dir=configured_output_dir)]
         yield
 
-    def make_environment(task, *, cfg):
+    def create_environment(task, cfg, args, *, convert_marl_to_single_agent):
+        assert convert_marl_to_single_agent is True
         recorder = cfg.video_recorders[0]
         expected_output_dir = configured_output_dir or str(tmp_path / "videos" / "play")
         assert recorder.output_dir == expected_output_dir
@@ -188,7 +187,7 @@ def test_play_backend_configures_video_before_environment_creation(
         raise VideoConfigured
 
     monkeypatch.setattr(app, "launch_simulation", launch_simulation)
-    monkeypatch.setattr(gym, "make", make_environment)
+    monkeypatch.setattr(entrypoint._common, "create_isaaclab_env", create_environment)
 
     with pytest.raises(VideoConfigured):
         entrypoint.run(
@@ -202,56 +201,6 @@ def test_play_backend_configures_video_before_environment_creation(
                 "--video",
                 "--video_length",
                 "37",
-            ]
-        )
-
-
-def test_rsl_play_converts_direct_marl_task_before_wrapping(monkeypatch, tmp_path) -> None:
-    """RSL-RL play should convert a DirectMARLEnv task before constructing its wrapper."""
-
-    class MultiAgentConversionRequested(Exception):
-        pass
-
-    class FakeMultiAgentEnvironment:
-        def __init__(self, cfg):
-            self.cfg = cfg
-            self.unwrapped = self
-
-        def close(self) -> None:
-            pass
-
-    entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
-    monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
-
-    import gymnasium as gym
-
-    import isaaclab.app as app
-    import isaaclab.envs as envs
-
-    @contextlib.contextmanager
-    def launch_simulation(env_cfg, args):
-        yield
-
-    def make_environment(task, *, cfg):
-        assert task == "Isaac-Shadow-Handover-Direct"
-        return FakeMultiAgentEnvironment(cfg)
-
-    def convert_environment(env):
-        raise MultiAgentConversionRequested
-
-    monkeypatch.setattr(app, "launch_simulation", launch_simulation)
-    monkeypatch.setattr(gym, "make", make_environment)
-    monkeypatch.setattr(envs, "multi_agent_to_single_agent", convert_environment)
-
-    with pytest.raises(MultiAgentConversionRequested):
-        entrypoint.run(
-            [
-                "--task",
-                "Isaac-Shadow-Handover-Direct",
-                "--checkpoint",
-                "/tmp/checkpoint",
-                "--output_path",
-                str(tmp_path),
             ]
         )
 

--- a/source/isaaclab/test/benchmark/test_api.py
+++ b/source/isaaclab/test/benchmark/test_api.py
@@ -164,7 +164,7 @@ def test_play_backend_configures_video_before_environment_creation(
         pass
 
     entrypoint = importlib.import_module(dispatch._workflow_module("play", "rsl_rl"))
-    monkeypatch.setattr(entrypoint._common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
+    monkeypatch.setattr(entrypoint.common, "resolve_play_checkpoint", lambda *args: "/tmp/checkpoint")
 
     import isaaclab.app as app
 
@@ -187,7 +187,7 @@ def test_play_backend_configures_video_before_environment_creation(
         raise VideoConfigured
 
     monkeypatch.setattr(app, "launch_simulation", launch_simulation)
-    monkeypatch.setattr(entrypoint._common, "create_isaaclab_env", create_environment)
+    monkeypatch.setattr(entrypoint.common, "create_isaaclab_env", create_environment)
 
     with pytest.raises(VideoConfigured):
         entrypoint.run(
@@ -338,10 +338,10 @@ def test_backend_entrypoints_register_environment_cleanup_before_wrapping() -> N
     for entrypoint in entrypoints:
         source = entrypoint.read_text()
         compile(source, str(entrypoint), "exec")
-        creation_index = max(source.find("gym.make("), source.find("_common.create_isaaclab_env("))
+        creation_index = max(source.find("gym.make("), source.find("common.create_isaaclab_env("))
         cleanup_index = source.find("cleanup.callback(lambda: env.close())", creation_index)
         wrapper_indices = [
-            source.find(wrapper, creation_index) for wrapper in ("_common.wrap_record_video(env", "VecEnvWrapper(env")
+            source.find(wrapper, creation_index) for wrapper in ("common.wrap_record_video(env", "VecEnvWrapper(env")
         ]
         first_wrapper_index = min(index for index in wrapper_indices if index >= 0)
 

--- a/source/isaaclab_rl/changelog.d/fix-wrapper-environment-type.rst
+++ b/source/isaaclab_rl/changelog.d/fix-wrapper-environment-type.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed RL environment wrapper validation errors reporting the outer Gymnasium wrapper type instead
+  of the rejected unwrapped environment type.

--- a/source/isaaclab_rl/isaaclab_rl/rl_games/rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/rl_games/rl_games.py
@@ -138,7 +138,7 @@ class RlGamesVecEnvWrapper(IVecEnv):
             raise ValueError(
                 "The environment must be inherited from ManagerBasedRLEnv / DirectRLEnv / DirectRLEnvWarp /"
                 " ManagerBasedRLEnvWarp. Environment type:"
-                f" {type(env)}"
+                f" {type(env.unwrapped)}"
             )
         # initialize the wrapper
         self.env = env

--- a/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
+++ b/source/isaaclab_rl/isaaclab_rl/rsl_rl/vecenv_wrapper.py
@@ -70,7 +70,7 @@ class RslRlVecEnvWrapper(VecEnv):
             raise ValueError(
                 "The environment must be inherited from ManagerBasedRLEnv / DirectRLEnv / DirectRLEnvWarp /"
                 " ManagerBasedRLEnvWarp. Environment type:"
-                f" {type(env)}"
+                f" {type(env.unwrapped)}"
             )
 
         # initialize the wrapper

--- a/source/isaaclab_rl/isaaclab_rl/sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/sb3.py
@@ -170,7 +170,7 @@ class Sb3VecEnvWrapper(VecEnv):
             raise ValueError(
                 "The environment must be inherited from ManagerBasedRLEnv / DirectRLEnv / DirectRLEnvWarp /"
                 " ManagerBasedRLEnvWarp. Environment type:"
-                f" {type(env)}"
+                f" {type(env.unwrapped)}"
             )
         # initialize the wrapper
         self.env = env

--- a/source/isaaclab_rl/isaaclab_rl/skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/skrl.py
@@ -111,7 +111,7 @@ def SkrlVecEnvWrapper(
     if not isinstance(env.unwrapped, allowed_types):
         raise ValueError(
             "The environment must be inherited from ManagerBasedRLEnv, DirectRLEnv, DirectMARLEnv,"
-            f" DirectRLEnvWarp or ManagerBasedRLEnvWarp. Environment type: {type(env)}"
+            f" DirectRLEnvWarp or ManagerBasedRLEnvWarp. Environment type: {type(env.unwrapped)}"
         )
 
     # import statements according to the ML framework

--- a/source/isaaclab_rl/test/test_rsl_rl_wrapper_observations.py
+++ b/source/isaaclab_rl/test/test_rsl_rl_wrapper_observations.py
@@ -12,6 +12,7 @@ regression is caught before the Kit-dependent wrapper tests run.
 
 import inspect
 
+import pytest
 import torch
 from tensordict import TensorDict
 
@@ -26,6 +27,15 @@ class _FakeEnv:
     def __init__(self):
         self.unwrapped = self
         self.obs_buf = {"policy": torch.tensor([[1.0, 2.0], [3.0, 4.0]])}
+
+
+class _UnsupportedEnv:
+    pass
+
+
+class _OuterEnv:
+    def __init__(self):
+        self.unwrapped = _UnsupportedEnv()
 
 
 def _make_wrapper(env: _FakeEnv, num_envs: int = 2) -> RslRlVecEnvWrapper:
@@ -74,3 +84,12 @@ def test_direct_rl_env_stores_the_observation_buffer():
     """The environment side of the contract: reset and step both publish ``obs_buf``."""
     assert "self.obs_buf" in inspect.getsource(DirectRLEnv.reset)
     assert "self.obs_buf" in inspect.getsource(DirectRLEnv.step)
+
+
+def test_invalid_environment_error_reports_unwrapped_type():
+    """The validation error should identify the object that failed the type check."""
+    with pytest.raises(ValueError) as exc_info:
+        RslRlVecEnvWrapper(_OuterEnv())
+
+    assert "_UnsupportedEnv" in str(exc_info.value)
+    assert "_OuterEnv" not in str(exc_info.value)


### PR DESCRIPTION
# Description

Use the shared Isaac Lab environment creation path in all benchmark play adapters so `DirectMARLEnv` tasks follow the same backend-specific conversion rules as training.

This also:
- Adds the frontend argument required by the shared environment creator.
- Preserves native SKRL multi-agent handling for IPPO and MAPPO while converting PPO.
- Reports the rejected unwrapped environment type in RL wrapper validation errors.
- Adds focused regression coverage and package changelog fragments.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run --isolated --frozen --extra test python -m pytest source/isaaclab/test/benchmark/test_api.py source/isaaclab_rl/test/test_rsl_rl_wrapper_observations.py -q --disable-warnings` (31 passed)
- `uv run --frozen isaaclab -f`
- One-step `Isaac-Shadow-Handover-Direct` RSL-RL play benchmark with Newton MJWarp completed successfully.
- Isaac Sim PhysX smoke was not run because the optional installation requires interactive NVIDIA EULA acceptance.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the repository formatting and pre-commit checks with `uv run isaaclab -f`
- [x] No public documentation changes are required; the behavior changes are covered by changelog fragments
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
