### PR TITLE
[Performance] Cache unchanged local wrench composition

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-cache-local-wrench-composition.rst
+++ b/source/isaaclab/changelog.d/antoiner-cache-local-wrench-composition.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Avoided redundant :class:`WrenchComposer` kernel launches for unchanged local-frame wrenches.

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -66,6 +66,7 @@ class WrenchComposer:
         self._asset = asset
         self._active = False
         self._dirty = False
+        self._pose_dependent = False
         if hasattr(self._asset.data, "body_com_pos_w"):
             self._get_com_pos_fn = lambda a=self._asset: a.data.body_com_pos_w.warp
         else:
@@ -265,6 +266,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._pose_dependent = self._pose_dependent or is_global
 
         wp.launch(
             add_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -328,6 +330,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._pose_dependent = self._pose_dependent or is_global
 
         wp.launch(
             set_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -388,6 +391,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._pose_dependent = self._pose_dependent or is_global
 
         wp.launch(
             add_forces_to_dual_buffers_mask,
@@ -453,6 +457,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._pose_dependent = self._pose_dependent or is_global
 
         wp.launch(
             set_forces_to_dual_buffers_mask,
@@ -493,6 +498,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._pose_dependent = self._pose_dependent or other._pose_dependent
 
         wp.launch(
             add_raw_wrench_buffers,
@@ -519,8 +525,12 @@ class WrenchComposer:
         body frame, then adds local-frame contributions. After this call, ``out_force_b`` and ``out_torque_b``
         contain the final composed wrench.
 
-        The dirty flag is cleared after composition.
+        The dirty flag is cleared after composition. Repeated calls reuse the composed output when all inputs are
+        local-frame wrenches. Global-frame wrenches are recomposed because their body-frame values depend on pose.
         """
+        if not self._dirty and not self._pose_dependent:
+            return
+
         com_pos_w = self._get_com_pos_fn()
         link_quat_w = self._get_link_quat_fn()
 
@@ -571,6 +581,7 @@ class WrenchComposer:
             self._out_torque_b.zero_()
             self._active = False
             self._dirty = False
+            self._pose_dependent = False
         elif env_mask is not None:
             wp.launch(
                 reset_wrench_composer_mask,

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -1502,6 +1502,33 @@ def test_lazy_composition_tracks_dirty_flag(device: str):
 
 
 @pytest.mark.parametrize("device", test_devices())
+@pytest.mark.parametrize(("is_global", "expected_launches"), [(False, 1), (True, 2)])
+def test_repeated_composition_caches_only_local_wrenches(
+    device: str, is_global: bool, expected_launches: int, monkeypatch: pytest.MonkeyPatch
+):
+    """Repeated composition skips only pose-independent local-frame wrenches."""
+    mock_asset = create_mock_asset(num_envs=2, num_bodies=1, device=device)
+    composer = WrenchComposer(mock_asset)
+    forces = wp.ones((2, 1), dtype=wp.vec3f, device=device)
+    composer.add_forces_and_torques_index(forces=forces, is_global=is_global)
+
+    launch_count = 0
+    original_launch = wp.launch
+
+    def count_launches(*args, **kwargs):
+        nonlocal launch_count
+        launch_count += 1
+        return original_launch(*args, **kwargs)
+
+    monkeypatch.setattr(wp, "launch", count_launches)
+
+    composer.compose_to_body_frame()
+    composer.compose_to_body_frame()
+
+    assert launch_count == expected_launches
+
+
+@pytest.mark.parametrize("device", test_devices())
 def test_compose_is_idempotent(device: str):
     """Calling compose_to_body_frame twice without intervening writes produces the same result."""
     rng = np.random.default_rng(seed=456)


### PR DESCRIPTION
# Description

Avoids repeated WrenchComposer body-frame composition kernel launches when inputs have not changed and all wrenches are local-frame. A conservative pose-dependency flag keeps global and mixed wrench paths recomposing on every explicit call.

Addresses isaac-sim/IsaacLab-Internal#911.

No new dependencies.

## Performance

A writer-level spike with 4,096 environments measured:

- Newton: about 40–45% lower external-wrench writer time
- PhysX: about 60% lower external-wrench writer time

These measurements used mocked asset writers and do not claim an end-to-end task speedup. The regression test verifies one composition launch for repeated unchanged local wrenches and two launches for global wrenches.

## Type of change

- Performance improvement (non-breaking change)

## Release backport

- [x] Backport this pull request to the active release branch after it merges into develop

## Screenshots

Not applicable.

## Validation

- [x] WrenchComposer unit suite: 376 passed
- [x] Repository formatting and pre-commit checks passed
- [x] Changelog fragment validation passed

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have updated the affected method documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the optimization is effective
- [x] I have added an isaaclab changelog fragment
- [x] My name is already present in CONTRIBUTORS.md