### PR TITLE
Refresh default joint action offsets on reset

### DIFF
--- a/source/isaaclab/changelog.d/caesar-jojo-fix-joint-action-reset-offsets.rst
+++ b/source/isaaclab/changelog.d/caesar-jojo-fix-joint-action-reset-offsets.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed default joint action offsets not refreshing when environments reset.

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
@@ -195,6 +195,13 @@ class JointPositionAction(JointAction):
         if cfg.use_default_offset:
             self._offset = self._asset.data.default_joint_pos.torch[:, self._joint_ids].clone()
 
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        if self.cfg.use_default_offset:
+            if env_ids is None:
+                env_ids = slice(None)
+            self._offset[env_ids] = self._asset.data.default_joint_pos.torch[env_ids][:, self._joint_ids]
+
     def apply_actions(self):
         # set position targets
         self._asset.set_joint_position_target_index(target=self.processed_actions, joint_ids=self._joint_ids)
@@ -245,6 +252,13 @@ class JointVelocityAction(JointAction):
         # use default joint velocity as offset
         if cfg.use_default_offset:
             self._offset = self._asset.data.default_joint_vel.torch[:, self._joint_ids].clone()
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> None:
+        super().reset(env_ids)
+        if self.cfg.use_default_offset:
+            if env_ids is None:
+                env_ids = slice(None)
+            self._offset[env_ids] = self._asset.data.default_joint_vel.torch[env_ids][:, self._joint_ids]
 
     def apply_actions(self):
         # set joint velocity targets

--- a/source/isaaclab/test/envs/test_joint_actions.py
+++ b/source/isaaclab/test/envs/test_joint_actions.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from isaaclab.envs.mdp.actions.joint_actions import JointPositionAction, JointVelocityAction
+
+
+def _make_action(action_type, default_state: torch.Tensor, joint_ids, use_default_offset: bool = True):
+    action = object.__new__(action_type)
+    action._raw_actions = torch.ones(default_state.shape[0], 2)
+    action._offset = torch.full_like(action._raw_actions, -1.0)
+    action._joint_ids = joint_ids
+    action.cfg = SimpleNamespace(use_default_offset=use_default_offset)
+
+    state_name = "default_joint_pos" if action_type is JointPositionAction else "default_joint_vel"
+    action._asset = SimpleNamespace(data=SimpleNamespace(**{state_name: SimpleNamespace(torch=default_state)}))
+    return action
+
+
+@pytest.mark.parametrize(
+    ("action_type", "default_state"),
+    [
+        (JointPositionAction, torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]])),
+        (JointVelocityAction, torch.tensor([[0.0, -1.0, -2.0], [-3.0, -4.0, -5.0], [-6.0, -7.0, -8.0]])),
+    ],
+)
+def test_reset_refreshes_default_offset_for_selected_environments(action_type, default_state):
+    action = _make_action(action_type, default_state, torch.tensor([0, 2]))
+    env_ids = torch.tensor([1])
+
+    action.reset(env_ids)
+
+    torch.testing.assert_close(action._offset[1], default_state[1, [0, 2]])
+    torch.testing.assert_close(action._offset[[0, 2]], torch.full((2, 2), -1.0))
+    torch.testing.assert_close(action._raw_actions[1], torch.zeros(2))
+    torch.testing.assert_close(action._raw_actions[[0, 2]], torch.ones(2, 2))
+
+
+@pytest.mark.parametrize("action_type", [JointPositionAction, JointVelocityAction])
+def test_reset_refreshes_default_offset_for_all_environments(action_type):
+    default_state = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    action = _make_action(action_type, default_state, slice(None))
+
+    action.reset()
+
+    torch.testing.assert_close(action._offset, default_state)
+    torch.testing.assert_close(action._raw_actions, torch.zeros_like(action._raw_actions))
+
+
+@pytest.mark.parametrize("action_type", [JointPositionAction, JointVelocityAction])
+def test_reset_preserves_configured_offset(action_type):
+    default_state = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+    action = _make_action(action_type, default_state, slice(None), use_default_offset=False)
+
+    action.reset([0])
+
+    torch.testing.assert_close(action._offset, torch.full_like(action._offset, -1.0))
+    torch.testing.assert_close(action._raw_actions[0], torch.zeros(2))
+    torch.testing.assert_close(action._raw_actions[1], torch.ones(2))


### PR DESCRIPTION
# Description

Refresh the default offsets used by `JointPositionAction` and
`JointVelocityAction` during full and partial environment resets. This keeps
processed actions aligned with the articulation's current default joint state
after reset-time randomization.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- Regression test against the unmodified base: 4 failed, 2 passed.
- CPU-only regression test with the fix: 6 passed.
- Ruff lint and format checks passed.
- `py_compile` and `git diff --check` passed.
- Full pre-commit initialization was unavailable because Git-based network
  access is blocked in the test environment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] Documentation changes are not required because no public API changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for the touched package
- [ ] I have added my name to `CONTRIBUTORS.md` or my name already exists there