### PR TITLE
Fix USD-only replication without Kit

### DIFF
--- a/source/isaaclab/changelog.d/fix-kitless-usd-replication.rst
+++ b/source/isaaclab/changelog.d/fix-kitless-usd-replication.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed USD-only scene replication when running without Kit.

--- a/source/isaaclab/isaaclab/assets/asset_base_cfg.py
+++ b/source/isaaclab/isaaclab/assets/asset_base_cfg.py
@@ -54,7 +54,8 @@ class AssetBaseCfg:
     (for example, ``isaaclab_physx.cloner.PHYSICS_CONTEXT`` or
     ``isaaclab_ov.cloner.PHYSICS_CONTEXT``). An empty tuple requests no explicit context.
     :class:`~isaaclab.cloner.UsdReplicateContext` is still added automatically when ``spawn``
-    is set and Kit is available; listing it explicitly forces USD replication even without Kit.
+    is set and Kit is available or physics replication is disabled. Listing it explicitly forces
+    USD replication otherwise.
     """
 
     prim_path: str = MISSING

--- a/source/isaaclab/isaaclab/cloner/replicate_session.py
+++ b/source/isaaclab/isaaclab/cloner/replicate_session.py
@@ -52,9 +52,9 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
     Physics contexts come from :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts` when
     set, otherwise from the backend's ``PHYSICS_CONTEXT`` class.
     :class:`~isaaclab.cloner.UsdReplicateContext` is added automatically when the cfg has a
-    spawner and Kit is available. Explicit contexts are honored regardless of Kit availability.
-    With ``replicate_physics=False`` physics contexts are dropped; USD replication still fires
-    when the spawner+Kit condition is met or the cfg explicitly requests it.
+    spawner and Kit is available, or when physics replication is disabled. Explicit contexts
+    are honored regardless of Kit availability. With ``replicate_physics=False`` physics
+    contexts are dropped and replication is USD-only.
 
     Cfgs absent from ``plan.cfg_rows`` are silently skipped. Backend contexts run in
     ascending ``replicate_priority`` order. The queue is cleared up front, so a backend
@@ -65,7 +65,7 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
         plan: Replication layout to dispatch.
         stage: USD stage to author replicated prim specs into.
         replicate_physics: Whether physics replication clones each environment. If False,
-            cloning is USD-only; an asset whose contexts are all physics-based is not cloned.
+            spawned assets are cloned through USD only.
     """
     from isaaclab.sim import SimulationContext  # noqa: PLC0415
 
@@ -92,7 +92,7 @@ def replicate(plan: ClonePlan, *, stage: Usd.Stage, replicate_physics: bool = Tr
         if not replicate_physics:
             contexts = [c for c in contexts if c is UsdReplicateContext]
         ctx_set = dict.fromkeys(contexts)
-        if cfg.spawn is not None and kit_available:
+        if cfg.spawn is not None and (kit_available or not replicate_physics):
             ctx_set.setdefault(UsdReplicateContext, None)
         for BackendCtxCls in ctx_set:
             backend_rows.setdefault(BackendCtxCls, set()).update(rows)

--- a/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base_cfg.py
@@ -26,8 +26,8 @@ class SensorBaseCfg:
     """Cloning contexts for this sensor. Defaults to no explicit cloning context.
 
     Sensors carry no physics of their own. When the sensor has a spawner, USD replication is
-    added automatically under Kit. Listing :class:`~isaaclab.cloner.UsdReplicateContext`
-    explicitly forces USD replication without Kit; see
+    added automatically under Kit or when physics replication is disabled. Listing
+    :class:`~isaaclab.cloner.UsdReplicateContext` explicitly forces USD replication otherwise; see
     :attr:`~isaaclab.assets.AssetBaseCfg.cloning_contexts`.
     """
 

--- a/source/isaaclab/test/cloner/test_replicate_session.py
+++ b/source/isaaclab/test/cloner/test_replicate_session.py
@@ -23,13 +23,13 @@ def test_sensor_default_does_not_request_a_cloning_context():
 
 
 @pytest.mark.parametrize(
-    ("kit_available", "explicit_request", "expected_instances"),
-    [(False, False, 0), (False, True, 1), (True, False, 1)],
+    ("kit_available", "explicit_request", "replicate_physics", "expected_instances"),
+    [(False, False, True, 0), (False, True, True, 1), (True, False, True, 1), (False, False, False, 1)],
 )
 def test_replicate_distinguishes_automatic_and_explicit_usd_contexts(
-    monkeypatch, kit_available, explicit_request, expected_instances
+    monkeypatch, kit_available, explicit_request, replicate_physics, expected_instances
 ):
-    """Kit gates automatic USD cloning without overriding an explicit cfg request."""
+    """Kit or disabled physics replication enables automatic USD cloning."""
 
     class FakeUsdContext:
         replicate_priority = 100
@@ -68,7 +68,7 @@ def test_replicate_distinguishes_automatic_and_explicit_usd_contexts(
         global_paths=("/World/Ground", "/World/Light"),
     )
 
-    replicate_session.replicate(plan, stage=object())
+    replicate_session.replicate(plan, stage=object(), replicate_physics=replicate_physics)
 
     assert len(FakeUsdContext.instances) == expected_instances
     if FakeUsdContext.instances:


### PR DESCRIPTION
## Description

Fix USD-only scene replication when running without Kit. When `replicate_physics=False`, physics cloning contexts are removed, but the USD cloning context was previously added automatically only when Kit was available. Kitless backends could therefore receive no cloning context, leaving spawned assets present only in the source environment.

Add `UsdReplicateContext` for spawned assets whenever physics replication is disabled. This makes `replicate_physics=False` consistently mean USD-only replication for both Kit and kitless backends.

This core fix preserves the deformable lift presets because Isaac Sim PhysX still requires physics replication to be disabled for deformables. It also fixes the behavior for every kitless task instead of special-casing the four affected presets.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- Extended the existing cloner unit test with the kitless and `replicate_physics=False` case: 5 passed.
- Constructed `Isaac-Lift-Soft-Franka` with 32 environments using `physics=physx`.
- Ran one training iteration of `Isaac-Lift-Cloth-Franka` with 32 environments using `physics=physx`.
- Ran `uv run --frozen isaaclab -f`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`