### PR TITLE
Run Docker CI from PR comments on develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,6 +46,9 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 
 ## Checklist
 
+Docker and GPU tests run on demand. Push the commits you want tested, then
+comment `run-ci` on the pull request.
+
 - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
 - [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
 - [ ] I have made corresponding changes to the documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # region help
-# Every test job runs on every PR and merge queue candidate. Pushes to protected branches run the
-# post-merge integration tests.
+# Docker builds and their dependent tests run only on a labeled PR event, a push to a protected
+# branch, or a manual workflow dispatch. Do not filter the label with a job-level ``if``:
+# GitHub treats skipped required jobs as successful status checks.
+#
+# GitHub cannot filter label names at trigger time, so adding any label to a PR
+# starts this workflow. Only a ``ci:run-docker`` event cancels an in-flight run;
+# other label events queue behind it so that a triage label cannot cancel a
+# build whose required checks have already been reported.
+#
+# Pushes to protected branches still run the post-merge integration tests.
 #
 # =============================================================================
 # CI DEBUGGING TIPS
@@ -53,7 +61,7 @@ on:
       - develop
       - 'release/**'
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled]
     branches:
       - main
       - develop
@@ -63,7 +71,9 @@ on:
 # Concurrency control to prevent parallel runs on the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Push and workflow_dispatch events carry no label, so this stays false for them and
+  # preserves the post-merge runs that ``github.event_name == 'pull_request'`` used to protect.
+  cancel-in-progress: ${{ github.event.label.name == 'ci:run-docker' }}
 
 permissions:
   contents: read

--- a/.github/workflows/run-docker-ci.yml
+++ b/.github/workflows/run-docker-ci.yml
@@ -1,0 +1,107 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Run Docker CI Command
+run-name: Run Docker CI for PR #${{ github.event.issue.number }}
+
+on:
+  # GitHub always runs ``issue_comment`` workflows from the repository default
+  # branch, so this file has to land there for the ``run-ci`` command to work.
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: run-docker-ci-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  request-docker-ci:
+    name: Request Docker CI
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.body == 'run-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Authorize the request
+        id: authorize
+        env:
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          read -r pr_author pr_state head_sha < <(
+            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '[.user.login, .state, .head.sha] | @tsv'
+          )
+          if [ "$pr_state" != "open" ]; then
+            echo "::error::PR #$PR_NUMBER is not open."
+            exit 1
+          fi
+          if [ "${COMMENT_AUTHOR,,}" != "${pr_author,,}" ]; then
+            commenter_permission="$(
+              gh api "repos/$REPOSITORY/collaborators/$COMMENT_AUTHOR/permission" \
+                --jq '.permission' 2>/dev/null || printf 'none'
+            )"
+            case "$commenter_permission" in
+              admin|write) ;;
+              *)
+                echo "::error::Only PR author @$pr_author or a user with write access can request Docker CI."
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Create isaaclab-bot token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          client-id: ${{ secrets.CHANGELOG_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Trigger Docker CI
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.authorize.outputs.head_sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          LABEL: ci:run-docker
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # GitHub resolves the head when it processes the label, so labeling a
+          # PR whose head has already moved on builds a revision nobody asked
+          # for. Skip the request instead of spending GPU minutes on it.
+          head_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [ "$head_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER moved from ${EXPECTED_HEAD_SHA:0:7} to ${head_sha:0:7} while this request was processed. Comment 'run-ci' again to test the current head."
+            exit 1
+          fi
+
+          endpoint="repos/$REPOSITORY/issues/$PR_NUMBER/labels"
+          gh api --method DELETE "$endpoint/$LABEL" --silent >/dev/null 2>&1 || true
+          gh api --method POST "$endpoint" -f "labels[]=$LABEL" --silent
+          gh api --method DELETE "$endpoint/$LABEL" --silent
+
+          # A push can still land between the check above and GitHub processing
+          # the label; nothing can make those two steps atomic. Re-read the head
+          # so the mismatch is reported rather than silently testing a revision
+          # the requester never saw.
+          built_sha="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [ "$built_sha" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER moved to ${built_sha:0:7} as the label was applied, so Docker CI is testing that revision and not the requested ${EXPECTED_HEAD_SHA:0:7}. Comment 'run-ci' again to test the current head."
+            exit 1
+          fi
+
+          echo "Requested Docker CI for PR #$PR_NUMBER at ${EXPECTED_HEAD_SHA:0:7}." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Port #7059 to `develop`. Cherry-pick of 367e498138c233e56896f3deb818aaed8a094dd8 with the two `build.yaml` conflicts resolved against develop's copy.

@kellyguo11 — **draft, because merging this blocks every open `develop` PR until its author asks for CI.** Details under Impact. Timing and announcement are your call; I'll mark it ready when you say.

## Why

#7059 merged into `release/3.0.0-beta2` only. That branch is the repository default, so the `run-ci` command itself is already live everywhere: `issue_comment` workflows always run from the default branch. `build.yaml` is not, because `pull_request` workflows are read from the PR's merge ref, so develop's own copy governs develop PRs.

Two consequences today:

1. Docker and GPU CI still starts automatically on every `develop` push. 192 of the 198 open PRs target `develop`, so the change currently saves nothing on ~97% of PR traffic.
2. Worse: commenting `run-ci` on a `develop` PR **silently succeeds**. The command workflow authorizes, applies and removes `ci:run-docker`, and writes "Requested Docker CI for PR #N" to the step summary — but develop's `build.yaml` has no `labeled` trigger, so nothing starts. The requester gets a green check and no CI.

`release/3.0.0` is in the same state (2 open PRs). `main` carries a different, legacy workflow set and is unaffected.

## Conflict resolution

`develop`'s `build.yaml` has diverged substantially from `release/3.0.0-beta2`'s — develop has the `push:` post-merge trigger and the `detect-changes` composite action, beta2 has neither. The `types: [labeled]` change auto-merged; two hunks did not:

- **Trigger comment.** Kept develop's post-merge `push` path, which `release/3.0.0-beta2` does not have, folded into the new gating explanation.
- **`cancel-in-progress`.** Took the label expression over develop's `${{ github.event_name == 'pull_request' }}`. It is a strict superset here: `push` and `workflow_dispatch` carry no `github.event.label`, so it evaluates `false` for them and preserves exactly the post-merge protection the old expression provided. Noted inline so the next reader does not have to re-derive it.

`run-docker-ci.yml` is inert on `develop` — it only ever executes from the default branch — but is carried here anyway so the next release branch cut from `develop` keeps the command. Without it, `run-ci` dies repo-wide at the next release cut.

`detect-changes`'s `triggered-jobs-pr` text is step-summary-only and remains accurate, so it is unchanged.

## Impact

The `develop` ruleset (`refs/heads/develop` and `refs/heads/release/*`, enforcement active) requires `Build Base Docker Image`, `Build cuRobo Docker Image`, `test-curobo`, `rendering-correctness-kitless (legacy)`, `isaaclab (core) [1-3/3]` and the rest of the Docker-produced contexts. Every one of those is produced by `build.yaml`, so this port covers the required-checks surface completely.

Once this merges, those contexts are produced only by a labeled or dispatched run, so **every open `develop` PR sits on "Expected — waiting for status" until its author comments `run-ci`.** That is the intended design, not a regression, but it needs an announcement rather than a quiet merge.

## Out of scope — `build.yaml` is not develop's whole GPU surface

`develop` carries self-hosted workflows that `release/3.0.0-beta2` does not, and they still start automatically on `pull_request: [opened, synchronize, reopened]`:

| Workflow | Runner | Gate today | On beta2? |
|---|---|---|---|
| `kitless-docker.yml` | self-hosted | `detect-changes` only | no |
| `arm-ci.yml` | self-hosted | `detect-changes` only | no |
| `test-multi-gpu-pytest.yaml` | self-hosted | path filter | no |
| `test-multi-gpu.yaml` | self-hosted | path filter | yes |

None of these produce a required check, so this is purely a cost question rather than anything blocking. Left alone deliberately: extending `run-ci` to them is a separate decision with its own fallout, not something to fold into a port. Happy to do it in a follow-up if you want the gate to cover the whole GPU surface on `develop`.

## Validation

- `pre-commit` passes on all three changed files.
- Both workflows parse as YAML.
- **This PR tested the mechanism on itself, and the gate holds.** Because `pull_request` workflows load from the merge ref, and this PR's merge ref already contains `types: [labeled]`, `Docker + Tests` did not start when the PR opened — confirmed, no `Build Base Docker Image` / `test-curobo` / `isaaclab (core)` contexts are present, while the ungated `Kit-less Docker Image` and `Installation Tests` workflows did start. The required contexts stay missing until someone comments `run-ci` here, which exercises the full path end to end against `develop`: the command workflow runs from the default branch, authorizes, labels, and the merge ref's `build.yaml` picks the label up. If CI turns green on this PR after a `run-ci` comment, the port is proven.

Worth noting separately: #7059's command workflow has fired exactly once since merging (run 32997166039) and that run skipped at the `if`. The App-token path is still unproven in production on either branch, so a `run-ci` here doubles as its first real exercise.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
