### PR TITLE
[CI] Drop the stale Isaac Sim version comment from the pin

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -9,7 +9,6 @@
 # (frozen at 6.1.0-alpha.2). Both images use Isaac Sim's NGC org, which is current and
 # which the CI credential can reach.
 isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
-# Isaac Sim 6.1.0-alpha.50 (b86cf6ce) includes Kit 110.3.0-360924's fix for NVBug 6566677.
 isaacsim_image_tag: latest-develop@sha256:0944d66e9eb4b8f78574a70704d970ef4398fb7121b1fd865a27682b58f300bb
 isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""


### PR DESCRIPTION
## 1. Summary

Deletes the comment above `isaacsim_image_tag`. It named a specific Isaac Sim build, nothing
keeps it in sync with the pin, and it is now wrong.

`nightly-isaacsim-image.yml` bumps the pin with a `sed` that matches `^isaacsim_image_tag:` and
rewrites the digest on that line only:

```bash
sed -i -E "s|^(isaacsim_image_tag: $SOURCE_TAG@sha256:)[0-9a-f]{64}$|\1$digest_value|" "$CONFIG_PATH"
```

The comment is never touched and nothing validates it.

## 2. Type of change

- Bug fix (non-breaking change which fixes an issue)

## 3. Design notes

Written in #7053 ("Use Isaac Sim alpha.50"). Two digest bumps have landed since — #7070 and
#7310 — and it still claimed `alpha.50` / Kit `110.3.0-360924`.

The pinned digest actually resolves to **`6.1.0-alpha.64+develop.47818.d8c9099e.gl`**, read from
the image itself:

```bash
docker run --rm --entrypoint cat \
  nvcr.io/0947644777160149/internal/isaac-sim@sha256:0944d66e... /isaac-sim/VERSION
```

So the comment is fourteen alpha versions behind, and it points the wrong way on a live question:
Kit `360924` predates `110.3.0-361511`, which fixes NVBug 6565122 (multi-GPU SIGSEGV when the
CUDA device set spans a non-P2P boundary). Read literally, the comment says CI cannot have that
fix. It can: a four-rank camera-training run across the socket boundary (GPUs `0,1,4,5`)
completes on this image -- `isaacsim_physx,isaacsim_rtx` in 27.4 s and
`newton_mjwarp,isaacsim_rtx` in 58.6 s -- where it previously died with `SIGSEGV 139`.

Deleted rather than corrected: any replacement naming a version rots on the next nightly bump,
for the same reason. The digest is the identity, and it can be resolved when needed:

```bash
docker buildx imagetools inspect <image>@<digest>
```

## 4. Validation

`config.yaml` still parses and `isaacsim_image_tag` is byte-identical. Comment-only change:
1 deletion, 0 additions.

## 5. Screenshots

None.

## 6. Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation — comment-only change
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — not testable; a comment
- [ ] I have updated the changelog — CI-only change, no release note
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
