### PR TITLE
Fixes configclass field ordering with mixed annotated members

### DIFF
--- a/source/isaaclab/config/extension.toml
+++ b/source/isaaclab/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.54.4"
+version = "0.54.5"
 
 # Description
 title = "Isaac Lab framework for Robot Learning"

--- a/source/isaaclab/docs/CHANGELOG.rst
+++ b/source/isaaclab/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.54.5 (2026-08-27)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.utils.configclass.configclass` reordering configuration members when a
+  class mixes members with and without explicit type annotations. Previously, explicitly annotated
+  members were hoisted to the front of the field ordering, regardless of their declaration
+  position. Since the ordering of a config instance's ``__dict__`` determines the iteration order
+  of manager terms (e.g. the concatenation order of observation terms in
+  :class:`~isaaclab.managers.observation_manager.ObservationManager`), this could silently
+  scramble the observation vector between training and deployment. Members now always follow
+  their declaration order, with base class members ordered before child class members.
+
+
 0.54.4 (2026-06-01)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -207,35 +207,44 @@ def _add_annotation_types(cls):
             continue
         # get base class annotations
         ann = base.__dict__.get("__annotations__", {})
-        # directly add all annotations from base class
-        hints.update(ann)
-        # iterate over base class members
+        # iterate over base class members in their declaration order
         # Note: Do not change this to dir(base) since it orders the members alphabetically.
         #   This is not desirable since the order of the members is important in some cases.
         for key in base.__dict__:
             # get class member
             value = getattr(base, key)
+            # keep members with explicit type annotations at their declaration position.
+            # note: re-assigning an existing key preserves its position in the dictionary, which
+            #   matches the dataclass behavior for fields overridden in a subclass.
+            if key in ann:
+                hints[key] = ann[key]
+                continue
             # skip members
             if _skippable_class_member(key, value, hints):
                 continue
             # add type annotations for members that don't have explicit type annotations
             # for these, we deduce the type from the default value
             if not isinstance(value, type):
-                if key not in hints:
-                    # check if var type is not MISSING
-                    # we cannot deduce type from MISSING!
-                    if value is MISSING:
-                        raise TypeError(
-                            f"Missing type annotation for '{key}' in class '{cls.__name__}'."
-                            " Please add a type annotation or set a default value."
-                        )
-                    # add type annotation
-                    hints[key] = type(value)
+                # check if var type is not MISSING
+                # we cannot deduce type from MISSING!
+                if value is MISSING:
+                    raise TypeError(
+                        f"Missing type annotation for '{key}' in class '{cls.__name__}'."
+                        " Please add a type annotation or set a default value."
+                    )
+                # add type annotation
+                hints[key] = type(value)
             elif key != value.__name__:
                 # note: we don't want to add type annotations for nested configclass. Thus, we check if
                 #   the name of the type matches the name of the variable.
                 # since Python 3.10, type hints are stored as strings
                 hints[key] = f"type[{value.__name__}]"
+        # add members that only have a type annotation and no default value
+        # note: these members are not present in the class ``__dict__``, so they cannot be
+        #   positioned among the other members. They are appended in their annotation order.
+        for key in ann:
+            if key not in hints:
+                hints[key] = ann[key]
 
     # Note: Do not change this line. `cls.__dict__.get("__annotations__", {})` is different from
     #   `cls.__annotations__` because of inheritance.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -241,10 +241,10 @@ def _add_annotation_types(cls):
                 hints[key] = f"type[{value.__name__}]"
         # add members that only have a type annotation and no default value
         # note: these members are not present in the class ``__dict__``, so they cannot be
-        #   positioned among the other members. They are appended in their annotation order.
+        #   positioned among the other members. Re-assigning an existing key preserves its
+        #   position, so a subclass can still refine the annotation of an inherited member.
         for key in ann:
-            if key not in hints:
-                hints[key] = ann[key]
+            hints[key] = ann[key]
 
     # Note: Do not change this line. `cls.__dict__.get("__annotations__", {})` is different from
     #   `cls.__annotations__` because of inheritance.

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -209,6 +209,36 @@ class InheritedMixedAnnotationOrderingDemoCfg(MixedAnnotationOrderingDemoCfg):
     go2: RobotDefaultStateCfg = RobotDefaultStateCfg()
 
 
+@configclass
+class ParentAnnotatedDemoCfg:
+    """Parent config class with explicitly annotated members."""
+
+    x: int = MISSING
+    func: Callable = MISSING
+
+
+@configclass
+class ChildUnannotatedOverrideDemoCfg(ParentAnnotatedDemoCfg):
+    """Child config class overriding annotated members without type annotations."""
+
+    x = 5
+    func = dummy_function1
+
+
+@configclass
+class ParentInferredDemoCfg:
+    """Parent config class with an inferred (non-annotated) member."""
+
+    a = 1
+
+
+@configclass
+class ChildReannotatedDemoCfg(ParentInferredDemoCfg):
+    """Child config class refining an inherited member with an annotation-only re-declaration."""
+
+    a: float
+
+
 """
 Dummy configuration: Inheritance
 """
@@ -844,6 +874,22 @@ def test_configclass_mixed_annotation_ordering():
     expected_inherited_order = ["anymal", "unitree", "franka", "spot", "go2"]
     assert list(cfg_inherited.__dict__.keys()) == expected_inherited_order
     assert list(cfg_inherited.to_dict().keys()) == expected_inherited_order
+
+
+def test_configclass_inherited_annotation_override():
+    """Checks that subclass overrides interact correctly with inherited type annotations."""
+    # unannotated overrides keep the inherited annotations
+    cfg = ChildUnannotatedOverrideDemoCfg()
+    assert cfg.x == 5
+    assert cfg.func == dummy_function1
+    # note: since python 3.10, annotations are stored as strings
+    assert cfg.__annotations__["x"] == "int"
+    assert cfg.__annotations__["func"] == "Callable"
+
+    # annotation-only re-declaration refines the inherited annotation
+    cfg_reannotated = ChildReannotatedDemoCfg()
+    assert cfg_reannotated.a == 1
+    assert cfg_reannotated.__annotations__["a"] == "float"
 
 
 def test_functions_config():

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -19,7 +19,7 @@ simulation_app = AppLauncher(headless=True).app
 import copy
 import os
 from collections.abc import Callable
-from dataclasses import MISSING, asdict, field
+from dataclasses import MISSING, asdict, field, fields
 from functools import wraps
 from typing import Any, ClassVar
 
@@ -181,6 +181,32 @@ class InheritedNonTypeAnnotationOrderingDemoCfg(NonTypeAnnotationOrderingDemoCfg
     """Inherited config class without type annotations."""
 
     pass
+
+
+@configclass
+class MixedAnnotationOrderingDemoCfg:
+    """Config class with mixed annotated and non-annotated members."""
+
+    anymal = RobotDefaultStateCfg()
+    unitree: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    franka = RobotDefaultStateCfg()
+
+
+@configclass
+class MixedAnnotationOrderingFirstDemoCfg:
+    """Config class where the annotated member is declared first."""
+
+    anymal: RobotDefaultStateCfg = RobotDefaultStateCfg()
+    unitree = RobotDefaultStateCfg()
+    franka = RobotDefaultStateCfg()
+
+
+@configclass
+class InheritedMixedAnnotationOrderingDemoCfg(MixedAnnotationOrderingDemoCfg):
+    """Inherited config class that adds both annotated and non-annotated members."""
+
+    spot = RobotDefaultStateCfg()
+    go2: RobotDefaultStateCfg = RobotDefaultStateCfg()
 
 
 """
@@ -785,6 +811,39 @@ def test_configclass_type_ordering():
     assert list(cfg_1.__dict__.keys()) == list(cfg_2.__dict__.keys())
     assert list(cfg_3.__dict__.keys()) == list(cfg_2.__dict__.keys())
     assert list(cfg_1.__dict__.keys()) == list(cfg_3.__dict__.keys())
+
+
+def test_configclass_mixed_annotation_ordering():
+    """Checks ordering of config objects when mixing annotated and non-annotated members.
+
+    Regression test: previously, explicitly annotated members were hoisted to the front of the
+    field ordering, regardless of their declaration position. This silently changed the order in
+    which managers iterate over the config members (e.g. the concatenation order of observation
+    terms in the observation manager).
+    """
+    expected_order = ["anymal", "unitree", "franka"]
+
+    # check ordering when the annotated member is declared in the middle
+    cfg = MixedAnnotationOrderingDemoCfg()
+    assert list(cfg.__dict__.keys()) == expected_order
+    assert list(cfg.__annotations__.keys()) == expected_order
+    assert [f.name for f in fields(cfg)] == expected_order
+
+    # check ordering is conserved when converting to dictionary
+    assert list(cfg.to_dict().keys()) == expected_order
+    assert list(class_to_dict(cfg).keys()) == expected_order
+
+    # check ordering when the annotated member is declared first
+    cfg_first = MixedAnnotationOrderingFirstDemoCfg()
+    assert list(cfg_first.__dict__.keys()) == expected_order
+    assert list(cfg_first.to_dict().keys()) == expected_order
+
+    # check ordering with inheritance: base class members come first, then child class members,
+    # each in their respective declaration order
+    cfg_inherited = InheritedMixedAnnotationOrderingDemoCfg()
+    expected_inherited_order = ["anymal", "unitree", "franka", "spot", "go2"]
+    assert list(cfg_inherited.__dict__.keys()) == expected_inherited_order
+    assert list(cfg_inherited.to_dict().keys()) == expected_inherited_order
 
 
 def test_functions_config():


### PR DESCRIPTION
# Description

When a `@configclass` mixes members with and without explicit type annotations,
`_add_annotation_types` hoisted all explicitly annotated members to the front of
`__annotations__` (via `hints.update(ann)` before iterating the class `__dict__`).
The generated dataclass fields — and therefore the instance `__dict__` — no longer
followed the member declaration order.

## Why this matters

Managers iterate over config members in `__dict__` order. For example,
`ObservationManager._prepare_terms` assembles observation terms via
`group_cfg.__dict__.items()`, so the scrambled ordering **silently changes the
concatenation order of the observation vector**. A config like

```python
@configclass
class PolicyCfg(ObsGroup):
    base_lin_vel: ObsTerm = ObsTerm(func=...)
    gait_phase: ObsTerm | None = None   # the only explicitly annotated member
    joint_pos = ObsTerm(func=...)
    actions = ObsTerm(func=...)