### PR TITLE
Resolve Isaac Lab paths from installed layouts

### DIFF
--- a/source/isaaclab/changelog.d/installed-path-resolution.rst
+++ b/source/isaaclab/changelog.d/installed-path-resolution.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Isaac Lab path resolution when ``apps`` and ``scripts`` are installed outside the editable source checkout layout.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -37,6 +37,7 @@ from isaaclab.app.loading_screen import report_activity
 from isaaclab.app.logging_utils import apply_python_logging_level, resolve_python_logging_level
 from isaaclab.app.settings_manager import get_settings_manager, initialize_carb_settings
 from isaaclab.utils._device import set_cuda_device
+from isaaclab.utils.path import resolve_isaaclab_path
 from isaaclab.utils.renderers import ISAAC_RTX_SHOW_ALL_PARTITIONS_BY_DEFAULT_SETTING
 
 # import logger
@@ -1180,7 +1181,7 @@ class AppLauncher:
                 ) from e
             kit_app_exp_path = os.path.join(os.path.dirname(_isaacsim_for_paths.__file__), "apps")
             os.environ["EXP_PATH"] = kit_app_exp_path
-        isaaclab_app_exp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), *[".."] * 4, "apps")
+        isaaclab_app_exp_path = os.path.join(resolve_isaaclab_path(__file__), "apps")
         # For Isaac Sim 4.5 compatibility, we use the 4.5 app files in a different folder
         # if launcher_args.get("use_isaacsim_45", False):
         if self.is_isaac_sim_version_5():

--- a/source/isaaclab/isaaclab/cli/utils.py
+++ b/source/isaaclab/isaaclab/cli/utils.py
@@ -13,8 +13,10 @@ import time
 from pathlib import Path
 from typing import IO, Any
 
+from isaaclab.utils.path import resolve_isaaclab_path
+
 # Path to Isaac Lab installation.
-ISAACLAB_ROOT = Path(__file__).parents[4].resolve()
+ISAACLAB_ROOT = resolve_isaaclab_path(__file__)
 
 # Default path to look for Isaac Sim is _isaac_sim symlink.
 DEFAULT_ISAAC_SIM_PATH = ISAACLAB_ROOT / "_isaac_sim"

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -29,6 +29,8 @@ from urllib.parse import urlparse
 
 from filelock import FileLock
 
+from isaaclab.utils.path import resolve_isaaclab_path
+
 logger = logging.getLogger(__name__)
 
 _UDIM_RE = re.compile(r"<UDIM>", re.IGNORECASE)
@@ -42,9 +44,7 @@ _MDL_RELATIVE_IMPORT_RE = re.compile(
 )
 
 
-_KIT_EXPERIENCE_PATH = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), *([".."] * 4), "apps", "isaaclab.python.kit")
-)
+_KIT_EXPERIENCE_PATH = os.path.normpath(resolve_isaaclab_path(__file__) / "apps" / "isaaclab.python.kit")
 
 # Isaac Sim resolves ``persistent.isaac.asset_root.default``, so it is read first. The
 # legacy ``cloud`` setting is only consulted for experience files that predate it.

--- a/source/isaaclab/isaaclab/utils/path.py
+++ b/source/isaaclab/isaaclab/utils/path.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Utilities for resolving Isaac Lab installation paths."""
+
+import os
+from pathlib import Path
+
+import isaaclab
+
+ISAACLAB_PATH_ENV_VAR = "ISAACLAB_PATH"
+
+
+def resolve_isaaclab_path(package_file: str | Path = __file__) -> Path:
+    """Resolve the Isaac Lab installation path.
+
+    Args:
+        package_file: File inside or below the ``isaaclab`` Python package.
+
+    Returns:
+        Path to the Isaac Lab installation root.
+    """
+    if isaaclab_path := os.environ.get(ISAACLAB_PATH_ENV_VAR):
+        return Path(isaaclab_path).expanduser().resolve()
+
+    package_path = Path(package_file).resolve()
+    if checkout_root := _find_source_checkout_root(package_path):
+        return checkout_root
+
+    if isaaclab.__file__ is not None:
+        package_root = Path(isaaclab.__file__).resolve().parent
+        if _has_installed_resources(package_root):
+            return package_root
+
+    return package_path.parents[4]
+
+
+def _find_source_checkout_root(package_path: Path) -> Path | None:
+    """Find the source checkout root containing a package file."""
+    for parent in package_path.parents:
+        if (parent / "apps").is_dir() and (parent / "scripts").is_dir():
+            return parent
+    return None
+
+
+def _has_installed_resources(path: Path) -> bool:
+    """Return whether an installed package root carries Isaac Lab resources."""
+    return (path / "apps").is_dir()

--- a/source/isaaclab/test/utils/test_path.py
+++ b/source/isaaclab/test/utils/test_path.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Isaac Lab path resolution."""
+
+from pathlib import Path
+
+import pytest
+
+from isaaclab.utils.path import ISAACLAB_PATH_ENV_VAR, resolve_isaaclab_path
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_isaaclab_path_uses_environment_variable(monkeypatch, tmp_path):
+    """An explicit install path is authoritative outside source-checkout layouts."""
+    install_root = tmp_path / "share" / "isaaclab"
+    monkeypatch.setenv(ISAACLAB_PATH_ENV_VAR, str(install_root))
+
+    assert resolve_isaaclab_path() == install_root
+
+
+def test_resolve_isaaclab_path_keeps_source_checkout_layout(monkeypatch):
+    """The editable checkout layout remains the default when ``ISAACLAB_PATH`` is unset."""
+    monkeypatch.delenv(ISAACLAB_PATH_ENV_VAR, raising=False)
+    test_file = Path(__file__).resolve()
+    package_file = test_file.parents[2] / "isaaclab" / "utils" / "nested" / "path.py"
+
+    assert resolve_isaaclab_path(package_file) == test_file.parents[4]
+
+
+def test_resolve_isaaclab_path_detects_installed_package_layout(monkeypatch, tmp_path):
+    """Installed wheels can carry ``apps`` next to the Python package."""
+    monkeypatch.delenv(ISAACLAB_PATH_ENV_VAR, raising=False)
+    site_package = tmp_path / "site-packages" / "isaaclab"
+    (site_package / "apps").mkdir(parents=True)
+    package_file = site_package / "utils" / "path.py"
+    package_file.parent.mkdir()
+    package_file.touch()
+
+    monkeypatch.setattr("isaaclab.__file__", site_package / "__init__.py")
+
+    assert resolve_isaaclab_path(package_file) == site_package


### PR DESCRIPTION
# Description

Isaac Lab resolves the `apps` and `scripts` directories relative to the editable source checkout. When the package is installed outside that layout (for example from a wheel or a conda package that lays the tree out differently), the CLI and the app launcher point at paths that do not exist. This adds a small resolver that finds these directories from `ISAACLAB_PATH` first, then from a source checkout, and finally from the installed package layout, so both the editable and the installed cases work.

The change adds `isaaclab/utils/path.py` with the resolver and routes `cli/utils.py`, `utils/assets.py`, and `app/app_launcher.py` through it. No public API changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there