### PR TITLE
Gate checkout-only tests with a root fixture

### DIFF
--- a/source/isaaclab/changelog.d/skip-checkout-only-unit-tests.skip
+++ b/source/isaaclab/changelog.d/skip-checkout-only-unit-tests.skip
@@ -1,0 +1,1 @@
+Test-only: added a source checkout root fixture for tests that inspect repository artifacts.

--- a/source/isaaclab/test/app/test_experience_files.py
+++ b/source/isaaclab/test/app/test_experience_files.py
@@ -12,19 +12,17 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-APPS_DIR = Path(__file__).resolve().parents[4] / "apps"
-
 # ``.kit`` files repeat section headers, so they cannot be parsed as TOML.
 _SECTION_RE = re.compile(r"^\s*\[+(?P<name>[^\[\]]+)\]+\s*$")
 _DEPENDENCY_RE = re.compile(r'^\s*"(?P<name>[^"]+)"\s*=')
 
 
-def _kit_dependencies(experience: str) -> set[str]:
+def _kit_dependencies(apps_dir: Path, experience: str) -> set[str]:
     """Collect the extension names declared in an experience file's dependency sections."""
     dependencies: set[str] = set()
     in_dependencies = False
 
-    for line in (APPS_DIR / experience).read_text(encoding="utf-8").splitlines():
+    for line in (apps_dir / experience).read_text(encoding="utf-8").splitlines():
         section = _SECTION_RE.match(line)
         if section is not None:
             in_dependencies = section.group("name").strip() == "dependencies"
@@ -38,9 +36,9 @@ def _kit_dependencies(experience: str) -> set[str]:
 
 
 @pytest.mark.parametrize("experience", ["isaaclab.python.kit", "isaaclab.python.headless.kit"])
-def test_base_experiences_enable_native_storage(experience: str):
+def test_base_experiences_enable_native_storage(source_checkout_root: Path, experience: str):
     """Test the base experiences load the extension that applies ``ISAACSIM_ASSET_ROOT``."""
-    assert "isaacsim.storage.native" in _kit_dependencies(experience)
+    assert "isaacsim.storage.native" in _kit_dependencies(source_checkout_root / "apps", experience)
 
 
 @pytest.mark.parametrize(
@@ -52,6 +50,6 @@ def test_base_experiences_enable_native_storage(experience: str):
         ("isaaclab.python.xr.openxr.headless.kit", "isaaclab.python.xr.openxr"),
     ],
 )
-def test_derived_experiences_inherit_native_storage(experience: str, base: str):
+def test_derived_experiences_inherit_native_storage(source_checkout_root: Path, experience: str, base: str):
     """Test the derived experiences inherit native storage from a base experience."""
-    assert base in _kit_dependencies(experience)
+    assert base in _kit_dependencies(source_checkout_root / "apps", experience)

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -476,11 +476,12 @@ class TestPinkIkStack:
     stack from there instead of mirroring the versions.
     """
 
-    def test_stack_derived_from_root_pyproject_pins(self):
+    def test_stack_derived_from_root_pyproject_pins(self, source_checkout_root: Path):
         """The derived stack covers every stack package, exactly pinned, markers stripped."""
         from isaaclab.cli.commands import install
 
-        stack = install._pink_ik_stack()
+        with mock.patch.object(install, "ISAACLAB_ROOT", source_checkout_root):
+            stack = install._pink_ik_stack()
         assert [install._requirement_name(r) for r in stack] == list(install._PINK_IK_PACKAGES)
         assert any(r.startswith("pin-pink==") for r in stack), "pin-pink must stay exactly pinned"
         assert any(r.startswith("daqp==") for r in stack), "daqp must stay exactly pinned"

--- a/source/isaaclab/test/cli/test_source_package_metadata.py
+++ b/source/isaaclab/test/cli/test_source_package_metadata.py
@@ -15,22 +15,14 @@ import tomllib
 pytestmark = pytest.mark.unit
 
 
-def _repo_root() -> Path:
-    """Find the Isaac Lab repository root from this test file."""
-    for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file() and (parent / "source").is_dir():
-            return parent
-    raise RuntimeError("Could not find Isaac Lab repository root.")
-
-
-def test_isaaclab_uses_one_standalone_usd_provider():
+def test_isaaclab_uses_one_standalone_usd_provider(source_checkout_root: Path):
     """Isaac Lab must install only the USD provider shared with its importer dependencies.
 
     ``usd-core`` and ``usd-exchange`` each install a complete ``pxr`` into the same directory, so
     a second provider silently overwrites the first and removing either one leaves ``pxr`` broken.
     Nothing detects that, because the two are separate distributions.
     """
-    with (_repo_root() / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
     dependencies = pyproject["project"]["dependencies"]
@@ -43,14 +35,14 @@ def test_isaaclab_uses_one_standalone_usd_provider():
     assert usd_providers == ["usd-exchange==2.3.0"]
 
 
-def test_resolved_environment_has_no_second_usd_provider():
+def test_resolved_environment_has_no_second_usd_provider(source_checkout_root: Path):
     """No dependency may pull ``usd-core`` back in behind an extra.
 
     ``newton[importers]``, ``mujoco[usd]`` and ``warp-lang[examples]`` all require it, so selecting
     any of them would reinstate the overlap that the direct dependencies avoid. Checking the lock
     catches that, where checking ``pyproject.toml`` alone would not.
     """
-    with (_repo_root() / "uv.lock").open("rb") as f:
+    with (source_checkout_root / "uv.lock").open("rb") as f:
         lock = tomllib.load(f)
 
     locked = {package["name"] for package in lock["package"]}
@@ -59,9 +51,9 @@ def test_resolved_environment_has_no_second_usd_provider():
     assert "usd-exchange" in locked
 
 
-def test_standalone_importers_are_opt_in():
+def test_standalone_importers_are_opt_in(source_checkout_root: Path):
     """Standalone URDF/MJCF importers must not constrain the base environment."""
-    with (_repo_root() / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
 
     project = pyproject["project"]

--- a/source/isaaclab/test/cli/test_teleop_entrypoints.py
+++ b/source/isaaclab/test/cli/test_teleop_entrypoints.py
@@ -47,7 +47,7 @@ def test_teleop_workflow_help_exposes_task_preset_selectors(command, script_part
 
 
 @pytest.mark.parametrize(("command", "script_parts"), TELEOP_WORKFLOWS.items())
-def test_teleop_dispatches_to_an_existing_script(command, script_parts):
+def test_teleop_dispatches_to_an_existing_script(source_checkout_root: Path, command, script_parts):
     """``isaaclab teleop`` forwards the remaining arguments to a script that exists."""
     args = [command, "--task", "IsaacContrib-PickPlace-Locomanipulation-G1-Abs", "--xr"]
 
@@ -57,7 +57,7 @@ def test_teleop_dispatches_to_an_existing_script(command, script_parts):
     ):
         cli.cli()
 
-    script = cli.ISAACLAB_ROOT.joinpath(*script_parts)
+    script = source_checkout_root.joinpath(*script_parts)
     run_python.assert_called_once_with(script, args[1:], check=True)
     assert script.is_file()
 
@@ -73,21 +73,21 @@ def _requirement_names(requirements: list[str]) -> set[str]:
 
 
 @pytest.mark.parametrize(("command", "script_parts"), TELEOP_WORKFLOWS.items())
-def test_teleop_workflow_isaaclab_imports_are_covered_by_the_extras(command, script_parts):
+def test_teleop_workflow_isaaclab_imports_are_covered_by_the_extras(source_checkout_root: Path, command, script_parts):
     """Every ``isaaclab_*`` package a teleop script imports must ship with the extras.
 
     ``record_demos.py`` imports ``isaaclab_mimic`` at module level, so an environment built
     from ``--extra teleop`` alone used to die with ``ModuleNotFoundError`` only after Isaac Sim
     had finished booting. This catches that class of gap without needing an install.
     """
-    with (cli.ISAACLAB_ROOT / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         pyproject = tomllib.load(f)
     project = pyproject["project"]
 
     available = _requirement_names(project["dependencies"])
     available |= _requirement_names(project["optional-dependencies"]["teleop"])
 
-    source = Path(cli.ISAACLAB_ROOT).joinpath(*script_parts).read_text(encoding="utf-8")
+    source = source_checkout_root.joinpath(*script_parts).read_text(encoding="utf-8")
     imported = set(re.findall(r"^\s*(?:import|from)\s+(isaaclab_\w+)", source, re.MULTILINE))
 
     missing = imported - available

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -16,34 +16,26 @@ import tomllib
 pytestmark = pytest.mark.unit
 
 
-def _repo_root() -> Path:
-    """Find the Isaac Lab repository root from this test file."""
-    for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file() and (parent / "source").is_dir():
-            return parent
-    raise RuntimeError("Could not find Isaac Lab repository root.")
-
-
-def _root_pyproject() -> dict:
+def _root_pyproject(source_checkout_root: Path) -> dict:
     """Load the root development ``pyproject.toml``."""
-    with (_repo_root() / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         return tomllib.load(f)
 
 
-def test_uv_run_extra_names_match_documented_workflow():
+def test_uv_run_extra_names_match_documented_workflow(source_checkout_root: Path):
     """Docs must only reference ``uv run --extra`` names that pyproject defines."""
-    repo_root = _repo_root()
+    repo_root = source_checkout_root
     docs = (repo_root / "docs/source/setup/installation/index.rst").read_text(encoding="utf-8")
     documented_extras = set(re.findall(r"--extra\s+([A-Za-z0-9_-]+)", docs))
-    optional_dependencies = _root_pyproject()["project"]["optional-dependencies"]
+    optional_dependencies = _root_pyproject(source_checkout_root)["project"]["optional-dependencies"]
 
     assert documented_extras
     assert documented_extras <= set(optional_dependencies)
 
 
-def test_uv_run_exposes_centralized_feature_extras():
+def test_uv_run_exposes_centralized_feature_extras(source_checkout_root: Path):
     """The root project centralizes optional third-party deps into named extras."""
-    optional_dependencies = _root_pyproject()["project"]["optional-dependencies"]
+    optional_dependencies = _root_pyproject(source_checkout_root)["project"]["optional-dependencies"]
 
     # Feature extras a user can activate with ``uv run --extra``.
     expected_extras = {
@@ -84,9 +76,9 @@ def test_uv_run_exposes_centralized_feature_extras():
     assert any(dep.startswith("ovstage") for dep in optional_dependencies["ovrtx"])
 
 
-def test_all_extra_aggregates_curated_ov_rl_and_visualizer_extras():
+def test_all_extra_aggregates_curated_ov_rl_and_visualizer_extras(source_checkout_root: Path):
     """``all`` aggregates only the curated OV, RL, and visualizer extras."""
-    optional = _root_pyproject()["project"]["optional-dependencies"]
+    optional = _root_pyproject(source_checkout_root)["project"]["optional-dependencies"]
 
     assert len(optional["all"]) == 1
     aggregated = set(re.fullmatch(r"isaaclab-dev\[(.+)\]", optional["all"][0]).group(1).split(","))
@@ -108,9 +100,9 @@ def test_all_extra_aggregates_curated_ov_rl_and_visualizer_extras():
     }
 
 
-def test_tetrahedralization_is_explicit_extra_only():
+def test_tetrahedralization_is_explicit_extra_only(source_checkout_root: Path):
     """TetWild and its visualization stack are installed only when requested."""
-    project = _root_pyproject()["project"]
+    project = _root_pyproject(source_checkout_root)["project"]
     optional = project["optional-dependencies"]
 
     assert not any(dep.startswith("pytetwild") for dep in project["dependencies"])
@@ -122,14 +114,14 @@ def test_tetrahedralization_is_explicit_extra_only():
         assert not any("tetrahedralization" in dep or dep.startswith("pytetwild") for dep in deps)
 
 
-def test_version_single_source_matches_literal_pins():
+def test_version_single_source_matches_literal_pins(source_checkout_root: Path):
     """``[tool.isaaclab.versions]`` is the single source for externally-pinned versions.
 
     TOML cannot interpolate, so the literal pins in ``[project.dependencies]``,
     ``[project.optional-dependencies]``, and ``[tool.uv].override-dependencies`` must
     mirror the table exactly. This test fails if any of them drift apart.
     """
-    pyproject = _root_pyproject()
+    pyproject = _root_pyproject(source_checkout_root)
     versions = pyproject["tool"]["isaaclab"]["versions"]
     dependencies = pyproject["project"]["dependencies"]
     optional = pyproject["project"]["optional-dependencies"]
@@ -156,7 +148,7 @@ def test_version_single_source_matches_literal_pins():
     # ovrtx`` ignores this ceiling). Each such install must therefore be pinned:
     # either by carrying the literal range, or by referencing the ``resolve-ov-pins``
     # action output, which reads the pin from this same table. Never a bare ``ovrtx``.
-    build_workflow = (_repo_root() / ".github/workflows/build.yaml").read_text(encoding="utf-8")
+    build_workflow = (source_checkout_root / ".github/workflows/build.yaml").read_text(encoding="utf-8")
     assert "ovphysx==0.4.13" not in build_workflow
     ovrtx_install_lines = [
         line.strip() for line in build_workflow.splitlines() if "extra-pip-packages:" in line and "ovrtx" in line
@@ -179,9 +171,9 @@ def test_version_single_source_matches_literal_pins():
     assert warp_spec in dependencies
 
 
-def test_public_ov_packages_use_public_pypi_index():
+def test_public_ov_packages_use_public_pypi_index(source_checkout_root: Path):
     """Public OV packages must not resolve from the NVIDIA package index."""
-    pyproject = _root_pyproject()
+    pyproject = _root_pyproject(source_checkout_root)
     indexes = {index.get("name"): index for index in pyproject["tool"]["uv"]["index"]}
     sources = pyproject["tool"]["uv"]["sources"]
 
@@ -194,7 +186,7 @@ def test_public_ov_packages_use_public_pypi_index():
         assert sources[package] == {"index": "pypi-public"}
 
 
-def test_uv_run_declares_no_extra_conflicts():
+def test_uv_run_declares_no_extra_conflicts(source_checkout_root: Path):
     """No extra is forked: every combination resolves into a single environment.
 
     ``[tool.uv].conflicts`` used to fork ``isaacsim`` / ``teleop`` away from the OV runtimes,
@@ -203,21 +195,21 @@ def test_uv_run_declares_no_extra_conflicts():
     importers install beside Isaac Sim without displacing it: the two distributions share no
     files, and Kit serves ``isaacsim.asset`` from its extension roots either way.
     """
-    tool_uv = _root_pyproject()["tool"]["uv"]
+    tool_uv = _root_pyproject(source_checkout_root)["tool"]["uv"]
 
     assert "conflicts" not in tool_uv
     for override in ("packaging>=20,<27", "websockets>=14.0,<17.0.0", "coverage>=7.6.1"):
         assert override in tool_uv["override-dependencies"]
 
 
-def test_uv_run_isaacsim_is_an_opt_in_extra():
+def test_uv_run_isaacsim_is_an_opt_in_extra(source_checkout_root: Path):
     """Isaac Sim is never a base dependency, but it is a real workspace extra.
 
     PhysX/Isaac Sim must stay out of ``[project.dependencies]`` so the bare ``uv run``
     keeps working without Kit, while still being an ``optional-dependencies`` entry so
     ``uv run --extra isaacsim`` resolves.
     """
-    pyproject = _root_pyproject()
+    pyproject = _root_pyproject(source_checkout_root)
     project = pyproject["project"]
     base_dependency_names = {re.split(r"[\s<>=!~\[;]", dep, maxsplit=1)[0] for dep in project["dependencies"]}
 
@@ -230,14 +222,14 @@ def test_uv_run_isaacsim_is_an_opt_in_extra():
     assert "wheel-extras" not in pyproject.get("tool", {}).get("isaaclab", {})
 
 
-def test_uv_run_teleop_extra_excludes_isaacsim():
+def test_uv_run_teleop_extra_excludes_isaacsim(source_checkout_root: Path):
     """``teleop`` carries the teleop stack only; Isaac Sim stays its own extra.
 
     XR teleop needs the Kit XR runtime, but environments that already provide Kit (the
     container images) must not install a second copy of it. Users who need the wheel run
     ``--extra teleop,isaacsim``.
     """
-    optional_dependencies = _root_pyproject()["project"]["optional-dependencies"]
+    optional_dependencies = _root_pyproject(source_checkout_root)["project"]["optional-dependencies"]
     teleop = optional_dependencies["teleop"]
 
     assert not any(dep.startswith("isaacsim") for dep in teleop)
@@ -247,9 +239,9 @@ def test_uv_run_teleop_extra_excludes_isaacsim():
     assert not any(dep.startswith("robomimic") for dep in teleop)
 
 
-def test_uv_run_base_dependencies_cover_newton_rsl_rl_training():
+def test_uv_run_base_dependencies_cover_newton_rsl_rl_training(source_checkout_root: Path):
     """The documented bare ``uv run isaaclab train`` command needs Newton and RSL-RL in core."""
-    dependencies = _root_pyproject()["project"]["dependencies"]
+    dependencies = _root_pyproject(source_checkout_root)["project"]["dependencies"]
 
     # Newton is the default physics engine and RSL-RL the default training library,
     # so both ship as core third-party requirements (not opt-in extras).
@@ -257,8 +249,8 @@ def test_uv_run_base_dependencies_cover_newton_rsl_rl_training():
     assert any(dep.startswith("rsl-rl-lib") for dep in dependencies)
 
 
-def test_uv_run_uses_managed_python():
+def test_uv_run_uses_managed_python(source_checkout_root: Path):
     """Avoid building the project venv from conda Python and its older C++ runtime."""
-    tool_uv = _root_pyproject()["tool"]["uv"]
+    tool_uv = _root_pyproject(source_checkout_root)["tool"]["uv"]
 
     assert tool_uv["python-preference"] == "only-managed"

--- a/source/isaaclab/test/cli/test_wheel_builder_metadata.py
+++ b/source/isaaclab/test/cli/test_wheel_builder_metadata.py
@@ -19,17 +19,9 @@ import tomllib
 pytestmark = pytest.mark.unit
 
 
-def _repo_root() -> Path:
-    """Find the Isaac Lab repository root from this test file."""
-    for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file() and (parent / "source").is_dir():
-            return parent
-    raise RuntimeError("Could not find Isaac Lab repository root.")
-
-
-def _root_rsl_rl_pin() -> str:
+def _root_rsl_rl_pin(source_checkout_root: Path) -> str:
     """Return the ``rsl-rl-lib`` pin declared by the root ``pyproject.toml`` core deps."""
-    with (_repo_root() / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         data = tomllib.load(f)
     for dependency in data["project"]["dependencies"]:
         if dependency.startswith("rsl-rl-lib=="):
@@ -37,15 +29,14 @@ def _root_rsl_rl_pin() -> str:
     raise AssertionError("Could not find rsl-rl-lib pin in the root pyproject.toml")
 
 
-def _generate_wheel_pyproject(tmp_path: Path) -> dict:
+def _generate_wheel_pyproject(source_checkout_root: Path, tmp_path: Path) -> dict:
     """Run ``gen_pyproject.py`` against the root pyproject and return the parsed result."""
-    repo_root = _repo_root()
     output = tmp_path / "pyproject.toml"
     subprocess.run(
         [
             sys.executable,
-            str(repo_root / "tools/wheel_builder/gen_pyproject.py"),
-            str(repo_root / "pyproject.toml"),
+            str(source_checkout_root / "tools/wheel_builder/gen_pyproject.py"),
+            str(source_checkout_root / "pyproject.toml"),
             str(output),
             "3.0.0",
         ],
@@ -55,15 +46,14 @@ def _generate_wheel_pyproject(tmp_path: Path) -> dict:
         return tomllib.load(f)
 
 
-def _generate_uv_overrides(tmp_path: Path) -> list[str]:
+def _generate_uv_overrides(source_checkout_root: Path, tmp_path: Path) -> list[str]:
     """Run ``gen_uv_overrides.py`` against the root pyproject and return its requirements."""
-    repo_root = _repo_root()
     output = tmp_path / "uv-overrides.txt"
     subprocess.run(
         [
             sys.executable,
-            str(repo_root / "tools/wheel_builder/gen_uv_overrides.py"),
-            str(repo_root / "pyproject.toml"),
+            str(source_checkout_root / "tools/wheel_builder/gen_uv_overrides.py"),
+            str(source_checkout_root / "pyproject.toml"),
             str(output),
         ],
         check=True,
@@ -71,17 +61,17 @@ def _generate_uv_overrides(tmp_path: Path) -> list[str]:
     return output.read_text(encoding="utf-8").splitlines()
 
 
-def test_wheel_builder_drops_workspace_members(tmp_path):
+def test_wheel_builder_drops_workspace_members(source_checkout_root: Path, tmp_path):
     """The generated wheel metadata must not depend on the bundled ``isaaclab*`` packages."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
     dependencies = generated["project"]["dependencies"]
 
     assert not [dep for dep in dependencies if dep.lower().startswith("isaaclab")]
 
 
-def test_wheel_console_delegates_to_the_full_isaaclab_cli():
+def test_wheel_console_delegates_to_the_full_isaaclab_cli(source_checkout_root: Path):
     """The wheel console command must expose the same workflows as a source installation."""
-    module_path = _repo_root() / "source" / "isaaclab" / "isaaclab" / "__main__.py"
+    module_path = source_checkout_root / "source" / "isaaclab" / "isaaclab" / "__main__.py"
     spec = util.spec_from_file_location("_isaaclab_wheel_main", module_path)
     assert spec is not None
     assert spec.loader is not None
@@ -94,25 +84,25 @@ def test_wheel_console_delegates_to_the_full_isaaclab_cli():
     cli.assert_called_once_with()
 
 
-def test_wheel_console_uses_compatibility_dispatcher(tmp_path):
+def test_wheel_console_uses_compatibility_dispatcher(source_checkout_root: Path, tmp_path):
     """The generated console script must preserve legacy installed-wheel options."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
 
     assert generated["project"]["scripts"]["isaaclab"] == "isaaclab.__main__:main"
 
 
-def test_wheel_builder_includes_isaacsim_extra(tmp_path):
+def test_wheel_builder_includes_isaacsim_extra(source_checkout_root: Path, tmp_path):
     """The ``isaacsim`` extra must ship in the generated wheel metadata."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
     optional_dependencies = generated["project"]["optional-dependencies"]
 
     assert "isaacsim" in optional_dependencies
     assert any(dep.startswith("isaacsim[") for dep in optional_dependencies["isaacsim"])
 
 
-def test_wheel_builder_keeps_standalone_importers_explicit(tmp_path):
+def test_wheel_builder_keeps_standalone_importers_explicit(source_checkout_root: Path, tmp_path):
     """The wheel must expose standalone importers only through their explicit extra."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
     project = generated["project"]
 
     assert "isaacsim-asset-isolated>=6.0,<6.1" not in project["dependencies"]
@@ -123,9 +113,9 @@ def test_wheel_builder_keeps_standalone_importers_explicit(tmp_path):
     ]
 
 
-def test_wheel_builder_expands_all_extra_into_concrete_requirements(tmp_path):
+def test_wheel_builder_expands_all_extra_into_concrete_requirements(source_checkout_root: Path, tmp_path):
     """``isaaclab[all]`` must contain concrete curated requirements."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
     optional_dependencies = generated["project"]["optional-dependencies"]
     all_extra = optional_dependencies["all"]
 
@@ -146,10 +136,10 @@ def test_wheel_builder_expands_all_extra_into_concrete_requirements(tmp_path):
         assert not any(dep.startswith(prefix) for dep in all_extra), f"'{prefix}' must not be in the 'all' extra"
 
 
-def test_wheel_builder_rsl_rl_pin_matches_root_pyproject(tmp_path):
+def test_wheel_builder_rsl_rl_pin_matches_root_pyproject(source_checkout_root: Path, tmp_path):
     """The bundled wheel metadata must install the RSL-RL version declared at the root."""
-    expected_pin = _root_rsl_rl_pin()
-    generated = _generate_wheel_pyproject(tmp_path)
+    expected_pin = _root_rsl_rl_pin(source_checkout_root)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
 
     # RSL-RL is a core dependency (default training library) and also exposed as an extra.
     core_pins = [dep for dep in generated["project"]["dependencies"] if dep.startswith("rsl-rl-lib==")]
@@ -161,9 +151,9 @@ def test_wheel_builder_rsl_rl_pin_matches_root_pyproject(tmp_path):
     assert rsl_rl_pins == [expected_pin]
 
 
-def test_wheel_builder_keeps_tetrahedralization_explicit(tmp_path):
+def test_wheel_builder_keeps_tetrahedralization_explicit(source_checkout_root: Path, tmp_path):
     """The generated wheel must expose PyTetWild only through its explicit extra."""
-    generated = _generate_wheel_pyproject(tmp_path)
+    generated = _generate_wheel_pyproject(source_checkout_root, tmp_path)
     project = generated["project"]
     optional_dependencies = project["optional-dependencies"]
 
@@ -175,17 +165,17 @@ def test_wheel_builder_keeps_tetrahedralization_explicit(tmp_path):
         assert not any(dep.startswith("pytetwild") for dep in deps)
 
 
-def test_wheel_builder_uv_overrides_match_root_pyproject(tmp_path):
+def test_wheel_builder_uv_overrides_match_root_pyproject(source_checkout_root: Path, tmp_path):
     """The wheel resolver override file must mirror the root uv overrides exactly."""
-    with (_repo_root() / "pyproject.toml").open("rb") as f:
+    with (source_checkout_root / "pyproject.toml").open("rb") as f:
         root = tomllib.load(f)
 
-    generated_overrides = _generate_uv_overrides(tmp_path)
+    generated_overrides = _generate_uv_overrides(source_checkout_root, tmp_path)
     published_overrides = (
-        (_repo_root() / "tools" / "wheel_builder" / "uv-overrides.txt").read_text(encoding="utf-8").splitlines()
+        (source_checkout_root / "tools" / "wheel_builder" / "uv-overrides.txt").read_text(encoding="utf-8").splitlines()
     )
     install_ci_overrides = (
-        (_repo_root() / "source" / "isaaclab" / "test" / "install_ci" / "uv_pip" / "uv-overrides.txt")
+        (source_checkout_root / "source" / "isaaclab" / "test" / "install_ci" / "uv_pip" / "uv-overrides.txt")
         .read_text(encoding="utf-8")
         .splitlines()
     )
@@ -195,9 +185,9 @@ def test_wheel_builder_uv_overrides_match_root_pyproject(tmp_path):
     assert install_ci_overrides == generated_overrides
 
 
-def test_wheel_builder_uv_overrides_relax_isaacsim_exact_pins(tmp_path):
+def test_wheel_builder_uv_overrides_relax_isaacsim_exact_pins(source_checkout_root: Path, tmp_path):
     """The wheel resolver must relax Isaac Sim 6.0's exact pins so the extras co-resolve."""
-    overrides = _generate_uv_overrides(tmp_path)
+    overrides = _generate_uv_overrides(source_checkout_root, tmp_path)
 
     for spec in ("typing-extensions>=4.15.0", "websockets>=14.0,<17.0.0", "coverage>=7.6.1"):
         assert spec in overrides

--- a/source/isaaclab/test/conftest.py
+++ b/source/isaaclab/test/conftest.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared fixtures for Isaac Lab tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _find_source_checkout_root() -> Path | None:
+    """Find the Isaac Lab source checkout containing this test tree, if present."""
+    for parent in Path(__file__).resolve().parents:
+        if (
+            (parent / "isaaclab.sh").is_file()
+            and (parent / "pyproject.toml").is_file()
+            and (parent / "source").is_dir()
+        ):
+            return parent
+    return None
+
+
+@pytest.fixture(scope="session")
+def source_checkout_root() -> Path:
+    """Return the Isaac Lab source checkout root, or skip tests from installed packages."""
+    root = _find_source_checkout_root()
+    if root is None:
+        pytest.skip("test requires an Isaac Lab source checkout")
+    return root

--- a/source/isaaclab/test/test_scripts_warp_backward_ordering.py
+++ b/source/isaaclab/test/test_scripts_warp_backward_ordering.py
@@ -17,8 +17,6 @@ from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parents[3]
-
 _ENTRY_SCRIPTS = [
     "scripts/reinforcement_learning/train.py",
     "scripts/reinforcement_learning/play.py",
@@ -29,10 +27,12 @@ _ENTRY_SCRIPTS = [
 _SETTING = "wp.config.enable_backward = False"
 
 
-@pytest.mark.unit
+pytestmark = pytest.mark.unit
+
+
 @pytest.mark.parametrize("script", _ENTRY_SCRIPTS)
-def test_entry_script_disables_warp_backward_before_isaaclab_imports(script: str):
-    lines = (_REPO_ROOT / script).read_text().splitlines()
+def test_entry_script_disables_warp_backward_before_isaaclab_imports(source_checkout_root: Path, script: str):
+    lines = (source_checkout_root / script).read_text().splitlines()
 
     setting_at = next((i for i, line in enumerate(lines) if line.strip() == _SETTING), None)
     assert setting_at is not None, f"{script} does not set '{_SETTING}'"


### PR DESCRIPTION
# Description

A handful of unit tests inspect repository artifacts that only exist in a source checkout (`apps`, `scripts`, the root `pyproject.toml`, `uv.lock`, `tools/wheel_builder`, and the workflow files). Run from an installed package they fail because those paths are absent. This gates them behind a shared `source_checkout_root` session fixture that locates the checkout and skips the test when it is not present, and returns the root path so the tests stop recomputing it by hand.

The fixture lives in `source/isaaclab/test/conftest.py`. The affected tests now take `source_checkout_root` and drop their local `_repo_root()` helpers, so the gating is explicit at the test and the requirement is hard to forget: a checkout-only test needs the root anyway, so it asks for the fixture and gets the skip for free.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there