### PR TITLE
Track camera origins in Newton visualizers

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/newton-visualizer-camera-origin.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-visualizer-camera-origin.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed Newton visualizer cameras ignoring environment and asset origins when interpreting ``eye`` and ``lookat``.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -971,6 +971,8 @@ class NewtonVisualizer(BaseVisualizer):
         self._scene_cameras: dict = {}
         self._scene_camera_names: list[str] = []
         self._active_camera_idx: int = 0
+        self._interactive_scene = None
+        self._viewer_origin: torch.Tensor | None = None
 
     # ------------------------------------------------------------------
     # Shared lifecycle
@@ -1040,6 +1042,7 @@ class NewtonVisualizer(BaseVisualizer):
             self._viewer.set_visible_worlds(self._resolved_visible_env_ids)
             self._viewer.set_world_offsets(self.cfg.world_spacing)
             self._apply_camera_focal_length()
+            self._setup_initial_camera_origin(apply=False)
             initial_pose = self._resolve_initial_camera_pose()
             self._apply_camera_pose(initial_pose)
             self._viewer._paused = False
@@ -1112,6 +1115,9 @@ class NewtonVisualizer(BaseVisualizer):
 
         self._sim_time += dt
         self._step_counter += 1
+
+        if self.cfg.origin_type == "asset":
+            self._update_asset_tracking_camera()
 
         # Headless mode renders on demand via render_rgb_array(). Keep the latest
         # physics state available without paying the per-step render cost.
@@ -1264,9 +1270,16 @@ class NewtonVisualizer(BaseVisualizer):
         """
         eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
         target_t = (float(target[0]), float(target[1]), float(target[2]))
-        self.cfg.eye = eye_t
-        self.cfg.lookat = target_t
         self._apply_camera_pose((eye_t, target_t))
+
+    def reapply_origin(self) -> None:
+        """Recompute the camera position from the current origin config."""
+        self._setup_initial_camera_origin()
+
+    @property
+    def viewer_origin(self) -> torch.Tensor | None:
+        """World-space origin offset in meters with shape ``(3,)``."""
+        return self._viewer_origin
 
     # ------------------------------------------------------------------
     # Hook methods — override in subclasses
@@ -1323,7 +1336,95 @@ class NewtonVisualizer(BaseVisualizer):
 
     def _resolve_initial_camera_pose(self) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
         """Resolve initial camera pose from config or USD camera path."""
-        return self._resolve_cfg_camera_pose(type(self).__name__)
+        return self._camera_pose_with_origin(self._resolve_cfg_camera_pose(type(self).__name__))
+
+    def _setup_initial_camera_origin(self, *, apply: bool = True) -> None:
+        """Position the viewer camera according to :attr:`NewtonVisualizerCfg.origin_type`."""
+        from isaaclab.sim import SimulationContext  # noqa: PLC0415
+
+        self._interactive_scene = getattr(SimulationContext.instance(), "_interactive_scene", None)
+        self._viewer_origin = self._resolve_configured_origin()
+
+        if apply:
+            self._apply_viewer_origin_to_camera()
+
+    def _resolve_configured_origin(self) -> torch.Tensor:
+        """Resolve the configured camera origin."""
+        if self.cfg.origin_type == "world":
+            return torch.zeros(3)
+        if self.cfg.origin_type == "env":
+            return self._resolve_env_origin()
+        if self.cfg.origin_type == "asset":
+            return self._resolve_asset_origin()
+        logger.warning("[NewtonVisualizer] Unknown origin_type '%s'; defaulting to world.", self.cfg.origin_type)
+        return torch.zeros(3)
+
+    def _resolve_env_origin(self) -> torch.Tensor:
+        """Resolve the configured environment origin."""
+        scene = self._interactive_scene
+        if scene is None:
+            logger.warning("[NewtonVisualizer] origin_type='env' requested but no scene is registered yet.")
+            return torch.zeros(3)
+
+        num_envs = scene.num_envs
+        if not (0 <= self.cfg.origin_env_index < num_envs):
+            raise ValueError(
+                f"[NewtonVisualizer] origin_env_index {self.cfg.origin_env_index} is out of range "
+                f"[0, {num_envs - 1}] for origin_type='env'."
+            )
+        return scene.env_origins[self.cfg.origin_env_index]
+
+    def _resolve_asset_origin(self) -> torch.Tensor:
+        """Resolve the initial asset origin."""
+        if self.cfg.origin_track_path is None:
+            raise ValueError("[NewtonVisualizer] origin_type='asset' requires origin_track_path to be set.")
+        origin = self._resolve_tracked_asset_origin()
+        if origin is not None:
+            return origin
+        return torch.zeros(3)
+
+    def _update_asset_tracking_camera(self) -> None:
+        """Update the viewer camera to track an asset root or body."""
+        origin = self._resolve_tracked_asset_origin()
+        if origin is None:
+            return
+        self._viewer_origin = origin
+        self._apply_viewer_origin_to_camera()
+
+    def _resolve_tracked_asset_origin(self) -> torch.Tensor | None:
+        """Resolve the configured tracked asset origin when scene state is available."""
+        scene = self._interactive_scene
+        if scene is None or self.cfg.origin_track_path is None:
+            return None
+        asset_name, _, body_name = self.cfg.origin_track_path.partition("/")
+        try:
+            asset = scene[asset_name]
+        except KeyError:
+            return None
+        if not body_name:
+            return asset.data.root_pos_w.torch[self.cfg.origin_env_index]
+
+        body_ids, _ = asset.find_bodies(body_name)
+        return asset.data.body_pos_w.torch[self.cfg.origin_env_index, body_ids[0]]
+
+    def _apply_viewer_origin_to_camera(self) -> None:
+        """Compute absolute eye/target from :attr:`_viewer_origin` and push to the viewer."""
+        self._apply_camera_pose(self._resolve_initial_camera_pose())
+
+    def _camera_pose_with_origin(
+        self,
+        pose: tuple[tuple[float, float, float], tuple[float, float, float]],
+    ) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+        if self._viewer_origin is None:
+            return pose
+        origin = self._viewer_origin.detach().cpu().numpy()
+        eye = np.array(pose[0], dtype=float) + origin
+        target = np.array(pose[1], dtype=float) + origin
+        return (float(eye[0]), float(eye[1]), float(eye[2])), (
+            float(target[0]),
+            float(target[1]),
+            float(target[2]),
+        )
 
     def _resolve_streaming_renderer_cfg(self):
         """Return the renderer cfg for the auto-created streaming camera.
@@ -1919,6 +2020,8 @@ class NewtonGLVisualizer(NewtonVisualizer):
         """
         if self._viewer is None:
             raise RuntimeError("NewtonGLVisualizer must be initialized before capturing an RGB frame.")
+        if self.cfg.origin_type == "asset":
+            self._update_asset_tracking_camera()
         if self._runtime_headless and self._state is not None and not self._viewer.is_paused():
             self._pre_step()
             self._viewer.begin_frame(self._sim_time)
@@ -2178,6 +2281,8 @@ class NewtonRTXVisualizer(NewtonVisualizer):
         """
         if self._viewer is None:
             return None
+        if self.cfg.origin_type == "asset":
+            self._update_asset_tracking_camera()
         if self._runtime_headless and self._state is not None and not self._viewer.is_paused():
             self._pre_step()
             self._viewer.begin_frame(self._sim_time)

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer_cfg.py
@@ -40,6 +40,35 @@ class NewtonVisualizerCfg(VisualizerCfg):
     window_height: int = 1080
     """Window height in pixels."""
 
+    origin_type: str = "world"
+    """Frame in which :attr:`~isaaclab.visualizers.VisualizerCfg.eye` and
+    :attr:`~isaaclab.visualizers.VisualizerCfg.lookat` are interpreted.
+
+    Options:
+
+    * ``"world"``: global origin.
+    * ``"env"``: origin of the environment at :attr:`origin_env_index`.
+    * ``"asset"``: a scene asset (or body) specified by :attr:`origin_track_path`.
+    """
+
+    origin_env_index: int = 0
+    """Index of the environment used as the viewer camera origin.
+
+    Only meaningful when :attr:`origin_type` is ``"env"`` or ``"asset"``.
+    """
+
+    origin_track_path: str | None = None
+    """Asset tracking path for the viewer camera origin.
+
+    Format: ``"<asset_name>"`` to track the asset root, or ``"<asset_name>/<body_name>"``
+    to track a specific body on the asset. Required when :attr:`origin_type` is ``"asset"``.
+
+    Examples::
+
+        origin_track_path = "robot"             # track robot root
+        origin_track_path = "robot/panda_hand"  # track panda_hand body on robot
+    """
+
     headless: bool = False
     """Run the Newton viewer without requiring a display server."""
 

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import numpy as np
 import pytest
@@ -22,7 +22,7 @@ from isaaclab_visualizers.newton import (
 )
 from isaaclab_visualizers.newton import newton_visualization_markers as newton_markers
 from isaaclab_visualizers.newton import newton_visualizer as newton_visualizer_module
-from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, _eye_lookat_to_pitch_yaw
+from isaaclab_visualizers.newton.newton_visualizer import NewtonViewerGL, NewtonVisualizer, _eye_lookat_to_pitch_yaw
 from isaaclab_visualizers.newton_adapter import (
     VISUALIZER_INFINITE_PLANE_SIZE,
     apply_viewer_visible_worlds,
@@ -125,6 +125,122 @@ def test_newton_visualizer_cfg_exposes_viewer_options():
     assert cfg.particle_color == (0.1, 0.2, 0.3)
 
 
+def test_newton_visualizer_offsets_cfg_camera_by_viewer_origin():
+    visualizer = NewtonVisualizer.__new__(NewtonVisualizer)
+    visualizer._viewer_origin = torch.tensor([10.0, 20.0, 30.0])
+
+    pose = visualizer._camera_pose_with_origin(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0)))
+
+    assert pose == ((11.0, 22.0, 33.0), (14.0, 25.0, 36.0))
+
+
+def test_newton_visualizer_set_camera_view_uses_absolute_coordinates():
+    visualizer = NewtonVisualizer.__new__(NewtonVisualizer)
+    visualizer.cfg = SimpleNamespace(eye=(0.0, 0.0, 0.0), lookat=(1.0, 0.0, 0.0))
+    visualizer._viewer_origin = torch.tensor([10.0, 20.0, 30.0])
+    visualizer._apply_camera_pose = Mock()
+
+    NewtonVisualizer.set_camera_view(visualizer, (1.0, 2.0, 3.0), (4.0, 5.0, 6.0))
+
+    assert visualizer.cfg.eye == (0.0, 0.0, 0.0)
+    assert visualizer.cfg.lookat == (1.0, 0.0, 0.0)
+    visualizer._apply_camera_pose.assert_called_once_with(((1.0, 2.0, 3.0), (4.0, 5.0, 6.0)))
+
+
+def test_newton_visualizer_reapply_origin_updates_env_camera(monkeypatch: pytest.MonkeyPatch):
+    import isaaclab.sim as sim_utils
+
+    scene = SimpleNamespace(num_envs=2, env_origins=torch.tensor([[0.0, 0.0, 0.0], [10.0, 20.0, 30.0]]))
+    context = SimpleNamespace(_interactive_scene=scene)
+
+    class _SimulationContext:
+        @staticmethod
+        def instance():
+            return context
+
+    monkeypatch.setattr(sim_utils, "SimulationContext", _SimulationContext)
+
+    visualizer = NewtonVisualizer.__new__(NewtonVisualizer)
+    visualizer.cfg = SimpleNamespace(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(4.0, 5.0, 6.0),
+        origin_type="env",
+        origin_env_index=1,
+        origin_track_path=None,
+    )
+    visualizer._resolve_cfg_camera_pose = Mock(return_value=(visualizer.cfg.eye, visualizer.cfg.lookat))
+    visualizer._apply_camera_pose = Mock()
+
+    NewtonVisualizer.reapply_origin(visualizer)
+
+    visualizer._apply_camera_pose.assert_called_once_with(((11.0, 22.0, 33.0), (14.0, 25.0, 36.0)))
+
+
+def test_newton_visualizer_reapply_origin_updates_asset_camera(monkeypatch: pytest.MonkeyPatch):
+    import isaaclab.sim as sim_utils
+
+    asset = SimpleNamespace(
+        data=SimpleNamespace(
+            root_pos_w=SimpleNamespace(torch=torch.tensor([[0.0, 0.0, 0.0], [10.0, 20.0, 30.0]])),
+        )
+    )
+
+    class _Scene:
+        def __getitem__(self, name):
+            if name == "robot":
+                return asset
+            raise KeyError(name)
+
+    context = SimpleNamespace(_interactive_scene=_Scene())
+
+    class _SimulationContext:
+        @staticmethod
+        def instance():
+            return context
+
+    monkeypatch.setattr(sim_utils, "SimulationContext", _SimulationContext)
+
+    visualizer = NewtonVisualizer.__new__(NewtonVisualizer)
+    visualizer.cfg = SimpleNamespace(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(4.0, 5.0, 6.0),
+        origin_type="asset",
+        origin_env_index=1,
+        origin_track_path="robot",
+    )
+    visualizer._resolve_cfg_camera_pose = Mock(return_value=(visualizer.cfg.eye, visualizer.cfg.lookat))
+    visualizer._apply_camera_pose = Mock()
+
+    NewtonVisualizer.reapply_origin(visualizer)
+
+    visualizer._apply_camera_pose.assert_called_once_with(((11.0, 22.0, 33.0), (14.0, 25.0, 36.0)))
+
+
+def test_newton_visualizer_asset_tracking_uses_configured_camera_after_set_camera_view():
+    visualizer = NewtonVisualizer.__new__(NewtonVisualizer)
+    visualizer.cfg = SimpleNamespace(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(4.0, 5.0, 6.0),
+        origin_track_path="robot",
+        origin_env_index=0,
+    )
+    visualizer._interactive_scene = object()
+    visualizer._viewer_origin = torch.tensor([100.0, 100.0, 100.0])
+    visualizer._resolve_cfg_camera_pose = Mock(return_value=(visualizer.cfg.eye, visualizer.cfg.lookat))
+    visualizer._resolve_tracked_asset_origin = Mock(return_value=torch.tensor([10.0, 20.0, 30.0]))
+    visualizer._apply_camera_pose = Mock()
+
+    NewtonVisualizer.set_camera_view(visualizer, (100.0, 101.0, 102.0), (103.0, 104.0, 105.0))
+    NewtonVisualizer._update_asset_tracking_camera(visualizer)
+
+    assert visualizer.cfg.eye == (1.0, 2.0, 3.0)
+    assert visualizer.cfg.lookat == (4.0, 5.0, 6.0)
+    assert visualizer._apply_camera_pose.call_args_list == [
+        call(((100.0, 101.0, 102.0), (103.0, 104.0, 105.0))),
+        call(((11.0, 22.0, 33.0), (14.0, 25.0, 36.0))),
+    ]
+
+
 def test_newton_marker_registry_lifecycle(monkeypatch: pytest.MonkeyPatch):
     """Construction caches the registry; close survives context teardown and is idempotent."""
 
@@ -174,14 +290,14 @@ def test_newton_visualizer_cfg_exposes_world_spacing():
     assert cfg.world_spacing == (2.0, 2.0, 0.0)
 
 
-def test_newton_visualizer_set_camera_view_updates_cfg_without_viewer():
+def test_newton_visualizer_set_camera_view_keeps_cfg_without_viewer():
     visualizer = NewtonGLVisualizer(NewtonGLVisualizerCfg())
 
     visualizer.set_camera_view((1, 2, 3), (0, 0, 1))
 
-    assert visualizer.cfg.eye == (1.0, 2.0, 3.0)
-    assert visualizer.cfg.lookat == (0.0, 0.0, 1.0)
-    assert visualizer._resolve_initial_camera_pose() == ((1.0, 2.0, 3.0), (0.0, 0.0, 1.0))
+    assert visualizer.cfg.eye == (4.0, -4.0, 3.0)
+    assert visualizer.cfg.lookat == (0.0, 0.0, 0.0)
+    assert visualizer._last_camera_pose is None
 
 
 def test_newton_visualizer_set_camera_view_updates_active_viewer():
@@ -207,8 +323,8 @@ def test_newton_visualizer_set_camera_view_updates_active_viewer():
 
     assert (viewer.camera.pos.x, viewer.camera.pos.y, viewer.camera.pos.z) == (1.0, 2.0, 3.0)
     assert viewer.camera.look_at_calls == [(0.0, 0.0, 1.0)]
-    assert visualizer.cfg.eye == (1.0, 2.0, 3.0)
-    assert visualizer.cfg.lookat == (0.0, 0.0, 1.0)
+    assert visualizer.cfg.eye == (4.0, -4.0, 3.0)
+    assert visualizer.cfg.lookat == (0.0, 0.0, 0.0)
 
 
 def test_newton_visualizer_auto_creates_streaming_camera_when_scene_camera_exists(monkeypatch):


### PR DESCRIPTION
# Description

The Newton visualizer interprets `eye` and `lookat` in world coordinates only, so in a multi-environment scene the camera ignores the environment and asset origins and frames the wrong place. This adds an `origin_type` to `NewtonVisualizerCfg` (`world`, `env`, `asset`) with `origin_env_index` and `origin_track_path`, mirroring how the Kit visualizer resolves its origin, and offsets the configured pose by the resolved origin. `world` keeps the current behavior, `env` frames a chosen environment, and `asset` tracks an asset root or body.

`set_camera_view()` stays an absolute setter, matching Kit and `SimulationContext.set_camera_view()`, so only the configured initial pose is origin-relative.

## Type of change

- New feature (non-breaking change which adds functionality)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Before and after (camera framing env/asset origin instead of world) to be attached from a GPU run.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there