### PR TITLE
Label RSL-RL play videos with checkpoint stems

### DIFF
--- a/source/isaaclab_rl/changelog.d/rsl-rl-play-video-checkpoint-prefix.rst
+++ b/source/isaaclab_rl/changelog.d/rsl-rl-play-video-checkpoint-prefix.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed RSL-RL play video filenames missing the numeric checkpoint stem used for playback.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -164,7 +164,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
             log_dir = os.path.dirname(resume_path)
 
             env_cfg.log_dir = log_dir
-            apply_video_recording(env_cfg, log_dir, args_cli, subdir="play")
+            apply_video_recording(env_cfg, log_dir, args_cli, subdir="play", checkpoint_path=resume_path)
 
             screen.stage("Creating environment")
             env = create_isaaclab_env(

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -783,7 +783,14 @@ def pre_launch_video_config(env_cfg: Any, log_dir: str | None = None, args_cli: 
         pass
 
 
-def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespace, *, subdir: str = "train") -> None:
+def apply_video_recording(
+    env_cfg: Any,
+    log_dir: str,
+    args_cli: argparse.Namespace,
+    *,
+    subdir: str = "train",
+    checkpoint_path: str | None = None,
+) -> None:
     """Configure internal video recording on the environment config.
 
     Enables recording by ensuring ``env_cfg.video_recorders`` is non-empty, then applies
@@ -809,6 +816,8 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
         args_cli: Parsed command-line arguments.
         subdir: Sub-directory name appended to ``<log_dir>/videos/`` for the fallback output
             path.  Use ``"train"`` for training runs and ``"play"`` for evaluation.
+        checkpoint_path: Checkpoint loaded by a play run.  When set to a ``model_<N>.pt``
+            path with a numeric id, the checkpoint stem is appended to play video names.
     """
     if not getattr(args_cli, "video", False):
         return
@@ -950,6 +959,8 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
             cfg.video_length = video_length
         if video_interval is not None:
             cfg.video_interval = video_interval
+        if subdir == "play" and (label := _checkpoint_video_label(checkpoint_path)) is not None:
+            cfg.output_filename_prefix = _checkpoint_video_prefix(cfg.output_filename_prefix, label)
 
     print("[INFO] Video recording enabled.")
     for cfg in env_cfg.video_recorders:
@@ -962,6 +973,22 @@ def apply_video_recording(env_cfg: Any, log_dir: str, args_cli: argparse.Namespa
             },
             nesting=4,
         )
+
+
+def _checkpoint_video_label(checkpoint_path: str | None) -> str | None:
+    if checkpoint_path is None:
+        return None
+
+    path = Path(checkpoint_path)
+    if re.fullmatch(r"model_\d+", path.stem) is None or path.suffix != ".pt":
+        return None
+    return path.stem
+
+
+def _checkpoint_video_prefix(prefix: str, label: str) -> str:
+    if prefix == label or prefix.endswith(f"_{label}"):
+        return prefix
+    return f"{prefix}_{label}"
 
 
 def wrap_record_video(env, log_dir: str, args_cli: argparse.Namespace):

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -89,7 +89,9 @@ def test_apply_video_recording_injects_correct_recorder():
         ("clip", "final.pt", "clip"),
     ],
 )
-def test_apply_video_recording_labels_play_video_with_checkpoint_stem(existing_prefix, checkpoint_name, expected_prefix):
+def test_apply_video_recording_labels_play_video_with_checkpoint_stem(
+    existing_prefix, checkpoint_name, expected_prefix
+):
     """Play videos append only a numeric model checkpoint stem, kept as a distinct token."""
     from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
 

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -77,86 +77,37 @@ def test_apply_video_recording_injects_correct_recorder():
     assert rec.output_filename_prefix == "clip"
 
 
-def test_apply_video_recording_labels_play_video_with_checkpoint_stem():
-    """Play videos from numeric checkpoints include the checkpoint stem."""
-
-    env_cfg = _env_cfg()
-    apply_video_recording(
-        env_cfg,
-        "/my/log",
-        _args(),
-        subdir="play",
-        checkpoint_path="/my/log/model_1200.pt",
-    )
-
-    assert env_cfg.video_recorders[0].output_filename_prefix == "clip_model_1200"
-
-
-def test_apply_video_recording_does_not_match_partial_checkpoint_label():
-    """Overlapping numeric checkpoint labels are treated as distinct tokens."""
+@pytest.mark.parametrize(
+    ("existing_prefix", "checkpoint_name", "expected_prefix"),
+    [
+        ("clip", "model_1200.pt", "clip_model_1200"),
+        ("eval", "model_42.pt", "eval_model_42"),
+        # Overlapping numeric ids stay distinct tokens instead of substrings.
+        ("clip_model_1200", "model_120.pt", "clip_model_1200_model_120"),
+        # Non-model or non-numeric stems keep the configured prefix.
+        ("clip", "custom_1200.pt", "clip"),
+        ("clip", "final.pt", "clip"),
+    ],
+)
+def test_apply_video_recording_labels_play_video_with_checkpoint_stem(existing_prefix, checkpoint_name, expected_prefix):
+    """Play videos append only a numeric model checkpoint stem, kept as a distinct token."""
     from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
 
     existing = VideoRecorderCfg()
-    existing.output_filename_prefix = "clip_model_1200"
+    existing.output_filename_prefix = existing_prefix
 
     env_cfg = _env_cfg()
     env_cfg.video_recorders = [existing]
-    apply_video_recording(env_cfg, "/my/log", _args(), subdir="play", checkpoint_path="/my/log/model_120.pt")
+    apply_video_recording(env_cfg, "/my/log", _args(), subdir="play", checkpoint_path=f"/my/log/{checkpoint_name}")
 
-    assert env_cfg.video_recorders[0].output_filename_prefix == "clip_model_1200_model_120"
-
-
-def test_apply_video_recording_ignores_digit_containing_non_model_checkpoint_stems():
-    """Pretrained and custom checkpoint names with digits keep the configured prefix."""
-
-    env_cfg = _env_cfg()
-    apply_video_recording(
-        env_cfg,
-        "/my/log",
-        _args(),
-        subdir="play",
-        checkpoint_path="/my/log/Isaac-Velocity-Rough-G1_physx_none_rsl_rl.pt",
-    )
-
-    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
-
-    env_cfg = _env_cfg()
-    apply_video_recording(
-        env_cfg,
-        "/my/log",
-        _args(),
-        subdir="play",
-        checkpoint_path="/my/log/custom_1200.pt",
-    )
-
-    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
+    assert env_cfg.video_recorders[0].output_filename_prefix == expected_prefix
 
 
 def test_apply_video_recording_leaves_train_video_prefix_unchanged():
-    """Checkpoint labels are only applied to play videos."""
+    """Checkpoint labels are only applied to play videos, not training videos."""
 
     env_cfg = _env_cfg()
-    apply_video_recording(
-        env_cfg,
-        "/my/log",
-        _args(),
-        checkpoint_path="/my/log/model_1200.pt",
-    )
-
-    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
-
-
-def test_apply_video_recording_ignores_non_numeric_checkpoint_stems():
-    """Published or custom checkpoints without numeric ids keep the configured prefix."""
-
-    env_cfg = _env_cfg()
-    apply_video_recording(
-        env_cfg,
-        "/my/log",
-        _args(),
-        subdir="play",
-        checkpoint_path="/my/log/final.pt",
-    )
+    apply_video_recording(env_cfg, "/my/log", _args(), checkpoint_path="/my/log/model_1200.pt")
 
     assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
 
@@ -196,20 +147,6 @@ def test_apply_video_recording_patches_existing_recorders():
     assert rec.fps == 60  # preserved
     assert rec.video_length == 10  # CLI override applied
     assert rec.video_interval == 500  # CLI override applied
-
-
-def test_apply_video_recording_labels_existing_play_recorders():
-    """Existing recorder prefixes are preserved and extended for play checkpoints."""
-    from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
-
-    existing = VideoRecorderCfg()
-    existing.output_filename_prefix = "eval"
-
-    env_cfg = _env_cfg()
-    env_cfg.video_recorders = [existing]
-    apply_video_recording(env_cfg, "/my/log", _args(), subdir="play", checkpoint_path="/my/log/model_42.pt")
-
-    assert env_cfg.video_recorders[0].output_filename_prefix == "eval_model_42"
 
 
 def test_apply_video_recording_injects_kit_visualizer_when_no_concrete_visualizer():

--- a/source/isaaclab_rl/test/test_apply_video_recording.py
+++ b/source/isaaclab_rl/test/test_apply_video_recording.py
@@ -74,6 +74,91 @@ def test_apply_video_recording_injects_correct_recorder():
     assert rec.video_length == 42  # CLI override applied
     assert rec.video_interval == 500  # CLI override applied
     assert rec.output_dir == os.path.join("/my/log", "videos", "play")
+    assert rec.output_filename_prefix == "clip"
+
+
+def test_apply_video_recording_labels_play_video_with_checkpoint_stem():
+    """Play videos from numeric checkpoints include the checkpoint stem."""
+
+    env_cfg = _env_cfg()
+    apply_video_recording(
+        env_cfg,
+        "/my/log",
+        _args(),
+        subdir="play",
+        checkpoint_path="/my/log/model_1200.pt",
+    )
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip_model_1200"
+
+
+def test_apply_video_recording_does_not_match_partial_checkpoint_label():
+    """Overlapping numeric checkpoint labels are treated as distinct tokens."""
+    from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+
+    existing = VideoRecorderCfg()
+    existing.output_filename_prefix = "clip_model_1200"
+
+    env_cfg = _env_cfg()
+    env_cfg.video_recorders = [existing]
+    apply_video_recording(env_cfg, "/my/log", _args(), subdir="play", checkpoint_path="/my/log/model_120.pt")
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip_model_1200_model_120"
+
+
+def test_apply_video_recording_ignores_digit_containing_non_model_checkpoint_stems():
+    """Pretrained and custom checkpoint names with digits keep the configured prefix."""
+
+    env_cfg = _env_cfg()
+    apply_video_recording(
+        env_cfg,
+        "/my/log",
+        _args(),
+        subdir="play",
+        checkpoint_path="/my/log/Isaac-Velocity-Rough-G1_physx_none_rsl_rl.pt",
+    )
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
+
+    env_cfg = _env_cfg()
+    apply_video_recording(
+        env_cfg,
+        "/my/log",
+        _args(),
+        subdir="play",
+        checkpoint_path="/my/log/custom_1200.pt",
+    )
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
+
+
+def test_apply_video_recording_leaves_train_video_prefix_unchanged():
+    """Checkpoint labels are only applied to play videos."""
+
+    env_cfg = _env_cfg()
+    apply_video_recording(
+        env_cfg,
+        "/my/log",
+        _args(),
+        checkpoint_path="/my/log/model_1200.pt",
+    )
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
+
+
+def test_apply_video_recording_ignores_non_numeric_checkpoint_stems():
+    """Published or custom checkpoints without numeric ids keep the configured prefix."""
+
+    env_cfg = _env_cfg()
+    apply_video_recording(
+        env_cfg,
+        "/my/log",
+        _args(),
+        subdir="play",
+        checkpoint_path="/my/log/final.pt",
+    )
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "clip"
 
 
 def test_apply_video_recording_uses_cfg_defaults_when_cli_not_passed():
@@ -111,6 +196,20 @@ def test_apply_video_recording_patches_existing_recorders():
     assert rec.fps == 60  # preserved
     assert rec.video_length == 10  # CLI override applied
     assert rec.video_interval == 500  # CLI override applied
+
+
+def test_apply_video_recording_labels_existing_play_recorders():
+    """Existing recorder prefixes are preserved and extended for play checkpoints."""
+    from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+
+    existing = VideoRecorderCfg()
+    existing.output_filename_prefix = "eval"
+
+    env_cfg = _env_cfg()
+    env_cfg.video_recorders = [existing]
+    apply_video_recording(env_cfg, "/my/log", _args(), subdir="play", checkpoint_path="/my/log/model_42.pt")
+
+    assert env_cfg.video_recorders[0].output_filename_prefix == "eval_model_42"
 
 
 def test_apply_video_recording_injects_kit_visualizer_when_no_concrete_visualizer():


### PR DESCRIPTION
# Description

When playing an RSL-RL checkpoint with video recording, the clip filenames do not say which checkpoint produced them, so videos from different checkpoints in the same run directory are indistinguishable. This appends the checkpoint stem to the play video filename prefix. The label is only applied to real RSL-RL checkpoints, matched as `model_<N>.pt`, so custom or pretrained checkpoint names that merely contain a digit are not mislabeled.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there