### PR TITLE
[Fix] Pin Newton to the commit carrying newton#4017 and stop the installer dangling its prebundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,10 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.10"
 ovrtx = "0.4.1.364340"
 ovstage = "0.1.1.355824"
-newton = "release-1.5"
+# Pinned past release-1.5 for newton#4017 (ArticulationView generic over custom frequencies),
+# which the MuJoCo tendon adapter needs to read mujoco.actuator_trntype. Merged to main and
+# not backported, so this is the merge commit rather than a branch.
+newton = "4055a1594d91ae8c1a8688b0932cd10f75d30603"
 warp = "1.16.0"
 
 [tool.ruff]
@@ -394,7 +397,7 @@ override-dependencies = [
     "numpy>=2",
     "mujoco~=3.11.0",
     "mujoco-warp~=3.11.0",
-    "newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@4055a1594d91ae8c1a8688b0932cd10f75d30603",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.4.1",
     "torch==2.11.0",

--- a/source/isaaclab/changelog.d/jichuanh-newton-pin-4017.minor.rst
+++ b/source/isaaclab/changelog.d/jichuanh-newton-pin-4017.minor.rst
@@ -1,0 +1,17 @@
+Changed
+^^^^^^^
+
+* Changed the pinned Newton build to the commit merging
+  `newton#4017 <https://github.com/newton-physics/newton/pull/4017>`_, which makes
+  ``ArticulationView`` generic over custom frequencies. Reading a MuJoCo actuator attribute such as
+  ``mujoco.actuator_trntype`` through an articulation view previously raised *"has custom frequency
+  'mujoco:actuator' which is not supported by ArticulationView"*.
+
+Fixed
+^^^^^
+
+* Fixed ``isaaclab.sh --install`` aborting whenever the pinned Newton commit changes. The installer
+  uninstalled Newton before reinstalling it, but Isaac Sim's ``isaacsim.pip.newton`` prebundle
+  symlinks into the installed tree, so removing the distribution left every link dangling and the
+  install failed its own prebundle check (nvbugs 6343978). The pinned build is now force-reinstalled
+  over the existing tree instead.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -368,7 +368,6 @@ def _ensure_newton() -> None:
 
     python_exe = extract_python_exe()
     pip_cmd = get_pip_command(python_exe)
-    using_uv = pip_cmd[0] == "uv"
 
     # git installs record the commit in freeze output; skip if it is already present.
     frozen = run_command(pip_cmd + ["freeze"], capture_output=True, text=True, check=False)
@@ -379,9 +378,12 @@ def _ensure_newton() -> None:
         return
 
     print_info(f"Installing pinned Newton git build ({commit[:10]})...")
-    uninstall_flags = ["-y"] if not using_uv else []
-    run_command(pip_cmd + ["uninstall"] + uninstall_flags + ["newton"], check=False)
-    _run_package_install(pip_cmd + ["install", requirement, *([schemas] if schemas else [])])
+    # Overwrite in place rather than uninstall-then-install. Isaac Sim's
+    # ``isaacsim.pip.newton`` prebundle is a symlink farm pointing at the installed tree, so
+    # removing the distribution first leaves every link dangling and trips
+    # :func:`_assert_no_new_dangling_prebundle_symlinks` -- see nvbugs 6343978. A forced
+    # reinstall replaces the files the new version ships without deleting the old tree.
+    _run_package_install(pip_cmd + ["install", "--force-reinstall", requirement, *([schemas] if schemas else [])])
 
 
 # Isaac Sim install settings.

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -311,7 +311,12 @@ class TestEnsureNewton:
         return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
 
     def test_installs_pinned_git_build_when_absent(self):
-        """When the pinned commit is not installed, uninstall newton then install the git build."""
+        """When the pinned commit is not installed, force-reinstall over the existing tree.
+
+        Never ``pip uninstall`` first: Isaac Sim's ``isaacsim.pip.newton`` prebundle symlinks
+        into the installed tree, so removing the distribution dangles every link and the
+        install aborts on the prebundle guard (nvbugs 6343978).
+        """
         from isaaclab.cli.commands import install
 
         commit = install._pinned_version("newton")
@@ -328,10 +333,11 @@ class TestEnsureNewton:
         ):
             install._ensure_newton()
 
-        assert any("uninstall" in cmd for cmd in calls), "old Newton should be uninstalled first"
+        assert not any("uninstall" in cmd for cmd in calls), "uninstalling dangles the prebundle symlinks"
         install_cmds = [cmd for cmd in calls if "install" in cmd]
         assert install_cmds, "expected a pip install call"
         install_args = install_cmds[-1]
+        assert "--force-reinstall" in install_args, "the new tree must overwrite the old in place"
         assert any(arg.startswith("newton[sim]") and arg.endswith(commit) for arg in install_args)
         assert any(arg.startswith("newton-usd-schemas") for arg in install_args), "schemas must be forced too"
 

--- a/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
+++ b/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5
+newton[sim] @ git+https://github.com/newton-physics/newton.git@4055a1594d91ae8c1a8688b0932cd10f75d30603
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/tools/wheel_builder/uv-overrides.txt
+++ b/tools/wheel_builder/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5
+newton[sim] @ git+https://github.com/newton-physics/newton.git@4055a1594d91ae8c1a8688b0932cd10f75d30603
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ overrides = [
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "mujoco", specifier = "~=3.11.0" },
     { name = "mujoco-warp", specifier = "~=3.11.0" },
-    { name = "newton", extras = ["sim"], git = "https://github.com/newton-physics/newton.git?rev=release-1.5" },
+    { name = "newton", extras = ["sim"], git = "https://github.com/newton-physics/newton.git?rev=4055a1594d91ae8c1a8688b0932cd10f75d30603" },
     { name = "newton-usd-schemas", specifier = ">=0.4.1" },
     { name = "numpy", specifier = ">=2" },
     { name = "packaging", specifier = ">=20,<27" },
@@ -3350,8 +3350,8 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.0"
-source = { git = "https://github.com/newton-physics/newton.git?rev=release-1.5#cca3bb8a17a3620a1343df3cf12c625e4161b317" }
+version = "1.6.0.dev0"
+source = { git = "https://github.com/newton-physics/newton.git?rev=4055a1594d91ae8c1a8688b0932cd10f75d30603#4055a1594d91ae8c1a8688b0932cd10f75d30603" }
 dependencies = [
     { name = "warp-lang", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]


### PR DESCRIPTION
# Description

Reading a MuJoCo actuator attribute through an articulation view — `mujoco.actuator_trntype`, which
the fixed-tendon adapter needs — fails on `release-1.5` with *"has custom frequency
'mujoco:actuator' which is not supported by ArticulationView"*.
[newton#4017](https://github.com/newton-physics/newton/pull/4017) makes `ArticulationView` generic
over custom frequencies. It merged to `main` and was not backported, so the pin is the merge commit;
`main` carries one further commit, so this takes 4017 and nothing else.

The bump also exposes a latent installer bug. `_ensure_newton` uninstalled Newton before
reinstalling it, but Isaac Sim's `isaacsim.pip.newton` prebundle symlinks into the installed tree
(`pip_prebundle/newton -> …/site-packages/newton`). Removing the distribution left every link
dangling and the install failed its own prebundle check (nvbugs 6343978) with 200 dangling symlinks.
It only ever fired when the pin changed, because the freeze check returns early while the pinned
commit is already installed — so the bug has been latent since the guard was added. The pinned build
is now force-reinstalled over the existing tree.

> [!NOTE]
> `uv.lock` is edited in place rather than regenerated. Newton's own dependencies are identical
> across the two revisions (`warp-lang>=1.16.0`), so nothing downstream re-resolves, and a
> regenerate rewrites 1087 unrelated lines: uv 0.12.6 simplifies away a marker equal to the union of
> the three declared `[tool.uv] environments`, which the committed lock still spells out. Verified
> with `uv sync --frozen`, which accepts the lock without re-resolving.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

The pin lives in four places, cross-checked by `test_wheel_builder_metadata.py` and
`test_uv_run_pyproject.py`: `[tool.isaaclab.versions]`, `[tool.uv] override-dependencies`,
`tools/wheel_builder/uv-overrides.txt` and `source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt`.

* `uv sync --frozen` resolves newton 1.6.0.dev0 without re-resolving the lock.
* Spawning the Shadow Hand on `newton_mjwarp` reports 4 fixed tendons in the expected order, where
  `release-1.5` raised at articulation start-up.
* `source/isaaclab/test/cli/` — 246 passed.

`test_installs_pinned_git_build_when_absent` now asserts the installer does **not** uninstall and
does pass `--force-reinstall`, so the dangling-symlink cause is covered rather than the old
uninstall-first contract.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
