### PR TITLE
Write camera poses through to sensor data on explicit set

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-camera-set-pose-writethrough.rst
+++ b/source/isaaclab/changelog.d/antoiner-camera-set-pose-writethrough.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab.sensors.Camera.set_world_poses` and
+  :meth:`~isaaclab.sensors.Camera.set_world_poses_from_view` leaving the camera data buffers
+  (:attr:`~isaaclab.sensors.CameraData.pos_w` and orientation fields) stale when
+  :attr:`~isaaclab.sensors.CameraCfg.update_latest_camera_pose` is disabled. Explicitly set poses
+  are now written through to the data buffers; the flag continues to govern pose refresh for
+  cameras moved by other means.

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -427,6 +427,9 @@ class Camera(SensorBase):
         idx_wp = self._resolve_env_ids_wp(env_ids)
         with self._view.xform_world_space_writer() as writer:
             writer.set_poses(pos_wp, ori_wp, idx_wp)
+        # write through to the data buffers so explicitly set poses are never stale,
+        # regardless of :attr:`CameraCfg.update_latest_camera_pose`
+        self._update_poses(env_ids=idx_wp, frame_op=0)
 
     def set_world_poses_from_view(
         self, eyes: torch.Tensor, targets: torch.Tensor, env_ids: Sequence[int] | None = None
@@ -490,6 +493,9 @@ class Camera(SensorBase):
                 wp.from_torch(orientations.contiguous(), dtype=wp.vec4f),
                 idx_wp,
             )
+        # write through to the data buffers so explicitly set poses are never stale,
+        # regardless of :attr:`CameraCfg.update_latest_camera_pose`
+        self._update_poses(env_ids=idx_wp, frame_op=0)
 
     """
     Operations

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -323,11 +323,11 @@ def test_camera_init_intrinsic_matrix(setup_sim_camera):
     )
 
 
-def test_camera_set_world_poses(setup_sim_camera):
-    """Test camera function to set specific world pose."""
+@pytest.mark.parametrize("update_latest_camera_pose", [False, True])
+def test_camera_set_world_poses(setup_sim_camera, update_latest_camera_pose):
+    """Test that an explicitly set world pose is reflected in the data buffers."""
     sim, camera_cfg, dt = setup_sim_camera
-    # enable update latest camera pose
-    camera_cfg.update_latest_camera_pose = True
+    camera_cfg.update_latest_camera_pose = update_latest_camera_pose
     # init camera
     camera = Camera(camera_cfg)
     # play sim
@@ -343,11 +343,11 @@ def test_camera_set_world_poses(setup_sim_camera):
     _assert_quat_close(camera.data.quat_w_world.warp.numpy(), orientation, rtol=1e-5, atol=1e-5)
 
 
-def test_camera_set_world_poses_from_view(setup_sim_camera):
-    """Test camera function to set specific world pose from view."""
+@pytest.mark.parametrize("update_latest_camera_pose", [False, True])
+def test_camera_set_world_poses_from_view(setup_sim_camera, update_latest_camera_pose):
+    """Test that a pose set from eye/target is reflected in the data buffers."""
     sim, camera_cfg, dt = setup_sim_camera
-    # enable update latest camera pose
-    camera_cfg.update_latest_camera_pose = True
+    camera_cfg.update_latest_camera_pose = update_latest_camera_pose
     # init camera
     camera = Camera(camera_cfg)
     # play sim


### PR DESCRIPTION
## Description

Fixes #6422.

`Camera.set_world_poses()` and `Camera.set_world_poses_from_view()` wrote the new pose to the simulation view only, leaving `camera.data.pos_w` and the orientation buffers at their initialization values unless `CameraCfg.update_latest_camera_pose=True` was set (a documented perf opt-in that forces a `FrameView` read every update). Any consumer of the pose data after an explicit `set_world_poses` — including the shipped `run_usd_camera.py` tutorial's point-cloud unprojection — silently used the stale init pose, producing the zero-pose / NaN point clouds reported.

The fix is a write-through: both setters now call `_update_poses(env_ids, frame_op=0)` after writing the view, so the data buffers always reflect an explicitly set pose. This reuses the existing tested path (convention conversion, partial position/orientation updates, renderer notification via `update_camera`) and costs one view read on an explicit user call. `update_latest_camera_pose` keeps its meaning: it governs pose refresh for cameras moved by other means (e.g. physics). `reset()` already refreshed poses unconditionally, so this extends an existing precedent to the setters.

The two existing `set_world_poses*` tests were parametrized over `update_latest_camera_pose` — the `False` cases fail on `develop` and pass with this change. Both tests previously worked around the bug by force-enabling the flag.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- `test_camera.py::test_camera_set_world_poses[False/True]`, `::test_camera_set_world_poses_from_view[False/True]` — `[False]` fails on `develop`, passes here
- `source/isaaclab/test/sensors/test_camera.py` — 39 passed
- `source/isaaclab/test/sensors/test_tiled_camera.py` — 8 passed (TiledCamera inherits the setters)
- Issue repro (default config, headless): `data.pos_w` now reads the set pose instead of zeros

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
