### PR TITLE
Update ovphysx to 0.5.11

### DIFF
--- a/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
+++ b/docs/source/overview/core-concepts/physical-backends/ovphysx/index.rst
@@ -11,7 +11,7 @@ OvPhysX Backend
 .. warning::
 
     Do not combine OvPhysX with the Kit visualizer. Commands such as
-    ``presets=ovphysx --visualizer kit`` are unsupported because OvPhysX
+    ``physics=ovphysx --visualizer kit`` are unsupported because ovphysx
     loads USD-dependent PhysX plugins from its own package, while Kit already
     owns a separate USD/plugin stack in the same process. Use
     ``--visualizer newton``, ``--visualizer rerun``, ``--visualizer viser``,
@@ -148,16 +148,17 @@ syntax as the other backends:
 
       .. code-block:: bash
 
-          uv run python scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct --num_envs 128 --viz none presets=ovphysx
+          uv run isaaclab zero_agent --task Isaac-Cartpole-Direct \
+              --num_envs 128 --max_steps 64 --viz none physics=ovphysx
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
       .. code-block:: bash
 
-          ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct --num_envs 128 --viz none presets=ovphysx
+          ./isaaclab.sh -p scripts/environments/zero_agent.py --task Isaac-Cartpole-Direct \
+              --num_envs 128 --max_steps 64 --viz none physics=ovphysx
 
-This command starts a headless zero-action rollout; stop it with ``Ctrl+C``
-after the environment has started and stepped successfully.
+This command runs a 64-step headless zero-action rollout and then exits.
 
 Supported locomotion environments
 ---------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,8 +162,8 @@ rerun = [
 
 isaacsim = ["isaacsim[all,extscache]==6.0.1.0"]
 
-ov = ["ovphysx==0.5.10", "ovrtx==0.4.1.364340", "ovstage==0.1.1.355824"]
-ovphysx = ["ovphysx==0.5.10", "ovstage==0.1.1.355824"]
+ov = ["ovphysx==0.5.11", "ovrtx==0.4.1.364340", "ovstage==0.1.1.355824"]
+ovphysx = ["ovphysx==0.5.11", "ovstage==0.1.1.355824"]
 ovrtx = ["ovrtx==0.4.1.364340", "ovstage==0.1.1.355824"]
 
 mimic = [
@@ -209,7 +209,7 @@ usd_exchange = "2.3.0"
 torch = "2.11.0"
 torchvision = "0.26.0"
 torchaudio = "2.11.0"
-ovphysx = "0.5.10"
+ovphysx = "0.5.11"
 ovrtx = "0.4.1.364340"
 ovstage = "0.1.1.355824"
 newton = "release-1.5"

--- a/source/isaaclab/changelog.d/malesiani-ovphysx-0-5-11.skip
+++ b/source/isaaclab/changelog.d/malesiani-ovphysx-0-5-11.skip
@@ -1,0 +1,1 @@
+Test-only: updated the asserted ovphysx dependency pin to match the supported runtime.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -133,7 +133,7 @@ def test_version_single_source_matches_literal_pins():
     optional = pyproject["project"]["optional-dependencies"]
     overrides = pyproject["tool"]["uv"]["override-dependencies"]
 
-    assert versions["ovphysx"] == "0.5.10"
+    assert versions["ovphysx"] == "0.5.11"
     assert "omniverseclient==2.72.3" in dependencies
 
     # Isaac Sim extra mirrors the table, and the teleop extra repeats the same pin.

--- a/source/isaaclab_ov/changelog.d/malesiani-ovphysx-0-5-11.rst
+++ b/source/isaaclab_ov/changelog.d/malesiani-ovphysx-0-5-11.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Updated the optional ovphysx runtime to 0.5.11. OVStage attachment now honors
+  explicit CUDA device selection. OVStage-backed articulation link and DOF
+  indices now use stable path-derived ordering, which may differ from 0.5.10;
+  use reported paths or names when identity matters.

--- a/uv.lock
+++ b/uv.lock
@@ -1764,12 +1764,12 @@ wheels = [
 
 [[package]]
 name = "isaaclab"
-version = "16.4.0"
+version = "19.0.2"
 source = { editable = "source/isaaclab" }
 
 [[package]]
 name = "isaaclab-assets"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "source/isaaclab_assets" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -1788,7 +1788,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-contrib"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "source/isaaclab_contrib" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2052,8 +2052,8 @@ requires-dist = [
     { name = "onnxscript", specifier = ">=0.5" },
     { name = "onnxscript", marker = "extra == 'rsl-rl'", specifier = ">=0.5" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux')", specifier = ">=0.19.0" },
-    { name = "ovphysx", marker = "extra == 'ov'", specifier = "==0.5.10", index = "https://pypi.org/simple" },
-    { name = "ovphysx", marker = "extra == 'ovphysx'", specifier = "==0.5.10", index = "https://pypi.org/simple" },
+    { name = "ovphysx", marker = "extra == 'ov'", specifier = "==0.5.11", index = "https://pypi.org/simple" },
+    { name = "ovphysx", marker = "extra == 'ovphysx'", specifier = "==0.5.11", index = "https://pypi.org/simple" },
     { name = "ovrtx", marker = "extra == 'ov'", specifier = "==0.4.1.364340", index = "https://pypi.org/simple" },
     { name = "ovrtx", marker = "extra == 'ovrtx'", specifier = "==0.4.1.364340", index = "https://pypi.org/simple" },
     { name = "ovstage", marker = "extra == 'ov'", specifier = "==0.1.1.355824", index = "https://pypi.org/simple" },
@@ -2156,7 +2156,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-newton"
-version = "5.3.0"
+version = "5.4.1"
 source = { editable = "source/isaaclab_newton" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2167,7 +2167,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-ov"
-version = "2.1.0"
+version = "2.3.0"
 source = { editable = "source/isaaclab_ov" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2182,7 +2182,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-physx"
-version = "5.1.0"
+version = "5.2.1"
 source = { editable = "source/isaaclab_physx" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2204,7 +2204,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-rl"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "source/isaaclab_rl" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2221,7 +2221,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-tasks"
-version = "17.0.0"
+version = "19.0.1"
 source = { editable = "source/isaaclab_tasks" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2251,7 +2251,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-teleop"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "source/isaaclab_teleop" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2262,7 +2262,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-visualizers"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "source/isaaclab_visualizers" }
 dependencies = [
     { name = "isaaclab", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -3978,16 +3978,16 @@ wheels = [
 
 [[package]]
 name = "ovphysx"
-version = "0.5.10"
+version = "0.5.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ovstage", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
     { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/a7/dbef61a44e1663eb70d14218d80e9eb4f5e87aa1552ae17f46058cad5c55/ovphysx-0.5.10-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:88b223278aa91c031aef6815f6dbf03497c18aacd441ec97ff86e1c917fcf5c8", size = 162095322, upload-time = "2026-08-07T08:25:52.199Z" },
-    { url = "https://files.pythonhosted.org/packages/df/65/6026f684b457576455fe599a0a3e74716857d50f30a02ace0d503e6aa528/ovphysx-0.5.10-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:b8ffa4a26570cbf252b161e752c4ea7f0843b32ed96573aba99757ceb19efeb1", size = 168897727, upload-time = "2026-08-07T08:23:51.141Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/76/939750c6d7e9ca8968413ac8ebd7a5a1c370338089a98fd41927ffc3c334/ovphysx-0.5.10-py3-none-win_amd64.whl", hash = "sha256:d75ae94c56e14191a4540dd955cd6d9217d5ed79f144244eb19ddf9bab200a7d", size = 148006495, upload-time = "2026-08-07T08:20:50.922Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/93/36e41c4ea7c9a1e0a4a7ab95286c7428b228bd78eccd1e5d5388f893c88b/ovphysx-0.5.11-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:fff7e648fe14989e6ae51b7c6e6c516beab0b4f0749110c32c5a142b31525946", size = 162111746, upload-time = "2026-08-28T08:44:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ea/df4b90eb2ba9136eac99d0da839fa687c77017016300674801254c79e107/ovphysx-0.5.11-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:4e6f904d9858674ecf4fccc2a462d048f9eeb7d20724a7eafd294bf5ccac9a2c", size = 168926695, upload-time = "2026-08-28T08:45:49.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8f/f653c0d8b8973c482ac0e93500c5d48d846ca0f49388122f60a1a49a6c99/ovphysx-0.5.11-py3-none-win_amd64.whl", hash = "sha256:409637574296f2f4c9a377444c2072c5539a8a5adf88b9536c02fdff6af387be", size = 148040678, upload-time = "2026-08-28T08:47:14.928Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Update the optional ovphysx runtime from 0.5.10 to 0.5.11 and refresh the
lockfile from the public PyPI artifacts. The matched OVStage 0.1.1.355824 and
OVRTX 0.4.1.364340 pins remain unchanged.

ovphysx 0.5.11 honors explicit CUDA device selection during OVStage attachment
and gives OVStage-backed articulation link and DOF indices stable path-derived
ordering. The changelog notes that columns may move relative to 0.5.10 and that
identity-sensitive code should use reported paths or names. The ovphysx backend
guide now uses the current typed `physics=ovphysx` selector and a bounded smoke
command.

Upstream release: https://github.com/NVIDIA-Omniverse/PhysX/releases/tag/ovphysx-0.5.11

## Type of change

- Dependency update
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this updates a dependency, lockfile, test assertion, changelog,
and command-line documentation.

## Testing

- `uvx --from uv==0.9.25 uv lock --check`
- Frozen public install with the `ov` and `test` extras
- `64 passed`: root dependency metadata and `source/isaaclab_ov/test/physics`
- `5 passed` on CPU and `4 passed` on `cuda:0`: focused rigid-object and articulation checks in isolated processes
- 64-step Cartpole Direct smokes on CPU and `cuda:0`, plus Ant Direct on `cuda:0`
- 64-step Cartpole Direct smoke on a true `cuda:1` device from a fresh frozen install
- Two RSL-RL Cartpole Direct training iterations on `cuda:0`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` - CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
