### PR TITLE
Keep configclass usable as a decorator after submodule imports

### DIFF
--- a/source/isaaclab/changelog.d/antoiner-configclass-shadowing.rst
+++ b/source/isaaclab/changelog.d/antoiner-configclass-shadowing.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed ``from isaaclab.utils import configclass`` returning the submodule instead of the decorator
+  after any import of ``isaaclab.utils.configclass`` (order-dependent
+  ``TypeError: 'module' object is not callable``). The submodule is now callable and forwards to
+  the decorator, so both import spellings work regardless of import order.

--- a/source/isaaclab/isaaclab/utils/configclass.py
+++ b/source/isaaclab/isaaclab/utils/configclass.py
@@ -8,6 +8,7 @@
 import dataclasses
 import inspect
 import re
+import sys
 import types
 from collections.abc import Callable
 from copy import deepcopy
@@ -638,3 +639,19 @@ def checked_apply(src: Any, target: Any) -> None:
                 f"{target_path} has no attribute `{f.name}`. {type(src).__name__} is out of sync with target."
             )
         setattr(target, f.name, getattr(src, f.name))
+
+
+class _ConfigclassModule(types.ModuleType):
+    """Module type that forwards calls to :func:`configclass`.
+
+    Importing the ``isaaclab.utils.configclass`` submodule binds this module object as the
+    ``configclass`` attribute on the :mod:`isaaclab.utils` package, shadowing the function
+    exported through the lazy-loader stub. Making the module callable keeps
+    ``from isaaclab.utils import configclass`` usable as a decorator regardless of import order.
+    """
+
+    def __call__(self, cls, **kwargs):
+        return configclass(cls, **kwargs)
+
+
+sys.modules[__name__].__class__ = _ConfigclassModule

--- a/source/isaaclab/test/utils/test_configclass.py
+++ b/source/isaaclab/test/utils/test_configclass.py
@@ -1240,3 +1240,27 @@ def test_checked_apply_rejects_non_dataclass_src():
 
     with pytest.raises(TypeError, match="must be a dataclass"):
         checked_apply(NotADataclass(), object())
+
+
+def test_configclass_import_survives_submodule_shadowing():
+    """``from isaaclab.utils import configclass`` must stay usable as a decorator.
+
+    Importing the ``isaaclab.utils.configclass`` submodule binds the module object as an
+    attribute on the package, shadowing the lazy-loader function export. Regression test for
+    the order-dependent ``TypeError: 'module' object is not callable``. Runs in a subprocess
+    so the import order is controlled.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import isaaclab.utils.configclass as _sub  # binds the submodule on the package\n"
+        "from isaaclab.utils import configclass\n"
+        "@configclass\n"
+        "class _Cfg:\n"
+        "    a: int = 1\n"
+        "assert _Cfg().a == 1\n"
+        "print('DECORATOR_OK')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0 and "DECORATOR_OK" in result.stdout, result.stderr[-500:]


### PR DESCRIPTION
## Description

`from isaaclab.utils import configclass` returns the *submodule* instead of the decorator whenever any code has previously imported `isaaclab.utils.configclass` — which most of `isaaclab` itself does (`terrains.sub_terrain_cfg`, `controllers.*_cfg`, `renderers.renderer_cfg`, `utils.noise.noise_cfg`, ...). The user-facing symptom is an order-dependent `TypeError: 'module' object is not callable` on the most common import in Isaac Lab user code:

```python
from isaaclab.scene import InteractiveScene   # imports the cfg chain
from isaaclab.utils import configclass        # -> module, not function

@configclass                                   # TypeError: 'module' object is not callable
class MyCfg: ...
```

Root cause: the lazy-loader stub exports the function through `__getattr__`, but a submodule import makes the import system bind the module object as the `configclass` attribute on the package. `__getattr__` is only consulted when the attribute is absent, so the module permanently shadows the function (the classic module-name/symbol-name collision).

Fix: make the `configclass` submodule callable — its module class now forwards `__call__` to the decorator. Both import spellings work regardless of import order, nothing is renamed, and no call sites change. Normalizing internal imports alone would not fix it, since any *user* submodule import re-triggers the shadowing.

Adds a subprocess-based regression test (fresh interpreter, controlled import order) that fails on `develop` and passes here.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- `test_configclass.py::test_configclass_import_survives_submodule_shadowing` — fails on `develop`, passes here
- `source/isaaclab/test/utils/test_configclass.py` — 45 passed

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
