### PR TITLE
Restructure and correct the troubleshooting and known issues references

### DIFF
--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -5,81 +5,47 @@ Known Issues
 
     Please also refer to the `Omniverse Isaac Sim documentation`_ for known issues and workarounds.
 
-Stale values after resetting the environment
---------------------------------------------
+Each entry below names the backends it affects. An issue listed under one backend does not
+apply to the others unless it says so.
 
-When resetting the environment, some of the data fields of assets and sensors are not updated.
-These include the poses of links in a kinematic chain, the camera images, the contact sensor readings,
-and the lidar point clouds. This is a known issue which has to do with the way the PhysX and
-rendering engines work in Omniverse.
+.. contents::
+   :local:
+   :depth: 2
+
+
+PhysX backends
+--------------
+
+Sensor readings are stale immediately after a reset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``physics=isaacsim_physx``, ``physics=ovphysx``, and any RTX-based renderer.
 
 Many physics engines do a simulation step as a two-level call: ``forward()`` and ``simulate()``,
-where the kinematic and dynamic states are updated, respectively. Unfortunately, PhysX has only a
-single ``step()`` call where the two operations are combined. Due to computations through GPU
-kernels, it is not so straightforward for them to split these operations. Thus, at the moment,
-it is not possible to set the root and/or joint states and do a forward call to update the
-kinematic states of links. This affects both initialization as well as episodic resets.
+where the kinematic and dynamic states are updated respectively. PhysX has only a single
+``step()`` call where the two operations are combined. Because of computations through GPU
+kernels, it is not straightforward to split them. As a result, writing a root or joint state
+does not by itself run a full forward pass.
 
-Similarly for RTX rendering related sensors (such as cameras), the sensor data is not updated
-immediately after setting the state of the sensor. The rendering engine update is bundled with
-the simulator's ``step()`` call which only gets called when the simulation is stepped forward.
-This means that the sensor data is not updated immediately after a reset and it will hold
-outdated values.
+For **articulation link poses** this is handled: reading
+:attr:`~isaaclab.assets.ArticulationData.body_link_pose_w` (or the deprecated
+:attr:`~isaaclab.assets.ArticulationData.body_state_w`) triggers a PhysX kinematic update, so
+link poses reflect a preceding root-state or joint-state write without an intervening
+``step()``.
 
-While the above is erroneous, there is currently no direct workaround for it. From our experience in
-using IsaacGym, the reset values affect the agent learning critically depending on how frequently
-the environment terminates. Eventually if the agent is learning successfully, this number drops
-and does not affect the performance that critically.
+For **RTX rendering-based sensors** — cameras in particular — the data is still not refreshed
+by a state write. The rendering engine update is bundled with the simulator's ``step()`` call,
+so the sensor data is only refreshed when the simulation is stepped forward, and a read taken
+between a reset and the next step returns the previous frame.
 
-We have made a feature request to the respective Omniverse teams to have complete control
-over stepping different parts of the simulation app. However, at this point, there is no set
-timeline for this feature request.
-
-.. note::
-    With Isaac Lab 1.2, we have introduced a PhysX kinematic update call inside the
-    :attr:`~isaaclab.assets.ArticulationData.body_state_w` attribute. This workaround
-    ensures that the states of the links are updated when the root state or joint state
-    of an articulation is set.
-
-
-Blank initial frames from the camera
-------------------------------------
-
-When using the :class:`~isaaclab.sensors.Camera` sensor in standalone scripts, the first few frames
-may be blank. This is a known issue with the simulator where it needs a few steps to load the material
-textures properly and fill up the render targets.
-
-A hack to work around this is to add the following after initializing the camera sensor and setting
-its pose:
-
-.. code-block:: python
-
-    from isaaclab.sim import SimulationContext
-
-    sim = SimulationContext.instance()
-
-    # note: the number of steps might vary depending on how complicated the scene is.
-    for _ in range(12):
-        sim.render()
-
-
-Using instanceable assets for markers
--------------------------------------
-
-When using `instanceable assets`_ for markers, the markers do not work properly, since Omniverse does not support
-instanceable assets when using the :class:`UsdGeom.PointInstancer` schema. This is a known issue and will hopefully
-be fixed in a future release.
-
-If you use an instanceable assets for markers, the marker class removes all the physics properties of the asset.
-This is then replicated across other references of the same asset since physics properties of instanceable assets
-are stored in the instanceable asset's USD file and not in its stage reference's USD file.
-
-.. _instanceable assets: https://docs.isaacsim.omniverse.nvidia.com/latest/isaac_lab_tutorials/tutorial_instanceable_assets.html
-.. _Omniverse Isaac Sim documentation: https://docs.isaacsim.omniverse.nvidia.com/latest/overview/known_issues.html#
-
+There is currently no direct workaround for the sensor case. From our experience, the reset
+values affect agent learning in proportion to how frequently the environment terminates; as an
+agent learns successfully, the termination rate drops and the effect becomes less significant.
 
 Exiting the process
--------------------
+~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``physics=isaacsim_physx``.
 
 When exiting a process with ``Ctrl+C``, occasionally the below error may appear:
 
@@ -93,54 +59,80 @@ message and continue with terminating the process. On Windows systems, please us
 ``Ctrl+Break`` or ``Ctrl+fn+B`` to terminate the process.
 
 
+Newton backends
+---------------
+
 .. _known-issues-closed-loop-newton:
 
-Closed-loop articulations on Newton (e.g. Agility Digit)
---------------------------------------------------------
+Closed-loop articulations are not available on Newton (e.g. Agility Digit)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Robots whose USD encodes a closed kinematic loop -- such as the achilles rod and
-toe push-rods on the Agility Digit -- do not currently run correctly on the
-``newton_mjwarp`` physics preset, even though they work on ``physx``. This affects:
+**Affects:** ``physics=newton_mjwarp``, ``physics=newton_kamino``.
+
+Robots whose USD encodes a closed kinematic loop — such as the achilles rod and toe push-rods
+on the Agility Digit — are not currently validated on the Newton backends. The Digit-based
+contrib tasks are PhysX-only and do not expose a Newton preset at all:
 
 * ``IsaacContrib-Velocity-Flat-Digit``
 * ``IsaacContrib-Velocity-Rough-Digit``
 * ``IsaacContrib-Tracking-LocoManip-Digit``
 
-The root cause sits inside Newton's :class:`~newton.selection.ArticulationView`. When
-it builds its per-link axis it walks each joint in the articulation's joint range and
-appends ``model.joint_child[joint_id]`` without deduplicating. A body that is the
-child of multiple joints (the standard closed-loop encoding) therefore occupies
-multiple slots on that axis, so ``view.link_count`` is larger than the number of
-unique physical bodies in the model. On Digit this is 49 link slots versus 43 actual
-bodies (the four loop-closed bodies -- left/right ``tarsus`` and left/right
-``toe_roll`` -- account for the six extra slots).
+Passing ``presets=newton_mjwarp`` to these tasks is rejected, because the preset never
+selected a Newton backend on them; it only stripped a center-of-mass randomization from a
+PhysX run. Use the default PhysX configuration for Digit-based environments.
 
-Until the upstream fix lands in Newton, please use the ``physx`` preset for
-Digit-based environments.
 
+Renderers
+---------
+
+Blank initial frames from the camera
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** RTX-based renderers (``renderer=isaacsim_rtx``, ``renderer=ovrtx``).
+
+When using the :class:`~isaaclab.sensors.Camera` sensor in standalone scripts, the first few frames
+may be blank. This is a known issue with the simulator where it needs a few steps to load the material
+textures properly and fill up the render targets. It is most likely on a cold asset cache and in
+scenes with many or large textures; simple scenes with locally cached assets often render content on
+the very first frame.
+
+If you do see blank frames, add the following after initializing the camera sensor and setting
+its pose:
+
+.. code-block:: python
+
+    from isaaclab.sim import SimulationContext
+
+    sim = SimulationContext.instance()
+
+    # note: the number of steps might vary depending on how complicated the scene is.
+    for _ in range(12):
+        sim.render()
 
 .. _known-issues-animated-curve-scene-partition:
 
 Animated curves disappear under Isaac RTX scene partitioning
--------------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled. The OVRTX backend
+updates animated-curve bounding boxes correctly and is unaffected.
 
 Cables are authored as ``UsdGeom.BasisCurves`` and animated every frame. Kit RTX
 computes a bounding box for a curve prim once and never refreshes it while the curve
 deforms (OMPE-105749). The per-environment scene partition is sized from the union of
 the bounding boxes of the prims it contains, so that union covers the cable's *initial*
 extent plus whatever static geometry shares the partition. Once the cable moves outside
-that union it is culled and vanishes from the tiled camera images -- for example a cable
+that union it is culled and vanishes from the tiled camera images — for example a cable
 resting on a table can disappear the moment a robot arm pushes it off the edge.
 
 The bug is specific to the Isaac RTX (Kit) backend with
 :attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` enabled.
-The OVRTX backend updates animated-curve bounding boxes correctly and is unaffected.
 
 The displacement needed to trip the cull is the distance from the curve's spawn extent to the edge
-of its partition's bounding box, so it depends on what else shares the partition. Measured on Kit
-110.1.2: the cable in ``Isaac-Lift-Cable-Franka-Camera`` vanishes at 0.6 m of displacement, while a
-lone curve in a partition containing only itself and a camera survives to roughly 4 m. Smaller
-motions render normally, which is why a settled or lightly perturbed cable looks fine.
+of its partition's bounding box, so it depends on what else shares the partition. In a measurement
+on Kit 110.1.2, the cable in ``Isaac-Lift-Cable-Franka-Camera`` vanished at 0.6 m of displacement,
+while a lone curve in a partition containing only itself and a camera survived to roughly 4 m.
+Smaller motions render normally, which is why a settled or lightly perturbed cable looks fine.
 
 There are two workarounds:
 
@@ -160,23 +152,49 @@ There are two workarounds:
   ``False`` to opt out of partitioning entirely, at the cost of the per-environment
   culling.
 
+Using instanceable assets for markers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-URDF Importer: Unresolved references for fixed joints
------------------------------------------------------
+**Affects:** all Kit-based renderers.
 
-Starting with Isaac Sim 5.1, links connected through ``fixed_joint`` elements are no longer merged when
-their URDF link entries specify mass and inertia even if ``merge-joint`` set to True.
-This is expected behaviour—those links are treated as full bodies rather than zero-mass reference frames.
+When using `instanceable assets`_ for markers, the markers do not work properly, since Omniverse does not support
+instanceable assets when using the :class:`UsdGeom.PointInstancer` schema. This is a known issue and will hopefully
+be fixed in a future release.
+
+If you use an instanceable assets for markers, the marker class removes all the physics properties of the asset.
+This is then replicated across other references of the same asset since physics properties of instanceable assets
+are stored in the instanceable asset's USD file and not in its stage reference's USD file.
+
+.. _instanceable assets: https://docs.isaacsim.omniverse.nvidia.com/latest/isaac_lab_tutorials/tutorial_instanceable_assets.html
+.. _Omniverse Isaac Sim documentation: https://docs.isaacsim.omniverse.nvidia.com/latest/overview/known_issues.html#
+
+
+Asset import
+------------
+
+URDF importer: unresolved references for fixed joints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** the URDF importer, independent of the physics backend.
+
+Links connected through ``fixed_joint`` elements are not merged when their URDF link entries
+specify mass and inertia, even if ``merge-joint`` is set to True. This is expected behaviour —
+those links are treated as full bodies rather than zero-mass reference frames.
 However, the USD importer currently raises ``ReportError`` warnings showing unresolved references for such links
 when they lack visuals or colliders. This is a known bug in the importer; it creates references to visuals
 that do not exist. The warnings can be safely ignored until the importer is updated.
 
 
-GLIBCXX errors in Conda
------------------------
+Environment and setup
+---------------------
 
-In Isaac Sim 5.0, we have observed some workflows exiting with an ``OSError`` indicating
-``version 'GLIBCXX_3.4.30' not found`` when running from a conda environment.
-The issue apperas to be stemming from importing torch or torch-related packages, such as tensorboard,
-prior to launching ``AppLauncher``. As a workaround, ensure that all torch imports happen after
-the ``AppLauncher`` instance has been created, which should resolve the error.
+GLIBCXX errors in conda environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** conda-based installations, independent of the physics backend.
+
+Some workflows exit with an ``OSError`` indicating ``version 'GLIBCXX_3.4.30' not found``
+when running from a conda environment. The issue appears to stem from importing torch or
+torch-related packages, such as tensorboard, prior to launching ``AppLauncher``. As a
+workaround, ensure that all torch imports happen after the ``AppLauncher`` instance has been
+created, which should resolve the error.

--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -15,129 +15,121 @@ Tricks and Troubleshooting
     <https://docs.omniverse.nvidia.com/kit/docs/kit-manual/latest/guide/linux_troubleshooting.html>`__ for more
     assistance.
 
+.. contents::
+   :local:
+   :depth: 2
 
-Installation Troubleshooting
-----------------------------
 
-``ModuleNotFoundError: No module named 'pip'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Installation and imports
+------------------------
 
-Your venv was created without pip. The install system auto-detects and uses
-``uv pip`` when pip is absent, so this error should no longer occur with the
-latest Isaac Lab.
+An Isaac Lab package cannot be imported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``ModuleNotFoundError: No module named 'isaacsim'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A ``ModuleNotFoundError`` naming an Isaac Lab package almost always means the command is
+not running inside the Isaac Lab environment, rather than that the package was skipped at
+install time. Most packages cannot be deselected at all.
 
-You are running a script that requires Isaac Sim, but it is not installed.
-Either:
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
 
-- Install Isaac Sim: ``./isaaclab.sh -i isaacsim``, or
-- Use a Newton-based task with ``physics=newton_mjwarp --visualizer newton`` (Kit-less path)
+   * - Missing module
+     - What it means
+   * - ``isaaclab``, ``isaaclab_assets``, ``isaaclab_tasks``, ``isaaclab_physx``,
+       ``isaaclab_ov``, ``isaaclab_newton``, ``isaaclab_rl``, ``isaaclab_visualizers``,
+       ``isaaclab_contrib``, ``isaaclab_experimental``, ``isaaclab_ppisp``,
+       ``isaaclab_tasks_experimental``
+     - Core packages. Every ``isaaclab install`` run installs them as editable packages and
+       there is no way to opt out, so the error points at the environment rather than at the
+       install command.
+   * - ``isaaclab_mimic``, ``isaaclab_teleop``
+     - Optional packages. ``isaaclab install`` (equivalently ``isaaclab install all``)
+       includes them; ``isaaclab install core`` does not.
+   * - ``rsl_rl``, ``rl_games``, ``skrl``, ``stable_baselines3``
+     - Reinforcement learning frameworks, installed by the ``rl`` feature. They are part of
+       the default install; ``isaaclab install 'rl[rsl-rl]'`` installs a single framework.
+   * - ``isaacsim``
+     - Isaac Sim itself, which is never installed implicitly. See
+       :ref:`troubleshooting-isaacsim-missing`.
 
-``ModuleNotFoundError: No module named 'isaaclab_physx'`` or ``'isaaclab_ov'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These config packages are auto-installed by ``./isaaclab.sh -i``. If using a
-selective install, re-run with the default ``./isaaclab.sh -i`` to get all
-packages.
-
-``ModuleNotFoundError: No module named 'isaaclab_assets'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Include ``assets`` in your install command, or use ``./isaaclab.sh -i`` to install
-everything.
-
-``ModuleNotFoundError: No module named 'isaaclab_tasks'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``isaaclab_tasks`` package contains the registered task environments. This
-error usually means the command is not running in the Isaac Lab Python
-environment or the repository packages were not installed in editable mode.
-
-Try the following checks:
-
-1. Run from the Isaac Lab repository root using uv:
-
-   .. code-block:: bash
-
-      uv run python -c "import isaaclab_tasks; print('ok')"
-
-2. If the import still fails, recreate the documented source-install
-   environment for your workflow.
-
-3. Re-run the task command from the repository root instead of a system Python:
-
-   .. code-block:: bash
-
-      uv run python scripts/environments/random_agent.py --task Isaac-Cartpole --num_envs 4
-
-``<package> requires <version>, but <other-package> requires <version>``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-During pip or uv installs, the package manager may print dependency warnings
-where an Isaac Lab package, Isaac Sim package, or third-party package declares
-an incompatible dependency constraint. Common examples include ``coverage``,
-``packaging``, ``numpy``, or ``Pillow`` constraints reported between
-``isaaclab``, ``isaacsim-kernel``, ``isaacsim-core``, ``nvidia-srl-usd``, and
-``moviepy``.
-
-These messages are generally benign when the install command completes
-successfully. They usually reflect package metadata that is stricter or older
-than the versions bundled and tested with Isaac Sim. Prefer starting from a
-fresh virtual environment and using the installation commands in the Isaac Lab
-docs. If the resolver aborts with ``No solution found`` or installation leaves
-missing modules at runtime, recreate the environment and install the documented
-Isaac Sim version before installing Isaac Lab.
-
-``ModuleNotFoundError: No module named 'rsl_rl'``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-RSL-RL is included in the default uv environment. Retry the command with ``uv run``, which
-syncs missing default dependencies before running it. For the legacy installer, use
-``./isaaclab.sh -i 'rl[rsl-rl]'`` or ``./isaaclab.sh -i`` to install all
-frameworks.
-
-Crash in ``libusd_tf`` / USD Symbol Collision with OVRTX
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you see a crash involving ``libusd_tf-*.so`` and conflicting USD versions
-(e.g. ``pxrInternal_v0_25_5`` vs ``pxrInternal_v0_25_11``):
-
-1. Ensure ``LD_PRELOAD`` is set to ovrtx's ``libcarb.so`` and install the OVRTX
-   runtime with ``./isaaclab.sh -i 'ov[ovrtx]'`` (see :ref:`modularized installation <installation-selective-install>`)
-2. Ensure ``isaacsim`` / ``omniverse-kit`` is **not** installed in the same
-   environment — their bundled USD libraries conflict with ovrtx's
-
-Visualizer Not Appearing
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-If ``--visualizer newton`` shows no window, you may be missing ``imgui-bundle``:
+First check whether the package resolves in the uv-managed environment, from the
+repository root:
 
 .. code-block:: bash
 
-   uv pip install imgui-bundle
+   uv run python -c "import isaaclab_tasks; print('ok')"
 
-For ``viser``, check the terminal for a URL (e.g. ``http://localhost:8012``).
+If that succeeds but your own command fails, the command is running against a different
+interpreter. Re-run it through ``uv run`` from the repository root:
 
-``GLIBC Version Too Old``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: bash
 
-Isaac Sim pip packages require GLIBC 2.35+. Check with ``ldd --version``.
-Ubuntu 22.04+ satisfies this. For older distributions, use the
+   uv run python scripts/environments/random_agent.py --task Isaac-Cartpole --num_envs 4
+
+If the import fails under ``uv run`` as well, recreate the documented source-install
+environment for your workflow.
+
+.. note::
+
+   The ``ov``, ``contrib`` and ``tetrahedralization`` features are deliberately excluded
+   from the default install and must be requested explicitly, for example
+   ``isaaclab install 'ov[ovrtx]'``.
+
+.. _troubleshooting-isaacsim-missing:
+
+Isaac Sim is not installed
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ModuleNotFoundError: No module named 'isaacsim'`` means a script that requires Isaac Sim
+was launched without it. Either install Isaac Sim:
+
+.. code-block:: bash
+
+   ./isaaclab.sh -i isaacsim
+
+or run a Newton-based task, which does not need Kit:
+
+.. code-block:: bash
+
+   uv run isaaclab train --task Isaac-Cartpole physics=newton_mjwarp --visualizer newton
+
+See :doc:`/source/setup/quickstart` for the full list of ``physics=`` and ``renderer=``
+selectors and the extras each one requires.
+
+Dependency version conflicts during installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+During pip or uv installs, the package manager may print dependency warnings of the form
+``<package> requires <version>, but <other-package> requires <version>``, where an Isaac
+Lab package, an Isaac Sim package, or a third-party package declares an incompatible
+constraint. Common examples include ``coverage``, ``packaging``, ``numpy``, or ``Pillow``
+constraints reported between ``isaaclab``, ``isaacsim-kernel``, ``isaacsim-core``,
+``nvidia-srl-usd``, and ``moviepy``.
+
+These messages are generally benign when the install command completes successfully. They
+usually reflect package metadata that is stricter or older than the versions bundled and
+tested with Isaac Sim. Prefer starting from a fresh virtual environment and using the
+installation commands in the Isaac Lab docs. If the resolver aborts with
+``No solution found``, or the installation leaves missing modules at runtime, recreate the
+environment and install the documented Isaac Sim version before installing Isaac Lab.
+
+GLIBC is too old
+~~~~~~~~~~~~~~~~
+
+Isaac Sim pip packages require GLIBC 2.35 or newer. Check your version with
+``ldd --version``. Ubuntu 22.04 and later satisfy this. On older distributions, use the
 `binary installation <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/install_workstation.html>`_
-method for Isaac Sim.
-
-Troubleshooting distributed training NCCL errors
-------------------------------------------------
-
-On some Linux multi-GPU systems, distributed training may fail with
-``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``.
-For documented NCCL workarounds, see :ref:`multi-gpu-nccl-troubleshooting`.
+method for Isaac Sim instead.
 
 
-Debugging physics simulation stability issues
----------------------------------------------
+PhysX backends
+--------------
+
+These entries apply to the ``physics=isaacsim_physx`` and ``physics=ovphysx`` backends.
+
+Simulation instability with newly imported robots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When importing new robots into Isaac Lab or setting up a new environment, simulation instability
 can often appear if the assets have not been tuned with reasonable simulation parameters.
@@ -148,10 +140,15 @@ If this happens, we recommend consulting the
 `Articulation and Robot Simulation Stability Guide <https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/dev_guide/guides/articulation_stability_guide.html>`_
 which recommends various simulation parameters and best practices to achieve better stability in robot simulations.
 
-Additionally, `Omniverse PhysX Visual Debugger <https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/extensions/ux/source/omni.physx.pvd/docs/dev_guide/physx_visual_debugger.html>`_
-allows for recording of data of PhysX simulations, which can often help simulation issues and aid the debugging process.
+Recording a simulation with OmniPVD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To enable OmniPVD capture in Isaac Lab, add the relevant kit arguments to the command line prompt when launching an Isaac Lab process
+The `Omniverse PhysX Visual Debugger <https://docs.omniverse.nvidia.com/kit/docs/omni_physics/latest/extensions/ux/source/omni.physx.pvd/docs/dev_guide/physx_visual_debugger.html>`_
+allows for recording of data of PhysX simulations, which can often help diagnose simulation
+issues and aid the debugging process.
+
+To enable OmniPVD capture in Isaac Lab, add the relevant kit arguments to the command line
+prompt when launching an Isaac Lab process:
 
 .. tab-set::
 
@@ -168,9 +165,62 @@ To enable OmniPVD capture in Isaac Lab, add the relevant kit arguments to the co
 
           ./isaaclab.sh -p scripts/demos/bipeds.py --kit_args "--/persistent/physics/omniPvdOvdRecordingDirectory=/tmp/ --/physics/omniPvdOutputEnabled=true"
 
+GPU buffer capacity errors
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the GPU pipeline, the buffers used for the physics simulation are allocated on
+the GPU only once at the start of the simulation. They do not grow dynamically as the number
+of collisions or objects in the scene changes. If the scene exceeds the size of a buffer, the
+simulation fails with an error such as:
+
+.. code:: bash
+
+    PhysX error: the application need to increase the PxgDynamicsMemoryConfig::foundLostPairsCapacity
+    parameter to 3072, otherwise the simulation will miss interactions
+
+Raise the matching field on the physics configuration for the backend you are running. The
+field is named after the PhysX parameter — for the error above it is
+:attr:`~isaaclab_physx.physics.PhysxCfg.gpu_found_lost_pairs_capacity`:
+
+.. code:: python
+
+    import isaaclab.sim as sim_utils
+    from isaaclab.sim import SimulationContext
+    from isaaclab_physx.physics import PhysxCfg
+
+    sim_cfg = sim_utils.SimulationCfg(physics=PhysxCfg(gpu_found_lost_pairs_capacity=2**22))
+    sim = SimulationContext(sim_cfg)
+
+The same field exists on :class:`~isaaclab_ov.physics.OvPhysxCfg` for the ``ovphysx``
+backend. Inside a task, set it on the task's preset so that both PhysX backends stay in
+sync:
+
+.. code:: python
+
+    from isaaclab.physics import PhysxAutoCfg
+    from isaaclab.utils.configclass import configclass
+    from isaaclab_ov.physics import OvPhysxCfg
+    from isaaclab_physx.physics import PhysxCfg
+    from isaaclab_tasks.utils import PresetCfg
+
+    @configclass
+    class MyPhysicsCfg(PresetCfg):
+        isaacsim_physx = PhysxCfg(gpu_found_lost_pairs_capacity=2**22)
+        ovphysx = OvPhysxCfg(gpu_found_lost_pairs_capacity=2**22)
+        physx = PhysxAutoCfg(isaacsim_physx=isaacsim_physx, ovphysx=ovphysx)
+
+The defaults are already large, so only raise a capacity when PhysX explicitly asks for it.
+Please see :class:`~isaaclab.sim.SimulationCfg` for the other parameters that configure the
+simulation.
+
+
+Newton backends
+---------------
+
+These entries apply to the ``physics=newton_mjwarp`` and ``physics=newton_kamino`` backends.
 
 Joints actuate in PhysX but not in a Newton-based backend
----------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Newton resolves target modes for joints covered by an Isaac Lab actuator
 configuration before constructing the solver. For an
@@ -189,34 +239,77 @@ actuator configuration. See :ref:`import-new-asset-ensure-drives-exist` for
 details.
 
 
-Checking the internal logs from the simulator
----------------------------------------------
+Renderers and visualizers
+-------------------------
 
-When running the simulator from a standalone script, it logs warnings and errors to the terminal. At the same time,
-it also logs internal messages to a file. These are useful for debugging and understanding the internal state of the
-simulator. Depending on your system, the log file can be found in the locations listed
+Crash in ``libusd_tf`` / USD symbol collision with OVRTX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you see a crash involving ``libusd_tf-*.so`` and conflicting USD versions
+(e.g. ``pxrInternal_v0_25_5`` vs ``pxrInternal_v0_25_11``):
+
+1. Ensure ``LD_PRELOAD`` is set to ovrtx's ``libcarb.so`` and install the OVRTX
+   runtime with ``./isaaclab.sh -i 'ov[ovrtx]'`` (see :ref:`modularized installation <installation-selective-install>`)
+2. Ensure ``isaacsim`` / ``omniverse-kit`` is **not** installed in the same
+   environment — their bundled USD libraries conflict with ovrtx's
+
+The Newton visualizer window does not appear
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Newton interactive viewer needs ``imgui-bundle``, which is a base dependency of Isaac
+Lab. In a uv-managed environment it is always present, so a missing window normally points
+at the display rather than the package. If you are running in an environment that was not
+built from the Isaac Lab dependency set, install it explicitly:
+
+.. code-block:: bash
+
+   uv pip install imgui-bundle
+
+The viser visualizer serves a web UI instead of opening a window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``--visualizer viser`` does not open a native window. Check the terminal for the served
+URL; the default port is ``8080``, configurable through
+:attr:`~isaaclab_visualizers.ViserVisualizerCfg.port`. The ``viser`` package ships in the
+``viser`` extra.
+
+
+Distributed training
+--------------------
+
+NCCL errors during multi-GPU training
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On some Linux multi-GPU systems, distributed training may fail with
+``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``.
+For documented NCCL workarounds, see :ref:`multi-gpu-nccl-troubleshooting`.
+
+
+Debugging and diagnostics
+-------------------------
+
+Checking the internal logs from the simulator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When running a Kit-based workflow from a standalone script, the simulator logs warnings and
+errors to the terminal. At the same time, it also logs internal messages to a file. These
+are useful for debugging and understanding the internal state of the simulator. Depending
+on your system, the log file can be found in the locations listed
 `here <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/install_faq.html#common-path-locations>`_.
 
-To obtain the exact location of the log file, you need to check the first few lines of the terminal output when
-you run the standalone script. The log file location is printed at the start of the terminal output. For example:
+To obtain the exact location of the log file, check the first few lines of the terminal
+output when you run the standalone script. The log file location is printed at the start of
+the terminal output, on a line of the form:
 
 .. code:: bash
 
-    [INFO] Using python from: /home/${USER}/git/IsaacLab/_isaac_sim/python.sh
-    ...
-    Passing the following args to the base kit application:  []
-    Loading user config located at: '.../data/Kit/Isaac-Sim/2023.1/user.config.json'
-    [Info] [carb] Logging to file: '.../logs/Kit/Isaac-Sim/2023.1/kit_20240328_183346.log'
+    [Info] [carb] Logging to file: '.../logs/Kit/Isaac-Sim/<version>/kit_<timestamp>.log'
 
-
-In the above example, the log file is located at ``.../logs/Kit/Isaac-Sim/2023.1/kit_20240328_183346.log``,
-``...`` is the path to the user's log directory. The log file is named ``kit_20240328_183346.log``
-
-You can open this file to check the internal logs from the simulator. Also when reporting issues, please include
-this log file to help us debug the issue.
+You can open this file to check the internal logs from the simulator. When reporting issues,
+please include this log file to help us debug the issue.
 
 Changing logging channel levels for the simulator
--------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the simulator logs messages at the ``WARN`` level and above on the terminal. You can change the logging
 channel levels to get more detailed logs. The logging channel levels can be set through Omniverse's logging system.
@@ -247,9 +340,56 @@ For instance, to run a standalone script with verbose logging, you can use the f
 For more fine-grained control, you can modify the logging channels through the ``logger`` module.
 For more information, please refer to its `documentation <https://docs.python.org/3/library/logging.html>`__.
 
+Understanding the error logs from crashes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a Kit-based script crashes, the terminal is often swamped with exceptions, many of
+which come from the Python interpreter calling ``__del__()`` destructors as the simulation
+application tears down. They look like this:
+
+.. code:: bash
+
+    ...
+
+    [INFO]: Completed setting up the environment...
+
+    Traceback (most recent call last):
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 166, in <module>
+        main()
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 126, in main
+        actions = pre_process_actions(delta_pose, gripper_command)
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 57, in pre_process_actions
+        return torch.concat([delta_pose, gripper_vel], dim=1)
+    TypeError: expected Tensor as element 1 in argument 0, but got int
+    Exception ignored in: <function _make_registry.<locals>._Registry.__del__ at 0x7f94ac097f80>
+    Traceback (most recent call last):
+      File ".../omni/kit/viewport/registry/registry.py", line 103, in __del__
+      File ".../omni/kit/viewport/registry/registry.py", line 98, in destroy
+    TypeError: 'NoneType' object is not callable
+    Exception ignored in: <function SettingChangeSubscription.__del__ at 0x7fa2ea173e60>
+    Traceback (most recent call last):
+      File ".../omni/kit/app/_impl/__init__.py", line 114, in __del__
+    AttributeError: 'NoneType' object has no attribute 'get_settings'
+    [Warning] [carb.audio.context] 1 contexts were leaked
+    Segmentation fault (core dumped)
+    There was an error running python
+
+The teardown exceptions are noise. Scroll **above** the ``registry`` and
+``Exception ignored in`` blocks to find the actual error — in the example above:
+
+.. code:: bash
+
+    Traceback (most recent call last):
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 166, in <module>
+        main()
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 126, in main
+        actions = pre_process_actions(delta_pose, gripper_command)
+      File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 57, in pre_process_actions
+        return torch.concat([delta_pose, gripper_vel], dim=1)
+    TypeError: expected Tensor as element 1 in argument 0, but got int
 
 Observing long load times at the start of the simulation
---------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The first time you run the simulator, it will take a long time to load up. This is because the
 simulator is compiling shaders and loading assets. Subsequent runs should be faster to start up,
@@ -264,40 +404,8 @@ When an instance of Isaac Sim is already running, launching another Isaac Sim in
 process may appear to hang at startup for the first time. Please be patient and give it some time as
 the second process will take longer to start up due to slower shader compilation.
 
-
-Receiving a “PhysX error” when running simulation on GPU
---------------------------------------------------------
-
-When using the GPU pipeline, the buffers used for the physics simulation are allocated on the GPU only
-once at the start of the simulation. This means that they do not grow dynamically as the number of
-collisions or objects in the scene changes. If the number of collisions or objects in the scene
-exceeds the size of the buffers, the simulation will fail with an error such as the following:
-
-.. code:: bash
-
-    PhysX error: the application need to increase the PxgDynamicsMemoryConfig::foundLostPairsCapacity
-    parameter to 3072, otherwise the simulation will miss interactions
-
-In this case, you need to increase the size of the buffers passed to the
-:class:`~isaaclab.sim.SimulationContext` class. The size of the buffers can be increased by setting
-the :attr:`~isaaclab.sim.PhysxCfg.gpu_found_lost_pairs_capacity` parameter in the
-:class:`~isaaclab.sim.PhysxCfg` class. For example, to increase the size of the buffers to
-4096, you can use the following code:
-
-.. code:: python
-
-    import isaaclab.sim as sim_utils
-
-    sim_cfg = sim_utils.SimulationConfig()
-    sim_cfg.physx.gpu_found_lost_pairs_capacity = 4096
-    sim = SimulationContext(sim_params=sim_cfg)
-
-Please see the documentation for :class:`~isaaclab.sim.SimulationCfg` for more details
-on the parameters that can be used to configure the simulation.
-
-
 Preventing memory leaks in the simulator
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Memory leaks in the Isaac Sim simulator can occur when C++ callbacks are registered with Python objects.
 This happens when callback functions within classes maintain references to the Python objects they are
@@ -309,7 +417,6 @@ To prevent memory leaks in the Isaac Sim simulator, it is essential to use weak 
 callbacks with the simulator. This ensures that Python objects can be garbage collected when they are no
 longer needed, thereby avoiding memory leaks. The `weakref <https://docs.python.org/3/library/weakref.html>`_
 module from the Python standard library can be employed for this purpose.
-
 
 For example, consider a class with a callback function ``on_event_callback`` that needs to be registered
 with the simulator. If you use a strong reference to the ``MyClass`` object when passing the callback,
@@ -364,66 +471,3 @@ In this revised code, the weak reference ``weakref.proxy(self)`` is used when re
 allowing the ``MyClass`` object to be properly garbage collected.
 
 By following this pattern, you can prevent memory leaks and maintain a more efficient and stable simulation.
-
-
-Understanding the error logs from crashes
------------------------------------------
-
-Many times the simulator crashes due to a bug in the implementation.
-This swamps the terminal with exceptions, some of which are coming from
-the python interpreter calling ``__del__()`` destructor of the
-simulation application. These typically look like the following:
-
-.. code:: bash
-
-    ...
-
-    [INFO]: Completed setting up the environment...
-
-    Traceback (most recent call last):
-    File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 166, in <module>
-        main()
-    File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 126, in main
-        actions = pre_process_actions(delta_pose, gripper_command)
-    File "scripts/imitation_learning/robomimic/collect_demonstrations.py", line 57, in pre_process_actions
-        return torch.concat([delta_pose, gripper_vel], dim=1)
-    TypeError: expected Tensor as element 1 in argument 0, but got int
-    Exception ignored in: <function _make_registry.<locals>._Registry.__del__ at 0x7f94ac097f80>
-    Traceback (most recent call last):
-    File "../IsaacLab/_isaac_sim/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 103, in __del__
-    File "../IsaacLab/_isaac_sim/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 98, in destroy
-    TypeError: 'NoneType' object is not callable
-    Exception ignored in: <function _make_registry.<locals>._Registry.__del__ at 0x7f94ac097f80>
-    Traceback (most recent call last):
-    File "../IsaacLab/_isaac_sim/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 103, in __del__
-    File "../IsaacLab/_isaac_sim/kit/extscore/omni.kit.viewport.registry/omni/kit/viewport/registry/registry.py", line 98, in destroy
-    TypeError: 'NoneType' object is not callable
-    Exception ignored in: <function SettingChangeSubscription.__del__ at 0x7fa2ea173e60>
-    Traceback (most recent call last):
-    File "../IsaacLab/_isaac_sim/kit/kernel/py/omni/kit/app/_impl/__init__.py", line 114, in __del__
-    AttributeError: 'NoneType' object has no attribute 'get_settings'
-    Exception ignored in: <function RegisteredActions.__del__ at 0x7f935f5cae60>
-    Traceback (most recent call last):
-    File "../IsaacLab/_isaac_sim/extscache/omni.kit.viewport.menubar.lighting-104.0.7/omni/kit/viewport/menubar/lighting/actions.py", line 345, in __del__
-    File "../IsaacLab/_isaac_sim/extscache/omni.kit.viewport.menubar.lighting-104.0.7/omni/kit/viewport/menubar/lighting/actions.py", line 350, in destroy
-    TypeError: 'NoneType' object is not callable
-    2022-12-02 15:41:54 [18,514ms] [Warning] [carb.audio.context] 1 contexts were leaked
-    ../IsaacLab/_isaac_sim/python.sh: line 41: 414372 Segmentation fault      (core dumped) $python_exe "$@" $args
-    There was an error running python
-
-This is a known error with running standalone scripts with the Isaac Sim
-simulator. Please scroll above the exceptions thrown with
-``registry`` to see the actual error log.
-
-In the above case, the actual error is:
-
-.. code:: bash
-
-    Traceback (most recent call last):
-    File "scripts/imitation_learning/robomimic/tools/collect_demonstrations.py", line 166, in <module>
-        main()
-    File "scripts/imitation_learning/robomimic/tools/collect_demonstrations.py", line 126, in main
-        actions = pre_process_actions(delta_pose, gripper_command)
-    File "scripts/imitation_learning/robomimic/tools/collect_demonstrations.py", line 57, in pre_process_actions
-        return torch.concat([delta_pose, gripper_vel], dim=1)
-    TypeError: expected Tensor as element 1 in argument 0, but got int


### PR DESCRIPTION
# Description

The `refs/troubleshooting.rst` and `refs/issues.rst` pages had drifted from the code. This reorganizes both by backend and fixes the claims that no longer hold. Every claim on these pages was checked against the current source or reproduced against a running simulator; the entries that could not be settled are called out below rather than silently kept.

## Structure

- `troubleshooting.rst` is grouped under **Installation**, **PhysX backends**, **Newton backends**, **Renderers and visualizers**, **Distributed training**, and **Debugging and diagnostics**, so backend-specific advice is no longer interleaved with generic advice.
- The seven `ModuleNotFoundError` headings are collapsed into one section with a lookup table. The raw error strings made the local table of contents unreadable, and five of them shared a single answer. The literal error strings stay in the body so docs search still finds them.
- Every `issues.rst` entry is grouped by backend and carries an **Affects:** line, since several are renderer-specific rather than physics-specific.

## Corrections

`troubleshooting.rst`:

- The PhysX GPU buffer section was wrong four ways at once: it referenced a nonexistent `SimulationConfig` class, passed a `sim_params` keyword that `SimulationContext` does not accept, pointed at `isaaclab.sim.PhysxCfg` instead of `isaaclab_physx.physics.PhysxCfg` (so both `:class:` xrefs were broken), and told the reader to raise the buffer "to 4096" when the default is `2**21`. Rewritten against the real config path, with a `PresetCfg` variant matching how tasks set it today.
- The `isaaclab_assets` entry told users to include an `assets` token in their install command. No such token exists — `isaaclab_assets` is in `CORE_ISAACLAB_SUBMODULES` and cannot be deselected. Same confusion applied to `isaaclab_physx`, `isaaclab_ov` and `isaaclab_tasks`.
- viser's URL example used port 8012; `ViserVisualizerCfg.port` defaults to 8080.
- The "install `imgui-bundle`" advice is obsolete — it is a base dependency, annotated in `pyproject.toml` as "in base, no extra required".
- Backend selection used a `--physics` flag; the correct form is the `physics=` Hydra override, with the quickstart as the canonical selector list.
- Removed the `No module named 'pip'` entry, whose own body said it no longer occurs, and refreshed the Isaac Sim 2022/2023-era log and crash-trace examples.

`issues.rst`:

- **Digit / closed-loop articulations** — the stated root cause is fixed upstream. Newton now deduplicates the link axis (`arti_link_ids = sorted(set(arti_link_ids))`), so `link_count` is no longer inflated. Separately, `DigitPhysicsCfg` declares only `isaacsim_physx`, so the recommended workaround ("use the `physx` preset") no longer describes a choice the user has. Rewritten.
- **Stale values after reset** — no longer true for articulation link poses. Reproduced by commanding a cartpole slider `+0.5 m` and reading `body_state_w` with no intervening step: it reflected exactly the commanded delta. The entry is narrowed to RTX sensors, where the behavior does still hold, rather than deleted.
- **Blank initial camera frames** — did not reproduce on Isaac Sim 6.0.1.0 using the maintained `run_usd_camera.py` scene (frame 0 already had content, all 20 frames non-blank). Since the stated mechanism is texture loading and that run had a warm asset cache, the entry is scoped to cold caches and texture-heavy scenes rather than removed.
- Dropped the Isaac Lab 1.2 and Isaac Sim 5.0 / 5.1 version references throughout.

## Entries deliberately left on trust

These could not be settled here and their guidance is unchanged: the `Ctrl+C` `omni.physx` message (nondeterministic), instanceable assets for markers, and the conda `GLIBCXX` error (no conda environment available; conda remains a documented install path). The URDF importer entry is also unchanged — a minimal repro on `URDF USD Converter v0.1.3` merged the fixed-joint child despite mass and inertia and emitted no `ReportError`, contradicting the entry's premise, but a single synthetic asset is not enough to rewrite it.

## Type of change

- This change requires a documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!-- Documentation-only change: no source package is modified, so no changelog fragment is required. The docs build passes with no warnings on either page. -->
