### PR TITLE
Exclude tensorboard link from link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -85,6 +85,7 @@ jobs:
           --exclude '^file://'
           --exclude '^mailto:'
           --exclude 'localhost'
+          --exclude 'www\.tensorflow\.org/tensorboard'
           --exclude '127\.0\.0\.1'
           --exclude 'example\.com'
           --exclude 'your-organization'


### PR DESCRIPTION
## Description

`Check for Broken Links` currently fails on every PR: `https://www.tensorflow.org/tensorboard` (referenced from `docs/source/overview/reinforcement-learning/rl_existing_scripts.rst`) now bounces anonymous crawlers into a Google OAuth redirect loop, which lychee reports as a broken link. The page loads fine in a browser, so the link itself is correct — the checker just can't follow the auth redirect.

Adds the URL to the existing lychee `--exclude` list. First observed failing on community PR #7246, whose docs-only change doesn't touch any links.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
