### PR TITLE
Add fingertip-tracking viewer default to Factory environments

### DIFF
--- a/source/isaaclab_tasks/changelog.d/antoiner-factory-viewer.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-factory-viewer.rst
@@ -1,0 +1,6 @@
+Added
+^^^^^
+
+* Added a default viewer camera to the Factory and FORGE environments that tracks the
+  ``panda_fingertip_centered`` body, so the viewport opens on the manipulation workspace
+  instead of the default wide world view.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/factory/factory_env_cfg.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from isaaclab_physx.physics import PhysxCfg
+from isaaclab_visualizers.kit import KitVisualizerCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
@@ -112,6 +113,12 @@ class FactoryEnvCfg(DirectRLEnvCfg):
         device="cuda:0",
         dt=1 / 120,
         gravity=(0.0, 0.0, -9.81),
+        default_visualizer_cfg=KitVisualizerCfg(
+            eye=(0.3, 0.3, 0.3),
+            lookat=(0.0, 0.0, 0.0),
+            origin_type="asset",
+            origin_track_path="robot/panda_fingertip_centered",
+        ),
         physics=PhysxCfg(
             solver_type=1,
             max_position_iteration_count=192,  # Important to avoid interpenetration.


### PR DESCRIPTION
## Description

Fixes #3359.

The Factory (and FORGE, which inherits its `sim` config) environments opened with the default wide world view, which is unhelpful for a tabletop insertion task. This adds a default viewer camera that tracks the `panda_fingertip_centered` body, so the viewport opens on the manipulation workspace.

The original proposal targeted the 2.x `env_cfg.viewer` field, which is deprecated in 3.0; this implements it through the current surface, `SimulationCfg.default_visualizer_cfg`, with a `KitVisualizerCfg` carrying `origin_type="asset"` / `origin_track_path="robot/panda_fingertip_centered"`. The hint-forwarding in `SimulationContext._apply_default_visualizer_cfg` skips fields the resolved visualizer doesn't have, so non-Kit visualizers (`--viz newton`) receive only the eye/lookat hint and are otherwise unaffected. `panda_fingertip_centered` is the body the env itself indexes (`factory_env.py:72`).

Verified both `FactoryEnvCfg()` and `ForgeEnvCfg()` construct with the tracking config resolved.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
