### PR TITLE
Document clearing the asset root for China profile

### DIFF
--- a/docs/source/setup/installation/asset_caching_details.inc
+++ b/docs/source/setup/installation/asset_caching_details.inc
@@ -83,7 +83,8 @@ experience file does work, because that is the value Isaac Lab reads when the va
 
 .. rubric:: Using the China Storage Profile
 
-To use the public China asset mirror, select the same named storage profile used by Isaac Sim before launch:
+To use the public China asset mirror, clear any explicit asset-root override, then select the same named storage
+profile used by Isaac Sim before launch:
 
 .. tab-set::
    :sync-group: os
@@ -93,6 +94,7 @@ To use the public China asset mirror, select the same named storage profile used
 
       .. code:: bash
 
+         unset ISAACSIM_ASSET_ROOT
          export ISAACSIM_STORAGE_PROFILE=china
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows
@@ -100,6 +102,7 @@ To use the public China asset mirror, select the same named storage profile used
 
       .. code:: batch
 
+         set ISAACSIM_ASSET_ROOT=
          set ISAACSIM_STORAGE_PROFILE=china
 
 Isaac Lab uses the same versioned public bucket paths shown by Isaac Sim and routes reads through the profile's CDN.


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Clarify that users must clear `ISAACSIM_ASSET_ROOT` before selecting the `china` storage profile. The explicit asset-root variable has higher precedence and otherwise prevents the profile's asset root from taking effect.

Related: #7086

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this change has no visual UI.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

## Validation

- Targeted pre-commit checks for the changed documentation file passed.
- `git diff --check` passed.
- The repository changelog-fragment hook still reports the fork's stale `origin/develop` baseline; this change touches no `source/<pkg>` package.
- A full Sphinx build was not run because Sphinx is not installed in the current environment.
