### PR TITLE
Drop Kit's bundled Python stdlib from PYTHONPATH in isaaclab.sh

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -181,6 +181,7 @@ Guidelines for modifications:
 * Rosario Scalise
 * Ruben D'Sa
 * Ruben Grandia
+* Ruoyan Han
 * Ryan Gresia
 * Ryley McCarroll
 * Sahara Yuta

--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -44,6 +44,10 @@ if [ -d "$ISAACLAB_PATH/_isaac_sim" ]; then
         export EXP_PATH="$ISAAC_PATH/apps"
         # shellcheck disable=SC1091
         . "$ISAACLAB_PATH/_isaac_sim/setup_python_env.sh" >/dev/null 2>&1 || true
+        # setup_python_env.sh also adds Kit's bundled Python stdlib
+        # (kit/python/lib/python3.12) which shadows the active interpreter's
+        # stdlib; its platform.py cannot parse conda-forge sys.version strings.
+        export PYTHONPATH="$(echo "$PYTHONPATH" | tr ':' '\n' | grep -vE '/kit/python/lib/python3\.[0-9]+$' | paste -sd:)"
         # Unlike setup_conda_env.sh, setup_python_env.sh prepends Kit's
         # pip_prebundle directories to PYTHONPATH. Those ship vendored copies of
         # common libraries (e.g. an older typing_extensions lacking Sentinel)


### PR DESCRIPTION
# Description

With a pre-built Isaac Sim 6.0 binary linked as `_isaac_sim` and a conda environment from `./isaaclab.sh --conda`, `./isaaclab.sh --install` fails on its first step (`pip install --upgrade pip`) with:

```
  File ".../_isaac_sim/kit/python/lib/python3.12/platform.py", line 1110, in _sys_version
ValueError: failed to parse CPython sys.version: '3.12.14 | packaged by conda-forge | (main, Aug 21 2026, 22:48:28) [GCC 14.4.0]'
```

Isaac Sim 6.0 ships no `setup_conda_env.sh`, so `isaaclab.sh` sources `setup_python_env.sh`, which appends Kit's **entire bundled Python stdlib** (`kit/python/lib/python3.12`) to `PYTHONPATH`. `PYTHONPATH` entries precede the interpreter's own stdlib on `sys.path`, so the bundled `platform.py` shadows the conda one. Its older `sys_version_parser` regex has no handling for the conda-forge `"| packaged by conda-forge |"` version string, so `platform.python_version()` raises — and pip calls it to build its user agent, so every pip invocation in the env fails.

The existing workaround in `isaaclab.sh` (prepending the env's `site-packages`) does not help here, because a stdlib directory rather than a package is being shadowed.

This PR filters that single directory out of `PYTHONPATH` right after sourcing `setup_python_env.sh`. Kit's `site-packages`, `python_packages`, extension and `pip_prebundle` paths are untouched.

Verified with Isaac Sim `6.0.0-rc.59` binary + conda-forge Python 3.12.14: `--install` completes, `scripts/tutorials/00_sim/create_empty.py` runs, and `scripts/reinforcement_learning/train.py --rl_library rsl_rl --task Isaac-Cartpole` trains.

Note: the same issue could alternatively be fixed on the Isaac Sim side by not adding the stdlib directory in `setup_python_env.sh`; this change makes Isaac Lab work with the already-shipped 6.0 binaries regardless.

Fixes #7417

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (no test harness exists for `isaaclab.sh`; verified manually as described above)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (not applicable — no `source/<pkg>/` changes)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
