### PR TITLE
Fix oversized stacking cubes under the Newton backend

### DIFF
--- a/source/isaaclab_tasks/changelog.d/newton-stack-cube-render-scale.rst
+++ b/source/isaaclab_tasks/changelog.d/newton-stack-cube-render-scale.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed the stacking cubes rendering at roughly 40x their intended size in the
+  ``IsaacContrib-Stack-Cube-*`` tasks when running with ``physics=newton_mjwarp``. The shipped
+  ``Props/Blocks/*_block.usd`` assets apply ``PhysicsRigidBodyAPI`` directly to a mesh prim whose
+  size comes solely from ``xformOp:scale``, and Newton body transforms carry no scale, so the world
+  matrix written back for rendering reset that scale to 1. The cubes are now spawned from an
+  equivalent :class:`~isaaclab.sim.CuboidCfg` under the ``newton_mjwarp`` physics preset, which
+  encodes the size in the geometry and leaves the rigid-body prim at unit scale. The PhysX presets
+  keep using the original USD block assets, so their behavior is unchanged.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -26,7 +26,7 @@ from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg, UsdF
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from . import mdp
 from .mdp import stack_events
@@ -40,6 +40,69 @@ _CUBE_PROPERTIES = RigidBodyPropertiesCfg(
     max_depenetration_velocity=5.0,
     disable_gravity=False,
 )
+
+# Properties of the shipped ``Props/Blocks/*_block.usd`` assets, mirrored by the Newton
+# cube spawns below. The block mesh spans 1.8802 units and is sized purely by an
+# ``xformOp:scale`` of 0.025 authored on the mesh prim, giving a 4.7 cm edge; mass and
+# friction are read from the asset's ``PhysicsMassAPI`` / ``PhysicsMaterialAPI``.
+_CUBE_EDGE_LEN = 0.047
+_CUBE_MASS = 0.02
+_CUBE_STATIC_FRICTION = 0.8
+_CUBE_DYNAMIC_FRICTION = 1.0
+# Approximate the blue / red / green block materials with flat colors.
+_CUBE_COLORS = {"cube_1": (0.05, 0.1, 0.75), "cube_2": (0.75, 0.05, 0.05), "cube_3": (0.05, 0.6, 0.1)}
+
+
+def _usd_cube_spawn(usd_name: str, semantic_class: str) -> UsdFileCfg:
+    """Build the shipped USD block spawn used by the PhysX backend."""
+    return UsdFileCfg(
+        usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/{usd_name}",
+        scale=(1.0, 1.0, 1.0),
+        rigid_props=_CUBE_PROPERTIES,
+        semantic_tags=[("class", semantic_class)],
+    )
+
+
+def _newton_cube_spawn(semantic_class: str) -> sim_utils.CuboidCfg:
+    """Build an equivalent procedural cube spawn that renders correctly under Newton.
+
+    The shipped block assets apply ``PhysicsRigidBodyAPI`` directly to a mesh prim whose
+    size comes solely from ``xformOp:scale``. Newton body transforms carry only
+    translation and rotation, so the world matrix written back for rendering resets that
+    scale to 1 and the block draws at its full unscaled mesh size. Spawning a
+    :class:`~isaaclab.sim.CuboidCfg` instead encodes the size in the geometry itself and
+    leaves the rigid-body prim at unit scale, which sidesteps the issue.
+
+    The cube matches the asset it replaces: same edge length, mass, and friction, and the
+    block's own collider was already a bounding cube.
+
+    Args:
+        semantic_class: Semantic class tag applied to the spawned cube.
+
+    Returns:
+        The configured :class:`~isaaclab.sim.CuboidCfg`.
+    """
+    return sim_utils.CuboidCfg(
+        size=(_CUBE_EDGE_LEN, _CUBE_EDGE_LEN, _CUBE_EDGE_LEN),
+        rigid_props=_CUBE_PROPERTIES,
+        mass_props=sim_utils.MassPropertiesCfg(mass=_CUBE_MASS),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            static_friction=_CUBE_STATIC_FRICTION,
+            dynamic_friction=_CUBE_DYNAMIC_FRICTION,
+            restitution=0.0,
+        ),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=_CUBE_COLORS[semantic_class], metallic=0.0),
+        semantic_tags=[("class", semantic_class)],
+    )
+
+
+def _cube_spawn(usd_name: str, semantic_class: str):
+    """Select the cube spawn appropriate for the active physics backend."""
+    return preset(
+        default=_usd_cube_spawn(usd_name, semantic_class),
+        newton_mjwarp=_newton_cube_spawn(semantic_class),
+    )
 
 
 def make_ee_frame_cfg(
@@ -125,32 +188,17 @@ class ObjectTableSceneCfg(InteractiveSceneCfg):
     cube_1 = RigidObjectCfg(
         prim_path="{ENV_REGEX_NS}/Cube_1",
         init_state=RigidObjectCfg.InitialStateCfg(pos=[0.4, 0.0, 0.0203], rot=[0, 0, 0, 1]),
-        spawn=UsdFileCfg(
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/blue_block.usd",
-            scale=(1.0, 1.0, 1.0),
-            rigid_props=_CUBE_PROPERTIES,
-            semantic_tags=[("class", "cube_1")],
-        ),
+        spawn=_cube_spawn("blue_block.usd", "cube_1"),
     )
     cube_2 = RigidObjectCfg(
         prim_path="{ENV_REGEX_NS}/Cube_2",
         init_state=RigidObjectCfg.InitialStateCfg(pos=[0.55, 0.05, 0.0203], rot=[0, 0, 0, 1]),
-        spawn=UsdFileCfg(
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/red_block.usd",
-            scale=(1.0, 1.0, 1.0),
-            rigid_props=_CUBE_PROPERTIES,
-            semantic_tags=[("class", "cube_2")],
-        ),
+        spawn=_cube_spawn("red_block.usd", "cube_2"),
     )
     cube_3 = RigidObjectCfg(
         prim_path="{ENV_REGEX_NS}/Cube_3",
         init_state=RigidObjectCfg.InitialStateCfg(pos=[0.60, -0.1, 0.0203], rot=[0, 0, 0, 1]),
-        spawn=UsdFileCfg(
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/green_block.usd",
-            scale=(1.0, 1.0, 1.0),
-            rigid_props=_CUBE_PROPERTIES,
-            semantic_tags=[("class", "cube_3")],
-        ),
+        spawn=_cube_spawn("green_block.usd", "cube_3"),
     )
 
 


### PR DESCRIPTION
The shipped Props/Blocks/*_block.usd assets apply PhysicsRigidBodyAPI directly to a mesh prim whose size comes solely from an xformOp:scale of 0.025 on a mesh that spans 1.88 units. Newton body transforms carry only translation and rotation, so the world matrix written back for rendering resets that scale to 1 and the cubes draw at their full unscaled mesh size, larger than the table and the robot.

Spawn the cubes from an equivalent CuboidCfg under the newton_mjwarp physics preset instead. That encodes the size in the geometry and leaves the rigid-body prim at unit scale, so there is no scale for the transform sync to drop. The replacement matches the asset it stands in for: same 4.7 cm edge, 0.02 kg mass and friction, and the block collider was already a bounding cube.

The preset is attached to the spawn field rather than the whole cube entry because __post_init__ runs before preset resolution and the SO-101 config mutates cube_N.init_state there. PhysX presets keep the original USD blocks, so their behavior is unchanged.

# Description

> [!IMPORTANT]
> Confirm the pull request base before submitting. Target `develop` for all
> contributions. The `release/3.0.0-beta2` branch is a frozen stable landing
> snapshot and is not used for ongoing maintenance.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
