### PR TITLE
Make Franka Pour reset artifact path root-relative

### DIFF
--- a/source/isaaclab_tasks/changelog.d/franka-pour-root-relative-reset-contract.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/franka-pour-root-relative-reset-contract.minor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed Franka Pour reset artifacts to store the robot asset path relative to the Isaac Lab
+  asset root. Regenerate custom reset datasets with ``generate_franka_pour_reset_dataset.py`` before using
+  them with the updated task.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/franka_pour/README.md
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/franka_pour/README.md
@@ -60,7 +60,8 @@ The generator and task load the Franka Pour cups USD from the standard Isaac Lab
 root. Set `ISAACLAB_FRANKA_POUR_CUPS_USD_PATH` only to use a compatible local copy instead. The
 published reset artifact lives alongside those assets at `Contrib/MPM/Pour/reset_dataset.pt`.
 Setting `ISAACSIM_ASSET_ROOT` redirects all three dependencies to a compatible local or self-hosted
-asset tree.
+asset tree. The reset artifact records the Franka path relative to that root so the task contract
+does not depend on the configured asset host.
 
 The `datasets/` directory is ignored by Git. Both downloaded and locally generated payloads validate
 their stored content digest, so no digest override is needed for ordinary training or playback. For

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/franka_pour/pour_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/franka_pour/pour_env_cfg.py
@@ -55,7 +55,8 @@ from .reset_sampler import ResetDatasetSamplerCfg
 RIGID_ENTRY = "arm"
 MPM_ENTRY = "media"
 
-FRANKA_POUR_ROBOT_ASSET_ID = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/franka_panda.usda"
+FRANKA_POUR_ROBOT_ASSET_PATH = "Robots/FrankaEmika/franka_panda.usda"
+FRANKA_POUR_ROBOT_ASSET_ID = f"{ISAACLAB_NUCLEUS_DIR}/{FRANKA_POUR_ROBOT_ASSET_PATH}"
 FRANKA_POUR_ROBOT_PHYSICS_PAYLOAD_SHA256 = "0dc38454f02ea14d9ddd2437995fdc7c4a65634443cacdcc2a04e3de25655e00"
 FRANKA_POUR_CUPS_ASSET_ID = f"{ISAACLAB_NUCLEUS_DIR}/Contrib/MPM/Pour/franka_pour_cups.usda"
 FRANKA_POUR_RESET_DATASET_ASSET_ID = f"{ISAACLAB_NUCLEUS_DIR}/Contrib/MPM/Pour/reset_dataset.pt"
@@ -806,7 +807,7 @@ def _reset_dataset_task_contract(cfg: FrankaPourResetDatasetEnvCfg) -> dict[str,
     gripper_open_pos = cfg.scene.robot.init_state.joint_pos["panda_finger_joint.*"]
 
     return {
-        "robot_asset": FRANKA_POUR_ROBOT_ASSET_ID,
+        "robot_asset": FRANKA_POUR_ROBOT_ASSET_PATH,
         "robot_physics_payload_sha256": FRANKA_POUR_ROBOT_PHYSICS_PAYLOAD_SHA256,
         "source_box_half": source_half,
         "source_mouth_height": SOURCE_CUP_GEOMETRY.rim_height,

--- a/source/isaaclab_tasks/test/contrib/test_franka_pour_env_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/test_franka_pour_env_cfg.py
@@ -7,8 +7,11 @@
 
 import pytest
 
+from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+
 from isaaclab_tasks.contrib.franka_pour import pour_env
 from isaaclab_tasks.contrib.franka_pour.pour_env_cfg import (
+    FRANKA_POUR_ROBOT_ASSET_ID,
     FrankaPourResetDatasetEnvCfg,
     _configure_mpm_capacities,
     _reset_dataset_task_contract,
@@ -60,6 +63,15 @@ def test_nested_overrides_are_authoritative_without_rebuilding_assets():
     assert solver.media_solver.max_iterations == 17
     assert not cfg.sim.physics.use_cuda_graph
     assert _reset_dataset_task_contract(cfg) == reset_contract
+
+
+def test_reset_dataset_contract_stores_root_relative_robot_asset_path():
+    """Reset artifacts identify the robot independently of the configured asset root."""
+    cfg = FrankaPourResetDatasetEnvCfg()
+
+    robot_asset = _reset_dataset_task_contract(cfg)["robot_asset"]
+    assert robot_asset == "Robots/FrankaEmika/franka_panda.usda"
+    assert f"{ISAACLAB_NUCLEUS_DIR}/{robot_asset}" == FRANKA_POUR_ROBOT_ASSET_ID
 
 
 def test_capacity_resolution_only_updates_world_dependent_solver_limits():


### PR DESCRIPTION
# Description

The Franka Pour reset artifact currently serializes the fully resolved robot asset URL in `metadata.task_contract.robot_asset`. Artifacts generated with the staging asset root therefore retain a staging hostname and fail contract validation when the same asset tree is served from another configured root.

This change:

- stores `Robots/FrankaEmika/franka_panda.usda` in the reset-artifact task contract;
- continues resolving the runtime robot USD from `ISAACLAB_NUCLEUS_DIR`;
- adds regression coverage for the root-relative contract;
- documents asset-root portability; and
- adds migration guidance for custom reset datasets.

No new dependencies are required.

## Type of change

- Breaking change (existing custom reset artifacts must be regenerated or migrated)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- Root-relative contract assertion failed against the pre-fix implementation and passed with this change.
- Import-light configuration validation passed with both the default staging root and a synthetic `ISAACSIM_ASSET_ROOT`.
- File-scoped `ruff`, `ruff-format`, and `codespell` hooks passed.
- `tools/changelog/cli.py check develop` passed against the latest upstream `develop`.
- Full pytest collection could not run because `usd-exchange==2.3.0` has no macOS ARM wheel.
- `uv run isaaclab -f` and the documentation build could not start because the lockfile supports Linux and Windows only, not macOS ARM.

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the full pre-commit checks with `uv run isaaclab -f` (platform unsupported; file-scoped hooks passed)
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (full platform validation unavailable locally)
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`


