### PR TITLE
Fix release 3.0 pretrained checkpoint matrix

### DIFF
--- a/scripts/tools/test/test_train_and_publish_checkpoints.py
+++ b/scripts/tools/test/test_train_and_publish_checkpoints.py
@@ -7,17 +7,47 @@
 
 from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from isaaclab_tasks.utils.preset_target import PresetTarget
+
 from scripts.tools.train_and_publish_checkpoints import (
     CheckpointJob,
+    _build_core_jobs,
     _play_command,
     _select_physics_variants,
     _training_command,
     collect_pretrained_checkpoint,
     publish_pretrained_checkpoint,
 )
+
+
+def test_build_core_jobs_skips_unsupported_preset_without_normalizing_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unsupported preset-only task must not abort construction of the supported core matrix."""
+    task_spec = SimpleNamespace(
+        id="Isaac-Unsupported-Core-Task",
+        kwargs={
+            "env_cfg_entry_point": "isaaclab_tasks.core.unsupported:UnsupportedEnvCfg",
+            "rsl_rl_cfg_entry_point": "isaaclab_tasks.core.unsupported:UnsupportedAgentCfg",
+        },
+    )
+    monkeypatch.setattr("scripts.tools.train_and_publish_checkpoints.gym.registry", {task_spec.id: task_spec})
+    monkeypatch.setattr("scripts.tools.train_and_publish_checkpoints.parse_env_cfg", lambda _: object())
+    monkeypatch.setattr(
+        "scripts.tools.train_and_publish_checkpoints.enumerate_task_presets",
+        lambda _: {PresetTarget.PHYSICS: ["newton_kamino"]},
+    )
+    monkeypatch.setattr(
+        "scripts.tools.train_and_publish_checkpoints.get_pretrained_checkpoint_backend_names",
+        lambda _: pytest.fail("preset-only tasks must not normalize their unsupported default backend"),
+    )
+    args = Namespace(physics_backends="physx,newtonmjwarp", render_backends="rtx,newton")
+
+    assert _build_core_jobs(args) == []
 
 
 def test_job_commands_use_uv_run_isaaclab() -> None:

--- a/scripts/tools/test/test_train_and_publish_checkpoints.py
+++ b/scripts/tools/test/test_train_and_publish_checkpoints.py
@@ -79,6 +79,15 @@ def test_select_physics_variants_uses_concrete_isaac_sim_physx() -> None:
     assert selections == [("physx", "isaacsim_physx"), ("newtonmjwarp", "newton_mjwarp")]
 
 
+def test_select_physics_variants_includes_franka_osc_newton_mjwarp() -> None:
+    """The effort-limited OSC task is supported by Newton MJWarp."""
+    selections = _select_physics_variants(
+        "Isaac-Reach-Franka-OSC", ["isaacsim_physx", "newton_mjwarp"], "physx", ["newtonmjwarp"]
+    )
+
+    assert selections == [("newtonmjwarp", "newton_mjwarp")]
+
+
 def test_select_physics_variants_does_not_fall_back_to_automatic_physx() -> None:
     """A task without a concrete Isaac Sim selector must not run as OvPhysX."""
     selections = _select_physics_variants("Isaac-Test", ["physx", "ovphysx"], "physx", ["physx"])

--- a/scripts/tools/train_and_publish_checkpoints.py
+++ b/scripts/tools/train_and_publish_checkpoints.py
@@ -101,10 +101,6 @@ from isaaclab_tasks.utils.preset_target import PresetTarget
 
 _TRAINING_COMPLETE_FILENAME = ".pretrained_checkpoint_training_complete"
 _CORE_WORKFLOWS = ("rl_games", "rsl_rl", "skrl")
-_NEWTON_MJWARP_EXCLUSIONS = {
-    # The OSC controller destabilizes MJWarp's articulated-body dynamics.
-    "Isaac-Reach-Franka-OSC",
-}
 
 
 @dataclass(frozen=True)
@@ -270,8 +266,6 @@ def _select_physics_variants(
                     (candidate for candidate in ("newton_mjwarp", "newton_mjwarp_vbd") if candidate in variants),
                     None,
                 )
-                if task_name in _NEWTON_MJWARP_EXCLUSIONS:
-                    selector = None
             if selector is None:
                 continue
         elif backend != default_backend:

--- a/scripts/tools/train_and_publish_checkpoints.py
+++ b/scripts/tools/train_and_publish_checkpoints.py
@@ -255,7 +255,7 @@ def _select_workflow(task_spec: gym.EnvSpec, env_cfg) -> tuple[str, str | None, 
 def _select_physics_variants(
     task_name: str,
     variants: list[str],
-    default_backend: str,
+    default_backend: str | None,
     requested_backends: list[str],
 ) -> list[tuple[str, str | None]]:
     """Return normalized physics backends and their task preset selectors."""
@@ -319,12 +319,14 @@ def _build_core_jobs(args: argparse.Namespace) -> list[CheckpointJob]:
         if not _is_core_task(task_spec):
             continue
 
-        env_cfg = parse_env_cfg(task_spec.id)
-        default_physics, _ = get_pretrained_checkpoint_backend_names(env_cfg)
-        workflow, agent, algorithm = _select_workflow(task_spec, env_cfg)
         preset_map = enumerate_task_presets(task_spec.id) or {}
         physics_variants = preset_map.get(PresetTarget.PHYSICS, [])
         render_variants = preset_map.get(PresetTarget.RENDERER, [])
+        env_cfg = parse_env_cfg(task_spec.id)
+        workflow, agent, algorithm = _select_workflow(task_spec, env_cfg)
+        default_physics = None
+        if not physics_variants:
+            default_physics, _ = get_pretrained_checkpoint_backend_names(env_cfg)
 
         physics_selections = _select_physics_variants(
             task_spec.id,


### PR DESCRIPTION
# Description

Fix the release 3.0 checkpoint workflow so unsupported preset-only tasks do not abort construction of the supported core matrix, and restore the Newton MJWarp checkpoint job for `Isaac-Reach-Franka-OSC`.

The OSC task previously required an exclusion because implicit feed-forward efforts were not limited by MJWarp. That controller issue was fixed by #7033 using a zero-gain explicit actuator that enforces the Franka asset effort limits before simulation. The checkpoint exclusion remained after that fix and is now stale.

## Validation

- `uv run isaaclab -f`
- `uv run --extra test python -m pytest scripts/tools/test/test_train_and_publish_checkpoints.py -q` — 8 passed
- Newton MJWarp OSC training: 1,000 PPO iterations, 4,096 environments, 98,304,000 steps, 92.92% final training success, no NaNs
- The trained checkpoint was loaded successfully and its staged download matched the local SHA-256

## Staged checkpoints

- `omniverse://isaac-dev.ov.nvidia.com/Isaac/IsaacLab/PretrainedCheckpoints/rsl_rl/Isaac-Open-Drawer-Franka_newtonmjwarp_none_rsl_rl.pt`
- `omniverse://isaac-dev.ov.nvidia.com/Isaac/IsaacLab/PretrainedCheckpoints/rsl_rl/Isaac-Reach-Franka-OSC_newtonmjwarp_none_rsl_rl.pt`

Public Isaac 6.1 asset-pack promotion is handled separately from this code change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

This PR targets `release/3.0.0` directly for the Isaac Sim 6.1 RC issue.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation/changelog requirements are satisfied with a skip fragment because only tooling is changed
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix
- [x] My name already exists in `CONTRIBUTORS.md`