### PR TITLE
Optimize PhysX global external wrench submission

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -219,6 +219,7 @@ Guidelines for modifications:
 * Yun Liu
 * YuTeh Shen
 * Zehao Wang
+* Zeng Qingcheng
 * Zijian Li
 * Ziqi Fan
 * Zoe McCarthy

--- a/source/isaaclab/changelog.d/external-wrench-global-submission.minor.rst
+++ b/source/isaaclab/changelog.d/external-wrench-global-submission.minor.rst
@@ -1,0 +1,4 @@
+Changed
+^^^^^^^
+
+* Exposed whether all buffered external wrenches are global-frame and applied at the bodies' centers of mass.

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -66,6 +66,9 @@ class WrenchComposer:
         self._asset = asset
         self._active = False
         self._dirty = False
+        # Track whether all buffered external-wrench contributions remain directly representable in the global frame
+        # at each body's CoM. Partial resets conservatively preserve false.
+        self._all_wrenches_global_at_com = True
         if hasattr(self._asset.data, "body_com_pos_w"):
             self._get_com_pos_fn = lambda a=self._asset: a.data.body_com_pos_w.warp
         else:
@@ -116,6 +119,16 @@ class WrenchComposer:
         compared to scanning the buffers every frame.
         """
         return self._active
+
+    @property
+    def all_wrenches_global_at_com(self) -> bool:
+        """Whether all buffered external wrenches are global-frame and applied at each body's CoM.
+
+        This invariant remains ``True`` only while every buffered contribution is expressed in the global frame and
+        every force acts at its body's CoM. It is conservative after partial resets: it may remain ``False`` even when
+        the selected reset removed every local or positioned contribution. A full :meth:`reset` restores it.
+        """
+        return self._all_wrenches_global_at_com
 
     @property
     def global_force_w(self) -> wp.array:
@@ -265,6 +278,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._all_wrenches_global_at_com &= is_global and (forces is None or positions is None)
 
         wp.launch(
             add_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -328,6 +342,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._all_wrenches_global_at_com &= is_global and (forces is None or positions is None)
 
         wp.launch(
             set_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -388,6 +403,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._all_wrenches_global_at_com &= is_global and (forces is None or positions is None)
 
         wp.launch(
             add_forces_to_dual_buffers_mask,
@@ -453,6 +469,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._all_wrenches_global_at_com &= is_global and (forces is None or positions is None)
 
         wp.launch(
             set_forces_to_dual_buffers_mask,
@@ -493,6 +510,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._all_wrenches_global_at_com &= other._all_wrenches_global_at_com
 
         wp.launch(
             add_raw_wrench_buffers,
@@ -571,6 +589,7 @@ class WrenchComposer:
             self._out_torque_b.zero_()
             self._active = False
             self._dirty = False
+            self._all_wrenches_global_at_com = True
         elif env_mask is not None:
             wp.launch(
                 reset_wrench_composer_mask,

--- a/source/isaaclab/test/assets/test_articulation_iface.py
+++ b/source/isaaclab/test/assets/test_articulation_iface.py
@@ -14,6 +14,7 @@ The setup is a bit convoluted so that we can run these tests without requiring I
 """
 
 import warnings
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -115,6 +116,38 @@ class TestArticulationIndexResolution:
 
         assert resolved_full.shape[0] == 4
         assert resolved_view.shape[0] == 2
+
+
+@pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+class TestPhysXArticulationExternalWrenches:
+    """Test PhysX-specific external wrench submission behavior."""
+
+    @_default_devices
+    def test_global_wrench_at_com_uses_direct_submission_without_pose_read(self, device):
+        """Submit a global-frame external wrench at the CoM without composing it through body poses."""
+        num_instances = 2
+        num_bodies = 3
+        art, root_view = get_articulation(
+            "physx", num_instances=num_instances, num_joints=2, num_bodies=num_bodies, device=device
+        )
+        root_view.get_link_transforms = MagicMock(side_effect=AssertionError("unexpected body-pose read"))
+        root_view.apply_forces_and_torques_at_position = MagicMock()
+
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        torques = torch.zeros_like(forces)
+        forces[:, 1, 2] = torch.tensor([3.0, 7.0], device=device)
+        torques[:, 1, 0] = torch.tensor([0.5, 1.5], device=device)
+        art.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+
+        art.write_data_to_sim()
+
+        call = root_view.apply_forces_and_torques_at_position.call_args.kwargs
+        assert call["is_global"] is True
+        assert call["position_data"] is None
+        actual_forces = wp.to_torch(call["force_data"]).reshape(num_instances, num_bodies, 3)
+        actual_torques = wp.to_torch(call["torque_data"]).reshape(num_instances, num_bodies, 3)
+        torch.testing.assert_close(actual_forces, forces)
+        torch.testing.assert_close(actual_torques, torques)
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_collection_iface.py
@@ -14,6 +14,8 @@ collection interfaces need to comply with the same interface contract.
 The setup is a bit convoluted so that we can run these tests without requiring Isaac Sim or GPU simulation.
 """
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 import torch
@@ -75,6 +77,40 @@ _reshape_3d_backends = pytest.mark.parametrize(
 _production_backends = pytest.mark.parametrize(
     "backend", [backend for backend in ("physx", "newton", "ovphysx") if backend in BACKENDS], indirect=False
 )
+
+
+@pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+class TestPhysXRigidObjectCollectionExternalWrenches:
+    """Test PhysX-specific external wrench submission behavior."""
+
+    @_default_devices
+    def test_global_wrench_at_com_uses_direct_submission_without_pose_read(self, device):
+        """Submit a global-frame external wrench at the CoM without composing it through body poses."""
+        num_instances = 2
+        num_bodies = 3
+        collection, root_view = get_rigid_object_collection(
+            "physx", num_instances=num_instances, num_bodies=num_bodies, device=device
+        )
+        root_view.get_transforms = MagicMock(side_effect=AssertionError("unexpected body-pose read"))
+        root_view.apply_forces_and_torques_at_position = MagicMock()
+
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        torques = torch.zeros_like(forces)
+        forces[:, 1, 2] = torch.tensor([3.0, 7.0], device=device)
+        torques[:, 1, 0] = torch.tensor([0.5, 1.5], device=device)
+        collection.permanent_wrench_composer.set_forces_and_torques_index(
+            forces=forces, torques=torques, is_global=True
+        )
+
+        collection.write_data_to_sim()
+
+        call = root_view.apply_forces_and_torques_at_position.call_args.kwargs
+        assert call["is_global"] is True
+        assert call["position_data"] is None
+        actual_forces = wp.to_torch(call["force_data"]).reshape(num_bodies, num_instances, 3)
+        actual_torques = wp.to_torch(call["torque_data"]).reshape(num_bodies, num_instances, 3)
+        torch.testing.assert_close(actual_forces, forces.transpose(0, 1))
+        torch.testing.assert_close(actual_torques, torques.transpose(0, 1))
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -13,6 +13,8 @@ the base rigid object class advertises. All rigid object interfaces need to comp
 The setup is a bit convoluted so that we can run these tests without requiring Isaac Sim or GPU simulation.
 """
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 import torch
@@ -75,6 +77,35 @@ class TestRigidObjectIndexResolution:
 
         assert resolved_full.shape[0] == 4
         assert resolved_view.shape[0] == 2
+
+
+@pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+class TestPhysXRigidObjectExternalWrenches:
+    """Test PhysX-specific external wrench submission behavior."""
+
+    @_default_devices
+    def test_global_wrench_at_com_uses_direct_submission_without_pose_read(self, device):
+        """Submit a global-frame external wrench at the CoM without composing it through body poses."""
+        num_instances = 2
+        obj, root_view = get_rigid_object("physx", num_instances=num_instances, device=device)
+        root_view.get_transforms = MagicMock(side_effect=AssertionError("unexpected body-pose read"))
+        root_view.apply_forces_and_torques_at_position = MagicMock()
+
+        forces = torch.zeros((num_instances, 1, 3), device=device)
+        torques = torch.zeros_like(forces)
+        forces[:, 0, 2] = torch.tensor([3.0, 7.0], device=device)
+        torques[:, 0, 0] = torch.tensor([0.5, 1.5], device=device)
+        obj.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+
+        obj.write_data_to_sim()
+
+        call = root_view.apply_forces_and_torques_at_position.call_args.kwargs
+        assert call["is_global"] is True
+        assert call["position_data"] is None
+        actual_forces = wp.to_torch(call["force_data"]).reshape(num_instances, 1, 3)
+        actual_torques = wp.to_torch(call["torque_data"]).reshape(num_instances, 1, 3)
+        torch.testing.assert_close(actual_forces, forces)
+        torch.testing.assert_close(actual_torques, torques)
 
 
 # ---------------------------------------------------------------------------

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -68,6 +68,54 @@ def create_mock_asset(
     )
 
 
+@pytest.mark.parametrize("device", test_devices())
+def test_all_external_wrenches_global_at_com_tracking(device: str):
+    """Track the conservative aggregate invariant across contributions, sources, and resets."""
+    asset = create_mock_asset(2, 1, device)
+    forces = torch.ones(2, 1, 3, device=device)
+    torques = torch.ones(2, 1, 3, device=device)
+    positions = torch.ones(2, 1, 3, device=device)
+
+    composer = WrenchComposer(asset)
+    composer.add_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+    assert composer.all_wrenches_global_at_com
+
+    # Multiple external-wrench terms can contribute to the same composer without losing eligibility.
+    composer.add_forces_and_torques_index(forces=forces, is_global=True)
+    assert composer.all_wrenches_global_at_com
+
+    # A global-frame torque does not use positions, even if an unused positions argument is present.
+    torque_only = WrenchComposer(asset)
+    torque_only.add_forces_and_torques_index(torques=torques, positions=positions, is_global=True)
+    assert torque_only.all_wrenches_global_at_com
+
+    global_source = WrenchComposer(asset)
+    global_source.set_forces_and_torques_mask(forces=forces, torques=torques, is_global=True)
+    assert global_source.all_wrenches_global_at_com
+    composer.add_raw_buffers_from(global_source)
+    assert composer.all_wrenches_global_at_com
+
+    positioned = WrenchComposer(asset)
+    positioned.add_forces_and_torques_index(forces=forces, positions=positions, is_global=True)
+    assert not positioned.all_wrenches_global_at_com
+
+    local_source = WrenchComposer(asset)
+    local_source.add_forces_and_torques_index(forces=forces, is_global=False)
+    assert not local_source.all_wrenches_global_at_com
+
+    # Merging instantaneous/permanent or other sources remains conservative if any source is ineligible.
+    composer.add_raw_buffers_from(local_source)
+    assert not composer.all_wrenches_global_at_com
+
+    # A partial reset cannot prove that all local or positioned contributions were removed.
+    composer.reset(env_ids=[0])
+    assert not composer.all_wrenches_global_at_com
+    composer.reset(env_mask=wp.array([True, False], dtype=wp.bool, device=device))
+    assert not composer.all_wrenches_global_at_com
+    composer.reset()
+    assert composer.all_wrenches_global_at_com
+
+
 # --- Helper functions for quaternion math ---
 
 

--- a/source/isaaclab_physx/changelog.d/external-wrench-global-submission.minor.rst
+++ b/source/isaaclab_physx/changelog.d/external-wrench-global-submission.minor.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Submitted eligible global-frame external wrenches directly at body centers of mass, avoiding unnecessary body-
+  transform reads.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -251,7 +251,16 @@ class Articulation(BaseArticulation):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            external_wrench_is_global = composer.all_wrenches_global_at_com
+            if external_wrench_is_global:
+                # PhysX can apply a global-frame external wrench at the current CoM directly. Avoid pulling all link
+                # transforms from PhysX only to rotate the same wrench into the body frame.
+                force_user = composer.global_force_at_com_w
+                torque_user = composer.global_torque_w
+            else:
+                composer.compose_to_body_frame()
+                force_user = composer.out_force_b.warp
+                torque_user = composer.out_torque_b.warp
             if self.data.has_body_ordering:
                 force_backend = self._body_wrench_force_backend
                 torque_backend = self._body_wrench_torque_backend
@@ -259,8 +268,8 @@ class Articulation(BaseArticulation):
                     ordering_kernels.reorder_body_wrench_user_to_backend,
                     dim=(self.num_instances, self.num_bodies),
                     inputs=[
-                        composer.out_force_b.warp,
-                        composer.out_torque_b.warp,
+                        force_user,
+                        torque_user,
                         self.data.body_ordering.backend_to_user,
                     ],
                     outputs=[force_backend, torque_backend],
@@ -269,14 +278,14 @@ class Articulation(BaseArticulation):
                 force_data = force_backend
                 torque_data = torque_backend
             else:
-                force_data = composer.out_force_b.warp
-                torque_data = composer.out_torque_b.warp
+                force_data = force_user
+                torque_data = torque_user
             self.root_view.apply_forces_and_torques_at_position(
                 force_data=force_data.flatten().view(wp.float32),
                 torque_data=torque_data.flatten().view(wp.float32),
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=False,
+                is_global=external_wrench_is_global,
             )
         if self._instantaneous_wrench_composer.active:
             self._instantaneous_wrench_composer.reset()

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -159,13 +159,20 @@ class RigidObject(BaseRigidObject):
                 composer = self._permanent_wrench_composer
                 get_force_data = self._get_perm_wrench_force_f32
                 get_torque_data = self._get_perm_wrench_torque_f32
-            composer.compose_to_body_frame()
+            external_wrench_is_global = composer.all_wrenches_global_at_com
+            if external_wrench_is_global:
+                force_data = composer.global_force_at_com_w.flatten().view(wp.float32)
+                torque_data = composer.global_torque_w.flatten().view(wp.float32)
+            else:
+                composer.compose_to_body_frame()
+                force_data = get_force_data()
+                torque_data = get_torque_data()
             self.root_view.apply_forces_and_torques_at_position(
-                force_data=get_force_data(),
-                torque_data=get_torque_data(),
+                force_data=force_data,
+                torque_data=torque_data,
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=False,
+                is_global=external_wrench_is_global,
             )
         self._instantaneous_wrench_composer.reset()
 

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -193,17 +193,22 @@ class RigidObjectCollection(BaseRigidObjectCollection):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            external_wrench_is_global = composer.all_wrenches_global_at_com
+            if external_wrench_is_global:
+                force_user = composer.global_force_at_com_w
+                torque_user = composer.global_torque_w
+            else:
+                composer.compose_to_body_frame()
+                force_user = composer.out_force_b.warp
+                torque_user = composer.out_torque_b.warp
             self.root_view.apply_forces_and_torques_at_position(
-                force_data=self.reshape_data_to_view_2d(composer.out_force_b.warp, device=self.device).view(wp.float32),
-                torque_data=self.reshape_data_to_view_2d(composer.out_torque_b.warp, device=self.device).view(
-                    wp.float32
-                ),
+                force_data=self.reshape_data_to_view_2d(force_user, device=self.device).view(wp.float32),
+                torque_data=self.reshape_data_to_view_2d(torque_user, device=self.device).view(wp.float32),
                 position_data=None,
                 indices=self._env_body_ids_to_view_ids(
                     self._ALL_ENV_INDICES, self._ALL_BODY_INDICES, device=self.device
                 ),
-                is_global=False,
+                is_global=external_wrench_is_global,
             )
         self._instantaneous_wrench_composer.reset()
 


### PR DESCRIPTION
# Description

This PR avoids unnecessary body-transform reads when PhysX can submit an external wrench directly in the global frame at the body's center of mass.

`WrenchComposer.all_wrenches_global_at_com` tracks a conservative aggregate invariant across all `add_*`, `set_*`, and `add_raw_buffers_from` inputs. The three PhysX writers use the raw global-at-CoM force and global torque buffers only while that invariant holds. Any local-frame or explicitly positioned force contribution, including one from another instantaneous or permanent composer, retains the existing body-frame composition path. Partial resets also retain the conservative fallback state.

This keeps the optimization independent of individual MDP terms and covers multiple external-wrench contributors without changing their existing add/set semantics. It is scoped to PhysX `Articulation`, `RigidObject`, and `RigidObjectCollection`; other backends and assist-force MDP code are unchanged. No new dependencies are required.

Related context: #7398 addressed cached COM-property access. This PR does not reopen that issue; it optimizes the remaining body-pose composition path for eligible external wrenches.

## Validation

- `uv run isaaclab -f` and `./isaaclab.sh --format`: all pre-commit hooks passed.
- WrenchComposer CPU/CUDA suite: 374 passed.
- PhysX writer regression using the existing kitless runtime fixtures: 18 passed on CPU/CUDA. It covers direct global-at-CoM submission and the local-frame/positioned-force fallbacks for all three affected asset types.
- Focused cross-backend interface/body-ordering suite: 6 passed, 18 skipped because the corresponding optional backends were unavailable, and 2293 deselected.
- The direct-submission regression fails on the unpatched develop writer and passes with this change because the baseline reads body poses before submission.

### PhysX performance profile

The workload was a custom articulated-robot recovery setup. A reset event installed a persistent world-frame upward assist force at a body CoM, and an interval event refreshed it every control step through:

```python
asset.permanent_wrench_composer.set_forces_and_torques_index(
    forces=forces,
    body_ids=[body_id],
    env_ids=env_ids,
    is_global=True,
)
```

The composer submitted the buffered force on every physics step. The same assist-force event code was used for the develop baseline and the patch.

A same-process A/B used 4096 environments, a 27-body articulation, 100 warmup steps, and 2000 alternating paired samples per path:

| Scope | Develop | Patch | Change |
|---|---:|---:|---:|
| External-wrench writer mean | 0.313958 ms | 0.188137 ms | -0.125821 ms (-40.08%) |
| Full physics-cycle mean | 10.971542 ms | 10.856342 ms | -0.115200 ms (-1.05%) |

The reported 20-iteration PhysX training profiles used the same seed and configuration. The task had no Eval or policy export. RSL-RL measures `collect_time` around the rollout and logs both collection and learning time before saving a checkpoint, so checkpoint writing, startup, shutdown, and process wall time are excluded. The means below discard iterations 0-4 and use the remaining 15 samples per run. Positive improvements indicate that the patch was faster.

Collection time:

| Environments | Develop | Patch | Improvement | Paired saving (95% interval) |
|---:|---:|---:|---:|---:|
| 4096 | 1.752667 s | 1.728533 s | +1.38% | 24.13 ms [13.85, 34.42] |
| 16384 | 3.170067 s | 3.131667 s | +1.21% | 38.40 ms [24.85, 51.95] |

Iteration time:

| Environments | Develop | Patch | Improvement |
|---:|---:|---:|---:|
| 4096 | 1.770000 s | 1.745333 s | +1.39% |
| 16384 | 3.198667 s | 3.160667 s | +1.19% |

All reported runs completed 20/20 iterations and show a small collection-time benefit. The targeted 2000-pair writer A/B remains the direct evidence for the optimized path, rather than a claim of a universal training speedup.

## Type of change

- New feature (non-breaking change which adds functionality)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this change has no visual output.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
