### PR TITLE
[Backport release/3.0.0] Drive fragment schema writers by prim path expressions

### DIFF
--- a/docs/source/api/lab/isaaclab.sim.schemas.rst
+++ b/docs/source/api/lab/isaaclab.sim.schemas.rst
@@ -30,6 +30,47 @@ isaaclab.sim.schemas
     BoundingCubePropertiesCfg
     BoundingSpherePropertiesCfg
 
+  .. rubric:: Schema fragments
+
+  A fragment mirrors exactly one USD applied schema and writes into a single attribute
+  namespace. The family writers below dispatch lists of fragments to the prims matched by
+  a target expression. See :ref:`schema-fragments` for the concept and the spawner-level
+  usage. Backend fragments live in :mod:`isaaclab_physx.sim.schemas` and
+  :mod:`isaaclab_newton.sim.schemas`.
+
+  .. autosummary::
+
+    SchemaFragment
+    RigidBodyFragment
+    CollisionFragment
+    MassFragment
+    ArticulationRootFragment
+    JointDriveFragment
+    MeshCollisionFragment
+    FixedTendonFragment
+    SpatialTendonFragment
+    UsdPhysicsRigidBodyCfg
+    UsdPhysicsCollisionCfg
+    UsdPhysicsDriveCfg
+    UsdPhysicsMeshCollisionCfg
+    MassCfg
+
+  .. rubric:: Fragment writers
+
+  .. autosummary::
+
+    apply_rigid_body_properties
+    apply_collision_properties
+    apply_mass_properties
+    apply_articulation_root_properties
+    apply_joint_drive_properties
+    apply_mesh_collision_properties
+    apply_fixed_tendon_properties
+    apply_spatial_tendon_properties
+    apply_namespaced
+    apply_drive
+    apply_mesh_collision
+
   .. rubric:: Functions
 
   .. autosummary::
@@ -50,6 +91,90 @@ isaaclab.sim.schemas
     define_deformable_body_properties
     define_deformable_curve_properties
     modify_deformable_body_properties
+
+Schema Fragments
+----------------
+
+.. autoclass:: SchemaFragment
+    :members:
+    :exclude-members: __init__
+
+.. autoclass:: RigidBodyFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: CollisionFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: MassFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: ArticulationRootFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: JointDriveFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: MeshCollisionFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: FixedTendonFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: SpatialTendonFragment
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsRigidBodyCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsCollisionCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsDriveCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: UsdPhysicsMeshCollisionCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autoclass:: MassCfg
+    :members:
+    :show-inheritance:
+    :exclude-members: __init__
+
+.. autofunction:: apply_rigid_body_properties
+.. autofunction:: apply_collision_properties
+.. autofunction:: apply_mass_properties
+.. autofunction:: apply_articulation_root_properties
+.. autofunction:: apply_joint_drive_properties
+.. autofunction:: apply_mesh_collision_properties
+.. autofunction:: apply_fixed_tendon_properties
+.. autofunction:: apply_spatial_tendon_properties
+.. autofunction:: apply_namespaced
+.. autofunction:: apply_drive
+.. autofunction:: apply_mesh_collision
 
 Articulation Root
 -----------------

--- a/docs/source/overview/core-concepts/index.rst
+++ b/docs/source/overview/core-concepts/index.rst
@@ -10,6 +10,7 @@ This section we introduce core concepts in Isaac Lab.
   multi_backend_architecture
   physical-backends/index
   schema_cfgs
+  schema_fragments
   task_workflows
   sensors/index.rst
   renderers

--- a/docs/source/overview/core-concepts/schema_cfgs.rst
+++ b/docs/source/overview/core-concepts/schema_cfgs.rst
@@ -390,6 +390,7 @@ Both aliases are scheduled for removal in 4.0.
 See also
 --------
 
+* :ref:`schema-fragments` — single-namespace fragments and expression-driven targeting
 * :doc:`/source/migration/migrating_to_isaaclab_3-0` — migration guide
 * :doc:`/source/api/lab/isaaclab.sim.schemas` — solver-common base class API
 * :doc:`/source/api/lab_physx/isaaclab_physx.sim.schemas` — PhysX subclass API

--- a/docs/source/overview/core-concepts/schema_fragments.rst
+++ b/docs/source/overview/core-concepts/schema_fragments.rst
@@ -1,0 +1,193 @@
+.. _schema-fragments:
+
+Schema Fragments
+================
+
+Isaac Lab authors physics properties onto USD prims through *schema fragments*: small
+configuration classes that each mirror exactly one USD applied schema and write into a
+single attribute namespace. Because fragments compose in lists, one asset configuration
+can carry OpenUSD physics (``physics:*``), PhysX (``physx*:*``), and Newton
+(``newton:*`` / ``mjc:*``) attributes side by side and run on any backend.
+
+This page explains the fragment model, the prim-path expressions that target fragments
+at prims, and the spawner-level configuration surface. For the solver-common vs.
+backend-specific class tiers, see :ref:`schema-cfgs`. For the full class and function
+reference, see :doc:`/source/api/lab/isaaclab.sim.schemas`.
+
+The fragment model
+------------------
+
+Every fragment subclasses :class:`~isaaclab.sim.schemas.SchemaFragment` and declares
+which USD namespace its fields write to and which applied schema, if any, it owns. A
+fragment's :attr:`~isaaclab.sim.schemas.SchemaFragment.func` names the callable that
+applies it to a prim; the default applier
+(:func:`~isaaclab.sim.schemas.apply_namespaced`) writes each non-``None`` field as
+``<namespace>:<camelCase(field)>`` and leaves ``None`` fields untouched (partial
+update). Irregular APIs override ``func`` — for example
+:class:`~isaaclab.sim.schemas.UsdPhysicsDriveCfg` dispatches through
+:func:`~isaaclab.sim.schemas.apply_drive` to handle the multi-instance
+``UsdPhysics.DriveAPI``.
+
+Fragments are grouped into *families*, one per spawner slot. Each family has a writer
+that resolves target prims from an expression and dispatches every fragment via its
+``func``. Backend fragments carry backend-specific appliers, so the core package never
+imports a backend:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - Spawner field
+     - Family writer
+     - Valid targets
+   * - ``rigid_props``
+     - :func:`~isaaclab.sim.schemas.apply_rigid_body_properties`
+     - prims with ``UsdPhysics.RigidBodyAPI``
+   * - ``collision_props``
+     - :func:`~isaaclab.sim.schemas.apply_collision_properties`
+     - prims with ``UsdPhysics.CollisionAPI``
+   * - ``mass_props``
+     - :func:`~isaaclab.sim.schemas.apply_mass_properties`
+     - prims with ``UsdPhysics.MassAPI``
+   * - ``articulation_props``
+     - :func:`~isaaclab.sim.schemas.apply_articulation_root_properties`
+     - prims with ``UsdPhysics.ArticulationRootAPI``
+   * - ``joint_drive_props``
+     - :func:`~isaaclab.sim.schemas.apply_joint_drive_properties`
+     - revolute / prismatic joint prims
+   * - ``fixed_tendons_props``
+     - :func:`~isaaclab.sim.schemas.apply_fixed_tendon_properties`
+     - tendon-bearing prims (existing tendon instances)
+   * - ``spatial_tendons_props``
+     - :func:`~isaaclab.sim.schemas.apply_spatial_tendon_properties`
+     - tendon attachment root / leaf prims
+
+The tendon families are *tune-not-apply*: the tendon topology is authored in the source
+asset, so their writers only tune existing instances and never create them.
+
+Targeting expressions
+---------------------
+
+Target prims are resolved with :func:`~isaaclab.sim.utils.queries.find_matching_prims`.
+The expression is a plain Python regular expression matched against the *whole* prim
+path. Standard regex semantics apply: ``.`` matches any character including ``/``, so
+``/World/Robot/.*`` selects every descendant at any depth, while ``[^/]+`` confines a
+wildcard to a single path segment and ``/World/Robot(/.*)?`` selects the prim together
+with its descendants. The traversal includes inactive and undefined prims as well as
+instance proxies.
+
+The matched set is then filtered to valid family targets (see the table above): API
+carriers for the rigid-body, collision, mass, and articulation families; revolute and
+prismatic joint prims for the joint-drive family; tendon-bearing prims for the tendon
+families. Non-joint matches of a joint-drive expression are ignored silently, since a
+subtree expression legitimately sweeps whole subtrees.
+
+Edge cases behave as follows:
+
+* **Instanced matches** cannot be authored on (prototypes are read-only) and are
+  skipped with a warning.
+* **Zero targets** emit a warning and the writer returns ``False`` without authoring
+  anything.
+* **An empty fragment list** is an authoring no-op and returns ``True``.
+
+Configuring fragments on spawners
+---------------------------------
+
+Spawner configurations (:class:`~isaaclab.sim.spawners.from_files.UsdFileCfg`,
+:class:`~isaaclab.sim.spawners.shapes.CuboidCfg`, ...) expose one field per family.
+Each field accepts either a mapping from target pattern to a list of fragments, a bare
+fragment or list of fragments (see the shorthand below), a
+single legacy dataclass cfg (e.g.
+:class:`~isaaclab.sim.schemas.RigidBodyBaseCfg` or a backend ``*PropertiesCfg``, routed
+to the legacy writers), or ``None``.
+
+Mapping keys are regular-expression suffixes appended to *the prim the spawner authors
+that family on*: the spawn prim for USD, URDF, and MJCF assets; for shape and mesh
+spawners, the geometry prim for the collision family and the container prim for the
+rigid-body and mass families. A key therefore carries its own leading ``/`` when it
+targets descendants: ``""`` selects the anchor prim itself, ``"/[^/]+"`` its direct
+children, and ``"/.*"`` everything beneath it. Prefer ``"/.*"`` for a whole-subtree
+rule: the anchor is usually a plain ``Xform`` that carries no family API, so including
+it changes nothing — except under ``create_if_missing``, where ``"(/.*)?"`` would also
+apply the API to the anchor itself. Reach for ``"(/.*)?"`` only when the anchor is
+genuinely a target too. Entries apply in insertion order, so when two patterns match the
+same prim, fragments from later entries override attributes authored by earlier ones.
+
+The bare fragment (or list of fragments) shorthand skips the mapping when a rule needs no
+targeting of its own. On the shape and mesh spawners it targets the anchor prim, the only
+prim those spawners author. On the file spawners it targets the spawn prim together with
+its descendants, so it reaches the schema carriers wherever the asset puts them; and when
+the subtree carries no prim with the family's defining API at all — the usual shape of an
+art asset shipped without physics schemas — the file spawners apply that API to the spawn
+prim and author there, turning the asset into a single body.
+
+A robot spawned from USD, with a broad rule and a narrowing override:
+
+.. code-block:: python
+
+   import isaaclab.sim as sim_utils
+   from isaaclab.sim.schemas import UsdPhysicsDriveCfg, UsdPhysicsRigidBodyCfg
+   from isaaclab_newton.sim.schemas import MujocoRigidBodyCfg
+   from isaaclab_physx.sim.schemas import PhysxRigidBodyCfg
+   from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+   spawn = sim_utils.UsdFileCfg(
+       usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka_instanceable.usd",
+       rigid_props={
+           # every rigid body: universal + PhysX + MuJoCo attributes side by side
+           "/.*": [
+               UsdPhysicsRigidBodyCfg(rigid_body_enabled=True),
+               PhysxRigidBodyCfg(max_depenetration_velocity=5.0),
+               MujocoRigidBodyCfg(gravcomp=1.0),
+           ],
+           # hand links (and their subtrees) get a tighter depenetration limit
+           "/.*_hand/.*": [PhysxRigidBodyCfg(max_depenetration_velocity=1.0)],
+       },
+       joint_drive_props={
+           "/.*": [UsdPhysicsDriveCfg(drive_type="force", stiffness=40.0, damping=4.0)],
+       },
+   )
+
+A primitive shape, where every family targets the anchor prim, so the mapping can be
+dropped entirely:
+
+.. code-block:: python
+
+   import isaaclab.sim as sim_utils
+   from isaaclab.sim.schemas import MassCfg, UsdPhysicsCollisionCfg, UsdPhysicsRigidBodyCfg
+   from isaaclab_newton.sim.schemas import NewtonCollisionCfg
+
+   cuboid = sim_utils.CuboidCfg(
+       size=(0.1, 0.1, 0.1),
+       rigid_props=UsdPhysicsRigidBodyCfg(),
+       mass_props=MassCfg(mass=0.5),
+       collision_props=[UsdPhysicsCollisionCfg(collision_enabled=True), NewtonCollisionCfg(contact_margin=0.001)],
+   )
+
+Reach for the mapping when a rule must target something other than the anchor prim — the
+usual situation for assets spawned from USD, URDF, or MJCF files, where the spawn prim is a
+container and the schema carriers sit beneath it.
+
+Creating missing APIs
+---------------------
+
+By default, the family writers only *modify* prims that already carry the family's
+defining USD API. Three per-family spawner flags — ``mass_props_create_if_missing``,
+``articulation_props_create_if_missing``, and ``joint_drive_props_create_if_missing`` —
+additionally apply the defining API to matched prims that lack it before the fragments
+are authored (for the joint-drive family, the axis-appropriate ``UsdPhysics.DriveAPI``
+instance). Shape and mesh spawners always create the APIs on the bare prims they
+author, since freshly created geometry carries no physics APIs yet.
+
+The writers trust the expression as written: with creation enabled, every matched prim
+receives the API, so a too-broad pattern can, for example, give every mesh in a subtree
+its own mass. Which bodies participate in an articulation is still decided by the
+asset's joints, not by the expression. Scope creation patterns deliberately.
+
+See also
+--------
+
+* :ref:`schema-cfgs` — solver-common vs. backend-specific configuration tiers
+* :doc:`/source/api/lab/isaaclab.sim.schemas` — fragment base classes and family writers
+* :doc:`/source/api/lab_physx/isaaclab_physx.sim.schemas` — PhysX fragments
+* :doc:`/source/api/lab_newton/isaaclab_newton.sim.schemas` — Newton / MuJoCo fragments

--- a/source/isaaclab/changelog.d/vidurv-regex-fragment-targeting.minor.rst
+++ b/source/isaaclab/changelog.d/vidurv-regex-fragment-targeting.minor.rst
@@ -1,0 +1,58 @@
+Added
+^^^^^
+
+* Added ``create_if_missing`` to the fragment schema writers and matching spawner
+  configuration flags (``mass_props_create_if_missing``,
+  ``articulation_props_create_if_missing``, ``joint_drive_props_create_if_missing``)
+  to apply a defining USD API to matched prims that do not carry it.
+
+Changed
+^^^^^^^
+
+* **Breaking:** Changed the fragment schema writers (e.g.
+  :func:`~isaaclab.sim.schemas.apply_rigid_body_properties`) to take a prim path
+  expression instead of traversing the subtree of the input prim. A bare prim path now
+  matches only that prim; pass ``f"{prim_path}(/.*)?"`` to recover the previous
+  subtree-wide behavior. Zero matched targets now log a warning and return ``False``
+  instead of raising ``ValueError`` on an invalid path.
+* **Breaking:** Changed the spawner configuration fragment fields
+  (e.g. :attr:`~isaaclab.sim.spawners.RigidObjectSpawnerCfg.rigid_props`,
+  :attr:`~isaaclab.sim.spawners.from_files.FileCfg.articulation_props`) to take a
+  mapping from target pattern to fragment list instead of a bare fragment or fragment
+  list. Keys are regular-expression suffixes appended to the spawn prim, so a key
+  carries its own leading ``/`` when it targets descendants: ``""`` is the spawn prim
+  itself, ``"/[^/]+"`` its direct children, ``"/.*"`` all descendants, and ``"(/.*)?"``
+  the spawn prim together with its descendants. Entries apply in insertion order, so on
+  overlapping targets later entries override earlier ones per attribute. Pass
+  ``{"(/.*)?": [...]}`` to recover the previous fragment-list behavior. A bare fragment or
+  list of fragments is accepted as shorthand: on the shape and mesh spawners it targets the
+  anchor prim, and on the file spawners it targets the spawn prim together with its
+  descendants, keeping the reach the legacy nested writers had.
+  Legacy single-cfg values are unaffected.
+* **Breaking:** Changed the fragment schema writers to no longer apply their defining
+  USD API implicitly on bare prims; pass ``create_if_missing=True`` instead. The file
+  spawners keep doing so on the user's behalf for the bare-fragment shorthand when the
+  spawn prim's subtree carries no prim with the family's defining API, so pointing
+  :class:`~isaaclab.sim.spawners.from_files.UsdFileCfg` at an art asset that ships without
+  physics schemas still turns it into a single body. For
+  articulation roots, anchoring on the spawn prim needs an entry targeting it in
+  :attr:`~isaaclab.sim.spawners.from_files.FileCfg.articulation_props` together with
+  ``articulation_props_create_if_missing=True`` on the spawner configuration.
+* **Breaking:** Changed :func:`~isaaclab.sim.schemas.apply_articulation_root_properties`
+  to author on every matched articulation root, warning when they nest, instead of
+  silently pruning nested roots; asset validity is the author's responsibility.
+
+Fixed
+^^^^^
+
+* Fixed backend applied schemas being stranded on the former root link when a backend relocates
+  an articulation root. Relocation resolved schemas through the USD schema registry, which cannot
+  describe a schema a backend ships as an unregistered token, so the schema and its attributes were
+  left behind. Backends now declare the pairing through
+  :func:`~isaaclab.sim.schemas.register_articulation_root_companion`.
+
+* Fixed :func:`~isaaclab.sim.schemas.apply_rigid_body_properties` and
+  :func:`~isaaclab.sim.schemas.apply_mass_properties` only reaching the outermost
+  schema-bearing prim on assets with nested rigid-body hierarchies (child links authored
+  under their parent link prims, as produced by the URDF importer in Isaac Sim 6.0 and
+  later). A whole-subtree target pattern (``{"/.*": [...]}``) reaches every carrier.

--- a/source/isaaclab/isaaclab/physics/physics_manager.py
+++ b/source/isaaclab/isaaclab/physics/physics_manager.py
@@ -151,13 +151,21 @@ class PhysicsManager(ABC):
                 f"Cannot relocate '{articulation_prim.GetPath()}' to existing articulation root '{new_root.GetPath()}'."
             )
 
+        # Keep this import local for the same reason as the pxr imports above.
+        from isaaclab.sim.schemas._backend_hooks import _articulation_root_companion_namespace  # noqa: PLC0415
+
         registry = Usd.SchemaRegistry()
         root_schema = UsdPhysics.Tokens.PhysicsArticulationRootAPI
         schemas_to_move = []
         for schema_name in articulation_prim.GetPrimTypeInfo().GetAppliedAPISchemas():
             definition = registry.FindAppliedAPIPrimDefinition(schema_name)
+            companion_namespace_override = _articulation_root_companion_namespace(schema_name)
             if schema_name == companion_schema:
                 properties = list(articulation_prim.GetAuthoredPropertiesInNamespace(companion_namespace))
+            elif companion_namespace_override is not None:
+                # a backend-registered schema, possibly an unregistered token the registry cannot
+                # describe, so take the namespace the backend declared for it
+                properties = list(articulation_prim.GetAuthoredPropertiesInNamespace(companion_namespace_override))
             elif schema_name == root_schema or (
                 definition is not None and root_schema in definition.GetAppliedAPISchemas()
             ):

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter.py
@@ -15,6 +15,7 @@ from isaaclab.sim.converters.asset_converter_base import AssetConverterBase
 from isaaclab.sim.converters.mesh_converter_cfg import MeshConverterCfg
 from isaaclab.sim.schemas import schemas
 from isaaclab.sim.schemas.schemas_cfg import SchemaFragment
+from isaaclab.sim.spawners._utils import fragment_mapping, props_expr
 from isaaclab.sim.utils import delete_prim, enable_extension, export_prim_to_file
 
 # import logger
@@ -126,12 +127,18 @@ class MeshConverter(AssetConverterBase):
                 # Apply collider properties to mesh
                 if cfg.collision_props is not None:
                     # -- Collider properties such as offset, scale, etc.
-                    # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> define_*
-                    coll_frags = (
-                        cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-                    )
-                    if coll_frags and all(isinstance(f, SchemaFragment) for f in coll_frags):
-                        schemas.apply_collision_properties(str(child_mesh_prim.GetPath()), coll_frags, stage=stage)
+                    # fragment path: mapping entries anchor at this mesh prim, so ``""`` preserves
+                    # the legacy placement; entries apply in insertion order. Otherwise a legacy
+                    # cfg routes to the legacy writer.
+                    collision_props_mapping = fragment_mapping(cfg.collision_props)
+                    if collision_props_mapping is not None:
+                        for pattern, fragments in collision_props_mapping.items():
+                            schemas.apply_collision_properties(
+                                props_expr(str(child_mesh_prim.GetPath()), pattern),
+                                fragments,
+                                create_if_missing=True,
+                                stage=stage,
+                            )
                     else:
                         schemas.define_collision_properties(
                             prim_path=child_mesh_prim.GetPath(), cfg=cfg.collision_props, stage=stage
@@ -202,19 +209,27 @@ class MeshConverter(AssetConverterBase):
         # Apply mass and rigid body properties after everything else
         # Properties are applied to the top level prim to avoid the case where all instances of this
         #   asset unintentionally share the same rigid body properties
-        # apply mass properties (transition shim, remove later: fragment list -> apply_*; legacy cfg -> define_*)
+        # fragment path: mapping entries anchor at the root Xform prim, so ``""`` preserves the
+        # legacy placement; entries apply in insertion order. Otherwise a legacy cfg routes to the
+        # legacy writer.
+        # apply mass properties
         if cfg.mass_props is not None:
-            # normalize a single fragment to a list so the convenience form routes like a list
-            mass_frags = [cfg.mass_props] if isinstance(cfg.mass_props, SchemaFragment) else cfg.mass_props
-            if isinstance(mass_frags, (list, tuple)) and all(isinstance(f, SchemaFragment) for f in mass_frags):
-                schemas.apply_mass_properties(str(xform_prim.GetPath()), mass_frags, stage=stage)
+            mass_props_mapping = fragment_mapping(cfg.mass_props)
+            if mass_props_mapping is not None:
+                for pattern, fragments in mass_props_mapping.items():
+                    schemas.apply_mass_properties(
+                        props_expr(str(xform_prim.GetPath()), pattern), fragments, create_if_missing=True, stage=stage
+                    )
             else:
                 schemas.define_mass_properties(prim_path=xform_prim.GetPath(), cfg=cfg.mass_props, stage=stage)
-        # apply rigid body properties (transition shim, remove later: fragment list -> apply_*; legacy cfg -> define_*)
+        # apply rigid body properties
         if cfg.rigid_props is not None:
-            rigid_frags = cfg.rigid_props if isinstance(cfg.rigid_props, (list, tuple)) else [cfg.rigid_props]
-            if rigid_frags and all(isinstance(f, SchemaFragment) for f in rigid_frags):
-                schemas.apply_rigid_body_properties(str(xform_prim.GetPath()), rigid_frags, stage=stage)
+            rigid_props_mapping = fragment_mapping(cfg.rigid_props)
+            if rigid_props_mapping is not None:
+                for pattern, fragments in rigid_props_mapping.items():
+                    schemas.apply_rigid_body_properties(
+                        props_expr(str(xform_prim.GetPath()), pattern), fragments, create_if_missing=True, stage=stage
+                    )
             else:
                 schemas.define_rigid_body_properties(prim_path=xform_prim.GetPath(), cfg=cfg.rigid_props, stage=stage)
 

--- a/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
+++ b/source/isaaclab/isaaclab/sim/converters/mesh_converter_cfg.py
@@ -12,29 +12,43 @@ from isaaclab.utils.configclass import configclass
 class MeshConverterCfg(AssetConverterBaseCfg):
     """The configuration class for MeshConverter."""
 
-    mass_props: schemas_cfg.MassPropertiesCfg = None
+    mass_props: dict[str, list[schemas_cfg.MassFragment]] | schemas_cfg.MassPropertiesCfg | None = None
     """Mass properties to apply to the USD. Defaults to None.
+
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.MassFragment` fragments (e.g. ``MassCfg(...)``) or a
+    single legacy :class:`~isaaclab.sim.schemas.MassPropertiesCfg`. Keys are target patterns
+    relative to the root Xform prim of the converted asset; an empty string targets that prim
+    itself. Entries are applied in insertion order, so on overlapping targets later entries
+    override earlier ones per attribute.
 
     Note:
         If None, then no mass properties will be added.
     """
 
-    rigid_props: schemas_cfg.RigidBodyBaseCfg = None
+    rigid_props: dict[str, list[schemas_cfg.RigidBodyFragment]] | schemas_cfg.RigidBodyBaseCfg | None = None
     """Rigid body properties to apply to the USD. Defaults to None.
+
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.RigidBodyFragment` fragments or a single legacy cfg
+    (e.g. :class:`~isaaclab.sim.schemas.RigidBodyBaseCfg`). Keys are target patterns relative to
+    the root Xform prim of the converted asset; an empty string targets that prim itself. Entries
+    are applied in insertion order, so on overlapping targets later entries override earlier ones
+    per attribute.
 
     Note:
         If None, then no rigid body properties will be added.
     """
 
-    collision_props: (
-        schemas_cfg.CollisionPropertiesCfg | schemas_cfg.CollisionFragment | list[schemas_cfg.CollisionFragment]
-    ) = None
+    collision_props: dict[str, list[schemas_cfg.CollisionFragment]] | schemas_cfg.CollisionPropertiesCfg | None = None
     """Collision properties to apply to the USD. Defaults to None.
 
-    Accepts either a single legacy cfg (e.g. :class:`~isaaclab.sim.schemas.CollisionBaseCfg`) or a
-    list of :class:`~isaaclab.sim.schemas.CollisionFragment` fragments. When a fragment list is
-    given, ``UsdPhysics.CollisionAPI`` is applied as the implicit anchor and each fragment writes
-    its own namespace.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.CollisionFragment` fragments or a single legacy cfg
+    (e.g. :class:`~isaaclab.sim.schemas.CollisionBaseCfg`). Keys are target patterns relative to
+    each Mesh prim of the converted asset; an empty string targets the mesh prim itself. Entries
+    are applied in insertion order, so on overlapping targets later entries override earlier ones
+    per attribute.
 
     Note:
         If None, then no collision properties will be added.

--- a/source/isaaclab/isaaclab/sim/schemas/_backend_hooks.py
+++ b/source/isaaclab/isaaclab/sim/schemas/_backend_hooks.py
@@ -41,3 +41,31 @@ def register_joint_drive_skip_predicate(predicate: Callable) -> None:
 def _skip_joint_drive(prim) -> bool:
     """Return whether any backend-registered predicate excludes ``prim`` from joint-drive authoring."""
     return any(predicate(prim) for predicate in _JOINT_DRIVE_SKIP_PREDICATES)
+
+
+# Backend applied schemas that travel with an articulation root when a backend relocates it.
+# Newton ships some of these as unregistered token schemas, which the USD schema registry cannot
+# resolve, so the relocation helper has no way to discover their namespace on its own. Backends
+# register the pairing here via :func:`register_articulation_root_companion`.
+_ARTICULATION_ROOT_COMPANIONS: dict[str, str] = {}
+
+
+def register_articulation_root_companion(schema_name: str, namespace: str) -> None:
+    """Register a backend applied schema that belongs with an articulation root.
+
+    When a backend relocates an articulation root to another prim, every schema that describes the
+    root must move with it, together with the attributes it owns. Registered applied schemas are
+    resolved through the USD schema registry, but a backend may ship a schema as an unregistered
+    token, which the registry cannot describe. Registering it here supplies the namespace the
+    relocation helper needs to carry the schema's authored attributes across.
+
+    Args:
+        schema_name: The applied schema name, e.g. ``"NewtonArticulationRootAPI"``.
+        namespace: The attribute namespace the schema owns, e.g. ``"newton"``.
+    """
+    _ARTICULATION_ROOT_COMPANIONS[schema_name] = namespace
+
+
+def _articulation_root_companion_namespace(schema_name: str) -> str | None:
+    """Return the registered attribute namespace for an articulation-root companion schema."""
+    return _ARTICULATION_ROOT_COMPANIONS.get(schema_name)

--- a/source/isaaclab/isaaclab/sim/schemas/schemas.py
+++ b/source/isaaclab/isaaclab/sim/schemas/schemas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import math
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import numpy as np
 import warp as wp
@@ -23,6 +23,7 @@ from ..utils import (
     apply_nested,
     create_prim,
     find_global_fixed_joint_prim,
+    find_matching_prims,
     get_all_matching_child_prims,
     has_deformable_body_api,
     safe_set_attribute_on_usd_prim,
@@ -277,32 +278,46 @@ Articulation root properties.
 
 
 def apply_articulation_root_properties(
-    prim_path: str,
+    prim_path_expr: str,
     fragments: Iterable[schemas_cfg.ArticulationRootFragment],
     stage: Usd.Stage | None = None,
     fix_root_link: bool | None = None,
+    create_if_missing: bool = False,
 ) -> bool:
-    """Apply fragments to every top-level articulation root under a prim.
+    """Apply a list of articulation-root fragments to the roots matched by an expression.
 
-    Existing roots are discovered before a fresh anchor is applied, including roots hidden in
-    instances. Nested roots are pruned, while sibling roots are all processed. Instance roots are
-    reported but not authored.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. Matched prims that
+    already carry ``UsdPhysics.ArticulationRootAPI`` are the targets: each fragment is
+    dispatched to every target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
+    Sibling roots (independent articulations matched by one expression) are all processed.
+    Nested targets are authored as matched, with a warning -- resolving nested roots is the
+    asset author's responsibility.
 
-    When fix_root_link is True, the active physics manager creates or enables the world joint and
-    returns the backend's final root prim. False only disables an existing joint.
+    With :paramref:`create_if_missing`, the API is applied to every matched prim that lacks
+    it. Zero targets warn and return False. Instanced matches are skipped with a warning.
+
+    An empty fragment list is an authoring no-op: it returns True immediately when
+    :paramref:`fix_root_link` is None, but still resolves targets and adjusts topology when the
+    flag is set. When :paramref:`fix_root_link` is True, the active physics manager creates or
+    enables the world joint on each target and returns the backend's final root prim; False
+    only disables an existing joint.
 
     Args:
-        prim_path: The prim path whose subtree is searched for articulation roots.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: Articulation-root fragments to apply.
-        stage: The stage containing the prim. Defaults to the current stage.
+        stage: The stage where to find the prims. Defaults to None, in which case the current
+            stage is used.
         fix_root_link: Whether to fix the root link. None leaves topology unchanged.
+        create_if_missing: Whether to apply ``UsdPhysics.ArticulationRootAPI`` to every
+            matched prim that does not carry it. Defaults to False.
 
     Returns:
-        True if every writable root and fragment succeeds and no instance root is skipped.
+        True if every target and fragment succeeded and no instanced prim was skipped.
 
     Raises:
         TypeError: If fragments contains a non-articulation fragment.
-        ValueError: If prim_path is invalid.
         RuntimeError: If fixing cannot resolve the active backend or relocate the root.
         NotImplementedError: If the backend cannot fix the resolved root.
     """
@@ -318,54 +333,39 @@ def apply_articulation_root_properties(
     ]
     if stage is None:
         stage = get_current_stage()
+    if not fragments and fix_root_link is None:
+        return True
 
-    roots = []
-    for candidate in get_all_matching_child_prims(
-        prim_path,
-        lambda prim: prim.HasAPI(UsdPhysics.ArticulationRootAPI),
-        stage=stage,
-        traverse_instance_prims=True,
-    ):
-        if not any(candidate.GetPath().HasPrefix(root.GetPath()) for root in roots):
-            roots.append(candidate)
-
-    writable_roots = []
-    skipped_roots = []
-    for root in roots:
-        if root.IsInstance() or root.IsInstanceProxy():
-            skipped_roots.append(root)
-        else:
-            writable_roots.append(root)
-
-    if not roots and fragments:
-        root = stage.GetPrimAtPath(prim_path)
-        if root.IsInstance() or root.IsInstanceProxy():
-            skipped_roots.append(root)
-        else:
-            UsdPhysics.ArticulationRootAPI.Apply(root)
-            writable_roots.append(root)
-
-    if skipped_roots:
+    targets, creation_candidates, any_skipped = _match_fragment_targets(
+        prim_path_expr, lambda p: p.HasAPI(UsdPhysics.ArticulationRootAPI), stage
+    )
+    if create_if_missing:
+        for prim in creation_candidates:
+            UsdPhysics.ArticulationRootAPI.Apply(prim)
+            targets.append(prim)
+    target_paths = [t.GetPath() for t in targets]
+    if any(path != other and path.HasPrefix(other) for path in target_paths for other in target_paths):
         logger.warning(
-            "Skipping articulation-root updates on instanced prims: %s.",
-            [root.GetPath().pathString for root in skipped_roots],
+            "Expression '%s' targets nested articulation roots (%s); authoring on all of them.",
+            prim_path_expr,
+            [p.pathString for p in target_paths],
         )
-    if not writable_roots:
-        if fix_root_link is not None and not skipped_roots:
-            logger.warning(
-                "No articulation root found under '%s': ignoring fix_root_link=%s.", prim_path, fix_root_link
-            )
-        return not skipped_roots and fix_root_link is None
+    if not targets:
+        logger.warning("No articulation-root targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
 
     if fix_root_link:
         from isaaclab.sim import SimulationContext
 
         sim = SimulationContext.instance()
         if sim is None:
-            raise RuntimeError(f"Cannot fix articulation roots under '{prim_path}' without an active simulation.")
+            raise RuntimeError(
+                f"Cannot fix articulation roots matched by '{prim_path_expr}' without an active simulation."
+            )
 
-    success = not skipped_roots
-    for root in writable_roots:
+    # aggregate per-target, per-fragment results so a reported failure is not masked
+    success = not any_skipped
+    for root in targets:
         if fix_root_link:
             root = sim.physics_manager.fix_articulation_root(root, stage)
         elif fix_root_link is False:
@@ -627,70 +627,45 @@ Fragment-writer helpers.
 """
 
 
-def _resolve_fragment_targets(
-    prim_path: str,
-    api_type,
+def _match_fragment_targets(
+    prim_path_expr: str,
+    is_target: Callable[[Usd.Prim], bool],
     stage: Usd.Stage,
-    apply_fresh: bool,
-) -> tuple[list, bool]:
-    """Resolve the prims that a fragment family writer should author on.
+) -> tuple[list[Usd.Prim], list[Usd.Prim], bool]:
+    """Resolve fragment-writer targets from a prim path expression.
 
-    This mirrors the legacy nested writers: prims under ``prim_path`` that already carry
-    ``api_type`` are modified in place, and the search does not descend past a match, since
-    nested applications of the same physics schema are not allowed. Only when the subtree
-    carries no such prim is the defining API applied freshly to ``prim_path`` itself -- the
-    bare-prim case used by the shape and mesh spawners. Instanced prims cannot be edited, so
-    they are skipped with a warning.
+    Matches ``prim_path_expr`` with :func:`~isaaclab.sim.utils.find_matching_prims` (a plain
+    regular expression over whole prim paths) and splits the matches: writable prims
+    passing ``is_target`` are targets, writable prims failing it are creation candidates, and
+    instanced prims passing it are skipped with a warning since prototypes cannot be authored on.
 
     Args:
-        prim_path: The prim path whose subtree is searched.
-        api_type: The defining USD API schema type (e.g. ``UsdPhysics.RigidBodyAPI``).
-        stage: The stage containing the prim.
-        apply_fresh: Whether to apply ``api_type`` to ``prim_path`` when the subtree contains
-            no carrier of it.
+        prim_path_expr: The prim path expression to match. Path-like objects (e.g.
+            ``Sdf.Path``) are accepted and converted with ``str``.
+        is_target: Predicate deciding whether a matched prim is a valid family target.
+        stage: The stage to match on.
 
     Returns:
-        A tuple ``(targets, any_skipped)`` holding the writable target prims and whether any
-        instanced prim was skipped.
-
-    Raises:
-        ValueError: When the prim path is not valid.
+        A tuple ``(targets, creation_candidates, any_skipped)``.
     """
-    prim = stage.GetPrimAtPath(prim_path)
-    if not prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # breadth-first search that stops descending at the first carrier on each branch, like the
-    # legacy nested writers: nested applications of the same physics schema are not allowed, so
-    # nothing below a carrier is ever a target. This keeps the search linear in the subtree size
-    # instead of collecting every carrier and pruning afterwards. Carriers on instanced prims are
-    # read-only and collected separately so they can be reported.
+    # tolerate path-like inputs such as Sdf.Path, whose string form is the path itself
+    prim_path_expr = str(prim_path_expr)
     targets = []
+    creation_candidates = []
     skipped = []
-    prims_queue = [prim]
-    index = 0
-    while index < len(prims_queue):
-        candidate = prims_queue[index]
-        index += 1
-        if candidate.HasAPI(api_type):
-            if candidate.IsInstance() or candidate.IsInstanceProxy():
-                skipped.append(candidate)
-            else:
-                targets.append(candidate)
-            continue
-        prims_queue += candidate.GetFilteredChildren(Usd.TraverseInstanceProxies())
-    if not targets and not skipped and apply_fresh:
-        if prim.IsInstance() or prim.IsInstanceProxy():
-            skipped.append(prim)
-        else:
-            api_type.Apply(prim)
-            targets.append(prim)
+    for prim in find_matching_prims(prim_path_expr, stage):
+        instanced = prim.IsInstance() or prim.IsInstanceProxy()
+        if is_target(prim):
+            (skipped if instanced else targets).append(prim)
+        elif not instanced:
+            creation_candidates.append(prim)
     if skipped:
         logger.warning(
-            "Skipping %s updates on instanced prims: %s.",
-            api_type.__name__,
+            "Skipping fragment updates on instanced prims matched by '%s': %s.",
+            prim_path_expr,
             [p.GetPath().pathString for p in skipped],
         )
-    return targets, bool(skipped)
+    return targets, creation_candidates, bool(skipped)
 
 
 """
@@ -699,37 +674,53 @@ Rigid body properties.
 
 
 def apply_rigid_body_properties(
-    prim_path: str, fragments: Iterable[schemas_cfg.RigidBodyFragment], stage: Usd.Stage | None = None
+    prim_path_expr: str,
+    fragments: Iterable[schemas_cfg.RigidBodyFragment],
+    create_if_missing: bool = False,
+    stage: Usd.Stage | None = None,
 ) -> bool:
-    """Apply a list of rigid-body fragments to the rigid bodies under a prim.
+    """Apply a list of rigid-body fragments to the rigid bodies matched by an expression.
 
-    Existing rigid bodies in the subtree are modified in place, matching the legacy nested
-    writer. Real assets author ``UsdPhysics.RigidBodyAPI`` on their link prims, so anchoring a
-    fresh rigid body on the spawn prim instead would nest those links under a new body and the
-    PhysX parser would drop the articulation's joint graph. Only when the subtree carries no
-    rigid body is ``UsdPhysics.RigidBodyAPI`` applied to ``prim_path`` itself -- the bare-prim
-    case used by the shape and mesh spawners. Each fragment is dispatched to every resolved
-    target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry
-    backend-specific funcs, so core never imports a backend.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. Matched prims that
+    already carry ``UsdPhysics.RigidBodyAPI`` are modified in place: each fragment is
+    dispatched to every such target via its
+    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry backend-specific
+    funcs, so core never imports a backend.
+
+    An empty fragment list is an authoring no-op and returns True. With
+    :paramref:`create_if_missing`, ``UsdPhysics.RigidBodyAPI`` is applied to every matched
+    prim that lacks it; only the asset's joints decide which bodies participate in the
+    articulation, so the expression is trusted as written. Zero targets warn and return
+    False. Instanced matches are skipped with a warning.
 
     Args:
-        prim_path: The prim path whose subtree is searched for rigid bodies.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.RigidBodyFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        create_if_missing: Whether to apply ``UsdPhysics.RigidBodyAPI`` to every matched
+            prim that does not carry it. Defaults to False.
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
 
     Returns:
         True if every target and fragment succeeded and no instanced prim was skipped.
-
-    Raises:
-        ValueError: When the prim path is not valid.
     """
     fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    targets, any_skipped = _resolve_fragment_targets(
-        prim_path, UsdPhysics.RigidBodyAPI, stage, apply_fresh=bool(fragments)
+    if not fragments:
+        return True
+    targets, creation_candidates, any_skipped = _match_fragment_targets(
+        prim_path_expr, lambda p: p.HasAPI(UsdPhysics.RigidBodyAPI), stage
     )
+    if create_if_missing:
+        for prim in creation_candidates:
+            UsdPhysics.RigidBodyAPI.Apply(prim)
+            targets.append(prim)
+    if not targets:
+        logger.warning("No rigid-body targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
     for target in targets:
@@ -934,36 +925,53 @@ Collision properties.
 
 
 def apply_collision_properties(
-    prim_path: str, fragments: Iterable[schemas_cfg.CollisionFragment], stage: Usd.Stage | None = None
+    prim_path_expr: str,
+    fragments: Iterable[schemas_cfg.CollisionFragment],
+    create_if_missing: bool = False,
+    stage: Usd.Stage | None = None,
 ) -> bool:
-    """Apply a list of collision fragments to the colliders under a prim.
+    """Apply a list of collision fragments to the colliders matched by an expression.
 
-    Existing colliders in the subtree are modified in place, matching the legacy nested writer.
-    Real assets author ``UsdPhysics.CollisionAPI`` on their collider prims, so anchoring a fresh
-    collider on the spawn prim would change the scene's collision geometry. Only when the
-    subtree carries no collider is ``UsdPhysics.CollisionAPI`` applied to ``prim_path`` itself
-    -- the bare-prim case used by the shape and mesh spawners. Each fragment is dispatched to
-    every resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend
-    fragments carry backend-specific funcs, so core never imports a backend.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. Matched prims that
+    already carry ``UsdPhysics.CollisionAPI`` are modified in place: each fragment is
+    dispatched to every such target via its
+    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend fragments carry backend-specific
+    funcs, so core never imports a backend.
+
+    An empty fragment list is an authoring no-op and returns True. With
+    :paramref:`create_if_missing`, ``UsdPhysics.CollisionAPI`` is applied to every matched
+    prim that lacks it. When no target remains, a warning is emitted and False is
+    returned without authoring anything. Matched prims inside instances cannot be authored on
+    and are skipped with a warning.
 
     Args:
-        prim_path: The prim path whose subtree is searched for colliders.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.CollisionFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        create_if_missing: Whether to apply ``UsdPhysics.CollisionAPI`` to matched prims that
+            do not carry it. Defaults to False.
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
 
     Returns:
         True if every target and fragment succeeded and no instanced prim was skipped.
-
-    Raises:
-        ValueError: When the prim path is not valid.
     """
     fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    targets, any_skipped = _resolve_fragment_targets(
-        prim_path, UsdPhysics.CollisionAPI, stage, apply_fresh=bool(fragments)
+    if not fragments:
+        return True
+    targets, creation_candidates, any_skipped = _match_fragment_targets(
+        prim_path_expr, lambda p: p.HasAPI(UsdPhysics.CollisionAPI), stage
     )
+    if create_if_missing:
+        for candidate in creation_candidates:
+            UsdPhysics.CollisionAPI.Apply(candidate)
+            targets.append(candidate)
+    if not targets:
+        logger.warning("No collision targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
     for target in targets:
@@ -1068,32 +1076,51 @@ Mass properties.
 
 
 def apply_mass_properties(
-    prim_path: str, fragments: Iterable[schemas_cfg.MassFragment], stage: Usd.Stage | None = None
+    prim_path_expr: str,
+    fragments: Iterable[schemas_cfg.MassFragment],
+    create_if_missing: bool = False,
+    stage: Usd.Stage | None = None,
 ) -> bool:
-    """Apply a list of mass fragments to the mass-bearing prims under a prim.
+    """Apply a list of mass fragments to the mass-bearing prims matched by an expression.
 
-    Existing mass-bearing prims in the subtree are modified in place, matching the legacy nested
-    writer, since real assets author ``UsdPhysics.MassAPI`` on their link prims. Only when the
-    subtree carries none is ``UsdPhysics.MassAPI`` applied to ``prim_path`` itself -- the
-    bare-prim case used by the shape and mesh spawners. Each fragment is dispatched to every
-    resolved target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. Matched prims that
+    already carry ``UsdPhysics.MassAPI`` are modified in place: each fragment is dispatched to
+    every such target via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`. Backend
+    fragments carry backend-specific funcs, so core never imports a backend.
+
+    An empty fragment list is an authoring no-op and returns True. With
+    :paramref:`create_if_missing`, ``UsdPhysics.MassAPI`` is applied to every matched prim
+    that lacks it; pairing the mass with a rigid body is the caller's responsibility. Zero
+    targets warn and return False. Instanced matches are skipped with a warning.
 
     Args:
-        prim_path: The prim path whose subtree is searched for mass-bearing prims.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.MassFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        create_if_missing: Whether to apply ``UsdPhysics.MassAPI`` to every matched prim
+            that does not carry it. Defaults to False.
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
 
     Returns:
         True if every target and fragment succeeded and no instanced prim was skipped.
-
-    Raises:
-        ValueError: When the prim path is not valid.
     """
     fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    targets, any_skipped = _resolve_fragment_targets(prim_path, UsdPhysics.MassAPI, stage, apply_fresh=bool(fragments))
+    if not fragments:
+        return True
+    targets, creation_candidates, any_skipped = _match_fragment_targets(
+        prim_path_expr, lambda p: p.HasAPI(UsdPhysics.MassAPI), stage
+    )
+    if create_if_missing:
+        for prim in creation_candidates:
+            UsdPhysics.MassAPI.Apply(prim)
+            targets.append(prim)
+    if not targets:
+        logger.warning("No mass targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
     # aggregate per-target, per-fragment results so a reported failure is not masked
     success = not any_skipped
     for target in targets:
@@ -1359,15 +1386,22 @@ def apply_drive(cfg, prim_path: str, stage: Usd.Stage | None = None) -> bool:
 
 
 def apply_joint_drive_properties(
-    prim_path: str, fragments, stage: Usd.Stage | None = None, ensure_drives_exist: bool = False
+    prim_path_expr: str,
+    fragments,
+    stage: Usd.Stage | None = None,
+    ensure_drives_exist: bool = False,
+    create_if_missing: bool = False,
 ) -> bool:
-    """Apply a list of joint-drive fragments to all joint prims under a prim path.
+    """Apply a list of joint-drive fragments to the joint prims matched by an expression.
 
-    Mirrors the recursion behaviour of :func:`modify_joint_drive_properties` (decorated with
-    :func:`~isaaclab.sim.utils.apply_nested`): the prim path and all its descendants are visited,
-    and the fragments are dispatched to every revolute/prismatic joint prim found. As soon as a
-    prim is successfully handled, its children are not descended into (nested joints are not
-    allowed).
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. The fragments are
+    dispatched to every matched revolute/prismatic joint prim that is not excluded by a
+    backend-registered skip predicate (see :func:`register_joint_drive_skip_predicate`, e.g.
+    PhysX tendon members). Non-joint matches are ignored silently -- a subtree expression
+    matches every descendant, so per-prim warnings would spam. Matched prims inside
+    instances cannot be authored on and are skipped with a warning.
 
     Unlike :func:`apply_rigid_body_properties`, the joint-drive family has no implicit anchor:
     ``UsdPhysics.DriveAPI`` is *presence-gated* and applied only by :func:`apply_drive` when a
@@ -1375,75 +1409,77 @@ def apply_joint_drive_properties(
     fragment is dispatched via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func`, so backend
     fragments carry backend-specific funcs and core never imports a backend.
 
+    An empty fragment list is an authoring no-op and returns True. When no fragment succeeds on
+    any joint, a warning is emitted and False is returned.
+
     Args:
-        prim_path: The root prim path to search for joint prims under.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.JointDriveFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
         ensure_drives_exist: If True, write a minimal stiffness (``1e-3``) to any drive whose
             authored stiffness *and* damping are both zero, so that backends (e.g. Newton) treat
             the drive as active. Reproduces the legacy
             :attr:`~isaaclab.sim.schemas.JointDriveBaseCfg.ensure_drives_exist` behaviour. This is
             a spawner-level flag, not a fragment field.
+        create_if_missing: If True, apply the axis-appropriate ``UsdPhysics.DriveAPI`` instance
+            (``"angular"`` for revolute joints, ``"linear"`` for prismatic joints) on matched
+            joints that do not carry it, before dispatching the fragments. Distinct from
+            :paramref:`ensure_drives_exist`: this flag creates the drive API itself, whereas
+            :paramref:`ensure_drives_exist` seeds a minimal stiffness on fully-passive drives
+            that already exist. Defaults to False.
 
     Returns:
-        True if the fragments were applied to at least one joint prim, False otherwise.
+        True if the fragments were applied to at least one joint prim and no instanced joint
+        was skipped, False otherwise.
     """
     if stage is None:
         stage = get_current_stage()
 
     fragments = list(fragments)
+    if not fragments:
+        return True
     # detect whether a UsdPhysics.DriveAPI fragment is present (governs presence-gating + the
     # ensure_drives_exist behaviour, which only makes sense for the solver-common drive fragment)
     drive_cfg = next((f for f in fragments if isinstance(f, schemas_cfg.UsdPhysicsDriveCfg)), None)
 
-    root_prim = stage.GetPrimAtPath(prim_path)
-    if not root_prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
+    # match revolute/prismatic joints not excluded by a backend-registered skip predicate;
+    # non-joint matches (creation_candidates) are ignored silently since a subtree expression
+    # matches every descendant
+    targets, _, any_skipped = _match_fragment_targets(
+        prim_path_expr,
+        lambda p: (p.IsA(UsdPhysics.RevoluteJoint) or p.IsA(UsdPhysics.PrismaticJoint)) and not _skip_joint_drive(p),
+        stage,
+    )
 
     count_success = 0
-    instanced_prim_paths = []
-    all_prims = [root_prim]
-    while len(all_prims) > 0:
-        child_prim = all_prims.pop(0)
-        child_prim_path = child_prim.GetPath().pathString
-        # skip instanced prims (cannot author on prototypes)
-        if child_prim.IsInstance():
-            instanced_prim_paths.append(child_prim_path)
-            continue
-        # a prim is a valid joint-drive target only if it is a revolute/prismatic joint
-        is_joint = child_prim.IsA(UsdPhysics.RevoluteJoint) or child_prim.IsA(UsdPhysics.PrismaticJoint)
-        if not is_joint:
-            all_prims += child_prim.GetChildren()
-            continue
-        # skip backend-owned joints wholesale (e.g. PhysX tendon members): no fragment may author on
-        # them. The backend registers the detector via register_joint_drive_skip_predicate, so this
-        # gate carries no backend-specific knowledge; descend into children to reach nested joints.
-        if _skip_joint_drive(child_prim):
-            all_prims += child_prim.GetChildren()
-            continue
+    for joint_prim in targets:
+        joint_prim_path = joint_prim.GetPath().pathString
+        if create_if_missing:
+            drive_api_name = _drive_instance_name(joint_prim)
+            if drive_api_name is not None and not joint_prim.HasAPI(UsdPhysics.DriveAPI, drive_api_name):
+                UsdPhysics.DriveAPI.Apply(joint_prim, drive_api_name)
         # dispatch each fragment via its func
         success = False
         for cfg in fragments:
             func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-            if func(cfg, child_prim_path, stage):
+            if func(cfg, joint_prim_path, stage):
                 success = True
         # seed a minimal stiffness only when the drive fragment authored neither stiffness nor
         # damping and the resulting drive is fully passive
         if ensure_drives_exist and drive_cfg is not None and success:
-            _ensure_drive_exists(drive_cfg, child_prim)
+            _ensure_drive_exists(drive_cfg, joint_prim)
         if success:
             count_success += 1
-        else:
-            all_prims += child_prim.GetChildren()
 
-    if count_success == 0:
+    # instanced skips were already reported by the matcher; only warn when nothing matched at all
+    if count_success == 0 and not any_skipped:
         logger.warning(
-            f"Could not apply joint-drive properties on any prims under: '{prim_path}'."
-            " This might be because no revolute/prismatic joint prims were found, or they are"
-            f" instanced. Discovered list of instanced prim paths: {instanced_prim_paths}"
+            "Could not apply joint-drive properties on any joints matched by '%s'."
+            " No revolute/prismatic joint prims matched or every fragment reported failure.",
+            prim_path_expr,
         )
-    return count_success > 0
+    return count_success > 0 and not any_skipped
 
 
 def _ensure_drive_exists(drive_cfg, prim) -> None:
@@ -1593,45 +1629,71 @@ Fixed tendon properties.
 """
 
 
+def _is_fixed_tendon_target(prim: Usd.Prim) -> bool:
+    """Whether a prim carries a fixed-tendon representation (PhysX multi-apply instance or MjcTendon prim)."""
+    if prim.GetTypeName() == "MjcTendon":
+        return True
+    return any("PhysxTendonAxisRootAPI" in s for s in prim.GetAppliedSchemas())
+
+
+def _is_spatial_tendon_target(prim: Usd.Prim) -> bool:
+    """Whether a prim carries a spatial-tendon multi-apply instance."""
+    return any(
+        "PhysxTendonAttachmentRootAPI" in s or "PhysxTendonAttachmentLeafAPI" in s for s in prim.GetAppliedSchemas()
+    )
+
+
 def apply_fixed_tendon_properties(
-    prim_path: str, fragments: Iterable[schemas_cfg.FixedTendonFragment], stage: Usd.Stage | None = None
+    prim_path_expr: str, fragments: Iterable[schemas_cfg.FixedTendonFragment], stage: Usd.Stage | None = None
 ) -> bool:
-    """Apply a list of fixed-tendon fragments to a prim.
+    """Apply a list of fixed-tendon fragments to the tendon prims matched by an expression.
 
-    Fixed tendons are a *tune-not-apply* family: the applied ``PhysxTendonAxisRootAPI``
-    multi-instance schemas already exist on the prim (authored in the source asset). This writer
-    therefore applies no anchor schema; it only dispatches each fragment via its
-    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`, which tunes the existing instances.
-    Backend fragments carry backend-specific funcs, so core never imports a backend.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. A matched prim is a
+    fixed-tendon target when it carries an applied ``PhysxTendonAxisRootAPI`` multi-apply
+    instance or is a ``MjcTendon`` prim.
 
-    Each fragment tunes only its own schema and returns ``False`` when that schema is not
-    present on the prim. A prim carries a single tendon backend, so compose backends across
-    prims rather than mixing PhysX and Mujoco fragments in one list on one prim.
+    Fixed tendons are a *tune-not-apply* family: the tendon topology is authored in the source
+    asset, so this writer never creates instances -- it only dispatches each fragment via its
+    :attr:`~isaaclab.sim.schemas.SchemaFragment.func` to every matched target. Backend
+    fragments carry backend-specific funcs, so core never imports a backend. A fragment
+    succeeds when its func returns True on at least one target: each func only tunes its own
+    backend's representation and no-ops (returns False) on the other backend's prims, so a
+    mixed-backend target set does not fail the write.
+
+    An empty fragment list is an authoring no-op and returns True. When no target matches, a
+    warning is emitted and False is returned without authoring anything. Matched prims inside
+    instances cannot be authored on and are skipped with a warning.
 
     Args:
-        prim_path: The prim path to apply the fixed-tendon schemas on.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.FixedTendonFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
 
     Returns:
-        True if all fragments applied successfully, False if any fragment reported failure.
-
-    Raises:
-        ValueError: If the prim at ``prim_path`` is not valid.
+        True if every fragment tuned at least one target and no instanced prim was skipped.
     """
+    fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    prim = stage.GetPrimAtPath(prim_path)
-    # fail loudly on an invalid path (matches the sibling apply_* writers)
-    if not prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # tune-not-apply: the PhysxTendonAxisRootAPI instances already exist; apply no anchor.
-    # aggregate per-fragment results so a reported failure is not silently masked.
-    success = True
+    if not fragments:
+        return True
+    targets, _, any_skipped = _match_fragment_targets(prim_path_expr, _is_fixed_tendon_target, stage)
+    if not targets:
+        logger.warning("No fixed-tendon targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
+    # per-fragment any-target aggregation: a fragment fails only when it tuned no target at all,
+    # since each backend's func legitimately no-ops on the other backend's tendon prims.
+    success = not any_skipped
     for cfg in fragments:
         func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-        success = bool(func(cfg, prim_path, stage)) and success
+        fragment_hit = False
+        for target in targets:
+            if func(cfg, target.GetPath().pathString, stage):
+                fragment_hit = True
+        success = fragment_hit and success
     return success
 
 
@@ -1712,46 +1774,56 @@ Spatial tendon properties.
 
 
 def apply_spatial_tendon_properties(
-    prim_path: str, fragments: Iterable[schemas_cfg.SpatialTendonFragment], stage: Usd.Stage | None = None
+    prim_path_expr: str, fragments: Iterable[schemas_cfg.SpatialTendonFragment], stage: Usd.Stage | None = None
 ) -> bool:
-    """Apply a list of spatial-tendon fragments to a prim.
+    """Apply a list of spatial-tendon fragments to the tendon prims matched by an expression.
 
-    Spatial tendons are a *tune-not-apply* family: the applied
-    ``PhysxTendonAttachmentRootAPI`` / ``PhysxTendonAttachmentLeafAPI`` multi-instance schemas
-    already exist on the prim (authored in the source asset). This writer therefore applies no
-    anchor schema; it only dispatches each fragment via its
-    :attr:`~isaaclab.sim.schemas.SchemaFragment.func`, which tunes the existing instances.
-    Backend fragments carry backend-specific funcs, so core never imports a backend.
+    The prims to author on are matched with :func:`~isaaclab.sim.utils.find_matching_prims`:
+    ``prim_path_expr`` is a plain regular expression over whole prim paths, so ``[^/]+``
+    selects one path segment and ``/World/Robot/.*`` every descendant of a prim. A matched prim is a
+    spatial-tendon target when it carries an applied ``PhysxTendonAttachmentRootAPI`` or
+    ``PhysxTendonAttachmentLeafAPI`` multi-apply instance.
 
-    Each fragment tunes only its own schema and returns ``False`` when that schema is not
-    present on the prim. A prim carries a single tendon backend, so compose backends across
-    prims rather than mixing PhysX and Mujoco fragments in one list on one prim.
+    Spatial tendons are a *tune-not-apply* family: the tendon topology is authored in the
+    source asset, so this writer never creates instances -- it only dispatches each fragment
+    via its :attr:`~isaaclab.sim.schemas.SchemaFragment.func` to every matched target. Backend
+    fragments carry backend-specific funcs, so core never imports a backend. A fragment
+    succeeds when its func returns True on at least one target: each func only tunes its own
+    backend's representation and no-ops (returns False) on the other backend's prims, so a
+    mixed-backend target set does not fail the write.
+
+    An empty fragment list is an authoring no-op and returns True. When no target matches, a
+    warning is emitted and False is returned without authoring anything. Matched prims inside
+    instances cannot be authored on and are skipped with a warning.
 
     Args:
-        prim_path: The prim path to apply the spatial-tendon schemas on.
+        prim_path_expr: The prim path expression matched against the stage.
         fragments: An iterable of :class:`~isaaclab.sim.schemas.SpatialTendonFragment` instances.
-        stage: The stage where to find the prim. Defaults to None, in which case the current
+        stage: The stage where to find the prims. Defaults to None, in which case the current
             stage is used.
 
     Returns:
-        True if all fragments applied successfully, False if any fragment reported failure.
-
-    Raises:
-        ValueError: If the prim at ``prim_path`` is not valid.
+        True if every fragment tuned at least one target and no instanced prim was skipped.
     """
+    fragments = list(fragments)
     if stage is None:
         stage = get_current_stage()
-    prim = stage.GetPrimAtPath(prim_path)
-    # fail loudly on an invalid path (matches the sibling apply_* writers)
-    if not prim.IsValid():
-        raise ValueError(f"Prim path '{prim_path}' is not valid.")
-    # tune-not-apply: the PhysxTendonAttachmentRootAPI / PhysxTendonAttachmentLeafAPI instances
-    # already exist; apply no anchor.
-    # aggregate per-fragment results so a reported failure is not silently masked.
-    success = True
+    if not fragments:
+        return True
+    targets, _, any_skipped = _match_fragment_targets(prim_path_expr, _is_spatial_tendon_target, stage)
+    if not targets:
+        logger.warning("No spatial-tendon targets matched expression '%s'; nothing was authored.", prim_path_expr)
+        return False
+    # per-fragment any-target aggregation: a fragment fails only when it tuned no target at all,
+    # since each backend's func legitimately no-ops on the other backend's tendon prims.
+    success = not any_skipped
     for cfg in fragments:
         func = cfg.func if callable(cfg.func) else string_to_callable(cfg.func)
-        success = bool(func(cfg, prim_path, stage)) and success
+        fragment_hit = False
+        for target in targets:
+            if func(cfg, target.GetPath().pathString, stage):
+                fragment_hit = True
+        success = fragment_hit and success
     return success
 
 

--- a/source/isaaclab/isaaclab/sim/spawners/_utils.py
+++ b/source/isaaclab/isaaclab/sim/spawners/_utils.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Private helpers shared by the spawner implementations."""
+
+from __future__ import annotations
+
+
+def props_expr(prim_path: str, pattern: str) -> str:
+    """Append a cfg-relative target pattern to an anchor prim path.
+
+    Implements the key convention of the fragment mapping spawner configuration fields
+    (e.g. :attr:`~isaaclab.sim.spawners.RigidObjectSpawnerCfg.rigid_props`): the key is a
+    regular-expression suffix appended to the anchor prim path, so it carries its own leading
+    ``/`` when it targets descendants. An empty key selects the anchor prim itself.
+
+    The result is a plain regular expression matched against whole prim paths by
+    :func:`~isaaclab.sim.utils.find_matching_prims`, so ``"/[^/]+"`` selects the anchor's direct
+    children and ``"/.*"`` everything beneath it. Use ``"(/.*)?"`` on the rare occasion the anchor
+    itself is also a valid family target.
+
+    Args:
+        prim_path: The absolute path of the anchor prim.
+        pattern: The cfg-relative target pattern.
+
+    Returns:
+        The absolute prim path expression to pass to a fragment family writer.
+    """
+    return f"{prim_path}{pattern}"
+
+
+def fragment_mapping(value, default_pattern: str = "") -> dict | None:
+    """Normalize a fragment spawner-configuration value to a target-pattern mapping.
+
+    The mapping form (``{pattern: [fragment, ...]}``) is the general spelling. As a convenience, a
+    bare fragment or a sequence of fragments is accepted and read as ``{default_pattern: [...]}``.
+    The caller picks that default so the convenience form keeps the reach the legacy writers had:
+    the file spawners tune a prim together with its subtree, while the shape, mesh, and converter
+    spawners author the one prim they just created. Legacy dataclass configurations are reported
+    as ``None`` so callers route them to the legacy writers.
+
+    Args:
+        value: The value of a fragment spawner-configuration field.
+        default_pattern: The target pattern to use for the bare fragment (or sequence) form.
+
+    Returns:
+        The equivalent target-pattern mapping, or None when the value is a legacy configuration.
+    """
+    from isaaclab.sim.schemas.schemas_cfg import SchemaFragment  # noqa: PLC0415
+
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, SchemaFragment):
+        return {default_pattern: [value]}
+    if isinstance(value, (list, tuple)) and all(isinstance(item, SchemaFragment) for item in value):
+        # an empty sequence carries no fragments and no targeting intent, so it maps to an empty
+        # mapping rather than a targeted entry with nothing to author
+        return {default_pattern: list(value)} if value else {}
+    return None
+
+
+def bare_fragments(value) -> bool:
+    """Report whether a fragment spawner-configuration value uses the convenience form.
+
+    The convenience form is a bare fragment or a sequence of fragments, i.e. everything
+    :func:`fragment_mapping` normalizes onto its default pattern. It carries no targeting
+    intent of its own, so callers may widen or narrow the target set on the user's behalf.
+
+    Args:
+        value: The value of a fragment spawner-configuration field.
+
+    Returns:
+        True when the value is a bare fragment or a sequence of fragments.
+    """
+    from isaaclab.sim.schemas.schemas_cfg import SchemaFragment  # noqa: PLC0415
+
+    if isinstance(value, SchemaFragment):
+        return True
+    return isinstance(value, (list, tuple)) and all(isinstance(item, SchemaFragment) for item in value)
+
+
+def subtree_carries_api(prim_path: str, api_type, stage) -> bool:
+    """Report whether a prim or any of its descendants carries a USD API schema.
+
+    Args:
+        prim_path: The absolute path of the prim rooted at the searched subtree.
+        api_type: The USD API schema type to look for (e.g. ``UsdPhysics.RigidBodyAPI``).
+        stage: The stage containing the prim.
+
+    Returns:
+        True when the prim itself or a prim beneath it carries the API schema.
+    """
+    from pxr import Usd  # noqa: PLC0415
+
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
+        return False
+    for candidate in Usd.PrimRange(prim, Usd.TraverseInstanceProxies(Usd.PrimAllPrimsPredicate)):
+        if candidate.HasAPI(api_type):
+            return True
+    return False

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from filelock import FileLock
 
 from isaaclab.sim import converters, schemas
+from isaaclab.sim.spawners._utils import bare_fragments, fragment_mapping, props_expr, subtree_carries_api
 from isaaclab.sim.spawners.materials import SurfaceDeformableBodyMaterialBaseCfg
 from isaaclab.sim.spawners.materials.physics_materials import spawn_physics_material
 from isaaclab.sim.utils import (
@@ -280,6 +281,196 @@ Helper functions.
 """
 
 
+def _body_family_targeting(value, prim_path: str, api_type) -> tuple[dict | None, bool]:
+    """Resolve the target mapping and API-creation flag for one body schema family.
+
+    Assets that already carry the family's defining API are tuned in place, wherever the carriers
+    sit in the subtree. Authored art assets ship without physics schemas, though, and a task
+    configuration turns one into a simulated body simply by handing the spawner a fragment. For
+    that convenience form the family falls back to the spawn prim: the API is created there and
+    the fragments are authored onto it, so the asset becomes a single body rather than silently
+    reaching the backend with none. An explicit mapping is always honored as written.
+
+    Args:
+        value: The value of the family's spawner-configuration field.
+        prim_path: The path of the spawn prim that anchors the target patterns.
+        api_type: The USD API schema that defines the family (e.g. ``UsdPhysics.RigidBodyAPI``).
+
+    Returns:
+        A tuple ``(mapping, create_if_missing)``. The mapping is None when the value is a legacy
+        configuration that must route to the legacy writers.
+    """
+    mapping = fragment_mapping(value, "(/.*)?")
+    if mapping is None or not mapping or not bare_fragments(value):
+        return mapping, False
+    if subtree_carries_api(prim_path, api_type, get_current_stage()):
+        return mapping, False
+    return {"": next(iter(mapping.values()))}, True
+
+
+def _apply_body_schema_properties(prim_path: str, cfg: from_files_cfg.FileCfg) -> None:
+    """Author the rigid-body, collision, and mass schema families on the spawned asset.
+
+    Fragment mappings apply one writer call per entry, in insertion order (later entries override
+    earlier ones per attribute); legacy single cfgs route to the legacy nested writers.
+
+    Args:
+        prim_path: The path of the spawn prim that anchors the target patterns.
+        cfg: The file spawner configuration carrying the schema fields.
+    """
+    from pxr import UsdPhysics  # noqa: PLC0415
+
+    # modify rigid body properties
+    if cfg.rigid_props is not None:
+        rigid_props_mapping, rigid_props_create = _body_family_targeting(
+            cfg.rigid_props, prim_path, UsdPhysics.RigidBodyAPI
+        )
+        if rigid_props_mapping is not None:
+            for pattern, fragments in rigid_props_mapping.items():
+                schemas.apply_rigid_body_properties(
+                    props_expr(prim_path, pattern), fragments, create_if_missing=rigid_props_create
+                )
+        else:
+            schemas.modify_rigid_body_properties(prim_path, cfg.rigid_props)
+    # modify collision properties
+    if cfg.collision_props is not None:
+        collision_props_mapping, collision_props_create = _body_family_targeting(
+            cfg.collision_props, prim_path, UsdPhysics.CollisionAPI
+        )
+        if collision_props_mapping is not None:
+            for pattern, fragments in collision_props_mapping.items():
+                schemas.apply_collision_properties(
+                    props_expr(prim_path, pattern), fragments, create_if_missing=collision_props_create
+                )
+        else:
+            schemas.modify_collision_properties(prim_path, cfg.collision_props)
+    # modify mass properties
+    if cfg.mass_props is not None:
+        mass_props_mapping, mass_props_create = _body_family_targeting(cfg.mass_props, prim_path, UsdPhysics.MassAPI)
+        if mass_props_mapping is not None:
+            for pattern, fragments in mass_props_mapping.items():
+                schemas.apply_mass_properties(
+                    props_expr(prim_path, pattern),
+                    fragments,
+                    create_if_missing=cfg.mass_props_create_if_missing or mass_props_create,
+                )
+        else:
+            schemas.modify_mass_properties(prim_path, cfg.mass_props)
+
+
+def _apply_articulation_schema_properties(prim_path: str, cfg: from_files_cfg.FileCfg) -> None:
+    """Author the articulation-root, tendon, and joint-drive schema families on the spawned asset.
+
+    Fragment mappings apply one writer call per entry, in insertion order (later entries override
+    earlier ones per attribute); legacy single cfgs route to the legacy nested writers.
+
+    Args:
+        prim_path: The path of the spawn prim that anchors the target patterns.
+        cfg: The file spawner configuration carrying the schema fields.
+    """
+    # modify articulation root properties
+    # ``fix_root_link`` is a spawner-level topology flag (not a schema property); it is honored on the
+    # fragment path independently of whether any articulation schema properties were supplied.
+    articulation_props = cfg.articulation_props
+    articulation_fix_root_link = cfg.fix_root_link
+    # a legacy single cfg routes to the legacy writer -- it owns its own ``fix_root_link`` field; a
+    # mapping (also an empty one) routes to the fragment writer, where the spawner-level topology
+    # flag is honored even without any schema properties to author.
+    articulation_mapping = fragment_mapping(articulation_props, "(/.*)?")
+    if articulation_props is not None and articulation_mapping is None:
+        if articulation_fix_root_link is not None:
+            logger.warning(
+                f"Ignoring the spawner-level 'fix_root_link={articulation_fix_root_link}' because"
+                " 'articulation_props' is a legacy cfg, which owns its own 'fix_root_link' field. Set"
+                " it on that cfg instead."
+            )
+        schemas.modify_articulation_root_properties(prim_path, articulation_props)
+    else:
+        articulation_entries = list(articulation_mapping.items()) if articulation_mapping else []
+        if articulation_entries:
+            # the root topology is fixed once; entries after the first must not re-fix it
+            for index, (pattern, fragments) in enumerate(articulation_entries):
+                schemas.apply_articulation_root_properties(
+                    props_expr(prim_path, pattern),
+                    fragments,
+                    fix_root_link=articulation_fix_root_link if index == 0 else None,
+                    create_if_missing=cfg.articulation_props_create_if_missing,
+                )
+        elif articulation_fix_root_link is not None:
+            # topology-only path: no fragments to author, but the root link must still be fixed
+            schemas.apply_articulation_root_properties(
+                props_expr(prim_path, "(/.*)?"),
+                [],
+                fix_root_link=articulation_fix_root_link,
+                create_if_missing=cfg.articulation_props_create_if_missing,
+            )
+    # modify tendon properties
+    if cfg.fixed_tendons_props is not None:
+        fixed_tendons_props_mapping = fragment_mapping(cfg.fixed_tendons_props, "(/.*)?")
+        if fixed_tendons_props_mapping is not None:
+            for pattern, fragments in fixed_tendons_props_mapping.items():
+                schemas.apply_fixed_tendon_properties(props_expr(prim_path, pattern), fragments)
+        else:
+            schemas.modify_fixed_tendon_properties(prim_path, cfg.fixed_tendons_props)
+    if cfg.spatial_tendons_props is not None:
+        spatial_tendons_props_mapping = fragment_mapping(cfg.spatial_tendons_props, "(/.*)?")
+        if spatial_tendons_props_mapping is not None:
+            for pattern, fragments in spatial_tendons_props_mapping.items():
+                schemas.apply_spatial_tendon_properties(props_expr(prim_path, pattern), fragments)
+        else:
+            schemas.modify_spatial_tendon_properties(prim_path, cfg.spatial_tendons_props)
+    # define drive API on the joints
+    # note: these are only for setting low-level simulation properties. all others should be set or are
+    #  and overridden by the articulation/actuator properties.
+    if cfg.joint_drive_props is not None:
+        # fragment mapping -> apply_joint_drive_properties (the MujocoJointCfg fragment handles its
+        # own body-gravcomp coupling in apply_mujoco_joint, so the fragment path adds no backend
+        # coupling here); a legacy single cfg -> the pre-existing gravcomp auto-enable +
+        # modify_joint_drive_properties below.
+        joint_drive_props_mapping = fragment_mapping(cfg.joint_drive_props, "(/.*)?")
+        if joint_drive_props_mapping is not None:
+            for pattern, fragments in joint_drive_props_mapping.items():
+                schemas.apply_joint_drive_properties(
+                    props_expr(prim_path, pattern),
+                    fragments,
+                    ensure_drives_exist=cfg.ensure_drives_exist,
+                    create_if_missing=cfg.joint_drive_props_create_if_missing,
+                )
+        else:
+            # auto-enable body-level gravcomp if joint-level actuator gravcomp is requested
+            # without it — actuatorgravcomp has no effect since there are no forces to route.
+            # Only auto-populates when the user did not already set ``gravcomp`` themselves;
+            # an explicit ``MujocoRigidBodyPropertiesCfg(gravcomp=0.5)`` is preserved as-is.
+            from isaaclab_newton.sim.schemas.schemas_cfg import (
+                MujocoJointDrivePropertiesCfg,
+                MujocoRigidBodyCfg,
+                MujocoRigidBodyPropertiesCfg,
+            )
+
+            # gravcomp may be authored either via the legacy MujocoRigidBodyPropertiesCfg or via a
+            # MujocoRigidBodyCfg fragment in the rigid_props mapping. Treat either as "already set".
+            rigid_props_mapping = fragment_mapping(cfg.rigid_props, "(/.*)?")
+            if rigid_props_mapping is not None:
+                rigid_props_list = [fragment for fragments in rigid_props_mapping.values() for fragment in fragments]
+            else:
+                rigid_props_list = [cfg.rigid_props]
+            body_gravcomp_unset = not any(
+                isinstance(f, (MujocoRigidBodyPropertiesCfg, MujocoRigidBodyCfg)) and f.gravcomp is not None
+                for f in rigid_props_list
+            )
+            if (
+                isinstance(cfg.joint_drive_props, MujocoJointDrivePropertiesCfg)
+                and cfg.joint_drive_props.actuatorgravcomp
+                and body_gravcomp_unset
+            ):
+                logger.info(
+                    "Joint-level actuator gravity compensation requires body-level gravcomp."
+                    " Auto-setting MujocoRigidBodyPropertiesCfg(gravcomp=1.0)."
+                )
+                schemas.modify_rigid_body_properties(prim_path, MujocoRigidBodyPropertiesCfg(gravcomp=1.0))
+            schemas.modify_joint_drive_properties(prim_path, cfg.joint_drive_props)
+
+
 def _spawn_from_usd_file(
     prim_path: str,
     usd_path: str,
@@ -348,133 +539,10 @@ def _spawn_from_usd_file(
     if getattr(cfg, "make_uninstanceable", False):
         make_uninstanceable(prim_path, stage=stage)
 
-    # modify rigid body properties
-    if cfg.rigid_props is not None:
-        # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> modify_*
-        rigid_frags = cfg.rigid_props if isinstance(cfg.rigid_props, (list, tuple)) else [cfg.rigid_props]
-        if rigid_frags and all(isinstance(f, schemas.SchemaFragment) for f in rigid_frags):
-            schemas.apply_rigid_body_properties(prim_path, rigid_frags)
-        else:
-            schemas.modify_rigid_body_properties(prim_path, cfg.rigid_props)
-    # modify collision properties
-    if cfg.collision_props is not None:
-        # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> modify_*
-        coll_frags = cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-        if coll_frags and all(isinstance(f, schemas.SchemaFragment) for f in coll_frags):
-            schemas.apply_collision_properties(prim_path, coll_frags)
-        else:
-            schemas.modify_collision_properties(prim_path, cfg.collision_props)
-    # modify mass properties (transition shim, remove later: fragment list -> apply_*; legacy cfg -> modify_*)
-    if cfg.mass_props is not None:
-        # normalize a single fragment to a list so the convenience form routes like a list
-        mass_frags = [cfg.mass_props] if isinstance(cfg.mass_props, schemas.SchemaFragment) else cfg.mass_props
-        if isinstance(mass_frags, (list, tuple)) and all(isinstance(f, schemas.SchemaFragment) for f in mass_frags):
-            schemas.apply_mass_properties(prim_path, mass_frags)
-        else:
-            schemas.modify_mass_properties(prim_path, cfg.mass_props)
-
-    # modify articulation root properties
-    # ``fix_root_link`` is a spawner-level topology flag (not a schema property); it is honored on the
-    # fragment path independently of whether any articulation schema properties were supplied.
-    articulation_props = cfg.articulation_props
-    articulation_fix_root_link = cfg.fix_root_link
-    # transition shim, remove later: route a legacy single cfg (a dataclass, not a fragment) to the
-    # legacy writer -- it owns its own ``fix_root_link`` field; everything else goes to the fragment
-    # writer, routing by type so an empty list is still a valid (topology-only) fragment collection
-    # rather than being mis-sent to the legacy writer.
-    if (
-        articulation_props is not None
-        and not isinstance(articulation_props, (list, tuple))
-        and not isinstance(articulation_props, schemas.SchemaFragment)
-    ):
-        if articulation_fix_root_link is not None:
-            logger.warning(
-                f"Ignoring the spawner-level 'fix_root_link={articulation_fix_root_link}' because"
-                " 'articulation_props' is a legacy cfg, which owns its own 'fix_root_link' field. Set"
-                " it on that cfg instead."
-            )
-        schemas.modify_articulation_root_properties(prim_path, articulation_props)
-    else:
-        articulation_frags = (
-            list(articulation_props)
-            if isinstance(articulation_props, (list, tuple))
-            else ([articulation_props] if isinstance(articulation_props, schemas.SchemaFragment) else [])
-        )
-        if articulation_frags or articulation_fix_root_link is not None:
-            schemas.apply_articulation_root_properties(
-                prim_path, articulation_frags, fix_root_link=articulation_fix_root_link
-            )
-    # modify tendon properties
-    if cfg.fixed_tendons_props is not None:
-        # transition shim, remove later: fragment(s) -> apply_*; legacy cfg -> modify_*
-        # normalize a single fragment to a list so the convenience form (and an empty list) route like a list
-        fixed_tendon_frags = (
-            [cfg.fixed_tendons_props]
-            if isinstance(cfg.fixed_tendons_props, schemas.SchemaFragment)
-            else cfg.fixed_tendons_props
-        )
-        if isinstance(fixed_tendon_frags, (list, tuple)) and all(
-            isinstance(f, schemas.SchemaFragment) for f in fixed_tendon_frags
-        ):
-            schemas.apply_fixed_tendon_properties(prim_path, fixed_tendon_frags)
-        else:
-            schemas.modify_fixed_tendon_properties(prim_path, cfg.fixed_tendons_props)
-    if cfg.spatial_tendons_props is not None:
-        # transition shim, remove later: fragment(s) -> apply_*; legacy cfg -> modify_*
-        # normalize a single fragment to a list so the convenience form (and an empty list) route like a list
-        spatial_tendon_frags = (
-            [cfg.spatial_tendons_props]
-            if isinstance(cfg.spatial_tendons_props, schemas.SchemaFragment)
-            else cfg.spatial_tendons_props
-        )
-        if isinstance(spatial_tendon_frags, (list, tuple)) and all(
-            isinstance(f, schemas.SchemaFragment) for f in spatial_tendon_frags
-        ):
-            schemas.apply_spatial_tendon_properties(prim_path, spatial_tendon_frags)
-        else:
-            schemas.modify_spatial_tendon_properties(prim_path, cfg.spatial_tendons_props)
-    # define drive API on the joints
-    # note: these are only for setting low-level simulation properties. all others should be set or are
-    #  and overridden by the articulation/actuator properties.
-    if cfg.joint_drive_props is not None:
-        # transition shim, remove later: a fragment list -> apply_joint_drive_properties (the
-        # MujocoJointCfg fragment handles its own body-gravcomp coupling in apply_mujoco_joint, so
-        # the fragment path adds no backend coupling here); a legacy single cfg -> the pre-existing
-        # gravcomp auto-enable + modify_joint_drive_properties below.
-        joint_frags = (
-            cfg.joint_drive_props if isinstance(cfg.joint_drive_props, (list, tuple)) else [cfg.joint_drive_props]
-        )
-        if joint_frags and all(isinstance(f, schemas.SchemaFragment) for f in joint_frags):
-            schemas.apply_joint_drive_properties(prim_path, joint_frags, ensure_drives_exist=cfg.ensure_drives_exist)
-        else:
-            # auto-enable body-level gravcomp if joint-level actuator gravcomp is requested
-            # without it — actuatorgravcomp has no effect since there are no forces to route.
-            # Only auto-populates when the user did not already set ``gravcomp`` themselves;
-            # an explicit ``MujocoRigidBodyPropertiesCfg(gravcomp=0.5)`` is preserved as-is.
-            from isaaclab_newton.sim.schemas.schemas_cfg import (
-                MujocoJointDrivePropertiesCfg,
-                MujocoRigidBodyCfg,
-                MujocoRigidBodyPropertiesCfg,
-            )
-
-            # gravcomp may be authored either via the legacy MujocoRigidBodyPropertiesCfg or via a
-            # MujocoRigidBodyCfg fragment in a rigid_props list. Treat either as "already set".
-            rigid_props_list = cfg.rigid_props if isinstance(cfg.rigid_props, (list, tuple)) else [cfg.rigid_props]
-            body_gravcomp_unset = not any(
-                isinstance(f, (MujocoRigidBodyPropertiesCfg, MujocoRigidBodyCfg)) and f.gravcomp is not None
-                for f in rigid_props_list
-            )
-            if (
-                isinstance(cfg.joint_drive_props, MujocoJointDrivePropertiesCfg)
-                and cfg.joint_drive_props.actuatorgravcomp
-                and body_gravcomp_unset
-            ):
-                logger.info(
-                    "Joint-level actuator gravity compensation requires body-level gravcomp."
-                    " Auto-setting MujocoRigidBodyPropertiesCfg(gravcomp=1.0)."
-                )
-                schemas.modify_rigid_body_properties(prim_path, MujocoRigidBodyPropertiesCfg(gravcomp=1.0))
-            schemas.modify_joint_drive_properties(prim_path, cfg.joint_drive_props)
+    # modify rigid body, collision, and mass properties
+    _apply_body_schema_properties(prim_path, cfg)
+    # modify articulation root, tendon, and joint drive properties
+    _apply_articulation_schema_properties(prim_path, cfg)
 
     # define deformable body properties, or modify if deformable body API is present (PhysX only)
     if cfg.deformable_props is not None:

--- a/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/from_files/from_files_cfg.py
@@ -35,18 +35,35 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     """Scale of the asset. Defaults to None, in which case the scale is not modified."""
 
     articulation_props: (
-        schemas.ArticulationRootBaseCfg
+        dict[str, list[schemas.ArticulationRootFragment]]
         | schemas.ArticulationRootFragment
         | list[schemas.ArticulationRootFragment]
+        | schemas.ArticulationRootBaseCfg
         | None
     ) = None
     """Properties to apply to the articulation root.
 
-    Accepts either a single legacy cfg (e.g. :class:`~isaaclab.sim.schemas.ArticulationRootBaseCfg`)
-    or a list of :class:`~isaaclab.sim.schemas.ArticulationRootFragment` fragments
-    (e.g. ``[PhysxArticulationCfg(...), NewtonArticulationCfg(...)]``). When a fragment list is
-    given, ``UsdPhysics.ArticulationRootAPI`` is applied as the anchor (presence-gated) and each
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.ArticulationRootFragment` fragments
+    (e.g. ``{"/.*": [PhysxArticulationCfg(...), NewtonArticulationCfg(...)]}``) or a single legacy
+    cfg (e.g. :class:`~isaaclab.sim.schemas.ArticulationRootBaseCfg`). On the fragment path each
     fragment writes its own namespace.
+
+    Keys are regular-expression suffixes appended to the spawn prim, so a key carries its own leading ``/`` when it
+    targets descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it).
+    Entries apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As
+    a shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the
+    anchor prim itself.
+    """
+
+    articulation_props_create_if_missing: bool = False
+    """Whether the articulation writer may apply ``UsdPhysics.ArticulationRootAPI`` when no matched
+    prim carries it. Defaults to False. The flag applies to every entry of the
+    :attr:`articulation_props` mapping.
+
+    Creation applies to every matched prim lacking the API; when enabling this, narrow the
+    pattern -- typically a bare fragment, which anchors the spawn prim itself. Only consumed when
+    :attr:`articulation_props` is given as fragments.
     """
 
     fix_root_link: bool | None = None
@@ -54,8 +71,10 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
 
     This is a non-USD, spawner-level behaviour flag consumed by
     :func:`~isaaclab.sim.schemas.apply_articulation_root_properties` on the fragment/topology path,
-    including when :attr:`articulation_props` is ``None`` or an empty fragment collection. It is handled
-    independently of whether any schema properties are supplied:
+    including when :attr:`articulation_props` is ``None`` or an empty mapping. When the mapping has
+    several entries, the flag is honored on the first entry only, since the root topology must not
+    be re-fixed per entry. It is handled independently of whether any schema properties are
+    supplied:
 
     * If set to None, the root link is not modified.
     * If the articulation already has a fixed root link, this flag enables or disables the fixed joint.
@@ -67,34 +86,67 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
     """
 
     fixed_tendons_props: (
-        schemas.FixedTendonPropertiesCfg | schemas.FixedTendonFragment | list[schemas.FixedTendonFragment] | None
+        dict[str, list[schemas.FixedTendonFragment]]
+        | schemas.FixedTendonFragment
+        | list[schemas.FixedTendonFragment]
+        | schemas.FixedTendonPropertiesCfg
+        | None
     ) = None
     """Properties to apply to the fixed tendons (if any).
 
-    Accepts either the legacy :class:`~isaaclab_physx.sim.schemas.PhysxFixedTendonPropertiesCfg`
-    or one or more :class:`~isaaclab.sim.schemas.FixedTendonFragment` instances.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.FixedTendonFragment` fragments or the legacy
+    :class:`~isaaclab_physx.sim.schemas.PhysxFixedTendonPropertiesCfg`.
+
+    Keys are regular-expression suffixes appended to the spawn prim, so a key carries its own leading ``/`` when it
+    targets descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it).
+    Entries apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As
+    a shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the
+    anchor prim itself.
     """
 
     spatial_tendons_props: (
-        schemas.SpatialTendonPropertiesCfg | schemas.SpatialTendonFragment | list[schemas.SpatialTendonFragment] | None
+        dict[str, list[schemas.SpatialTendonFragment]]
+        | schemas.SpatialTendonFragment
+        | list[schemas.SpatialTendonFragment]
+        | schemas.SpatialTendonPropertiesCfg
+        | None
     ) = None
     """Properties to apply to the spatial tendons (if any).
 
-    Accepts either the legacy :class:`~isaaclab_physx.sim.schemas.PhysxSpatialTendonPropertiesCfg`
-    or one or more :class:`~isaaclab.sim.schemas.SpatialTendonFragment` instances.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.SpatialTendonFragment` fragments or the legacy
+    :class:`~isaaclab_physx.sim.schemas.PhysxSpatialTendonPropertiesCfg`.
+
+    Keys are regular-expression suffixes appended to the spawn prim, so a key carries its own leading ``/`` when it
+    targets descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it).
+    Entries apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As
+    a shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the
+    anchor prim itself.
     """
 
     joint_drive_props: (
-        schemas.JointDriveBaseCfg | schemas.JointDriveFragment | list[schemas.JointDriveFragment] | None
+        dict[str, list[schemas.JointDriveFragment]]
+        | schemas.JointDriveFragment
+        | list[schemas.JointDriveFragment]
+        | schemas.JointDriveBaseCfg
+        | None
     ) = None
     """Properties to apply to a joint.
 
-    Accepts either a single legacy cfg (e.g. :class:`~isaaclab.sim.schemas.JointDriveBaseCfg`) or a
-    list of :class:`~isaaclab.sim.schemas.JointDriveFragment` fragments
-    (e.g. ``[UsdPhysicsDriveCfg(...), PhysxJointCfg(...)]``). When a fragment list is given,
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.JointDriveFragment` fragments
+    (e.g. ``{"/.*": [UsdPhysicsDriveCfg(...), PhysxJointCfg(...)]}``) or a single legacy cfg
+    (e.g. :class:`~isaaclab.sim.schemas.JointDriveBaseCfg`). On the fragment path,
     ``UsdPhysics.DriveAPI`` is applied (presence-gated) only when a
     :class:`~isaaclab.sim.schemas.UsdPhysicsDriveCfg` fragment is present, and each fragment writes
     its own namespace.
+
+    Keys are regular-expression suffixes appended to the spawn prim, so a key carries its own leading ``/`` when it
+    targets descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it).
+    Entries apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As
+    a shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the
+    anchor prim itself.
 
     .. note::
         The joint drive properties set the USD attributes of all the joint drives in the asset.
@@ -103,14 +155,23 @@ class FileCfg(RigidObjectSpawnerCfg, DeformableObjectSpawnerCfg):
         for specific joints in an articulation.
     """
 
+    joint_drive_props_create_if_missing: bool = False
+    """Whether the joint-drive writer may apply the defining USD drive API to matched joint prims
+    that lack it. Defaults to False. The flag applies to every entry of the
+    :attr:`joint_drive_props` mapping.
+
+    Only consumed when :attr:`joint_drive_props` is given as fragments. This is independent of
+    :attr:`ensure_drives_exist`, which instead patches zero-gain drives with a minimal stiffness.
+    """
+
     ensure_drives_exist: bool = False
     """Whether to ensure every joint drive is active when authoring :attr:`joint_drive_props`.
 
     When True, any joint drive whose authored stiffness *and* damping are both zero is given a
     minimal stiffness (``1e-3``) so that backends (e.g. Newton) create proper actuators for it.
     This is a spawner-level behavior flag (not a USD attribute and not a fragment field). It is
-    only consumed when :attr:`joint_drive_props` is given as a fragment list; legacy
-    :class:`~isaaclab.sim.schemas.JointDriveBaseCfg` cfgs carry their own
+    only consumed when :attr:`joint_drive_props` is given as fragments, and applies to every entry
+    of the mapping; legacy :class:`~isaaclab.sim.schemas.JointDriveBaseCfg` cfgs carry their own
     ``ensure_drives_exist`` field.
     """
 

--- a/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/meshes/meshes.py
@@ -14,6 +14,7 @@ import trimesh.transformations
 from pxr import Usd, UsdPhysics
 
 from isaaclab.sim import schemas
+from isaaclab.sim.spawners._utils import fragment_mapping, props_expr
 from isaaclab.sim.utils import bind_physics_material, bind_visual_material, clone, create_prim, get_current_stage
 
 from ..materials import (
@@ -348,6 +349,26 @@ Helper functions.
 """
 
 
+def _apply_deformable_collision_props(prim_path: str, collision_props, stage: Usd.Stage) -> None:
+    """Apply collision fragments to the simulation mesh of a deformable body.
+
+    The collider is the simulation mesh authored under the body prim, so mapping keys anchor there
+    (e.g. ``{"/sim_mesh": [...]}``) while a bare fragment list sweeps the subtree to reach it.
+
+    Args:
+        prim_path: The prim path of the deformable body.
+        collision_props: A mapping from target pattern to collision fragments, or a fragment or
+            sequence of fragments.
+        stage: The stage where the prims live.
+    """
+    if isinstance(collision_props, dict):
+        for pattern, fragments in collision_props.items():
+            schemas.apply_collision_properties(props_expr(prim_path, pattern), fragments, stage=stage)
+        return
+    fragments = collision_props if isinstance(collision_props, (list, tuple)) else [collision_props]
+    schemas.apply_collision_properties(props_expr(prim_path, "/.*"), fragments, stage=stage)
+
+
 def _spawn_mesh_geom_from_mesh(
     prim_path: str,
     cfg: meshes_cfg.MeshCfg,
@@ -404,8 +425,12 @@ def _spawn_mesh_geom_from_mesh(
         raise ValueError("Cannot use both deformable and rigid properties at the same time.")
     if cfg.deformable_props is not None and cfg.collision_props is not None:
         # only fragments resolve onto the simulation mesh, legacy cfgs would target the inert body prim
-        frags = cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-        if not all(isinstance(frag, schemas.SchemaFragment) for frag in frags):
+        collision_props_mapping = fragment_mapping(cfg.collision_props)
+        if collision_props_mapping is not None:
+            frags = [frag for fragments in collision_props_mapping.values() for frag in fragments]
+        else:
+            frags = [cfg.collision_props]
+        if not frags or not all(isinstance(frag, schemas.SchemaFragment) for frag in frags):
             raise ValueError("Deformable bodies require 'collision_props' as collision fragments.")
     # check material types are correct
     if cfg.deformable_props is not None and cfg.physics_material is not None:
@@ -449,10 +474,8 @@ def _spawn_mesh_geom_from_mesh(
         schemas.define_deformable_body_properties(
             prim_path, cfg.deformable_props, stage=stage, deformable_type=deformable_type
         )
-        # the collider is the simulation mesh, resolved from the body prim
         if cfg.collision_props is not None:
-            frags = cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-            schemas.apply_collision_properties(prim_path, frags, stage=stage)
+            _apply_deformable_collision_props(prim_path, cfg.collision_props, stage)
         if cfg.mass_props is not None:
             raise ValueError(
                 """MassPropertiesCfg are not supported for deformable bodies
@@ -472,10 +495,15 @@ def _spawn_mesh_geom_from_mesh(
         mesh_collision_api = UsdPhysics.MeshCollisionAPI.Apply(mesh_prim)
         mesh_collision_api.GetApproximationAttr().Set(collision_approximation)
         # apply collision properties
-        # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> define_*
-        coll_frags = cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-        if coll_frags and all(isinstance(f, schemas.SchemaFragment) for f in coll_frags):
-            schemas.apply_collision_properties(mesh_prim_path, coll_frags, stage=stage)
+        # fragment path: a mapping from target pattern to fragment list, applied entry by entry in
+        # insertion order; patterns anchor at the geometry prim this spawner authors, so ``""``
+        # preserves the legacy placement. Otherwise a legacy cfg routes to the legacy writer.
+        collision_props_mapping = fragment_mapping(cfg.collision_props)
+        if collision_props_mapping is not None:
+            for pattern, fragments in collision_props_mapping.items():
+                schemas.apply_collision_properties(
+                    props_expr(mesh_prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                )
         else:
             schemas.define_collision_properties(mesh_prim_path, cfg.collision_props, stage=stage)
 
@@ -502,18 +530,25 @@ def _spawn_mesh_geom_from_mesh(
         bind_physics_material(prim_path, material_path, stage=stage)
 
     # note: we apply the rigid properties to the parent prim in case of rigid objects.
+    # fragment path: mapping entries anchor at the container prim, so ``""`` preserves the legacy
+    # placement; entries apply in insertion order. Otherwise a legacy cfg routes to the legacy writer.
     if cfg.rigid_props is not None:
-        # apply mass properties (transition shim, remove later: fragment list -> apply_*; legacy cfg -> define_*)
+        # apply mass properties
         if cfg.mass_props is not None:
-            # normalize a single fragment to a list so the convenience form routes like a list
-            mass_frags = [cfg.mass_props] if isinstance(cfg.mass_props, schemas.SchemaFragment) else cfg.mass_props
-            if isinstance(mass_frags, (list, tuple)) and all(isinstance(f, schemas.SchemaFragment) for f in mass_frags):
-                schemas.apply_mass_properties(prim_path, mass_frags, stage=stage)
+            mass_props_mapping = fragment_mapping(cfg.mass_props)
+            if mass_props_mapping is not None:
+                for pattern, fragments in mass_props_mapping.items():
+                    schemas.apply_mass_properties(
+                        props_expr(prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                    )
             else:
                 schemas.define_mass_properties(prim_path, cfg.mass_props, stage=stage)
-        # apply rigid properties (transition shim, remove later: fragment list -> apply_*; legacy cfg -> define_*)
-        rigid_frags = cfg.rigid_props if isinstance(cfg.rigid_props, (list, tuple)) else [cfg.rigid_props]
-        if rigid_frags and all(isinstance(f, schemas.SchemaFragment) for f in rigid_frags):
-            schemas.apply_rigid_body_properties(prim_path, rigid_frags, stage=stage)
+        # apply rigid properties
+        rigid_props_mapping = fragment_mapping(cfg.rigid_props)
+        if rigid_props_mapping is not None:
+            for pattern, fragments in rigid_props_mapping.items():
+                schemas.apply_rigid_body_properties(
+                    props_expr(prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                )
         else:
             schemas.define_rigid_body_properties(prim_path, cfg.rigid_props, stage=stage)

--- a/source/isaaclab/isaaclab/sim/spawners/shapes/shapes.py
+++ b/source/isaaclab/isaaclab/sim/spawners/shapes/shapes.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from pxr import Usd, UsdGeom
 
 from isaaclab.sim import schemas
+from isaaclab.sim.spawners._utils import fragment_mapping, props_expr
 from isaaclab.sim.spawners.materials.physics_materials import spawn_physics_material
 from isaaclab.sim.utils import bind_physics_material, bind_visual_material, clone, create_prim, get_current_stage
 
@@ -355,11 +356,16 @@ def _spawn_geom_from_prim_type(
     if geometry_schema_func is not None:
         geometry_schema_func(mesh_prim_path, stage=stage)
     # apply collision properties
+    # fragment path: a mapping from target pattern to fragment list, applied entry by entry in
+    # insertion order; patterns anchor at the geometry prim this spawner authors, so ``""``
+    # preserves the legacy placement. Otherwise a legacy cfg routes to the legacy writer.
     if getattr(cfg, "collision_props", None) is not None:
-        # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> define_*
-        coll_frags = cfg.collision_props if isinstance(cfg.collision_props, (list, tuple)) else [cfg.collision_props]
-        if coll_frags and all(isinstance(f, schemas.SchemaFragment) for f in coll_frags):
-            schemas.apply_collision_properties(mesh_prim_path, coll_frags, stage=stage)
+        collision_props_mapping = fragment_mapping(cfg.collision_props)
+        if collision_props_mapping is not None:
+            for pattern, fragments in collision_props_mapping.items():
+                schemas.apply_collision_properties(
+                    props_expr(mesh_prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                )
         else:
             schemas.define_collision_properties(mesh_prim_path, cfg.collision_props, stage=stage)
     # apply visual material
@@ -385,19 +391,24 @@ def _spawn_geom_from_prim_type(
 
     # note: we apply rigid properties in the end to later make the instanceable prim
     # apply mass properties
+    # fragment path: mapping entries anchor at the container prim, so ``""`` preserves the legacy
+    # placement; entries apply in insertion order. Otherwise a legacy cfg routes to the legacy writer.
     if getattr(cfg, "mass_props", None) is not None:
-        # transition shim, remove later: fragment(s) -> apply_*; legacy cfg -> define_*
-        # normalize a single fragment to a list so the convenience form routes like a list
-        mass_frags = [cfg.mass_props] if isinstance(cfg.mass_props, schemas.SchemaFragment) else cfg.mass_props
-        if isinstance(mass_frags, (list, tuple)) and all(isinstance(f, schemas.SchemaFragment) for f in mass_frags):
-            schemas.apply_mass_properties(prim_path, mass_frags, stage=stage)
+        mass_props_mapping = fragment_mapping(cfg.mass_props)
+        if mass_props_mapping is not None:
+            for pattern, fragments in mass_props_mapping.items():
+                schemas.apply_mass_properties(
+                    props_expr(prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                )
         else:
             schemas.define_mass_properties(prim_path, cfg.mass_props, stage=stage)
     # apply rigid body properties
     if getattr(cfg, "rigid_props", None) is not None:
-        # transition shim, remove later: new fragment list -> apply_*; legacy single cfg -> define_*
-        rigid_frags = cfg.rigid_props if isinstance(cfg.rigid_props, (list, tuple)) else [cfg.rigid_props]
-        if rigid_frags and all(isinstance(f, schemas.SchemaFragment) for f in rigid_frags):
-            schemas.apply_rigid_body_properties(prim_path, rigid_frags, stage=stage)
+        rigid_props_mapping = fragment_mapping(cfg.rigid_props)
+        if rigid_props_mapping is not None:
+            for pattern, fragments in rigid_props_mapping.items():
+                schemas.apply_rigid_body_properties(
+                    props_expr(prim_path, pattern), fragments, create_if_missing=True, stage=stage
+                )
         else:
             schemas.define_rigid_body_properties(prim_path, cfg.rigid_props, stage=stage)

--- a/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
+++ b/source/isaaclab/isaaclab/sim/spawners/spawner_cfg.py
@@ -82,23 +82,57 @@ class RigidObjectSpawnerCfg(SpawnerCfg):
         to the prim outside of the properties available by default when spawning the prim.
     """
 
-    mass_props: schemas.MassPropertiesCfg | schemas.MassFragment | list[schemas.MassFragment] | None = None
+    mass_props: (
+        dict[str, list[schemas.MassFragment]]
+        | schemas.MassFragment
+        | list[schemas.MassFragment]
+        | schemas.MassPropertiesCfg
+        | None
+    ) = None
     """Mass properties.
 
-    Accepts either a single legacy :class:`~isaaclab.sim.schemas.MassPropertiesCfg` or a list of
-    :class:`~isaaclab.sim.schemas.MassFragment` fragments (e.g. ``[MassCfg(...)]``). When a fragment
-    list is given, ``UsdPhysics.MassAPI`` is applied as the implicit anchor and each fragment writes
-    its own namespace.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.MassFragment` fragments (e.g. ``{"/.*": [MassCfg(...)]}``) or a
+    single legacy :class:`~isaaclab.sim.schemas.MassPropertiesCfg`. On the fragment path each
+    fragment writes its own namespace.
+
+    Keys are regular-expression suffixes appended to the prim the spawner anchors this family on (for USD assets: the
+    spawn prim; for shapes and meshes: the container prim), so a key carries its own leading ``/`` when it targets
+    descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it). Entries
+    apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As a
+    shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the anchor
+    prim itself.
     """
 
-    rigid_props: schemas.RigidBodyBaseCfg | schemas.RigidBodyFragment | list[schemas.RigidBodyFragment] | None = None
+    mass_props_create_if_missing: bool = False
+    """Whether the mass writer may apply ``UsdPhysics.MassAPI`` to matched prims that lack it.
+    Defaults to False. The flag applies to every entry of the :attr:`mass_props` mapping.
+
+    Only consumed when :attr:`mass_props` is given as fragments and the asset is spawned from a
+    USD file; the shape and mesh spawners always create the API on the bare prim they author.
+    """
+
+    rigid_props: (
+        dict[str, list[schemas.RigidBodyFragment]]
+        | schemas.RigidBodyFragment
+        | list[schemas.RigidBodyFragment]
+        | schemas.RigidBodyBaseCfg
+        | None
+    ) = None
     """Rigid body properties.
 
-    Accepts either a single legacy cfg (e.g. :class:`~isaaclab.sim.schemas.RigidBodyBaseCfg`) or a
-    list of :class:`~isaaclab.sim.schemas.RigidBodyFragment` fragments
-    (e.g. ``[UsdPhysicsRigidBodyCfg(...), PhysxRigidBodyCfg(...)]``). When a fragment list is given,
-    ``UsdPhysics.RigidBodyAPI`` is applied as the implicit anchor and each fragment writes its own
-    namespace.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.RigidBodyFragment` fragments
+    (e.g. ``{"/.*": [UsdPhysicsRigidBodyCfg(...), PhysxRigidBodyCfg(...)]}``) or a single legacy cfg
+    (e.g. :class:`~isaaclab.sim.schemas.RigidBodyBaseCfg`). On the fragment path each fragment
+    writes its own namespace.
+
+    Keys are regular-expression suffixes appended to the prim the spawner anchors this family on (for USD assets: the
+    spawn prim; for shapes and meshes: the container prim), so a key carries its own leading ``/`` when it targets
+    descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything beneath it). Entries
+    apply in insertion order, so on overlapping targets later entries override earlier ones per attribute. As a
+    shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``, i.e. the anchor
+    prim itself.
 
     For making a rigid object static, set the :attr:`schemas.RigidBodyBaseCfg.kinematic_enabled`
     (or :attr:`~isaaclab.sim.schemas.UsdPhysicsRigidBodyCfg.kinematic_enabled`) as True. This will
@@ -106,15 +140,26 @@ class RigidObjectSpawnerCfg(SpawnerCfg):
     """
 
     collision_props: (
-        schemas.CollisionPropertiesCfg | schemas.CollisionFragment | list[schemas.CollisionFragment] | None
+        dict[str, list[schemas.CollisionFragment]]
+        | schemas.CollisionFragment
+        | list[schemas.CollisionFragment]
+        | schemas.CollisionPropertiesCfg
+        | None
     ) = None
     """Properties to apply to all collision meshes.
 
-    Accepts either a single legacy cfg (e.g. :class:`~isaaclab.sim.schemas.CollisionBaseCfg`) or a
-    list of :class:`~isaaclab.sim.schemas.CollisionFragment` fragments
-    (e.g. ``[UsdPhysicsCollisionCfg(...), PhysxCollisionCfg(...)]``). When a fragment list is given,
-    ``UsdPhysics.CollisionAPI`` is applied as the implicit anchor and each fragment writes its own
-    namespace.
+    Accepts either a mapping from target pattern to a list of
+    :class:`~isaaclab.sim.schemas.CollisionFragment` fragments
+    (e.g. ``{"/.*": [UsdPhysicsCollisionCfg(...), PhysxCollisionCfg(...)]}``) or a single legacy cfg
+    (e.g. :class:`~isaaclab.sim.schemas.CollisionBaseCfg`). On the fragment path each fragment
+    writes its own namespace.
+
+    Keys are regular-expression suffixes appended to the prim the spawner anchors this family on (for USD assets: the
+    spawn prim; for shapes and meshes: the geometry prim the spawner authors), so a key carries its own leading ``/``
+    when it targets descendants (``""`` the anchor itself, ``"/[^/]+"`` its direct children, ``"/.*"`` everything
+    beneath it). Entries apply in insertion order, so on overlapping targets later entries override earlier ones per
+    attribute. As a shorthand for the common case, a bare fragment or a list of fragments is read as ``{"": [...]}``,
+    i.e. the anchor prim itself.
     """
 
     activate_contact_sensors: bool = False

--- a/source/isaaclab/test/sim/test_articulation_fragments.py
+++ b/source/isaaclab/test/sim/test_articulation_fragments.py
@@ -111,6 +111,7 @@ def test_apply_articulation_root_properties_composes_namespaces():
             NewtonArticulationCfg(self_collision_enabled=True),
         ],
         stage,
+        create_if_missing=True,
     )
     prim = stage.GetPrimAtPath("/World/A3")
     assert bool(UsdPhysics.ArticulationRootAPI(prim))  # presence-gated anchor applied
@@ -141,7 +142,7 @@ def test_apply_articulation_root_properties_tunes_existing_child_root():
     UsdPhysics.ArticulationRootAPI.Apply(child)  # asset already carries its root on a child prim
 
     apply_articulation_root_properties(
-        "/World/Asset",
+        "/World/Asset(/.*)?",
         [PhysxArticulationCfg(solver_position_iteration_count=8)],
         stage,
     )
@@ -158,7 +159,7 @@ def test_apply_articulation_root_properties_tunes_existing_child_root():
 
 
 def test_apply_articulation_root_properties_processes_siblings_and_aggregates_results():
-    """Every non-nested sibling root is visited and a failing applier makes the family result False."""
+    """Every sibling root is visited and a failing applier makes the family result False."""
     from isaaclab_physx.sim.schemas import PhysxArticulationCfg
 
     from isaaclab.sim.schemas import apply_articulation_root_properties
@@ -166,7 +167,7 @@ def test_apply_articulation_root_properties_processes_siblings_and_aggregates_re
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
-    for path in ("/World/A", "/World/B", "/World/A/Nested"):
+    for path in ("/World/A", "/World/B"):
         root = _make_xform(stage, path)
         UsdPhysics.ArticulationRootAPI.Apply(root)
 
@@ -176,10 +177,62 @@ def test_apply_articulation_root_properties_processes_siblings_and_aggregates_re
         visited.append(path)
         return path != "/World/B"
 
-    result = apply_articulation_root_properties("/World", [PhysxArticulationCfg(func=record_result)], stage)
+    result = apply_articulation_root_properties("/World(/.*)?", [PhysxArticulationCfg(func=record_result)], stage)
 
     assert visited == ["/World/A", "/World/B"]
     assert result is False
+
+
+def test_apply_articulation_root_properties_warns_on_nested_roots(caplog):
+    """Nested roots matched by the expression are all authored, with a warning.
+
+    The writer trusts the expression; asset validity is the author's responsibility.
+    """
+    from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
+    from isaaclab.sim.schemas import apply_articulation_root_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    outer = UsdGeom.Xform.Define(stage, "/World/Bot").GetPrim()
+    inner = UsdGeom.Xform.Define(stage, "/World/Bot/base").GetPrim()
+    UsdPhysics.ArticulationRootAPI.Apply(outer)
+    UsdPhysics.ArticulationRootAPI.Apply(inner)
+
+    with caplog.at_level("WARNING"):
+        result = apply_articulation_root_properties(
+            "/World/Bot(/.*)?", [PhysxArticulationCfg(solver_position_iteration_count=8)], stage=stage
+        )
+
+    assert result is True
+    for prim in (outer, inner):
+        assert prim.GetAttribute("physxArticulation:solverPositionIterationCount").Get() == 8
+    assert "nested" in caplog.text.lower()
+
+
+def test_apply_articulation_root_properties_processes_sibling_roots_via_expression():
+    """Independent sibling articulations matched by one expression are all tuned."""
+    from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
+    from isaaclab.sim.schemas import apply_articulation_root_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Rig")
+    left = UsdGeom.Xform.Define(stage, "/World/Rig/armL").GetPrim()
+    right = UsdGeom.Xform.Define(stage, "/World/Rig/armR").GetPrim()
+    UsdPhysics.ArticulationRootAPI.Apply(left)
+    UsdPhysics.ArticulationRootAPI.Apply(right)
+
+    result = apply_articulation_root_properties(
+        "/World/Rig(/.*)?", [PhysxArticulationCfg(solver_position_iteration_count=8)], stage=stage
+    )
+
+    assert result is True
+    for prim in (left, right):
+        assert prim.GetAttribute("physxArticulation:solverPositionIterationCount").Get() == 8
 
 
 def test_apply_articulation_root_properties_does_not_duplicate_instance_proxy_root(caplog):
@@ -202,7 +255,7 @@ def test_apply_articulation_root_properties_does_not_duplicate_instance_proxy_ro
 
     with caplog.at_level("WARNING"):
         result = apply_articulation_root_properties(
-            "/World/Asset", [PhysxArticulationCfg(solver_position_iteration_count=4)], stage
+            "/World/Asset(/.*)?", [PhysxArticulationCfg(solver_position_iteration_count=4)], stage
         )
 
     assert result is False
@@ -258,7 +311,7 @@ def test_apply_articulation_root_properties_enables_existing_joint_and_relocates
     joint.CreateBody1Rel().SetTargets([root.GetPath()])
     joint.CreateJointEnabledAttr(False)
 
-    apply_articulation_root_properties("/World/ExistingJointRobot", [], stage, fix_root_link=True)
+    apply_articulation_root_properties("/World/ExistingJointRobot(/.*)?", [], stage, fix_root_link=True)
 
     joints = [prim for prim in stage.Traverse() if prim.IsA(UsdPhysics.FixedJoint)]
     assert joints == [joint.GetPrim()]
@@ -293,7 +346,7 @@ def test_apply_articulation_root_properties_creates_fixed_joint_and_reparents_ro
     assert not any(p.IsA(UsdPhysics.FixedJoint) for p in stage.Traverse())
 
     apply_articulation_root_properties(
-        "/World/Robot",
+        "/World/Robot(/.*)?",
         [PhysxArticulationCfg(articulation_enabled=True)],
         stage,
         fix_root_link=True,
@@ -371,7 +424,7 @@ def test_physx_and_newton_fragments_fix_root_link_keeps_single_root():
     UsdPhysics.ArticulationRootAPI.Apply(child)
 
     apply_articulation_root_properties(
-        "/World/Robot5",
+        "/World/Robot5(/.*)?",
         [
             PhysxArticulationCfg(solver_position_iteration_count=8),
             NewtonArticulationCfg(self_collision_enabled=True),
@@ -396,10 +449,11 @@ def test_physx_fix_root_link_migrates_preauthored_newton_root_api():
     """A pre-authored backend root API (as on URDF/MJCF-imported assets) moves with the root when
     PhysX relocates it, together with its authored attributes.
 
-    Regression: ``NewtonArticulationRootAPI`` composes ``PhysicsArticulationRootAPI``, so removing
-    only the directly applied anchor from the former root link leaves that prim an articulation root
-    through schema composition -- two roots -- with the ``newton:*`` values stranded on the wrong prim.
+    Regression: leaving the backend root API behind strands the ``newton:*`` values on the former
+    root link, and leaves that prim carrying a root API the relocation was meant to move.
     """
+    import isaaclab_newton.sim.schemas  # noqa: F401  -- registers the Newton root companion
+
     from isaaclab.sim.schemas import apply_articulation_root_properties
 
     sim_utils.create_new_stage()
@@ -408,23 +462,24 @@ def test_physx_fix_root_link_migrates_preauthored_newton_root_api():
     _make_xform(stage, "/World/UrdfBot")
     child = _make_xform(stage, "/World/UrdfBot/base")
     UsdPhysics.RigidBodyAPI.Apply(child)
+    UsdPhysics.ArticulationRootAPI.Apply(child)
     # the asset ships with the Newton root API (and its attribute) already authored on the root link
     child.AddAppliedSchema("NewtonArticulationRootAPI")
     child.CreateAttribute("newton:selfCollisionEnabled", Sdf.ValueTypeNames.Bool).Set(True)
-    # precondition: the composed schema makes the prim an articulation root without a direct anchor
-    assert child.HasAPI(UsdPhysics.ArticulationRootAPI)
 
-    apply_articulation_root_properties("/World/UrdfBot", [], stage, fix_root_link=True)
+    apply_articulation_root_properties("/World/UrdfBot(/.*)?", [], stage, fix_root_link=True)
 
     parent = stage.GetPrimAtPath("/World/UrdfBot")
     # exactly one articulation root remains, and it is the (relocated) parent
     roots = [p for p in stage.Traverse() if p.HasAPI(UsdPhysics.ArticulationRootAPI)]
     assert len(roots) == 1 and roots[0] == parent
     # the pre-authored backend schema and its value moved with the root
-    assert "NewtonArticulationRootAPI" in parent.GetAppliedSchemas()
+    # a token schema is only visible through the prim type info, not GetAppliedSchemas()
+    assert "NewtonArticulationRootAPI" in parent.GetPrimTypeInfo().GetAppliedAPISchemas()
     assert parent.GetAttribute("newton:selfCollisionEnabled").Get() is True
-    # the former root link no longer carries the composed root API
+    # the former root link keeps neither the root anchor nor the stranded backend schema
     assert not child.HasAPI(UsdPhysics.ArticulationRootAPI)
+    assert "NewtonArticulationRootAPI" not in child.GetPrimTypeInfo().GetAppliedAPISchemas()
 
 
 def test_physx_fix_root_link_preserves_complete_authored_property_spec():
@@ -449,7 +504,7 @@ def test_physx_fix_root_link_preserves_complete_authored_property_spec():
     source_attr.SetMetadata("documentation", "sampled sleep threshold")
     source_attr.AddConnection(driver_attr.GetPath())
 
-    apply_articulation_root_properties("/World/UsdBot", [], stage, fix_root_link=True)
+    apply_articulation_root_properties("/World/UsdBot(/.*)?", [], stage, fix_root_link=True)
 
     parent = stage.GetPrimAtPath("/World/UsdBot")
     assert parent.HasAPI(UsdPhysics.ArticulationRootAPI)
@@ -628,7 +683,7 @@ def test_newton_legacy_cfg_matches_equivalent_fragment_composition():
         stage,
     )
     apply_articulation_root_properties(
-        fragments.GetPath(),
+        fragments.GetPath().pathString,
         [
             PhysxArticulationCfg(articulation_enabled=False),
             NewtonArticulationCfg(self_collision_enabled=True),
@@ -642,7 +697,7 @@ def test_newton_legacy_cfg_matches_equivalent_fragment_composition():
 
 
 # -------------------------------------------------------------------------------------
-# end-to-end: the from-files transition bridge routes articulation_props by type
+# end-to-end: the from-files spawner routes articulation_props by type
 # -------------------------------------------------------------------------------------
 
 
@@ -657,9 +712,9 @@ def _author_articulation_usd(path: str) -> None:
     asset_stage.Save()
 
 
-@pytest.mark.parametrize("articulation_props", [None, []], ids=["none", "empty"])
+@pytest.mark.parametrize("articulation_props", [None, {}], ids=["none", "empty"])
 def test_spawn_from_usd_file_topology_only_honors_fix_root_link(tmp_path, articulation_props):
-    """None and an empty fragment collection both honor the independent topology flag."""
+    """None and an empty fragment mapping both honor the independent topology flag."""
     from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
     from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 
@@ -678,7 +733,7 @@ def test_spawn_from_usd_file_topology_only_honors_fix_root_link(tmp_path, articu
 
 
 def test_spawn_from_usd_file_applies_composed_fragment_list(tmp_path):
-    """The real FileCfg transition bridge composes backend fragments on the relocated root."""
+    """The real FileCfg fragment path composes backend fragments on the relocated root."""
     from isaaclab_newton.sim.schemas import NewtonArticulationCfg
     from isaaclab_physx.sim.schemas import PhysxArticulationCfg
 
@@ -691,10 +746,12 @@ def test_spawn_from_usd_file_applies_composed_fragment_list(tmp_path):
     _author_articulation_usd(usd_path)
     cfg = UsdFileCfg(
         usd_path=usd_path,
-        articulation_props=[
-            PhysxArticulationCfg(solver_position_iteration_count=8),
-            NewtonArticulationCfg(self_collision_enabled=True),
-        ],
+        articulation_props={
+            "(/.*)?": [
+                PhysxArticulationCfg(solver_position_iteration_count=8),
+                NewtonArticulationCfg(self_collision_enabled=True),
+            ],
+        },
         fix_root_link=True,
     )
 
@@ -722,3 +779,29 @@ def test_public_imports():
         SchemaFragment,
         apply_articulation_root_properties,
     )
+
+
+def test_apply_articulation_root_properties_creates_on_every_matched_prim():
+    """Creation applies the root API to every matched sibling prim; the expression is trusted."""
+    from isaaclab_physx.sim.schemas import PhysxArticulationCfg
+
+    from isaaclab.sim.schemas import apply_articulation_root_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Rig")
+    left = UsdGeom.Xform.Define(stage, "/World/Rig/armL").GetPrim()
+    right = UsdGeom.Xform.Define(stage, "/World/Rig/armR").GetPrim()
+
+    result = apply_articulation_root_properties(
+        "/World/Rig/.*",
+        [PhysxArticulationCfg(solver_position_iteration_count=8)],
+        stage=stage,
+        create_if_missing=True,
+    )
+
+    assert result is True
+    for prim in (left, right):
+        assert prim.HasAPI(UsdPhysics.ArticulationRootAPI)
+        assert prim.GetAttribute("physxArticulation:solverPositionIterationCount").Get() == 8

--- a/source/isaaclab/test/sim/test_collision_fragments.py
+++ b/source/isaaclab/test/sim/test_collision_fragments.py
@@ -176,7 +176,7 @@ def test_mujoco_collision_fragment_rejects_invalid_values(cfg, message):
 
 
 # -------------------------------------------------------------------------------------
-# apply_collision_properties dispatch (implicit anchor + multi-namespace)
+# apply_collision_properties dispatch (explicit anchor creation + multi-namespace)
 # -------------------------------------------------------------------------------------
 
 
@@ -198,7 +198,8 @@ def test_apply_collision_properties_composes_namespaces():
             NewtonCollisionCfg(contact_margin=0.01),
             MujocoCollisionCfg(condim=4),
         ],
-        stage,
+        create_if_missing=True,
+        stage=stage,
     )
     prim = stage.GetPrimAtPath("/World/C4")
     assert bool(UsdPhysics.CollisionAPI(prim))  # implicit anchor applied
@@ -209,7 +210,71 @@ def test_apply_collision_properties_composes_namespaces():
 
 
 # -------------------------------------------------------------------------------------
-# spawner slot accepts a fragment list + transition routing
+# expression targeting: gprim gate, pattern narrowing, zero-target warning
+# -------------------------------------------------------------------------------------
+
+
+def test_mesh_collision_fragments_author_on_every_matched_collider():
+    """Mesh-collision fragments author on all matched colliders; the expression is trusted."""
+    from isaaclab.sim.schemas import UsdPhysicsMeshCollisionCfg, apply_collision_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    xform_collider = UsdGeom.Xform.Define(stage, "/World/Grp/agg").GetPrim()
+    mesh_collider = UsdGeom.Cube.Define(stage, "/World/Grp/box").GetPrim()
+    UsdPhysics.CollisionAPI.Apply(xform_collider)
+    UsdPhysics.CollisionAPI.Apply(mesh_collider)
+
+    result = apply_collision_properties(
+        "/World/Grp(/.*)?", [UsdPhysicsMeshCollisionCfg(mesh_approximation_name="convexHull")], stage=stage
+    )
+
+    assert result is True
+    for prim in (xform_collider, mesh_collider):
+        assert prim.HasAPI(UsdPhysics.MeshCollisionAPI), prim.GetPath()
+        assert prim.GetAttribute("physics:approximation").HasAuthoredValue(), prim.GetPath()
+
+
+def test_collision_fragments_pattern_narrows_targets():
+    """An expression targets only the colliders it matches."""
+    from isaaclab_physx.sim.schemas import PhysxCollisionCfg
+
+    from isaaclab.sim.schemas import apply_collision_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    for path in ("/World/Bot/colL", "/World/Bot/colR"):
+        prim = UsdGeom.Cube.Define(stage, path).GetPrim()
+        UsdPhysics.CollisionAPI.Apply(prim)
+    result = apply_collision_properties("/World/Bot/colL", [PhysxCollisionCfg(contact_offset=0.02)], stage=stage)
+    assert result is True
+    left = stage.GetPrimAtPath("/World/Bot/colL")
+    right = stage.GetPrimAtPath("/World/Bot/colR")
+    assert abs(left.GetAttribute("physxCollision:contactOffset").Get() - 0.02) < 1e-6
+    assert not right.GetAttribute("physxCollision:contactOffset").HasAuthoredValue()
+
+
+def test_collision_fragments_zero_targets_warn_and_return_false(caplog):
+    """No collider matched and no creation requested: warn, author nothing, report failure."""
+    from isaaclab_physx.sim.schemas import PhysxCollisionCfg
+
+    from isaaclab.sim.schemas import apply_collision_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    with caplog.at_level("WARNING"):
+        result = apply_collision_properties(
+            "/World/DoesNotExist", [PhysxCollisionCfg(contact_offset=0.02)], stage=stage
+        )
+    assert result is False
+    assert "/World/DoesNotExist" in caplog.text
+
+
+# -------------------------------------------------------------------------------------
+# spawner slot accepts a fragment mapping + routing by type
 # -------------------------------------------------------------------------------------
 
 
@@ -222,7 +287,7 @@ def test_spawn_shape_with_collision_fragment_list():
     SimulationContext(SimulationCfg(dt=0.01))
     cfg = sim_utils.CuboidCfg(
         size=(1, 1, 1),
-        collision_props=[UsdPhysicsCollisionCfg(collision_enabled=True), PhysxCollisionCfg(contact_offset=0.03)],
+        collision_props={"": [UsdPhysicsCollisionCfg(collision_enabled=True), PhysxCollisionCfg(contact_offset=0.03)]},
     )
     cfg.func("/World/Cube", cfg)
     prim = sim_utils.get_current_stage().GetPrimAtPath("/World/Cube/geometry/mesh")
@@ -246,3 +311,26 @@ def test_public_imports():
         apply_collision_properties,
         apply_namespaced,
     )
+
+
+def test_collision_fragments_create_on_every_matched_prim():
+    """Creation applies ``CollisionAPI`` to every matched prim lacking it."""
+    from isaaclab_physx.sim.schemas import PhysxCollisionCfg
+
+    from isaaclab.sim.schemas import apply_collision_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    for path in ("/World/Grp", "/World/Grp/a", "/World/Grp/b"):
+        UsdGeom.Xform.Define(stage, path)
+
+    result = apply_collision_properties(
+        "/World/Grp(/.*)?", [PhysxCollisionCfg(contact_offset=0.02)], create_if_missing=True, stage=stage
+    )
+
+    assert result is True
+    for path in ("/World/Grp", "/World/Grp/a", "/World/Grp/b"):
+        prim = stage.GetPrimAtPath(path)
+        assert prim.HasAPI(UsdPhysics.CollisionAPI), path
+        assert prim.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02), path

--- a/source/isaaclab/test/sim/test_joint_drive_fragments.py
+++ b/source/isaaclab/test/sim/test_joint_drive_fragments.py
@@ -200,7 +200,7 @@ def test_mujoco_joint_actuatorgravcomp_enables_child_body_gravcomp():
     stage = sim_utils.get_current_stage()
     prim = _make_revolute_joint(stage)
     UsdPhysics.RevoluteJoint(prim).CreateBody1Rel().SetTargets(["/World/Articulation/body1"])
-    apply_joint_drive_properties("/World/Articulation", [MujocoJointCfg(actuatorgravcomp=True)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [MujocoJointCfg(actuatorgravcomp=True)], stage)
     body = stage.GetPrimAtPath("/World/Articulation/body1")
     assert body.GetAttribute("mjc:gravcomp").Get() == pytest.approx(1.0)
 
@@ -217,7 +217,7 @@ def test_mujoco_joint_without_actuatorgravcomp_leaves_body_gravcomp_untouched():
     stage = sim_utils.get_current_stage()
     prim = _make_revolute_joint(stage)
     UsdPhysics.RevoluteJoint(prim).CreateBody1Rel().SetTargets(["/World/Articulation/body1"])
-    apply_joint_drive_properties("/World/Articulation", [MujocoJointCfg()], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [MujocoJointCfg()], stage)
     body = stage.GetPrimAtPath("/World/Articulation/body1")
     assert body.GetAttribute("mjc:gravcomp").Get() is None
 
@@ -238,7 +238,7 @@ def test_mujoco_joint_actuatorgravcomp_enables_gravcomp_on_every_joint_body():
     j0.CreateBody1Rel().SetTargets(["/World/Articulation/link_a"])
     j1 = UsdPhysics.PrismaticJoint.Define(stage, "/World/Articulation/joint_1")
     j1.CreateBody1Rel().SetTargets(["/World/Articulation/link_b"])
-    apply_joint_drive_properties("/World/Articulation", [MujocoJointCfg(actuatorgravcomp=True)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [MujocoJointCfg(actuatorgravcomp=True)], stage)
     # both the revolute joint's body and the prismatic joint's body get gravcomp enabled
     assert stage.GetPrimAtPath("/World/Articulation/link_a").GetAttribute("mjc:gravcomp").Get() == pytest.approx(1.0)
     assert stage.GetPrimAtPath("/World/Articulation/link_b").GetAttribute("mjc:gravcomp").Get() == pytest.approx(1.0)
@@ -258,7 +258,7 @@ def test_mujoco_joint_actuatorgravcomp_preserves_authored_body_gravcomp():
     UsdPhysics.RevoluteJoint(prim).CreateBody1Rel().SetTargets(["/World/Articulation/body1"])
     body = stage.GetPrimAtPath("/World/Articulation/body1")
     safe_set_attribute_on_usd_prim(body, "mjc:gravcomp", 0.5, camel_case=False)
-    apply_joint_drive_properties("/World/Articulation", [MujocoJointCfg(actuatorgravcomp=True)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [MujocoJointCfg(actuatorgravcomp=True)], stage)
     assert body.GetAttribute("mjc:gravcomp").Get() == pytest.approx(0.5)
 
 
@@ -278,7 +278,7 @@ def test_apply_joint_drive_properties_composes_namespaces():
     stage = sim_utils.get_current_stage()
     prim = _make_revolute_joint(stage)
     apply_joint_drive_properties(
-        "/World/Articulation",
+        "/World/Articulation(/.*)?",
         [
             UsdPhysicsDriveCfg(drive_type="acceleration", max_force=80.0, stiffness=10.0, damping=0.1),
             PhysxJointCfg(max_joint_velocity=5.0),
@@ -303,7 +303,7 @@ def test_apply_joint_drive_properties_without_drive_does_not_apply_drive_api():
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     prim = _make_revolute_joint(stage)
-    apply_joint_drive_properties("/World/Articulation", [PhysxJointCfg(max_joint_velocity=5.0)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [PhysxJointCfg(max_joint_velocity=5.0)], stage)
     # DriveAPI is presence-gated: not applied when no UsdPhysicsDriveCfg fragment is present
     assert not bool(UsdPhysics.DriveAPI(prim, "angular"))
     # revolute joint -> rad/s to deg/s conversion via apply_physx_joint
@@ -329,7 +329,7 @@ def test_apply_joint_drive_properties_skips_tendon_child_joint():
     assert "PhysxTendonAxisAPI" in applied and "PhysxTendonAxisRootAPI" not in applied
 
     apply_joint_drive_properties(
-        "/World/Articulation",
+        "/World/Articulation(/.*)?",
         [
             UsdPhysicsDriveCfg(drive_type="acceleration", max_force=80.0, stiffness=10.0, damping=0.1),
             PhysxJointCfg(max_joint_velocity=5.0),
@@ -357,7 +357,7 @@ def test_apply_joint_drive_properties_skips_joint_via_registered_predicate(monke
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     joint = _make_revolute_joint(stage)
-    apply_joint_drive_properties("/World/Articulation", [UsdPhysicsDriveCfg(stiffness=10.0)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [UsdPhysicsDriveCfg(stiffness=10.0)], stage)
     assert not bool(UsdPhysics.DriveAPI(joint, "angular"))
 
 
@@ -371,7 +371,7 @@ def test_apply_joint_drive_properties_authors_when_no_skip_predicate(monkeypatch
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     joint = _make_revolute_joint(stage)
-    apply_joint_drive_properties("/World/Articulation", [UsdPhysicsDriveCfg(stiffness=10.0)], stage)
+    apply_joint_drive_properties("/World/Articulation(/.*)?", [UsdPhysicsDriveCfg(stiffness=10.0)], stage)
     assert bool(UsdPhysics.DriveAPI(joint, "angular"))
 
 
@@ -384,10 +384,39 @@ def test_apply_joint_drive_properties_ensure_drives_exist_seeds_stiffness():
     prim = _make_revolute_joint(stage)
     # neither stiffness nor damping authored -> ensure_drives_exist seeds a minimal stiffness
     apply_joint_drive_properties(
-        "/World/Articulation", [UsdPhysicsDriveCfg(max_force=1.0)], stage, ensure_drives_exist=True
+        "/World/Articulation(/.*)?", [UsdPhysicsDriveCfg(max_force=1.0)], stage, ensure_drives_exist=True
     )
     assert bool(UsdPhysics.DriveAPI(prim, "angular"))
     assert prim.GetAttribute("drive:angular:physics:stiffness").Get() == pytest.approx(1e-3 * math.pi / 180.0, rel=1e-6)
+
+
+def test_joint_drive_fragments_create_missing_drive_api():
+    """``create_if_missing`` applies the axis-appropriate DriveAPI on matched bare joints.
+
+    Uses a fragment list without a drive fragment on purpose: ``apply_drive`` applies the
+    DriveAPI itself, so only a non-drive fragment isolates the flag as the API's sole source.
+    """
+    from isaaclab_physx.sim.schemas import PhysxJointCfg
+
+    from isaaclab.sim.schemas import apply_joint_drive_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Bot")
+    UsdGeom.Cube.Define(stage, "/World/Bot/body0")
+    UsdGeom.Cube.Define(stage, "/World/Bot/body1")
+    UsdPhysics.RevoluteJoint.Define(stage, "/World/Bot/elbow")
+    joint = stage.GetPrimAtPath("/World/Bot/elbow")
+    assert not joint.HasAPI(UsdPhysics.DriveAPI, "angular")
+
+    result = apply_joint_drive_properties(
+        "/World/Bot(/.*)?", [PhysxJointCfg(max_joint_velocity=5.0)], stage=stage, create_if_missing=True
+    )
+
+    assert result is True
+    assert joint.HasAPI(UsdPhysics.DriveAPI, "angular")
+    assert joint.GetAttribute("physxJoint:maxJointVelocity").Get() == pytest.approx(math.degrees(5.0))
 
 
 # -------------------------------------------------------------------------------------
@@ -406,3 +435,26 @@ def test_public_imports():
         apply_drive,
         apply_joint_drive_properties,
     )
+
+
+def test_joint_drive_fragments_instanced_joints_warn_once_and_fail(caplog):
+    """Instanced joints are reported by the matcher only, and the writer returns False."""
+    from isaaclab_physx.sim.schemas import PhysxJointCfg
+
+    from isaaclab.sim.schemas import apply_joint_drive_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    source = UsdGeom.Xform.Define(stage, "/World/Src").GetPrim()
+    UsdPhysics.RevoluteJoint.Define(stage, "/World/Src/j0")
+    instance = UsdGeom.Xform.Define(stage, "/World/Bot").GetPrim()
+    instance.GetReferences().AddInternalReference(source.GetPath())
+    instance.SetInstanceable(True)
+
+    with caplog.at_level("WARNING"):
+        result = apply_joint_drive_properties("/World/Bot(/.*)?", [PhysxJointCfg(max_joint_velocity=5.0)], stage=stage)
+
+    assert result is False
+    assert "Skipping fragment updates on instanced prims" in caplog.text
+    assert "Could not apply joint-drive properties" not in caplog.text

--- a/source/isaaclab/test/sim/test_mass_fragments.py
+++ b/source/isaaclab/test/sim/test_mass_fragments.py
@@ -74,7 +74,7 @@ def test_apply_mass_properties_applies_anchor_and_writes_fields():
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     _make_xform(stage, "/World/B2")
-    apply_mass_properties("/World/B2", [MassCfg(mass=5.0, density=100.0)], stage)
+    apply_mass_properties("/World/B2", [MassCfg(mass=5.0, density=100.0)], create_if_missing=True, stage=stage)
     prim = stage.GetPrimAtPath("/World/B2")
     assert bool(UsdPhysics.MassAPI(prim))  # implicit anchor applied
     assert abs(prim.GetAttribute("physics:mass").Get() - 5.0) < 1e-6
@@ -82,19 +82,19 @@ def test_apply_mass_properties_applies_anchor_and_writes_fields():
 
 
 # -------------------------------------------------------------------------------------
-# spawner slot accepts a fragment list + transition routing
+# spawner slot accepts a fragment mapping + routing by type
 # -------------------------------------------------------------------------------------
 
 
-def test_spawn_shape_with_mass_fragment_list():
+def test_spawn_shape_with_mass_fragment_dict():
     from isaaclab.sim.schemas import MassCfg, UsdPhysicsRigidBodyCfg
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     cfg = sim_utils.CuboidCfg(
         size=(1, 1, 1),
-        rigid_props=[UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)],
-        mass_props=[MassCfg(mass=4.0)],
+        rigid_props={"": [UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)]},
+        mass_props={"": [MassCfg(mass=4.0)]},
     )
     cfg.func("/World/Cube", cfg)
     prim = sim_utils.get_current_stage().GetPrimAtPath("/World/Cube")
@@ -102,38 +102,22 @@ def test_spawn_shape_with_mass_fragment_list():
     assert abs(prim.GetAttribute("physics:mass").Get() - 4.0) < 1e-6
 
 
-def test_spawn_shape_with_single_mass_fragment():
-    # the ``mass_props`` slot advertises a single fragment (convenience form), not only a list;
-    # the spawn shim must route a bare fragment through ``apply_mass_properties`` (not the legacy writer)
-    from isaaclab.sim.schemas import MassCfg, UsdPhysicsRigidBodyCfg
-
-    sim_utils.create_new_stage()
-    SimulationContext(SimulationCfg(dt=0.01))
-    cfg = sim_utils.CuboidCfg(
-        size=(1, 1, 1),
-        rigid_props=[UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)],
-        mass_props=MassCfg(mass=4.0),
-    )
-    cfg.func("/World/CubeSingle", cfg)
-    prim = sim_utils.get_current_stage().GetPrimAtPath("/World/CubeSingle")
-    assert bool(UsdPhysics.MassAPI(prim))
-    assert abs(prim.GetAttribute("physics:mass").Get() - 4.0) < 1e-6
-
-
 # -------------------------------------------------------------------------------------
-# Review follow-ups -- prim-validity guard, aggregated return, empty-list no-op
+# Review follow-ups -- unmatched-path warning, aggregated return, empty-list no-op
 # -------------------------------------------------------------------------------------
 
 
-def test_apply_mass_properties_raises_on_invalid_prim():
+def test_apply_mass_properties_warns_on_unmatched_path(caplog):
     from isaaclab.sim.schemas import MassCfg, apply_mass_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
-    # no prim authored at this path -> GetPrimAtPath returns an invalid prim
-    with pytest.raises(ValueError):
-        apply_mass_properties("/World/DoesNotExist", [MassCfg(mass=1.0)], stage)
+    # no prim authored at this path -> zero matches -> warning + False, no exception
+    with caplog.at_level("WARNING"):
+        result = apply_mass_properties("/World/DoesNotExist", [MassCfg(mass=1.0)], stage=stage)
+    assert result is False
+    assert "/World/DoesNotExist" in caplog.text
 
 
 def test_apply_mass_properties_aggregates_fragment_results():
@@ -147,11 +131,31 @@ def test_apply_mass_properties_aggregates_fragment_results():
     # a fragment whose applier reports failure must make the aggregate return False
     failing = MassCfg(mass=1.0)
     failing.func = lambda cfg, prim_path, stage=None: False
-    assert apply_mass_properties("/World/Agg", [failing], stage) is False
+    assert apply_mass_properties("/World/Agg", [failing], create_if_missing=True, stage=stage) is False
 
     # all-succeeding fragments return True
     ok = MassCfg(mass=1.0)
-    assert apply_mass_properties("/World/Agg", [ok], stage) is True
+    assert apply_mass_properties("/World/Agg", [ok], create_if_missing=True, stage=stage) is True
+
+
+def test_apply_mass_properties_creates_on_every_matched_prim():
+    """Creation applies ``MassAPI`` to every matched prim lacking it, rigid body or not."""
+    from isaaclab.sim.schemas import MassCfg, apply_mass_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    root = UsdGeom.Xform.Define(stage, "/World/Bot").GetPrim()
+    body = UsdGeom.Xform.Define(stage, "/World/Bot/link").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(body)
+    plain = UsdGeom.Xform.Define(stage, "/World/Bot/frame").GetPrim()
+
+    result = apply_mass_properties("/World/Bot(/.*)?", [MassCfg(mass=2.0)], create_if_missing=True, stage=stage)
+
+    assert result is True
+    for prim in (root, body, plain):
+        assert prim.HasAPI(UsdPhysics.MassAPI), prim.GetPath()
+        assert prim.GetAttribute("physics:mass").Get() == pytest.approx(2.0), prim.GetPath()
 
 
 def test_spawn_shape_with_empty_mass_list_is_noop():
@@ -161,10 +165,10 @@ def test_spawn_shape_with_empty_mass_list_is_noop():
     SimulationContext(SimulationCfg(dt=0.01))
     cfg = sim_utils.CuboidCfg(
         size=(1, 1, 1),
-        rigid_props=[UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)],
-        mass_props=[],
+        rigid_props={"": [UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)]},
+        mass_props={"": []},
     )
-    # an empty fragment list routes through the fragment path and applies nothing (no exception)
+    # an entry with an empty fragment list routes through the fragment path and applies nothing (no exception)
     cfg.func("/World/Cube", cfg)
     prim = sim_utils.get_current_stage().GetPrimAtPath("/World/Cube")
     # mass anchor is not required when there are zero fragments to apply

--- a/source/isaaclab/test/sim/test_schema_fragments.py
+++ b/source/isaaclab/test/sim/test_schema_fragments.py
@@ -119,7 +119,7 @@ def test_mujoco_rigid_body_fragment_does_not_write_gravcomp_when_none():
 
 
 # -------------------------------------------------------------------------------------
-# apply_rigid_body_properties dispatch (implicit anchor + multi-namespace)
+# apply_rigid_body_properties dispatch (explicit anchor creation + multi-namespace)
 # -------------------------------------------------------------------------------------
 
 
@@ -140,17 +140,18 @@ def test_apply_rigid_body_properties_composes_namespaces():
             PhysxRigidBodyCfg(linear_damping=0.2),
             MujocoRigidBodyCfg(gravcomp=1.0),
         ],
-        stage,
+        create_if_missing=True,
+        stage=stage,
     )
     prim = stage.GetPrimAtPath("/World/B4")
-    assert bool(UsdPhysics.RigidBodyAPI(prim))  # implicit anchor applied
+    assert bool(UsdPhysics.RigidBodyAPI(prim))  # anchor created on the bare prim
     assert prim.GetAttribute("physics:rigidBodyEnabled").Get() is True
     assert abs(prim.GetAttribute("physxRigidBody:linearDamping").Get() - 0.2) < 1e-6
     assert abs(prim.GetAttribute("mjc:gravcomp").Get() - 1.0) < 1e-6
 
 
 # -------------------------------------------------------------------------------------
-# spawner slot accepts a fragment list + transition routing
+# spawner slot accepts a fragment mapping + routing by type
 # -------------------------------------------------------------------------------------
 
 
@@ -163,7 +164,7 @@ def test_spawn_shape_with_rigid_fragment_list():
     SimulationContext(SimulationCfg(dt=0.01))
     cfg = sim_utils.CuboidCfg(
         size=(1, 1, 1),
-        rigid_props=[UsdPhysicsRigidBodyCfg(rigid_body_enabled=True), PhysxRigidBodyCfg(linear_damping=0.3)],
+        rigid_props={"": [UsdPhysicsRigidBodyCfg(rigid_body_enabled=True), PhysxRigidBodyCfg(linear_damping=0.3)]},
     )
     cfg.func("/World/Cube", cfg)
     prim = sim_utils.get_current_stage().GetPrimAtPath("/World/Cube")
@@ -205,14 +206,18 @@ def test_apply_namespaced_raises_on_invalid_prim():
         apply_namespaced(UsdPhysicsRigidBodyCfg(rigid_body_enabled=True), "/World/DoesNotExist", stage)
 
 
-def test_apply_rigid_body_properties_raises_on_invalid_prim():
+def test_apply_rigid_body_properties_warns_on_unmatched_path(caplog):
     from isaaclab.sim.schemas import UsdPhysicsRigidBodyCfg, apply_rigid_body_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
-    with pytest.raises(ValueError):
-        apply_rigid_body_properties("/World/DoesNotExist", [UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)], stage)
+    with caplog.at_level("WARNING"):
+        result = apply_rigid_body_properties(
+            "/World/DoesNotExist", [UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)], stage=stage
+        )
+    assert result is False
+    assert "/World/DoesNotExist" in caplog.text
 
 
 def test_apply_rigid_body_properties_aggregates_fragment_results():
@@ -226,11 +231,11 @@ def test_apply_rigid_body_properties_aggregates_fragment_results():
     # a fragment whose applier reports failure must make the aggregate return False
     failing = UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)
     failing.func = lambda cfg, prim_path, stage=None: False
-    assert apply_rigid_body_properties("/World/Agg", [failing], stage) is False
+    assert apply_rigid_body_properties("/World/Agg", [failing], create_if_missing=True, stage=stage) is False
 
     # all-succeeding fragments return True
     ok = UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)
-    assert apply_rigid_body_properties("/World/Agg", [ok], stage) is True
+    assert apply_rigid_body_properties("/World/Agg", [ok], stage=stage) is True
 
 
 def test_apply_namespaced_raises_without_namespace():
@@ -253,3 +258,46 @@ def test_apply_namespaced_raises_without_namespace():
     UsdPhysics.RigidBodyAPI.Apply(prim)
     with pytest.raises(ValueError):
         apply_namespaced(_NoNamespaceFragment(rigid_body_enabled=True), "/World/NoNs", stage)
+
+
+def test_fragment_mapping_normalizes_bare_fragment_and_list():
+    """A bare fragment (or list) on a spawner field is shorthand for the anchor-prim mapping."""
+    from isaaclab.sim.schemas import MassCfg, MassPropertiesCfg, UsdPhysicsRigidBodyCfg
+    from isaaclab.sim.spawners._utils import fragment_mapping
+
+    frag = UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)
+    assert fragment_mapping(frag) == {"": [frag]}
+
+    a, b = MassCfg(mass=1.0), MassCfg(density=10.0)
+    assert fragment_mapping([a, b]) == {"": [a, b]}
+    assert fragment_mapping((a, b)) == {"": [a, b]}
+
+    # an explicit mapping is passed through untouched
+    mapping = {"/.*": [frag]}
+    assert fragment_mapping(mapping) is mapping
+
+    # legacy dataclass cfgs report None so callers route them to the legacy writers
+    assert fragment_mapping(MassPropertiesCfg(mass=1.0)) is None
+    assert fragment_mapping(None) is None
+
+
+def test_shape_spawner_accepts_bare_fragment_for_props():
+    """A bare fragment authors on the shape's anchor prim, exactly as ``{"": [...]}`` would."""
+    from pxr import UsdPhysics
+
+    from isaaclab.sim.schemas import MassCfg, UsdPhysicsRigidBodyCfg
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    cfg = sim_utils.CuboidCfg(
+        size=(0.1, 0.1, 0.1),
+        rigid_props=UsdPhysicsRigidBodyCfg(rigid_body_enabled=True),
+        mass_props=MassCfg(mass=0.5),
+    )
+    cfg.func("/World/Bare", cfg)
+
+    prim = stage.GetPrimAtPath("/World/Bare")
+    assert prim.HasAPI(UsdPhysics.RigidBodyAPI)
+    assert prim.GetAttribute("physics:rigidBodyEnabled").Get() is True
+    assert abs(prim.GetAttribute("physics:mass").Get() - 0.5) < 1e-6

--- a/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
+++ b/source/isaaclab/test/sim/test_schema_writer_nested_targets.py
@@ -21,9 +21,13 @@ from pxr import Usd, UsdGeom, UsdPhysics
 
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
-from isaaclab.sim.schemas import MassCfg
+from isaaclab.sim.schemas import MassCfg, UsdPhysicsCollisionCfg, UsdPhysicsRigidBodyCfg
 
 pytestmark = pytest.mark.integration
+
+
+LINK_REL_PATHS = ("link1", "link2", "link2/link3")
+"""Link prim paths relative to the robot root; ``link2/link3`` is a nested child link."""
 
 
 def _author_robot_usd(path: str) -> None:
@@ -32,12 +36,13 @@ def _author_robot_usd(path: str) -> None:
     Mirrors how real robot assets are structured: the default (spawn) prim carries
     ``ArticulationRootAPI``, the link prims carry ``RigidBodyAPI`` and ``MassAPI``, and the
     collider prims under the links carry ``CollisionAPI``. The spawn prim itself carries no
-    rigid-body, collision, or mass schema.
+    rigid-body, collision, or mass schema. ``link3`` is authored under ``link2`` the way the
+    URDF importer nests child links under their parent link.
     """
     stage = Usd.Stage.CreateNew(path)
     robot = UsdGeom.Xform.Define(stage, "/Robot")
     UsdPhysics.ArticulationRootAPI.Apply(robot.GetPrim())
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         link = UsdGeom.Xform.Define(stage, f"/Robot/{link_name}").GetPrim()
         UsdPhysics.RigidBodyAPI.Apply(link)
         UsdPhysics.MassAPI.Apply(link)
@@ -70,26 +75,26 @@ def _spawn_robot(tmp_path, prim_path: str, **cfg_kwargs):
 def test_rigid_body_fragments_target_existing_bodies_on_usd_asset(tmp_path):
     """Fragment ``rigid_props`` on a USD robot must modify the existing link bodies in place.
 
-    Force-applying ``RigidBodyAPI`` on the spawn prim (which already carries the articulation
-    root) turns the asset's links into nested rigid bodies, and the PhysX parser then drops the
-    articulation's joints. The fragment path must match the legacy nested writer: author onto the
-    prims that already carry the API and leave the spawn prim untouched.
+    Force-applying ``RigidBodyAPI`` on the spawn prim would invent a body the asset's joints
+    never reference and change the asset's dynamics. The fragment path must match the legacy
+    nested writer: author onto the prims that already carry the API and leave the spawn prim
+    untouched.
     """
     stage = _spawn_robot(
         tmp_path,
         "/World/RobotA",
-        rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)],
+        rigid_props={"(/.*)?": [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)]},
     )
     spawn_prim = stage.GetPrimAtPath("/World/RobotA")
     # the spawn prim keeps its articulation root and gains NO rigid-body anchor or attrs
     assert spawn_prim.HasAPI(UsdPhysics.ArticulationRootAPI)
     assert not spawn_prim.HasAPI(UsdPhysics.RigidBodyAPI)
     assert not spawn_prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
-    # every existing link body received the fragment's attribute
-    for link_name in ("link1", "link2"):
+    # every existing link body received the fragment's attribute, including the nested one
+    for link_name in LINK_REL_PATHS:
         link = stage.GetPrimAtPath(f"/World/RobotA/{link_name}")
         assert link.HasAPI(UsdPhysics.RigidBodyAPI)
-        assert link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+        assert link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0), link_name
 
 
 def test_collision_fragments_target_existing_colliders_on_usd_asset(tmp_path):
@@ -97,15 +102,15 @@ def test_collision_fragments_target_existing_colliders_on_usd_asset(tmp_path):
     stage = _spawn_robot(
         tmp_path,
         "/World/RobotB",
-        collision_props=[PhysxCollisionCfg(contact_offset=0.02)],
+        collision_props={"(/.*)?": [PhysxCollisionCfg(contact_offset=0.02)]},
     )
     spawn_prim = stage.GetPrimAtPath("/World/RobotB")
     assert not spawn_prim.HasAPI(UsdPhysics.CollisionAPI)
     assert not spawn_prim.GetAttribute("physxCollision:contactOffset").HasAuthoredValue()
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         collider = stage.GetPrimAtPath(f"/World/RobotB/{link_name}/collider")
         assert collider.HasAPI(UsdPhysics.CollisionAPI)
-        assert collider.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02)
+        assert collider.GetAttribute("physxCollision:contactOffset").Get() == pytest.approx(0.02), link_name
 
 
 def test_mass_fragments_target_existing_mass_prims_on_usd_asset(tmp_path):
@@ -113,14 +118,14 @@ def test_mass_fragments_target_existing_mass_prims_on_usd_asset(tmp_path):
     stage = _spawn_robot(
         tmp_path,
         "/World/RobotC",
-        mass_props=[MassCfg(mass=2.0)],
+        mass_props={"(/.*)?": [MassCfg(mass=2.0)]},
     )
     spawn_prim = stage.GetPrimAtPath("/World/RobotC")
     assert not spawn_prim.HasAPI(UsdPhysics.MassAPI)
     assert not spawn_prim.GetAttribute("physics:mass").HasAuthoredValue()
-    for link_name in ("link1", "link2"):
+    for link_name in LINK_REL_PATHS:
         link = stage.GetPrimAtPath(f"/World/RobotC/{link_name}")
-        assert link.GetAttribute("physics:mass").Get() == pytest.approx(2.0)
+        assert link.GetAttribute("physics:mass").Get() == pytest.approx(2.0), link_name
 
 
 def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path):
@@ -140,7 +145,9 @@ def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path)
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     legacy_cfg = UsdFileCfg(usd_path=usd_path, rigid_props=PhysxRigidBodyPropertiesCfg(max_depenetration_velocity=5.0))
-    frag_cfg = UsdFileCfg(usd_path=usd_path, rigid_props=[PhysxRigidBodyCfg(max_depenetration_velocity=5.0)])
+    frag_cfg = UsdFileCfg(
+        usd_path=usd_path, rigid_props={"(/.*)?": [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)]}
+    )
     _spawn_from_usd_file("/World/Legacy", usd_path, legacy_cfg)
     _spawn_from_usd_file("/World/Frag", usd_path, frag_cfg)
     stage = sim_utils.get_current_stage()
@@ -158,54 +165,154 @@ def test_fragment_and_legacy_paths_place_apis_identically_on_usd_asset(tmp_path)
         assert legacy_attrs == frag_attrs, rel_path
 
 
+def test_rigid_body_pattern_cfg_narrows_spawned_targets(tmp_path):
+    """A narrowing dict key on the spawner cfg restricts which links receive fragments."""
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/RobotD",
+        rigid_props={"/link2(/.*)?": [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)]},
+    )
+    modified = stage.GetPrimAtPath("/World/RobotD/link2")
+    nested = stage.GetPrimAtPath("/World/RobotD/link2/link3")
+    untouched = stage.GetPrimAtPath("/World/RobotD/link1")
+    assert modified.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+    assert nested.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+    assert not untouched.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+
+
+def test_fragment_dicts_target_and_override_in_insertion_order(tmp_path):
+    """Dict entries target independently; later entries override earlier ones on overlap."""
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/RobotE",
+        rigid_props={
+            "(/.*)?": [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)],
+            "/link2(/.*)?": [PhysxRigidBodyCfg(max_depenetration_velocity=1.0)],
+        },
+    )
+    broad_only = stage.GetPrimAtPath("/World/RobotE/link1")
+    overridden = stage.GetPrimAtPath("/World/RobotE/link2")
+    nested_overridden = stage.GetPrimAtPath("/World/RobotE/link2/link3")
+    assert broad_only.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(5.0)
+    assert overridden.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(1.0)
+    assert nested_overridden.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(1.0)
+
+
 # -------------------------------------------------------------------------------------
-# Preserved behavior: bare prims (shape/mesh spawners) still get a fresh anchor,
-# and traversal does not descend past an existing schema-bearing prim.
+# Preserved behavior: bare prims (shape/mesh spawners) still get a fresh anchor, and
+# nested rigid-body trees (URDF-importer layouts) have every body modified.
 # -------------------------------------------------------------------------------------
 
 
-def test_rigid_body_fragments_define_fresh_on_bare_prim():
-    """With no rigid body anywhere in the subtree, the writer anchors the input prim itself."""
+def test_rigid_body_fragments_create_on_bare_prim():
+    """With ``create_if_missing`` and one non-carrier match, the writer anchors that prim."""
     from isaaclab.sim.schemas import apply_rigid_body_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     UsdGeom.Xform.Define(stage, "/World/Bare")
-    result = apply_rigid_body_properties("/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], stage)
+    result = apply_rigid_body_properties(
+        "/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], create_if_missing=True, stage=stage
+    )
     prim = stage.GetPrimAtPath("/World/Bare")
     assert result is True
     assert prim.HasAPI(UsdPhysics.RigidBodyAPI)
     assert prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(3.0)
 
 
-def test_rigid_body_fragments_do_not_descend_past_existing_body():
-    """Traversal stops at the first schema-bearing prim on each branch (nested bodies are
-    illegal in physics), matching the legacy nested writer's stop-on-success behavior."""
+def test_rigid_body_fragments_create_on_every_matched_prim():
+    """Creation applies ``RigidBodyAPI`` to every matched prim lacking it; the expression is trusted."""
     from isaaclab.sim.schemas import apply_rigid_body_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
-    UsdGeom.Xform.Define(stage, "/World/Top")
-    outer = UsdGeom.Xform.Define(stage, "/World/Top/outer").GetPrim()
-    inner = UsdGeom.Xform.Define(stage, "/World/Top/outer/inner").GetPrim()
-    UsdPhysics.RigidBodyAPI.Apply(outer)
-    UsdPhysics.RigidBodyAPI.Apply(inner)  # ill-formed nesting in the source asset
-
-    result = apply_rigid_body_properties("/World/Top", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage)
-
+    for path in ("/World/Grp", "/World/Grp/a", "/World/Grp/b"):
+        UsdGeom.Xform.Define(stage, path)
+    result = apply_rigid_body_properties(
+        "/World/Grp(/.*)?", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], create_if_missing=True, stage=stage
+    )
     assert result is True
-    assert outer.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0)
-    # the nested body is not modified: legacy stops descending once a prim succeeds
-    assert not inner.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+    for path in ("/World/Grp", "/World/Grp/a", "/World/Grp/b"):
+        prim = stage.GetPrimAtPath(path)
+        assert prim.HasAPI(UsdPhysics.RigidBodyAPI), path
+        assert prim.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(3.0), path
+
+
+def test_rigid_body_fragments_pattern_narrows_targets():
+    """An expression targets only the carriers it matches."""
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    for path in ("/World/Bot/armL", "/World/Bot/armR"):
+        prim = UsdGeom.Xform.Define(stage, path).GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(prim)
+    result = apply_rigid_body_properties(
+        "/World/Bot/armL", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage=stage
+    )
+    assert result is True
+    left = stage.GetPrimAtPath("/World/Bot/armL")
+    right = stage.GetPrimAtPath("/World/Bot/armR")
+    assert left.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0)
+    assert not right.GetAttribute("physxRigidBody:maxDepenetrationVelocity").HasAuthoredValue()
+
+
+def test_rigid_body_fragments_zero_targets_warn_and_return_false(caplog):
+    """No carrier matched and no creation requested: warn, author nothing, report failure."""
+    from isaaclab.sim.schemas import apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    UsdGeom.Xform.Define(stage, "/World/Bare")
+    with caplog.at_level("WARNING"):
+        result = apply_rigid_body_properties(
+            "/World/Bare", [PhysxRigidBodyCfg(max_depenetration_velocity=3.0)], stage=stage
+        )
+    assert result is False
+    assert not stage.GetPrimAtPath("/World/Bare").HasAPI(UsdPhysics.RigidBodyAPI)
+    assert "/World/Bare" in caplog.text
+
+
+def test_rigid_body_and_mass_fragments_modify_nested_bodies():
+    """Every body in a nested rigid-body tree is modified, not just the outermost one.
+
+    The URDF importer authors child links under their parent link prims, so carriers of
+    ``RigidBodyAPI`` (and ``MassAPI``) legitimately nest. A subtree expression must
+    reach all of them, matching the legacy writers' full-subtree traversal for these families.
+    """
+    from isaaclab.sim.schemas import apply_mass_properties, apply_rigid_body_properties
+
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    stage = sim_utils.get_current_stage()
+    body_paths = ["/World/Robot/pelvis", "/World/Robot/pelvis/hip", "/World/Robot/pelvis/hip/knee"]
+    UsdGeom.Xform.Define(stage, "/World/Robot")
+    for body_path in body_paths:
+        body = UsdGeom.Xform.Define(stage, body_path).GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(body)
+        UsdPhysics.MassAPI.Apply(body)
+
+    rigid_result = apply_rigid_body_properties(
+        "/World/Robot(/.*)?", [PhysxRigidBodyCfg(max_depenetration_velocity=7.0)], stage=stage
+    )
+    mass_result = apply_mass_properties("/World/Robot(/.*)?", [MassCfg(mass=2.5)], stage=stage)
+
+    assert rigid_result is True
+    assert mass_result is True
+    for body_path in body_paths:
+        body = stage.GetPrimAtPath(body_path)
+        assert body.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() == pytest.approx(7.0), body_path
+        assert body.GetAttribute("physics:mass").Get() == pytest.approx(2.5), body_path
 
 
 def test_rigid_body_fragments_skip_instanced_carriers(caplog):
     """A carrier inside an instance is a read-only proxy: skipped with a warning and a False return.
 
-    The hidden carrier also suppresses the define-fresh fallback, so the input prim gains no
-    rigid-body anchor.
+    Creation is not requested, so the instance root gains no rigid-body anchor either.
     """
     from isaaclab.sim.schemas import apply_rigid_body_properties
 
@@ -222,7 +329,9 @@ def test_rigid_body_fragments_skip_instanced_carriers(caplog):
     assert proxy_body.IsInstanceProxy() and proxy_body.HasAPI(UsdPhysics.RigidBodyAPI)
 
     with caplog.at_level("WARNING"):
-        result = apply_rigid_body_properties("/World/Asset", [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)], stage)
+        result = apply_rigid_body_properties(
+            "/World/Asset(/.*)?", [PhysxRigidBodyCfg(max_depenetration_velocity=5.0)], stage=stage
+        )
 
     assert result is False
     assert not instance.HasAPI(UsdPhysics.RigidBodyAPI)
@@ -238,7 +347,114 @@ def test_rigid_body_fragments_empty_list_authors_nothing():
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     UsdGeom.Xform.Define(stage, "/World/Bare")
-    result = apply_rigid_body_properties("/World/Bare", [], stage)
+    result = apply_rigid_body_properties("/World/Bare", [], stage=stage)
     prim = stage.GetPrimAtPath("/World/Bare")
     assert result is True
     assert not prim.HasAPI(UsdPhysics.RigidBodyAPI)
+
+
+def _author_child_root_robot_usd(path: str) -> None:
+    """Author a robot whose articulation root sits on a child link, as ANYmal-style assets do."""
+    stage = Usd.Stage.CreateNew(path)
+    robot = UsdGeom.Xform.Define(stage, "/Robot")
+    base = UsdGeom.Xform.Define(stage, "/Robot/base").GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(base)
+    UsdPhysics.ArticulationRootAPI.Apply(base)
+    stage.SetDefaultPrim(robot.GetPrim())
+    stage.Save()
+
+
+def test_empty_articulation_fragments_still_fix_the_root_link(tmp_path):
+    """``articulation_props=[]`` with ``fix_root_link`` must still reach a root on a child prim.
+
+    An empty fragment list carries no targeting intent, so the spawner has to fall through to the
+    topology-only path, which sweeps the spawn prim's subtree. Treating it as an anchor-targeted
+    entry instead pins the expression to the spawn prim, which carries no root API, so nothing is
+    authored and the world joint is never created.
+    """
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+
+    usd_path = os.path.join(tmp_path, "child_root_robot.usda")
+    _author_child_root_robot_usd(usd_path)
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    cfg = UsdFileCfg(usd_path=usd_path, articulation_props=[], fix_root_link=True)
+    _spawn_from_usd_file("/World/Robot", usd_path, cfg)
+
+    stage = sim_utils.get_current_stage()
+    assert sim_utils.find_global_fixed_joint_prim("/World/Robot", stage=stage) is not None
+
+
+def test_bare_fragment_on_usd_asset_reaches_nested_bodies(tmp_path):
+    """A bare fragment on a USD asset must keep the reach the legacy nested writer had.
+
+    Task configurations pass ``rigid_props=UsdPhysicsRigidBodyCfg(...)`` directly on a
+    ``UsdFileCfg``. The bodies live beneath the spawn prim, so pinning the convenience form to the
+    spawn prim authors nothing and the asset reaches the backend without a rigid body.
+    """
+    stage = _spawn_robot(
+        tmp_path,
+        "/World/Robot",
+        rigid_props=PhysxRigidBodyCfg(max_depenetration_velocity=5.0),
+        mass_props=MassCfg(mass=2.0),
+    )
+
+    for link_rel_path in LINK_REL_PATHS:
+        link = stage.GetPrimAtPath(f"/World/Robot/{link_rel_path}")
+        assert abs(link.GetAttribute("physxRigidBody:maxDepenetrationVelocity").Get() - 5.0) < 1e-6
+        assert abs(link.GetAttribute("physics:mass").Get() - 2.0) < 1e-6
+
+
+def _author_prop_usd(path: str) -> None:
+    """Author a rigid prop that carries no physics schemas, as authored art assets usually do.
+
+    Task configurations point ``UsdFileCfg`` at meshes like this and rely on the spawner to turn
+    the asset into a single rigid body, so nothing in the subtree carries ``RigidBodyAPI``,
+    ``CollisionAPI``, or ``MassAPI``.
+    """
+    stage = Usd.Stage.CreateNew(path)
+    prop = UsdGeom.Xform.Define(stage, "/Prop")
+    UsdGeom.Cube.Define(stage, "/Prop/geometry")
+    stage.SetDefaultPrim(prop.GetPrim())
+    stage.Save()
+
+
+def _spawn_prop(tmp_path, prim_path: str, **cfg_kwargs):
+    """Author the schema-free prop asset and spawn it through the production USD spawn path."""
+    from isaaclab.sim.spawners.from_files.from_files import _spawn_from_usd_file
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+
+    usd_path = os.path.join(tmp_path, "prop.usda")
+    _author_prop_usd(usd_path)
+    sim_utils.create_new_stage()
+    SimulationContext(SimulationCfg(dt=0.01))
+    cfg = UsdFileCfg(usd_path=usd_path, **cfg_kwargs)
+    _spawn_from_usd_file(prim_path, usd_path, cfg)
+    return sim_utils.get_current_stage()
+
+
+def test_bare_fragment_makes_a_schema_free_asset_a_single_rigid_body(tmp_path):
+    """A bare fragment on an asset that carries no physics schema must author the spawn prim.
+
+    Art assets ship without physics APIs, so there is nothing in the subtree to modify. The
+    convenience form has to fall back to making the spawn prim itself the body, otherwise the
+    asset reaches the backend with no rigid body at all.
+    """
+    stage = _spawn_prop(
+        tmp_path,
+        "/World/Prop",
+        rigid_props=UsdPhysicsRigidBodyCfg(rigid_body_enabled=True),
+        mass_props=MassCfg(mass=0.05),
+        collision_props=UsdPhysicsCollisionCfg(collision_enabled=True),
+    )
+
+    prop = stage.GetPrimAtPath("/World/Prop")
+    assert prop.HasAPI(UsdPhysics.RigidBodyAPI)
+    assert prop.HasAPI(UsdPhysics.MassAPI)
+    assert prop.HasAPI(UsdPhysics.CollisionAPI)
+    assert prop.GetAttribute("physics:rigidBodyEnabled").Get() is True
+    assert abs(prop.GetAttribute("physics:mass").Get() - 0.05) < 1e-6
+    assert prop.GetAttribute("physics:collisionEnabled").Get() is True
+    # the geometry below the spawn prim must not become a second, nested body
+    assert not stage.GetPrimAtPath("/World/Prop/geometry").HasAPI(UsdPhysics.RigidBodyAPI)

--- a/source/isaaclab/test/sim/test_tendon_fragments.py
+++ b/source/isaaclab/test/sim/test_tendon_fragments.py
@@ -133,31 +133,42 @@ def test_apply_fixed_tendon_writes_all_instances():
         assert abs(prim.GetAttribute(f"PhysxTendonAxisRootAPI:{inst}:stiffness").Get() - 9.0) < 1e-6
 
 
-def test_apply_fixed_tendon_descends_to_child_prims():
+def test_apply_fixed_tendon_writer_descends_to_child_prims():
     # tendon schemas are authored on child joint prims, not the articulation root the spawner
-    # targets; applying at the root must descend to every descendant carrying the schema.
+    # targets. Targeting is owned by the core writer: its subtree expression descends to
+    # every descendant carrying the schema, while the backend func is a per-prim tuner that
+    # no-ops on a prim without the schema.
     from isaaclab_physx.sim.schemas import PhysxFixedTendonCfg, apply_fixed_tendon
+
+    from isaaclab.sim.schemas import apply_fixed_tendon_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     UsdGeom.Xform.Define(stage, "/World/Robot")  # root: no tendon schema
     child = _make_fixed_tendon_prim(stage, "/World/Robot/joint", instance="t0")  # child joint carries it
-    # apply at the ROOT, not the joint
-    assert apply_fixed_tendon(PhysxFixedTendonCfg(stiffness=8.0), "/World/Robot", stage) is True
+    # the backend func is per-prim: applied at the root it tunes nothing
+    assert apply_fixed_tendon(PhysxFixedTendonCfg(stiffness=8.0), "/World/Robot", stage) is False
+    # the core writer's subtree expression descends from the root to the joint
+    assert apply_fixed_tendon_properties("/World/Robot(/.*)?", [PhysxFixedTendonCfg(stiffness=8.0)], stage) is True
     prefix = _tendon_attr_prefix(child, "PhysxTendonAxisRootAPI")
     assert abs(child.GetAttribute(f"{prefix}:stiffness").Get() - 8.0) < 1e-6
 
 
-def test_apply_spatial_tendon_descends_to_child_prims():
+def test_apply_spatial_tendon_writer_descends_to_child_prims():
     from isaaclab_physx.sim.schemas import PhysxSpatialTendonCfg, apply_spatial_tendon
+
+    from isaaclab.sim.schemas import apply_spatial_tendon_properties
 
     sim_utils.create_new_stage()
     SimulationContext(SimulationCfg(dt=0.01))
     stage = sim_utils.get_current_stage()
     UsdGeom.Xform.Define(stage, "/World/Robot2")  # root: no tendon schema
     child = _make_prim_with_schemas(stage, "/World/Robot2/joint", ["PhysxTendonAttachmentRootAPI:s0"])
-    assert apply_spatial_tendon(PhysxSpatialTendonCfg(stiffness=5.0), "/World/Robot2", stage) is True
+    # the backend func is per-prim: applied at the root it tunes nothing
+    assert apply_spatial_tendon(PhysxSpatialTendonCfg(stiffness=5.0), "/World/Robot2", stage) is False
+    # the core writer's subtree expression descends from the root to the joint
+    assert apply_spatial_tendon_properties("/World/Robot2(/.*)?", [PhysxSpatialTendonCfg(stiffness=5.0)], stage) is True
     assert abs(child.GetAttribute("PhysxTendonAttachmentRootAPI:s0:stiffness").Get() - 5.0) < 1e-6
 
 
@@ -260,22 +271,30 @@ def test_public_imports():
 # -------------------------------------------------------------------------------------
 
 
-def test_apply_fixed_tendon_raises_on_invalid_prim():
+def test_apply_fixed_tendon_warns_on_unmatched_path(caplog):
+    from isaaclab_physx.sim.schemas import PhysxFixedTendonCfg
+
     from isaaclab.sim.schemas import apply_fixed_tendon_properties
 
     _new_sim()
     stage = sim_utils.get_current_stage()
-    with pytest.raises(ValueError):
-        apply_fixed_tendon_properties("/World/DoesNotExist", [], stage)
+    with caplog.at_level("WARNING"):
+        result = apply_fixed_tendon_properties("/World/DoesNotExist", [PhysxFixedTendonCfg(stiffness=1.0)], stage)
+    assert result is False
+    assert "/World/DoesNotExist" in caplog.text
 
 
-def test_apply_spatial_tendon_raises_on_invalid_prim():
+def test_apply_spatial_tendon_warns_on_unmatched_path(caplog):
+    from isaaclab_physx.sim.schemas import PhysxSpatialTendonCfg
+
     from isaaclab.sim.schemas import apply_spatial_tendon_properties
 
     _new_sim()
     stage = sim_utils.get_current_stage()
-    with pytest.raises(ValueError):
-        apply_spatial_tendon_properties("/World/DoesNotExist", [], stage)
+    with caplog.at_level("WARNING"):
+        result = apply_spatial_tendon_properties("/World/DoesNotExist", [PhysxSpatialTendonCfg(stiffness=1.0)], stage)
+    assert result is False
+    assert "/World/DoesNotExist" in caplog.text
 
 
 def test_apply_fixed_tendon_aggregates_fragment_results():
@@ -292,6 +311,43 @@ def test_apply_fixed_tendon_aggregates_fragment_results():
     ok = UsdPhysicsRigidBodyCfg(rigid_body_enabled=True)
     ok.func = lambda cfg, prim_path, stage=None: True
     assert apply_fixed_tendon_properties("/World/Agg", [ok], stage) is True
+
+
+def test_apply_fixed_tendon_properties_narrows_to_exact_path():
+    from isaaclab_physx.sim.schemas import PhysxFixedTendonCfg
+
+    from isaaclab.sim.schemas import apply_fixed_tendon_properties
+
+    stage = _new_sim()
+    first = _make_fixed_tendon_prim(stage, "/World/Narrow/J0", instance="t1")
+    second = _make_fixed_tendon_prim(stage, "/World/Narrow/J1", instance="t1")
+    # the exact path of the first joint must tune only that joint
+    assert apply_fixed_tendon_properties("/World/Narrow/J0", [PhysxFixedTendonCfg(stiffness=50.0)], stage) is True
+    prefix = _tendon_attr_prefix(first, "PhysxTendonAxisRootAPI")
+    assert abs(first.GetAttribute(f"{prefix}:stiffness").Get() - 50.0) < 1e-6
+    second_prefix = _tendon_attr_prefix(second, "PhysxTendonAxisRootAPI")
+    second_attr = second.GetAttribute(f"{second_prefix}:stiffness")
+    assert not (second_attr and second_attr.HasAuthoredValue())
+
+
+def test_apply_fixed_tendon_properties_bare_parent_path_does_not_descend(caplog):
+    from isaaclab_physx.sim.schemas import PhysxFixedTendonCfg
+
+    from isaaclab.sim.schemas import apply_fixed_tendon_properties
+
+    stage = _new_sim()
+    UsdGeom.Xform.Define(stage, "/World/Parent")  # plain Xform: carries no tendon schema
+    first = _make_fixed_tendon_prim(stage, "/World/Parent/J0", instance="t1")
+    second = _make_fixed_tendon_prim(stage, "/World/Parent/J1", instance="t1")
+    # a bare parent path (no ``(/.*)?`` suffix) matches only the parent, which is not a tendon target
+    with caplog.at_level("WARNING"):
+        result = apply_fixed_tendon_properties("/World/Parent", [PhysxFixedTendonCfg(stiffness=50.0)], stage)
+    assert result is False
+    for prim in (first, second):
+        prefix = _tendon_attr_prefix(prim, "PhysxTendonAxisRootAPI")
+        attr = prim.GetAttribute(f"{prefix}:stiffness")
+        assert not (attr and attr.HasAuthoredValue())
+    assert "/World/Parent" in caplog.text
 
 
 def test_apply_fixed_tendon_raises_on_invalid_prim_backend():
@@ -387,7 +443,7 @@ def test_legacy_and_fragment_fixed_tendon_produce_identical_attrs():
 
     # apply each path at the ROOT; both must descend to the child joints
     modify_fixed_tendon_properties("/World/legacy", PhysxFixedTendonPropertiesCfg(limit_stiffness=30.0, damping=0.1))
-    apply_fixed_tendon_properties("/World/fragment", [PhysxFixedTendonCfg(limit_stiffness=30.0, damping=0.1)])
+    apply_fixed_tendon_properties("/World/fragment(/.*)?", [PhysxFixedTendonCfg(limit_stiffness=30.0, damping=0.1)])
 
     def _collect(root):
         attrs = {}
@@ -412,8 +468,8 @@ def test_legacy_and_fragment_fixed_tendon_produce_identical_attrs():
 
 
 def test_spawn_from_file_with_empty_tendon_lists_is_noop(tmp_path):
-    # an empty tendon list is type-valid for the slot; the spawner shim must route it through the
-    # fragment path (a no-op) rather than handing [] to the legacy modify_*_tendon_properties writer.
+    # a mapping entry with an empty fragment list is type-valid for the slot; the spawner must route
+    # it through the fragment path (a no-op) rather than the legacy modify_*_tendon_properties writer.
     asset = tmp_path / "mini.usda"
     src = Usd.Stage.CreateNew(str(asset))
     UsdGeom.Xform.Define(src, "/Root")
@@ -422,6 +478,8 @@ def test_spawn_from_file_with_empty_tendon_lists_is_noop(tmp_path):
     del src
 
     _new_sim()
-    cfg = sim_utils.UsdFileCfg(usd_path=str(asset), fixed_tendons_props=[], spatial_tendons_props=[])
+    cfg = sim_utils.UsdFileCfg(
+        usd_path=str(asset), fixed_tendons_props={"(/.*)?": []}, spatial_tendons_props={"(/.*)?": []}
+    )
     cfg.func("/World/Asset", cfg)  # must not raise
     assert sim_utils.get_current_stage().GetPrimAtPath("/World/Asset").IsValid()

--- a/source/isaaclab/test/sim/test_utils_queries.py
+++ b/source/isaaclab/test/sim/test_utils_queries.py
@@ -245,6 +245,18 @@ def test_get_first_matching_child_prim():
     assert isaaclab_result.GetPrimPath() == "/World/env_1/Franka/panda_link0/visuals/panda_link0"
 
 
+def test_find_matching_prims_traverses_instance_proxies():
+    """Matching descends into instanceable prims so callers can detect (and skip) proxy carriers."""
+    stage = sim_utils.get_current_stage()
+    stage.DefinePrim("/World/Source", "Xform")
+    stage.DefinePrim("/World/Source/body", "Xform")
+    instance = stage.DefinePrim("/World/Asset", "Xform")
+    instance.GetReferences().AddInternalReference("/World/Source")
+    instance.SetInstanceable(True)
+    matched_paths = sim_utils.find_matching_prim_paths("/World/Asset(/.*)?")
+    assert "/World/Asset/body" in matched_paths
+
+
 def test_find_global_fixed_joint_prim():
     """Test find_global_fixed_joint_prim() function."""
     # create scene

--- a/source/isaaclab_newton/changelog.d/vidurv-regex-fragment-targeting.rst
+++ b/source/isaaclab_newton/changelog.d/vidurv-regex-fragment-targeting.rst
@@ -1,0 +1,8 @@
+Changed
+^^^^^^^
+
+* Changed :func:`~isaaclab_newton.sim.schemas.apply_mujoco_fixed_tendon` to author on
+  the given prim only. Target selection, including subtree matching via prim path
+  expressions, is now owned by the core family writer
+  :func:`~isaaclab.sim.schemas.apply_fixed_tendon_properties`; pass
+  ``f"{prim_path}(/.*)?"`` to it to reach descendant ``MjcTendon`` prims.

--- a/source/isaaclab_newton/isaaclab_newton/sim/schemas/__init__.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/schemas/__init__.py
@@ -8,3 +8,10 @@
 from isaaclab.utils.module import lazy_export
 
 lazy_export()
+
+# ``NewtonArticulationRootAPI`` is applied as a token schema, so the USD schema registry cannot
+# describe it. Declare the namespace it owns so a backend relocating an articulation root carries
+# the schema and its ``newton:*`` attributes across instead of stranding them on the former root.
+from isaaclab.sim.schemas._backend_hooks import register_articulation_root_companion  # noqa: E402
+
+register_articulation_root_companion("NewtonArticulationRootAPI", "newton")

--- a/source/isaaclab_newton/isaaclab_newton/sim/schemas/schemas.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/schemas/schemas.py
@@ -87,7 +87,10 @@ def apply_mujoco_fixed_tendon(cfg: MujocoFixedTendonCfg, prim_path: str, stage: 
     """Write ``mjc:*`` fixed-tendon attributes on a ``MjcTendon`` prim.
 
     Custom ``func`` override for :class:`~isaaclab_newton.sim.schemas.MujocoFixedTendonCfg`.
-    No-op (returns False) on any prim whose type is not ``MjcTendon``.
+    This is a strictly per-prim tuner: the core writer
+    (:func:`~isaaclab.sim.schemas.apply_fixed_tendon_properties`) owns targeting and hands it the
+    exact resolved prim paths, so it never descends into descendants. No-op (returns False) on any
+    prim whose type is not ``MjcTendon``.
 
     Args:
         cfg: The :class:`MujocoFixedTendonCfg` fragment to apply.
@@ -102,24 +105,19 @@ def apply_mujoco_fixed_tendon(cfg: MujocoFixedTendonCfg, prim_path: str, stage: 
     """
     if stage is None:
         stage = get_current_stage()
-    root = stage.GetPrimAtPath(prim_path)
-    if not root.IsValid():
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
         raise ValueError(f"Prim path '{prim_path}' is not valid.")
+    if prim.GetTypeName() != "MjcTendon":
+        return False
     values = {
         f.name: getattr(cfg, f.name)
         for f in dataclasses.fields(cfg)
         if f.name != "func" and getattr(cfg, f.name) is not None
     }
-    # Descend the whole subtree (matching legacy apply_nested): ``MjcTendon`` prims may sit below
-    # the prim_path the spawner targets. Write ``mjc:*`` on every ``MjcTendon`` descendant.
-    found = False
-    for prim in Usd.PrimRange(root):
-        if prim.GetTypeName() != "MjcTendon":
-            continue
-        found = True
-        for attr_name, value in values.items():
-            safe_set_attribute_on_usd_prim(prim, f"mjc:{to_camel_case(attr_name, 'cC')}", value, camel_case=False)
-    return found
+    for attr_name, value in values.items():
+        safe_set_attribute_on_usd_prim(prim, f"mjc:{to_camel_case(attr_name, 'cC')}", value, camel_case=False)
+    return True
 
 
 def apply_mujoco_joint(cfg: MujocoJointCfg, prim_path: str, stage: Usd.Stage | None = None) -> bool:

--- a/source/isaaclab_ov/changelog.d/vidurv-regex-fragment-targeting.skip
+++ b/source/isaaclab_ov/changelog.d/vidurv-regex-fragment-targeting.skip
@@ -1,0 +1,1 @@
+Test-only change: prim path expression respelled for the plain-regex matcher.

--- a/source/isaaclab_ov/test/assets/test_articulation.py
+++ b/source/isaaclab_ov/test/assets/test_articulation.py
@@ -1719,7 +1719,7 @@ def test_fragment_fix_root_reenables_existing_joint(sim, device):
     joint.CreateBody1Rel().SetTargets([root.GetPath()])
     joint.CreateJointEnabledAttr().Set(False)
 
-    assert sim_utils.apply_articulation_root_properties(asset_path, [], stage, fix_root_link=True)
+    assert sim_utils.apply_articulation_root_properties(f"{asset_path}(/.*)?", [], stage, fix_root_link=True)
     assert joint.GetJointEnabledAttr().Get() is True
     world_joints = []
     for prim in sim_utils.get_all_matching_child_prims(

--- a/source/isaaclab_physx/changelog.d/vidurv-regex-fragment-targeting.rst
+++ b/source/isaaclab_physx/changelog.d/vidurv-regex-fragment-targeting.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+* Changed the tendon fragment functions (e.g. the ``func`` behind
+  :class:`~isaaclab_physx.sim.schemas.PhysxFixedTendonCfg`) to author on the given prim
+  only. Target selection, including subtree matching via prim path expressions, is now
+  owned by the core family writers such as
+  :func:`~isaaclab.sim.schemas.apply_fixed_tendon_properties`; pass
+  ``f"{prim_path}(/.*)?"`` to those writers to reach descendant tendon prims.

--- a/source/isaaclab_physx/isaaclab_physx/sim/schemas/schemas.py
+++ b/source/isaaclab_physx/isaaclab_physx/sim/schemas/schemas.py
@@ -92,45 +92,44 @@ def _strip_fragment_fields(cfg) -> dict:
 
 
 def _tune_multi_instance_tendon(cfg, prim_path: str, stage: Usd.Stage | None, markers: tuple[str, ...]) -> bool:
-    """Tune every multi-instance tendon schema (matching one of ``markers``) under ``prim_path``.
+    """Tune the multi-instance tendon schemas (matching one of ``markers``) on the prim at ``prim_path``.
 
     Shared backend for :func:`apply_fixed_tendon` / :func:`apply_spatial_tendon`. These schemas are
-    *tune-not-apply* (instances are authored in the source asset) and are typically applied on the
-    descendant joint prims rather than the ``prim_path`` the spawner targets, so this descends the
-    whole subtree (matching the legacy ``apply_nested`` traversal) and writes each set fragment field
-    as ``<schema_name>:<camelCase(field)>`` on every prim carrying a matching instance. Applies no
-    schema. The fragment's ``_usd_namespace`` is unused (these are not flat-namespace fragments); the
-    schema marker is matched explicitly via ``markers``.
+    *tune-not-apply* (instances are authored in the source asset). This is a strictly per-prim
+    tuner: the core writers (e.g. :func:`~isaaclab.sim.schemas.apply_fixed_tendon_properties`) own
+    targeting and hand it the exact resolved prim paths, so it never descends into descendants. It
+    writes each set fragment field as ``<schema_name>:<camelCase(field)>`` across every matching
+    applied instance on the prim. Applies no schema. The fragment's ``_usd_namespace`` is unused
+    (these are not flat-namespace fragments); the schema marker is matched explicitly via
+    ``markers``.
 
     Args:
         cfg: The tendon fragment whose set fields are written.
-        prim_path: The prim path (or articulation root) whose subtree carries the schemas.
+        prim_path: The prim path carrying the tendon schema instances.
         stage: The stage to resolve the prim on. Defaults to the current stage.
         markers: Substrings identifying the applied schema(s) to tune (e.g. ``("PhysxTendonAxisRootAPI",)``).
 
     Returns:
-        True if at least one matching instance was tuned, False if none is applied.
+        True if at least one matching instance was tuned, False if none is applied on the prim.
+
+    Raises:
+        ValueError: If the prim at ``prim_path`` does not exist in the stage.
     """
     if stage is None:
         stage = get_current_stage()
-    root = stage.GetPrimAtPath(prim_path)
-    if not root.IsValid():
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
         raise ValueError(f"Prim path '{prim_path}' is not valid.")
+    matching_schemas = [s for s in prim.GetAppliedSchemas() if any(m in s for m in markers)]
+    if not matching_schemas:
+        return False
     values = _strip_fragment_fields(cfg)
-    found = False
-    for prim in Usd.PrimRange(root):
-        applied_schemas = prim.GetAppliedSchemas()
-        if not any(m in s for s in applied_schemas for m in markers):
-            continue
-        found = True
-        for schema_name in applied_schemas:
-            if not any(m in schema_name for m in markers):
-                continue
-            for attr_name, value in values.items():
-                safe_set_attribute_on_usd_prim(
-                    prim, f"{schema_name}:{to_camel_case(attr_name, 'cC')}", value, camel_case=False
-                )
-    return found
+    for schema_name in matching_schemas:
+        for attr_name, value in values.items():
+            safe_set_attribute_on_usd_prim(
+                prim, f"{schema_name}:{to_camel_case(attr_name, 'cC')}", value, camel_case=False
+            )
+    return True
 
 
 def apply_fixed_tendon(cfg: PhysxFixedTendonCfg, prim_path: str, stage: Usd.Stage | None = None) -> bool:

--- a/source/isaaclab_physx/test/sim/test_spawn_meshes.py
+++ b/source/isaaclab_physx/test/sim/test_spawn_meshes.py
@@ -70,6 +70,28 @@ def test_spawn_cone_with_deformable_and_mass_props(sim):
         sim.step()
 
 
+def test_spawn_cone_with_deformable_and_collision_fragment_mapping(sim):
+    """A deformable mesh accepts ``collision_props`` as a target-pattern mapping.
+
+    Regression: the mapping was wrapped in a list, failed the fragment type check and raised, and
+    the writer call neither dispatched mapping entries nor anchored their patterns.
+    """
+    from isaaclab_physx.sim.schemas import PhysxCollisionCfg
+
+    cfg = sim_utils.MeshConeCfg(
+        radius=1.0,
+        height=2.0,
+        deformable_props=PhysxDeformableBodyPropertiesCfg(deformable_body_enabled=True, mass=1.0),
+        collision_props={"/sim_mesh": [PhysxCollisionCfg(contact_offset=0.02, rest_offset=0.001)]},
+    )
+    cfg.func("/World/ConeMap", cfg)
+
+    sim_mesh = sim.stage.GetPrimAtPath("/World/ConeMap/sim_mesh")
+    assert sim_mesh.IsValid()
+    assert abs(sim_mesh.GetAttribute("physxCollision:contactOffset").Get() - 0.02) < 1e-6
+    assert abs(sim_mesh.GetAttribute("physxCollision:restOffset").Get() - 0.001) < 1e-6
+
+
 def test_spawn_cone_with_deformable_and_density_props(sim):
     """Test spawning of UsdGeomMesh prim for a cone with deformable body and mass API,
     specifying density instead of mass.


### PR DESCRIPTION
# Description

Backports #6640 onto `release/3.0.0`.

This moves the experimental physics schema-fragment surface to prim-path expressions, adds per-family target mappings to spawner configs, makes schema API creation explicit, and keeps the PhysX/Newton tendon backends per-prim. It also fixes nested rigid-body and mass fragment targeting.

The prerequisite whole-path regular-expression matcher from #6841 is already present on the release branch. This is an exact `cherry-pick -x` of the merged commit.

## Risk assessment

- The source PR's 33 touched paths were identical between its `develop` base and the current release tip, so the commit applied without conflicts or release-specific edits; source and backport patch IDs match.
- Legacy single-cfg values and the legacy `define_*` / `modify_*` writers are unchanged, and there are no in-tree fragment users.
- The bounded compatibility risk is for out-of-tree users of the experimental fragment surface. They must wrap fragment lists as `{"(/.*)?": [...]}` and pass `create_if_missing=True` where API creation was previously implicit.

## Type of change

- New feature
- Breaking change (experimental schema-fragment surface only)
- Documentation update

## Validation

- Exact source/backport patch identity and clean release-branch application
- `git diff --check`
- Python 3.12 static compilation of the changed simulation/schema modules
- Formatting, lint, spelling, license, and RST pre-commit hooks
- Changelog-fragment gate against `release/3.0.0`
- Upstream #6640 CI passed pre-commit, changelog, docs, core, Newton, PhysX, wheel, x86 installation, rendering, and the targeted schema/spawner suites

The full project test and docs commands were not rerun locally because the project lockfile supports Linux and Windows, not this macOS host. Release-branch CI should provide the final platform validation. The source PR's unrelated Franka Pour dataset-contract failure and ARM runner-queue cancellation did not involve these paths.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have made corresponding documentation changes
- [x] I have added tests that cover the changed behavior
- [x] I have added a changelog fragment for every touched source package
- [x] The contributor is already listed in `CONTRIBUTORS.md`
