### PR TITLE
[Backport] Fix conda installation commands (#7436)

### DIFF
--- a/docs/_extensions/isaaclab_docs.py
+++ b/docs/_extensions/isaaclab_docs.py
@@ -189,13 +189,20 @@ def _quickstart_kitless(branch: str, platform: str) -> str:
 
 
 class IsaacLabIsaacSimInstall(SphinxDirective):
-    """Render the ``uv pip install isaacsim`` command pinned to the pyproject version."""
+    """Render the Isaac Sim install command pinned to the pyproject version."""
 
-    has_content = False
+    optional_arguments = 1  # installer: "pip" (default is "uv pip")
 
     def run(self) -> list[nodes.Node]:
         version = self.config.isaacsim_version
-        content = f"""\
+        if self.arguments and self.arguments[0] == "pip":
+            content = f"""\
+.. code-block:: bash
+
+   python -m pip install "isaacsim[all,extscache]=={version}" --extra-index-url https://pypi.nvidia.com
+"""
+        else:
+            content = f"""\
 .. code-block:: bash
 
    uv pip install "isaacsim[all,extscache]=={version}" --extra-index-url https://pypi.nvidia.com --index-strategy unsafe-best-match --prerelease=allow
@@ -260,7 +267,7 @@ class IsaacLabTorchInstall(SphinxDirective):
 
     def run(self) -> list[nodes.Node]:
         cuda_tag = self.arguments[0]
-        installer = "pip" if len(self.arguments) > 1 and self.arguments[1] == "pip" else "uv pip"
+        installer = "python -m pip" if len(self.arguments) > 1 and self.arguments[1] == "pip" else "uv pip"
         torch_version = self.config.torch_version
         torchvision_version = self.config.torchvision_version
         content = f"""\

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -392,8 +392,10 @@ before installing on Windows.
 Create and activate a Python 3.12 environment:
 
 .. tab-set::
+   :sync-group: python-environment
 
    .. tab-item:: uv environment (recommended)
+      :sync: uv
 
       .. tab-set::
          :sync-group: os
@@ -415,6 +417,7 @@ Create and activate a Python 3.12 environment:
                env_isaaclab\Scripts\activate
 
    .. tab-item:: conda environment
+      :sync: conda
 
       .. code-block:: bash
 
@@ -423,7 +426,18 @@ Create and activate a Python 3.12 environment:
 
 Install Isaac Sim and the CUDA-enabled PyTorch build for your platform:
 
-.. isaaclab-isaacsim-install::
+.. tab-set::
+   :sync-group: python-environment
+
+   .. tab-item:: uv environment (recommended)
+      :sync: uv
+
+      .. isaaclab-isaacsim-install::
+
+   .. tab-item:: conda environment
+      :sync: conda
+
+      .. isaaclab-isaacsim-install:: pip
 
 .. tab-set::
    :sync-group: pip-platform
@@ -431,12 +445,34 @@ Install Isaac Sim and the CUDA-enabled PyTorch build for your platform:
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (x86_64)
       :sync: linux-x86_64
 
-      .. isaaclab-torch-install:: cu128
+      .. tab-set::
+         :sync-group: python-environment
+
+         .. tab-item:: uv environment (recommended)
+            :sync: uv
+
+            .. isaaclab-torch-install:: cu128
+
+         .. tab-item:: conda environment
+            :sync: conda
+
+            .. isaaclab-torch-install:: cu128 pip
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows (x86_64)
       :sync: windows-x86_64
 
-      .. isaaclab-torch-install:: cu128
+      .. tab-set::
+         :sync-group: python-environment
+
+         .. tab-item:: uv environment (recommended)
+            :sync: uv
+
+            .. isaaclab-torch-install:: cu128
+
+         .. tab-item:: conda environment
+            :sync: conda
+
+            .. isaaclab-torch-install:: cu128 pip
 
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (aarch64)
       :sync: linux-aarch64
@@ -451,7 +487,18 @@ Install Isaac Sim and the CUDA-enabled PyTorch build for your platform:
             sudo apt install python3.12-dev libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev \
                libxinerama-dev libxrandr-dev
 
-      .. isaaclab-torch-install:: cu130
+      .. tab-set::
+         :sync-group: python-environment
+
+         .. tab-item:: uv environment (recommended)
+            :sync: uv
+
+            .. isaaclab-torch-install:: cu130
+
+         .. tab-item:: conda environment
+            :sync: conda
+
+            .. isaaclab-torch-install:: cu130 pip
 
       .. note::
 


### PR DESCRIPTION
## Description

Backports #7436 to `release/3.0.0`.

The automated backport run completed successfully but skipped the backport because the source PR body did not retain the hidden `<!-- backport-active-release -->` selection marker. This branch manually cherry-picks the merged source commit `99b0d660be5e9671579c70bdfb198c410610d225`.

## Type of change

- Documentation update
- Bug fix

## Release backport

- This PR already targets the active release branch.

## Validation

- Exact-patch backport validation passed for both original paths.
- `git diff --check upstream/release/3.0.0 HEAD` passed.
- Changed-file Ruff, RST syntax, spelling, license, whitespace, and conflict hooks passed.
- The original PR warning-free documentation build passed for this exact patch.
- The release lockfile excludes macOS, so `uv run --isolated --extra test -- make -C docs current-docs` and `uv run isaaclab -f` could not start locally; Linux CI should run the authoritative checks.
- The changed-file pre-commit run also reported release-branch-wide changelog-fragment history issues and missing local Git LFS, unrelated to these two documentation files.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have made corresponding changes to the documentation
- [x] No source package was changed, so no changelog fragment is required
- [x] The original contributor is already present in `CONTRIBUTORS.md`
