### PR TITLE
[omniperf-agent] test(sim): reproduce Newton/UsdPhysics rigid-body de…

### DIFF
--- a/source/isaaclab/test/sim/check_newton_usdphysics_shadowhand_crash.py
+++ b/source/isaaclab/test/sim/check_newton_usdphysics_shadowhand_crash.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Standalone reproducer for the Newton/UsdPhysics rigid-body-descriptor native crash.
+
+Builds ``Isaac-Shadow-Handover-Direct`` on the Newton (``physics=newton_mjwarp``) backend and
+amplifies ``UsdPhysics.LoadUsdPhysicsFromRange`` on the environment subtree so the intermittent
+(~2-3%/call) native NULL-deref in OpenUSD / usd-exchange
+``UsdPhysics::moveDescsToDict<UsdPhysicsRigidBodyDesc>`` becomes near-deterministic in a single run.
+
+This is a *process-crash* reproducer: on the unfixed OpenUSD/usd-exchange stack it terminates the
+whole process with SIGSEGV / SIGABRT (exit 134 / 139 / 245). It therefore prints
+``COMPLETED_NO_CRASH`` and exits 0 ONLY when the underlying bug is fixed. It is meant to be driven
+as a subprocess by ``test_newton_usdphysics_shadowhand_repro.py`` so the parent can assert on the
+exit code.
+
+The amplification wraps the ``pxr`` binding in-process only -- it does NOT modify any installed
+Newton/USD file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--task", default=os.environ.get("NEWTON_REPRO_TASK", "Isaac-Shadow-Handover-Direct"))
+    parser.add_argument("--num_envs", type=int, default=int(os.environ.get("NEWTON_REPRO_NUM_ENVS", "4")))
+    parser.add_argument("--loops", type=int, default=int(os.environ.get("NEWTON_REPRO_LOOP_N", "60")))
+
+    from isaaclab.app import AppLauncher
+
+    AppLauncher.add_app_launcher_args(parser)
+    args = parser.parse_args()
+    args.headless = True
+
+    app_launcher = AppLauncher(args)
+    simulation_app = app_launcher.app
+
+    # Optional: point the asset root at an offline mirror (e.g. staging S3) so the ShadowHand USD
+    # resolves without Nucleus auth. No-op if the env var is unset.
+    asset_root = os.environ.get("ISAAC_ASSET_ROOT")
+    if asset_root:
+        import carb
+
+        carb.settings.get_settings().set("/persistent/isaac/asset_root/default", asset_root)
+        carb.settings.get_settings().set("/rtx/verifyDriverVersion/enabled", False)
+
+    # --- amplification: repeat the env-subtree physics load to make the rare crash near-certain.
+    from pxr import UsdPhysics
+
+    _orig_load = UsdPhysics.LoadUsdPhysicsFromRange
+    _loops = max(1, int(args.loops))
+
+    def _amplified_load(stage, include_paths, *rest, **kw):
+        result = _orig_load(stage, include_paths, *rest, **kw)
+        try:
+            roots = [str(p) for p in include_paths]
+        except TypeError:
+            roots = [str(include_paths)]
+        if any("/World/envs/env" in r for r in roots):
+            for _ in range(_loops):
+                _orig_load(stage, include_paths, *rest, **kw)
+        return result
+
+    UsdPhysics.LoadUsdPhysicsFromRange = _amplified_load
+
+    # --- build the Newton env; the Newton model import (add_usd -> LoadUsdPhysicsFromRange) runs here.
+    import gymnasium as gym
+
+    import isaaclab_tasks  # noqa: F401  (registers Isaac Lab tasks)
+    from isaaclab_tasks.utils import resolve_task_config
+
+    env_cfg, _ = resolve_task_config(args.task, None, overrides=("physics=newton_mjwarp",))
+    env_cfg.scene.num_envs = args.num_envs
+    if hasattr(env_cfg, "seed"):
+        env_cfg.seed = 0
+
+    print(f"[repro] building {args.task} num_envs={args.num_envs} loops={_loops}", flush=True)
+    env = gym.make(args.task, cfg=env_cfg)
+    env.reset()
+    env.close()
+
+    print(f"COMPLETED_NO_CRASH task={args.task} num_envs={args.num_envs} loops={_loops}", flush=True)
+    try:
+        simulation_app.close()
+    finally:
+        os._exit(0)  # Isaac Sim teardown deadlocks; hard-exit so the no-crash path terminates
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/source/isaaclab/test/sim/test_newton_usdphysics_shadowhand_repro.py
+++ b/source/isaaclab/test/sim/test_newton_usdphysics_shadowhand_repro.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression reproducer for the Newton / UsdPhysics rigid-body-descriptor native crash.
+
+Building an Isaac Lab Newton (``physics=newton_mjwarp``) environment whose USD carries the Shadow
+Hand rigid-body set intermittently crashes the whole process inside OpenUSD / usd-exchange
+``UsdPhysics::moveDescsToDict<UsdPhysicsRigidBodyDesc>``, reached from
+``UsdPhysics.LoadUsdPhysicsFromRange`` (called by ``newton.ModelBuilder.add_usd``). It is a native
+memory fault, so it surfaces either as a SIGSEGV NULL-deref in ``moveDescsToDict`` or as a glibc
+heap-corruption abort (``double free`` / ``unaligned tcache`` / ``free(): invalid next size``) --
+both are the same out-of-bounds access.
+
+Because the fault kills the process it cannot be caught in-process, so this test drives
+``check_newton_usdphysics_shadowhand_crash.py`` as a subprocess. The helper amplifies the offending
+call, turning the intermittent (~2-3 %/call) fault into a ~100 %/run one, and prints
+``COMPLETED_NO_CRASH`` only if the environment builds without crashing.
+
+Semantics: on the current (unfixed) OpenUSD / usd-exchange stack the subprocess is killed and this
+test FAILS -- that failure *is* the reproduction. A fix in OpenUSD/usd-exchange ``UsdPhysics`` (or a
+defensive guard in Newton ``import_usd``) makes the helper reach ``COMPLETED_NO_CRASH`` and this
+test pass. The bug is NOT in Isaac Lab; the test lives here so a Newton/Isaac Sim bump that pulls in
+the fix can be verified, and is meant to ship in the same PR as that fix.
+
+The crash is Ada-only in practice (observed on L40 / B40, absent on Blackwell / Hopper), so the test
+skips on non-Ada (non ``sm_89``) GPUs to avoid a misleading green result.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_THIS_DIR = Path(__file__).resolve().parent
+_HELPER = _THIS_DIR / "check_newton_usdphysics_shadowhand_crash.py"
+
+# Substrings that indicate the native crash reproduced (any manifestation).
+_CRASH_MARKERS = (
+    "moveDescsToDict",            # NULL-deref manifestation (UsdPhysicsRigidBodyDesc)
+    "LoadUsdPhysicsFromRange",    # offending call, present in the crash backtrace
+    "crashreporter-breakpad",     # Kit breakpad engaged (both SIGSEGV and SIGABRT paths)
+    "double free or corruption",  # glibc heap-corruption manifestations
+    "unaligned tcache",
+    "free(): invalid",
+    "malloc(): ",
+    "corrupted",
+    "Segmentation fault",
+)
+
+
+def _find_isaaclab_sh() -> Path | None:
+    for parent in _THIS_DIR.parents:
+        candidate = parent / "isaaclab.sh"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _gpu_is_ada_only() -> bool:
+    """True only if every visible GPU is Ada (compute capability 8.9)."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            text=True,
+            timeout=30,
+        )
+    except Exception:
+        return False
+    caps = [line.strip() for line in out.splitlines() if line.strip()]
+    return bool(caps) and all(cap == "8.9" for cap in caps)
+
+
+@pytest.mark.skipif(not _HELPER.is_file(), reason="reproducer helper script not found")
+def test_newton_usdphysics_shadowhand_no_native_crash():
+    """Isaac-Shadow-Handover-Direct on Newton must build without the UsdPhysics rigid-body crash."""
+    try:
+        import isaaclab  # noqa: F401
+        import newton  # noqa: F401
+    except Exception as exc:
+        pytest.skip(f"Isaac Sim / Newton not importable: {exc}")
+
+    if not _gpu_is_ada_only():
+        pytest.skip("Newton/UsdPhysics rigid-body crash reproduces only on NVIDIA Ada (sm_89) GPUs")
+
+    isaaclab_sh = _find_isaaclab_sh()
+    if isaaclab_sh is None:
+        pytest.skip("isaaclab.sh launcher not found; run under the Isaac Lab environment")
+
+    env = dict(os.environ)
+    env.setdefault("NEWTON_REPRO_LOOP_N", "100")
+    num_envs = env.get("NEWTON_REPRO_NUM_ENVS", "4")
+
+    proc = subprocess.run(
+        [
+            str(isaaclab_sh),
+            "-p",
+            str(_HELPER),
+            "--task",
+            "Isaac-Shadow-Handover-Direct",
+            "--num_envs",
+            num_envs,
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    output = (proc.stdout or "") + (proc.stderr or "")
+
+    if "COMPLETED_NO_CRASH" in output:
+        return  # environment built cleanly -> bug fixed / not present
+
+    tail = output[-4000:]
+    crashed = any(marker in output for marker in _CRASH_MARKERS)
+    assert not crashed, (
+        "Reproduced the Newton/UsdPhysics rigid-body-descriptor native crash "
+        f"(launcher exit={proc.returncode}). NULL-deref / heap OOB in "
+        "UsdPhysics::moveDescsToDict<UsdPhysicsRigidBodyDesc> via LoadUsdPhysicsFromRange "
+        "(newton.ModelBuilder.add_usd). This is the bug under test; a fix in OpenUSD/usd-exchange "
+        "UsdPhysics (or a Newton import_usd guard) makes this pass.\n"
+        f"--- reproducer output tail ---\n{tail}"
+    )
+    pytest.fail(
+        "Reproducer neither completed nor produced a known crash signature "
+        f"(launcher exit={proc.returncode}); treat as an environment/setup failure, "
+        f"not the target crash.\n--- reproducer output tail ---\n{tail}"
+    )


### PR DESCRIPTION
…scriptor crash

Add a regression reproducer for the intermittent native crash in OpenUSD/usd-exchange UsdPhysics::moveDescsToDict<UsdPhysicsRigidBodyDesc>, reached via UsdPhysics.LoadUsdPhysicsFromRange (newton.ModelBuilder.add_usd) when building the Isaac-Shadow-Handover-Direct env on the Newton (newton_mjwarp) backend.

- check_newton_usdphysics_shadowhand_crash.py: standalone reproducer; amplifies the offending load so the ~2-3%/call fault becomes ~100%/run. Prints COMPLETED_NO_CRASH (exit 0) only when the underlying bug is fixed.
- test_newton_usdphysics_shadowhand_repro.py: pytest wrapper; runs the reproducer as a subprocess and asserts it completes. Skips on non-Ada GPUs and without Isaac Sim/Newton.

The bug is in OpenUSD/usd-exchange UsdPhysics (or needs a Newton import_usd guard), NOT in Isaac Lab. Verified on develop 630317b on an L40 (Ada, sm_89): SIGSEGV in moveDescsToDict (exit 139) or a glibc heap-corruption abort. Expected to FAIL until the upstream fix lands; ship it in the same PR as that fix.

# Description

> [!IMPORTANT]
> Confirm the pull request base before submitting. Target `develop` for all
> contributions. The `release/3.0.0-beta2` branch is a frozen stable landing
> snapshot and is not used for ongoing maintenance.

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
