### PR TITLE
Turn off OVRTX shadows by default

### DIFF
--- a/source/isaaclab_ov/changelog.d/mataylor-ovrtx-shadows-off-by-default.minor.rst
+++ b/source/isaaclab_ov/changelog.d/mataylor-ovrtx-shadows-off-by-default.minor.rst
@@ -1,0 +1,12 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows`, which authors
+  ``omni:rtx:shadows:enabled`` and ``omni:rtx:minimal:castShadows`` on the OVRTX render product so
+  the toggle covers the path-traced and minimal render modes alike.
+
+Changed
+^^^^^^^
+
+* Changed the OVRTX renderer to request shadows off by default. Renders that need cast shadows must
+  now set ``OVRTXRendererCfg(enable_shadows=True)``.

--- a/source/isaaclab_ov/changelog.d/mataylor-ovrtx-shadows-off-by-default.minor.rst
+++ b/source/isaaclab_ov/changelog.d/mataylor-ovrtx-shadows-off-by-default.minor.rst
@@ -2,11 +2,13 @@ Added
 ^^^^^
 
 * Added :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows`, which authors
-  ``omni:rtx:shadows:enabled`` and ``omni:rtx:minimal:castShadows`` on the OVRTX render product so
-  the toggle covers the path-traced and minimal render modes alike.
+  ``omni:rtx:minimal:castShadows`` on the OVRTX render product. It applies to the
+  ``simple_shading_*`` data types, which are the ones that select RTX Minimal mode; OVRTX's
+  path-traced modes provide no shadow switch and always cast shadows.
 
 Changed
 ^^^^^^^
 
-* Changed the OVRTX renderer to request shadows off by default. Renders that need cast shadows must
-  now set ``OVRTXRendererCfg(enable_shadows=True)``.
+* Changed the OVRTX renderer to turn shadows off by default in RTX Minimal mode. Renders that need
+  cast shadows from the ``simple_shading_*`` data types must now set
+  ``OVRTXRendererCfg(enable_shadows=True)``.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -538,6 +538,7 @@ class OVRTXRenderer(BaseRenderer):
             camera_rel_path=self._camera_rel_path,
             background_color=getattr(spec.cfg, "background_color", None),
             device_id=self._warp_device.ordinal,
+            enable_shadows=self.cfg.enable_shadows,
         )
         self._render_product_paths.append(render_product_path)
 
@@ -1794,6 +1795,7 @@ class OVRTXRenderer(BaseRenderer):
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
             camera_rel_path=self._camera_rel_path,
             device_id=self._warp_device.ordinal,
+            enable_shadows=self.cfg.enable_shadows,
         )
         self._render_product_paths.append(render_product_path)
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -49,6 +49,15 @@ class OVRTXRendererCfg(RendererCfg):
     log_file_path: str = os.path.join(tempfile.gettempdir(), "ovrtx_renderer.log")
     """Path for OVRTX log file. Defaults to ``<system temp>/ovrtx_renderer.log``."""
 
+    enable_shadows: bool = False
+    """Whether lights cast shadows. Defaults to False.
+
+    Shadow rays cost render time that rarely changes what a policy learns, so they are requested
+    off and opted back into for visually faithful renders. The value is authored on the render
+    product for every OVRTX render mode: ``omni:rtx:shadows:enabled`` for the path-traced modes
+    and ``omni:rtx:minimal:castShadows`` for the ``simple_shading_*`` data types.
+    """
+
     colorize_semantic_segmentation: bool = True
     """Whether to colorize semantic segmentation output. Defaults to True.
 

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_cfg.py
@@ -50,12 +50,16 @@ class OVRTXRendererCfg(RendererCfg):
     """Path for OVRTX log file. Defaults to ``<system temp>/ovrtx_renderer.log``."""
 
     enable_shadows: bool = False
-    """Whether lights cast shadows. Defaults to False.
+    """Whether lights cast shadows in RTX Minimal mode. Defaults to False.
 
-    Shadow rays cost render time that rarely changes what a policy learns, so they are requested
-    off and opted back into for visually faithful renders. The value is authored on the render
-    product for every OVRTX render mode: ``omni:rtx:shadows:enabled`` for the path-traced modes
-    and ``omni:rtx:minimal:castShadows`` for the ``simple_shading_*`` data types.
+    Shadow rays cost render time that rarely changes what a policy learns, so they are turned off
+    and opted back into for visually faithful renders.
+
+    Only the ``simple_shading_constant_diffuse``, ``simple_shading_diffuse_mdl`` and
+    ``simple_shading_full_mdl`` data types are affected, because those are the ones that put the
+    render product into RTX Minimal mode, whose ``omni:rtx:minimal:castShadows`` switch this drives.
+    OVRTX's path-traced modes offer no equivalent switch and always cast shadows, so this setting
+    does not change ``rgb`` and the other AOV outputs.
     """
 
     colorize_semantic_segmentation: bool = True

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -194,9 +194,8 @@ def build_render_scope_usd(
             When ``None``, the default dome-light background is used.
         device_id: CUDA device index the render product is pinned to via ``deviceIds``. When ``None``,
             OVRTX assigns the device automatically.
-        enable_shadows: Whether lights cast shadows. Defaults to False. Both the path-traced and the
-            minimal render modes are authored, so the mode chosen by ``minimal_mode`` does not change
-            whether shadows are drawn.
+        enable_shadows: Whether lights cast shadows. Defaults to False. Only honored in RTX Minimal
+            mode, that is when ``minimal_mode`` is set; the path-traced modes always cast shadows.
 
     Returns:
         The USD string for the render scope.
@@ -216,22 +215,17 @@ def build_render_scope_usd(
             f"        color3f omni:rtx:background:source:color = ({r}, {g}, {b})"
         )
 
+    # Minimal is the only OVRTX render mode with a shadow switch, so ``enable_shadows`` is authored
+    # only there. The path-traced modes always trace shadows: ``omni:rtx:shadows:enabled`` exists as
+    # a setting name and authors without error, but no path-tracing backend reads it.
     if minimal_mode is None:
         render_mode_lines = ['token omni:rtx:rendermode = "RealTimePathTracing"']
     else:
         render_mode_lines = [
             'token omni:rtx:rendermode = "Minimal"',
             f"int omni:rtx:minimal:mode = {minimal_mode}",
+            f"bool omni:rtx:minimal:castShadows = {'true' if enable_shadows else 'false'}",
         ]
-
-    # RTX splits the shadow toggle per render mode, so author both to keep the two modes consistent.
-    shadow_value = "true" if enable_shadows else "false"
-    shadow_block = "\n        ".join(
-        [
-            f"bool omni:rtx:shadows:enabled = {shadow_value}",
-            f"bool omni:rtx:minimal:castShadows = {shadow_value}",
-        ]
-    )
 
     render_mode_block = "\n        ".join(render_mode_lines)
     if render_var_configs is None:
@@ -254,7 +248,6 @@ def Scope "Render"
         rel camera = [{camera_rel_list}]{device_ids_line}
         {bg_type_line}
         float omni:rtx:rt:ambientLight:intensity = 1.0
-        {shadow_block}
         {render_mode_block}
         token[] omni:rtx:waitForEvents = ["AllLoadingFinished", "OnlyOnFirstRequest"]
         rel orderedVars = [{ordered_vars}]
@@ -307,7 +300,8 @@ def build_render_product_as_string(
         device_id: CUDA device index the render product is pinned to, so its render var buffers are
             allocated on the same device as the Warp kernels that read them. When ``None``, OVRTX
             assigns the device automatically.
-        enable_shadows: Whether lights cast shadows. Defaults to False.
+        enable_shadows: Whether lights cast shadows. Defaults to False. Only honored for the
+            ``simple_shading_*`` data types, which are the ones that select RTX Minimal mode.
 
     Returns:
         Tuple of (render product USD snippet as a string, absolute render product prim path).

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_usd.py
@@ -175,6 +175,7 @@ def build_render_scope_usd(
     render_var_configs: list[tuple[str, str, str]] | None = None,
     background_color: tuple[float, float, float] | None = None,
     device_id: int | None = None,
+    enable_shadows: bool = False,
 ) -> str:
     """Build the Render scope USD string (def Scope Render, RenderProduct, Vars).
 
@@ -193,6 +194,9 @@ def build_render_scope_usd(
             When ``None``, the default dome-light background is used.
         device_id: CUDA device index the render product is pinned to via ``deviceIds``. When ``None``,
             OVRTX assigns the device automatically.
+        enable_shadows: Whether lights cast shadows. Defaults to False. Both the path-traced and the
+            minimal render modes are authored, so the mode chosen by ``minimal_mode`` does not change
+            whether shadows are drawn.
 
     Returns:
         The USD string for the render scope.
@@ -220,6 +224,15 @@ def build_render_scope_usd(
             f"int omni:rtx:minimal:mode = {minimal_mode}",
         ]
 
+    # RTX splits the shadow toggle per render mode, so author both to keep the two modes consistent.
+    shadow_value = "true" if enable_shadows else "false"
+    shadow_block = "\n        ".join(
+        [
+            f"bool omni:rtx:shadows:enabled = {shadow_value}",
+            f"bool omni:rtx:minimal:castShadows = {shadow_value}",
+        ]
+    )
+
     render_mode_block = "\n        ".join(render_mode_lines)
     if render_var_configs is None:
         render_var_configs = [(render_var_path, render_var_name, source_name)]
@@ -241,6 +254,7 @@ def Scope "Render"
         rel camera = [{camera_rel_list}]{device_ids_line}
         {bg_type_line}
         float omni:rtx:rt:ambientLight:intensity = 1.0
+        {shadow_block}
         {render_mode_block}
         token[] omni:rtx:waitForEvents = ["AllLoadingFinished", "OnlyOnFirstRequest"]
         rel orderedVars = [{ordered_vars}]
@@ -271,6 +285,7 @@ def build_render_product_as_string(
     camera_rel_path: str = "Camera",
     background_color: tuple[float, float, float] | None = None,
     device_id: int | None = None,
+    enable_shadows: bool = False,
 ) -> tuple[str, str]:
     """Build the render product USD snippet as a string.
 
@@ -292,6 +307,7 @@ def build_render_product_as_string(
         device_id: CUDA device index the render product is pinned to, so its render var buffers are
             allocated on the same device as the Warp kernels that read them. When ``None``, OVRTX
             assigns the device automatically.
+        enable_shadows: Whether lights cast shadows. Defaults to False.
 
     Returns:
         Tuple of (render product USD snippet as a string, absolute render product prim path).
@@ -318,6 +334,7 @@ def build_render_product_as_string(
         render_var_configs,
         background_color,
         device_id,
+        enable_shadows,
     )
     return camera_content, render_product_path
 

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -111,6 +111,47 @@ def test_build_render_scope_usd_solid_background_color():
     assert 'token omni:rtx:background:source:type = "domeLight"' not in render_scope
 
 
+@pytest.mark.parametrize("minimal_mode", [None, 1])
+def test_build_render_scope_usd_disables_shadows_by_default(minimal_mode):
+    """Shadows are off by default in every render mode."""
+    render_scope = build_render_scope_usd(
+        camera_paths=["/World/envs/env_0/Camera"],
+        render_product_name="RenderProduct",
+        render_var_path="/Render/Vars/LdrColor",
+        render_var_name="LdrColor",
+        source_name="LdrColor",
+        tiled_width=16,
+        tiled_height=8,
+        minimal_mode=minimal_mode,
+    )
+    assert "bool omni:rtx:shadows:enabled = false" in render_scope
+    assert "bool omni:rtx:minimal:castShadows = false" in render_scope
+
+
+def test_build_render_scope_usd_enable_shadows_opts_back_in():
+    """Setting enable_shadows re-enables the shadow toggles of every render mode."""
+    render_scope = build_render_scope_usd(
+        camera_paths=["/World/envs/env_0/Camera"],
+        render_product_name="RenderProduct",
+        render_var_path="/Render/Vars/LdrColor",
+        render_var_name="LdrColor",
+        source_name="LdrColor",
+        tiled_width=16,
+        tiled_height=8,
+        enable_shadows=True,
+    )
+    assert "bool omni:rtx:shadows:enabled = true" in render_scope
+    assert "bool omni:rtx:minimal:castShadows = true" in render_scope
+
+
+def test_build_render_product_as_string_forwards_enable_shadows():
+    """The render product builder passes enable_shadows through to the render scope."""
+    disabled, _ = build_render_product_as_string(width=16, height=8, num_envs=1, data_types=["rgb"])
+    enabled, _ = build_render_product_as_string(width=16, height=8, num_envs=1, data_types=["rgb"], enable_shadows=True)
+    assert "bool omni:rtx:shadows:enabled = false" in disabled
+    assert "bool omni:rtx:shadows:enabled = true" in enabled
+
+
 def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():
     """Requesting RGB_HDR from OVRTX selects the HdrColor render variable."""
     assert get_render_var_config(["rgb_hdr"]) == ("/Render/Vars/HdrColor", "HdrColor", "HdrColor")

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -111,50 +111,6 @@ def test_build_render_scope_usd_solid_background_color():
     assert 'token omni:rtx:background:source:type = "domeLight"' not in render_scope
 
 
-@pytest.mark.parametrize("enable_shadows,expected", [(False, "false"), (True, "true")])
-def test_build_render_scope_usd_authors_minimal_cast_shadows(enable_shadows, expected):
-    """enable_shadows drives the RTX Minimal shadow switch, and defaults to off."""
-    render_scope = build_render_scope_usd(
-        camera_paths=["/World/envs/env_0/Camera"],
-        render_product_name="RenderProduct",
-        render_var_path="/Render/Vars/LdrColor",
-        render_var_name="LdrColor",
-        source_name="LdrColor",
-        tiled_width=16,
-        tiled_height=8,
-        minimal_mode=1,
-        enable_shadows=enable_shadows,
-    )
-    assert f"bool omni:rtx:minimal:castShadows = {expected}" in render_scope
-
-
-@pytest.mark.parametrize("enable_shadows", [False, True])
-def test_build_render_scope_usd_omits_shadow_settings_outside_minimal_mode(enable_shadows):
-    """The path-traced modes have no shadow switch, so neither shadow setting is authored for them."""
-    render_scope = build_render_scope_usd(
-        camera_paths=["/World/envs/env_0/Camera"],
-        render_product_name="RenderProduct",
-        render_var_path="/Render/Vars/LdrColor",
-        render_var_name="LdrColor",
-        source_name="LdrColor",
-        tiled_width=16,
-        tiled_height=8,
-        enable_shadows=enable_shadows,
-    )
-    assert "castShadows" not in render_scope
-    # exists as a setting name but is never read by the path-tracing backends
-    assert "omni:rtx:shadows:enabled" not in render_scope
-
-
-def test_build_render_product_as_string_forwards_enable_shadows():
-    """The render product builder passes enable_shadows through to the render scope."""
-    kwargs = dict(width=16, height=8, num_envs=1, data_types=["simple_shading_full_mdl"], minimal_mode=3)
-    disabled, _ = build_render_product_as_string(**kwargs)
-    enabled, _ = build_render_product_as_string(**kwargs, enable_shadows=True)
-    assert "bool omni:rtx:minimal:castShadows = false" in disabled
-    assert "bool omni:rtx:minimal:castShadows = true" in enabled
-
-
 def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():
     """Requesting RGB_HDR from OVRTX selects the HdrColor render variable."""
     assert get_render_var_config(["rgb_hdr"]) == ("/Render/Vars/HdrColor", "HdrColor", "HdrColor")

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -111,9 +111,9 @@ def test_build_render_scope_usd_solid_background_color():
     assert 'token omni:rtx:background:source:type = "domeLight"' not in render_scope
 
 
-@pytest.mark.parametrize("minimal_mode", [None, 1])
-def test_build_render_scope_usd_disables_shadows_by_default(minimal_mode):
-    """Shadows are off by default in every render mode."""
+@pytest.mark.parametrize("enable_shadows,expected", [(False, "false"), (True, "true")])
+def test_build_render_scope_usd_authors_minimal_cast_shadows(enable_shadows, expected):
+    """enable_shadows drives the RTX Minimal shadow switch, and defaults to off."""
     render_scope = build_render_scope_usd(
         camera_paths=["/World/envs/env_0/Camera"],
         render_product_name="RenderProduct",
@@ -122,14 +122,15 @@ def test_build_render_scope_usd_disables_shadows_by_default(minimal_mode):
         source_name="LdrColor",
         tiled_width=16,
         tiled_height=8,
-        minimal_mode=minimal_mode,
+        minimal_mode=1,
+        enable_shadows=enable_shadows,
     )
-    assert "bool omni:rtx:shadows:enabled = false" in render_scope
-    assert "bool omni:rtx:minimal:castShadows = false" in render_scope
+    assert f"bool omni:rtx:minimal:castShadows = {expected}" in render_scope
 
 
-def test_build_render_scope_usd_enable_shadows_opts_back_in():
-    """Setting enable_shadows re-enables the shadow toggles of every render mode."""
+@pytest.mark.parametrize("enable_shadows", [False, True])
+def test_build_render_scope_usd_omits_shadow_settings_outside_minimal_mode(enable_shadows):
+    """The path-traced modes have no shadow switch, so neither shadow setting is authored for them."""
     render_scope = build_render_scope_usd(
         camera_paths=["/World/envs/env_0/Camera"],
         render_product_name="RenderProduct",
@@ -138,18 +139,20 @@ def test_build_render_scope_usd_enable_shadows_opts_back_in():
         source_name="LdrColor",
         tiled_width=16,
         tiled_height=8,
-        enable_shadows=True,
+        enable_shadows=enable_shadows,
     )
-    assert "bool omni:rtx:shadows:enabled = true" in render_scope
-    assert "bool omni:rtx:minimal:castShadows = true" in render_scope
+    assert "castShadows" not in render_scope
+    # exists as a setting name but is never read by the path-tracing backends
+    assert "omni:rtx:shadows:enabled" not in render_scope
 
 
 def test_build_render_product_as_string_forwards_enable_shadows():
     """The render product builder passes enable_shadows through to the render scope."""
-    disabled, _ = build_render_product_as_string(width=16, height=8, num_envs=1, data_types=["rgb"])
-    enabled, _ = build_render_product_as_string(width=16, height=8, num_envs=1, data_types=["rgb"], enable_shadows=True)
-    assert "bool omni:rtx:shadows:enabled = false" in disabled
-    assert "bool omni:rtx:shadows:enabled = true" in enabled
+    kwargs = dict(width=16, height=8, num_envs=1, data_types=["simple_shading_full_mdl"], minimal_mode=3)
+    disabled, _ = build_render_product_as_string(**kwargs)
+    enabled, _ = build_render_product_as_string(**kwargs, enable_shadows=True)
+    assert "bool omni:rtx:minimal:castShadows = false" in disabled
+    assert "bool omni:rtx:minimal:castShadows = true" in enabled
 
 
 def test_ovrtx_rgb_hdr_uses_hdr_color_render_var():


### PR DESCRIPTION
# Description

Turns off shadows by default for the OVRTX renderer, in the one render mode that can turn them off.

`OVRTXRendererCfg` gains `enable_shadows`, defaulting to `False`. When the render product is in RTX
Minimal mode it authors `omni:rtx:minimal:castShadows` accordingly. Minimal mode is what the
`simple_shading_constant_diffuse`, `simple_shading_diffuse_mdl` and `simple_shading_full_mdl` data
types select, so those are the outputs this affects. Opt back in with
`OVRTXRendererCfg(enable_shadows=True)`.

## Screenshots

`simple_shading_full_mdl`, kit-less Newton scene, 640×480, single distant light at 45°, rendered
through the unmodified `Camera` / `OVRTXRendererCfg` path.

| `enable_shadows=True` | `enable_shadows=False` (new default) |
| --- | --- |
| ![minimal mode, shadows on](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/mataylor/ovrtx-shadow-evidence/ovrtx-minimal-shadows-on.png) | ![minimal mode, shadows off](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/mataylor/ovrtx-shadow-evidence/ovrtx-minimal-shadows-off.png) |

The pillar and sphere shadows are gone in the right-hand frame (`mean abs diff 1.49`, `max 116`,
1.3% of pixels differing by more than `8/255`).

## Why the path-traced modes are not covered

RTPT and PathTracing provide no shadow switch — they always trace shadows. `omni:rtx:shadows:enabled`
exists as a setting name and authors onto the render product without error, but it only feeds
`renderConfig.shadows`, which no path-tracing backend reads. It is inert in every OVRTX mode.

An earlier revision of this PR authored it alongside `castShadows`; that has been removed rather than
left in place advertising a control that does nothing. `enable_shadows` therefore does not change
`rgb` or the other AOV outputs, and the config docstring says so.

## Testing

* `source/isaaclab_ov/test/test_ovrtx_usd.py` — covers the authored attribute in Minimal mode, and
  that neither shadow setting is authored for the path-traced modes.
* `test_rendering_lift_kuka_homo_kitless[legacy-newton-ovrtx-simple_shading_full_mdl]` and
  `[legacy-newton-ovrtx_renderer-static]` both pass against their existing golden images.

## Type of change

- New feature (non-breaking change which adds functionality)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
