### PR TITLE
[Docs] Document CloudXR port 49100 conflict troubleshooting

### DIFF
--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -349,15 +349,17 @@ Isaac Lab is now ready to receive connections from a CloudXR client.
 
 .. note::
 
-   **``ERROR_STREAMSDK_PORT_UNAVAILABLE`` / port 49100 already in use.** The CloudXR runtime
+   **ERROR_STREAMSDK_PORT_UNAVAILABLE / port 49100 already in use.** The CloudXR runtime
    binds TCP port 49100 for WebRTC signaling. If a previous CloudXR runtime instance is still
-   running, ``Server::create`` fails with this error. Find and stop the process holding the
-   port, then retry:
+   running, ``Server::create`` fails with this error. Identify the process holding the port,
+   confirm it is safe to stop, then terminate it -- try a graceful ``kill`` before escalating
+   to ``kill -9``:
 
    .. code-block:: bash
 
       ss -tlnp | grep 49100  # or: lsof -i :49100
-      lsof -ti tcp:49100 | xargs -r kill -9
+      kill $(lsof -ti tcp:49100)       # SIGTERM first
+      kill -9 $(lsof -ti tcp:49100)    # only if it is still running
 
    Alternatively, set a different port with the ``NV_CXR_SERVER_PORT`` environment variable.
 

--- a/docs/source/how-to/cloudxr_teleoperation.rst
+++ b/docs/source/how-to/cloudxr_teleoperation.rst
@@ -347,6 +347,20 @@ Isaac Lab is now ready to receive connections from a CloudXR client.
    CloudXR client connects. The ``--headless`` flag was removed in Isaac Lab 3.0; ``HEADLESS=1``
    in the environment also forces headless.
 
+.. note::
+
+   **``ERROR_STREAMSDK_PORT_UNAVAILABLE`` / port 49100 already in use.** The CloudXR runtime
+   binds TCP port 49100 for WebRTC signaling. If a previous CloudXR runtime instance is still
+   running, ``Server::create`` fails with this error. Find and stop the process holding the
+   port, then retry:
+
+   .. code-block:: bash
+
+      ss -tlnp | grep 49100  # or: lsof -i :49100
+      lsof -ti tcp:49100 | xargs -r kill -9
+
+   Alternatively, set a different port with the ``NV_CXR_SERVER_PORT`` environment variable.
+
 
 .. _connect-xr-device:
 


### PR DESCRIPTION
  ## Description

  QA reported that CloudXR teleoperation (`isaaclab teleop run --xr`) failed with
  `Server::create failed: Result::ERROR_STREAMSDK_PORT_UNAVAILABLE` because TCP port
  49100 (used for CloudXR.js WebRTC signaling) was already bound by a leftover CloudXR
  runtime process. Killing the stale process resolved the issue, and QA requested a
  documentation note so future users can self-diagnose this without filing a ticket.
 
  This PR adds a "Known Issues" entry to the CloudXR teleoperation guide describing the
  error, how to check which process is holding port 49100, and how to free it or select
  a different port via `NV_CXR_SERVER_PORT`.
 
  Fixes # (issue)
  
  ## Type of change

  - Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
 
  ## Checklist
  
  - [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
  - [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
  - [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there