### PR TITLE
[Backport release/3.0.0] Consolidate multi-GPU documentation

### DIFF
--- a/docs/source/features/include/cluster_details.inc
+++ b/docs/source/features/include/cluster_details.inc
@@ -204,7 +204,7 @@ conversion is needed and there is no code copy step -- the image is the unit of 
 
 The workflow definition lives in ``docker/cluster/osmo_multi_gpu_workflow.yaml``. It requests a
 single node and scales training across the GPUs on that node through the
-:ref:`train_multigpu <train-multigpu-command>` command. The following parameters can be overridden
+:ref:`train_multigpu <train_multigpu-command>` command. The following parameters can be overridden
 at submission time:
 
 .. list-table::

--- a/docs/source/features/multi_gpu.rst
+++ b/docs/source/features/multi_gpu.rst
@@ -1,508 +1,380 @@
+.. _train_multigpu-command:
+
 Multi-GPU and Multi-Node Training
 =================================
 
-.. currentmodule:: isaaclab
+Scale one reinforcement learning job across the GPUs in a workstation or across
+several nodes with ``train_multigpu``. Isaac Lab starts one training process per
+GPU, gives each process its own simulation environments, and synchronizes policy
+updates across the processes.
 
-Isaac Lab supports multi-GPU and multi-node reinforcement learning. Currently, this feature is only
-available for RL-Games, RSL-RL and skrl libraries workflows. We are working on extending this feature to
-other workflows.
+The same launcher model is used in three multi-GPU benchmarks for measuring startup,
+simulation, and end-to-end training performance.
 
 .. attention::
 
-    Multi-GPU and multi-node training is only supported on Linux. Windows support is not available at this time.
-    This is due to limitations of the NCCL library on Windows.
-
-
-Multi-GPU Training
-------------------
-
-Isaac Lab supports the following multi-GPU training frameworks:
-
-* `Torchrun <https://docs.pytorch.org/docs/stable/elastic/run.html>`_ through `PyTorch distributed <https://pytorch.org/docs/stable/distributed.html>`_
-* `JAX distributed <https://jax.readthedocs.io/en/latest/jax.distributed.html>`_
-
-Pytorch Torchrun Implementation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We are using `Pytorch Torchrun <https://docs.pytorch.org/docs/stable/elastic/run.html>`_ to manage multi-GPU
-training. Torchrun manages the distributed training by:
-
-* **Process Management**: Launching one process per GPU, where each process is assigned to a specific GPU.
-* **Script Execution**: Running the same training script (e.g., RL Games trainer) on each process.
-* **Environment Instances**: Each process creates its own instance of the Isaac Lab environment.
-* **Gradient Synchronization**: Aggregating gradients across all processes and broadcasting the synchronized
-  gradients back to each process after each training step.
-
-.. tip::
-    Check out this `3 minute youtube video from PyTorch <https://www.youtube.com/watch?v=Cvdhwx-OBBo&list=PL_lsbAsL_o2CSuhUhJIiW0IkdT5C2wGWj&index=2>`_
-    to understand how Torchrun works.
-
-The key components in this setup are:
-
-* **Torchrun**: Handles process spawning, communication, and gradient synchronization.
-* **RL Library**: The reinforcement learning library that runs the actual training algorithm.
-* **Isaac Lab**: Provides the simulation environment that each process instantiates independently.
-
-Under the hood, Torchrun uses the `DistributedDataParallel <https://docs.pytorch.org/docs/2.7/notes/ddp.html#internal-design>`_
-module to manage the distributed training. When training with multiple GPUs using Torchrun, the following happens:
-
-* Each GPU runs an independent process
-* Each process executes the full training script
-* Each process maintains its own:
-
-  * Isaac Lab environment instance (with *n* parallel environments)
-  * Policy network copy
-  * Experience buffer for rollout collection
-
-* All processes synchronize only for gradient updates
-
-For a deeper dive into how Torchrun works, checkout
-`PyTorch Docs: DistributedDataParallel - Internal Design <https://pytorch.org/docs/stable/notes/ddp.html#internal-design>`_.
-
-Console Output From Multiple Ranks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Because every rank executes the full training script, every rank also writes the same startup banners,
-simulation warnings, and model summaries. Without filtering, that output is repeated once per GPU, which
-makes an eight-GPU log nearly unreadable.
-
-``train_multigpu`` therefore restricts console output to local rank 0 by default, by passing torchrun's
-``--local_ranks_filter``. Per-iteration training metrics are already reported by global rank 0 alone, so
-the filtered log contains the same information with none of the repetition. Because the filter is applied
-per node, a multi-node launch shows one copy of the startup output per node rather than one in total.
-
-Failures are still reported. ``train.py`` wraps its entry point in
-`torch.distributed.elastic record <https://pytorch.org/docs/stable/elastic/errors.html>`_, so when any
-rank crashes, torchrun names the failing rank and prints its traceback as the root cause, even though
-that rank's console output is otherwise hidden.
-
-To see the raw output from every rank, for example when ranks disagree about the environment they built:
-
-.. code-block:: shell
-
-    uv run isaaclab train_multigpu --rl_library rsl_rl --task Isaac-Cartpole --log_all_ranks
-
-To keep every rank's output while still reading a clean console, write per-rank log files instead:
-
-.. code-block:: shell
-
-    uv run isaaclab train_multigpu --rl_library rsl_rl --task Isaac-Cartpole --tee 3 --log_dir /tmp/ranklogs
-
-This writes ``stdout.log`` and ``stderr.log`` per rank under ``--log_dir`` while the console still shows
-only local rank 0.
-
-.. note::
-
-    This applies to the torchrun path. skrl with ``--ml_framework jax`` uses skrl's own launcher, which
-    does not support rank filtering, so all ranks write to the console.
-
-Jax Implementation
-^^^^^^^^^^^^^^^^^^
-
-.. tip::
-    JAX is only supported with the skrl library.
-
-With JAX, we are using `skrl.utils.distributed.jax <https://skrl.readthedocs.io/en/latest/api/utils/distributed.html>`_
-Since the ML framework doesn't automatically start multiple processes from a single program invocation,
-the skrl library provides a module to start them.
-
-.. image:: ../_static/multi-gpu-rl/a3c-light.svg
-    :class: only-light
-    :align: center
-    :alt: Multi-GPU training paradigm
-    :width: 80%
-
-.. image:: ../_static/multi-gpu-rl/a3c-dark.svg
-    :class: only-dark
-    :align: center
-    :width: 80%
-    :alt: Multi-GPU training paradigm
-
-|
-
-Running Multi-GPU Training
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To train with multiple GPUs, use the following command, where ``--nproc_per_node`` represents the number of available GPUs:
-
-.. tab-set::
-    :sync-group: rl-train
-
-    .. tab-item:: rl_games
-        :sync: rl_games
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: rsl_rl
-        :sync: rsl_rl
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: skrl
-        :sync: skrl
-
-        .. tab-set::
-
-            .. tab-item:: PyTorch
-                :sync: torch
-
-                .. code-block:: shell
-
-                    python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed
-
-            .. tab-item:: JAX
-                :sync: jax
-
-                .. code-block:: shell
-
-                    python -m skrl.utils.distributed.jax --nnodes=1 --nproc_per_node=2 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed --ml_framework jax
-
-.. _multi-gpu-nccl-troubleshooting:
-
-Troubleshooting NCCL Errors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-On some Linux multi-GPU systems, distributed training may fail with
-``CUDA error: an illegal memory access was encountered`` reported by ``ProcessGroupNCCL``
-during or shortly after communicator initialization.
-
-If this occurs, try disabling the NCCL shared-memory transport before launching training:
-
-.. code-block:: shell
-
-    export NCCL_SHM_DISABLE=1
-
-If the issue persists, additional NCCL fallbacks that may help are:
-
-.. code-block:: shell
-
-    export NCCL_IB_DISABLE=1
-    export NCCL_ALGO=Ring
-
-When the failure only occurs with RTX rendering enabled (for example, for camera-based tasks),
-CUDA and the renderer may enumerate the same GPUs in different orders. Make CUDA enumerate GPUs
-by ascending PCI bus ID before launching training:
-
-.. code-block:: shell
-
-    export CUDA_DEVICE_ORDER=PCI_BUS_ID
-
-This changes the CUDA device ordinals, but not which GPUs are visible. The PCI bus IDs and their
-corresponding GPUs can be inspected with ``nvidia-smi --query-gpu=name,pci.bus_id``.
-
-On some multi-GPU systems, distributed training with RTX rendering enabled (for example,
-camera-based tasks) fails when the participating GPUs span
-multiple NUMA nodes, while the same training runs fine on GPUs attached to a single PCIe
-switch. The failure typically surfaces as a hang or abort on one of the first collectives,
-with ``Watchdog caught collective operation timeout: WorkNCCL(..., OpType=BROADCAST, ...)``
-or ``OpType=ALLREDUCE`` reported by ``ProcessGroupNCCL``, and does not occur when rendering
-is disabled. On affected systems, disabling NCCL's cuMem host-memory allocations resolves
-the failure:
-
-.. code-block:: shell
-
-    export NCCL_CUMEM_HOST_ENABLE=0
-
-If the failure persists, disable NCCL's CUDA virtual-memory-management allocator entirely:
-
-.. code-block:: shell
-
-    export NCCL_CUMEM_ENABLE=0
-
-Separately, on systems where the GPUs are connected over PCIe without NVLink (check with
-``nvidia-smi topo -m``; affected systems show only ``PHB``, ``NODE``, or ``SYS`` links and no
-``NV#`` links), training can hang during communicator initialization or on the first collective,
-with no error reported and the participating GPUs spinning at 100% utilization. This is most
-commonly seen with a **world size of 2**, because NCCL selects a direct peer-to-peer (P2P)
-transport for a two-rank communicator; the same job often runs fine at three or more ranks, which
-can make the failure look intermittent or task-specific.
-
-A two-rank world size arises both from ``--num_gpus 2`` (or ``--nproc_per_node=2``) on a larger
-machine and from restricting visible devices with ``CUDA_VISIBLE_DEVICES=0,1``. On affected
-systems, disabling NCCL's P2P transport resolves the hang:
-
-.. code-block:: shell
-
-    export NCCL_P2P_DISABLE=1
-
-The same restriction can be expressed with NCCL's topology cutoff:
-
-.. code-block:: shell
-
-    export NCCL_P2P_LEVEL=LOC
-
-In NCCL, ``LOC`` means that P2P is never used between GPUs, so set either
-``NCCL_P2P_DISABLE=1`` or ``NCCL_P2P_LEVEL=LOC`` rather than both.
-
-Then relaunch the distributed training command as usual.
-
-To confirm the problem is NCCL rather than Isaac Lab, reproduce it without Isaac Lab in the loop.
-Save the following as ``nccl_probe.py``:
-
-.. code-block:: python
-
-    import os, torch, torch.distributed as dist
-
-    local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
-    dist.init_process_group("nccl")
-    tensor = torch.ones(1024, device=f"cuda:{local_rank}")
-    dist.all_reduce(tensor)
-    torch.cuda.synchronize()
-    print(f"rank {dist.get_rank()} ok", flush=True)
-    dist.destroy_process_group()
-
-Then run it at the world size that hangs, and at a larger one:
-
-.. code-block:: shell
-
-    python -m torch.distributed.run --nproc_per_node 2 nccl_probe.py
-    python -m torch.distributed.run --nproc_per_node 4 nccl_probe.py
-
-If the probe hangs, the problem is in NCCL or the system topology, not in Isaac Lab or the RL
-library. Re-run the hanging case with ``NCCL_P2P_DISABLE=1`` to confirm the workaround before
-applying it to training.
-
-.. note::
-
-    These variables are NCCL-level workarounds intended for affected systems. They are not
-    required on all machines, and may change communication behavior or performance depending
-    on the hardware topology. In particular, ``NCCL_P2P_DISABLE=1`` and
-    ``NCCL_P2P_LEVEL=LOC`` prevent direct P2P communication and force NCCL to select another
-    transport, which can reduce communication bandwidth, so only set one after confirming it
-    resolves an observed hang.
-
-Multi-Node Training
--------------------
-
-To scale up training beyond multiple GPUs on a single machine, it is also possible to train across multiple nodes.
-To train across multiple nodes/machines, it is required to launch an individual process on each node.
-
-For the master node, use the following command, where ``--nproc_per_node`` represents the number of available GPUs, and
-``--nnodes`` represents the number of nodes:
-
-.. tab-set::
-    :sync-group: rl-train
-
-    .. tab-item:: rl_games
-        :sync: rl_games
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: rsl_rl
-        :sync: rsl_rl
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: skrl
-        :sync: skrl
-
-        .. tab-set::
-
-            .. tab-item:: PyTorch
-                :sync: torch
-
-                .. code-block:: shell
-
-                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed
-
-            .. tab-item:: JAX
-                :sync: jax
-
-                .. code-block:: shell
-
-                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=0 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed --ml_framework jax
-
-Note that the port (``5555``) can be replaced with any other available port.
-
-For non-master nodes, use the following command, replacing ``--node_rank`` with the index of each machine:
-
-.. tab-set::
-    :sync-group: rl-train
-
-    .. tab-item:: rl_games
-        :sync: rl_games
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rl_games --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: rsl_rl
-        :sync: rsl_rl
-
-        .. code-block:: shell
-
-            python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library rsl_rl --task=Isaac-Cartpole --distributed
-
-    .. tab-item:: skrl
-        :sync: skrl
-
-        .. tab-set::
-
-            .. tab-item:: PyTorch
-                :sync: torch
-
-                .. code-block:: shell
-
-                    python -m torch.distributed.run --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr=<ip_of_master> --master_port=5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed
-
-            .. tab-item:: JAX
-                :sync: jax
-
-                .. code-block:: shell
-
-                    python -m skrl.utils.distributed.jax --nproc_per_node=2 --nnodes=2 --node_rank=1 --coordinator_address=ip_of_master_machine:5555 scripts/reinforcement_learning/train.py --rl_library skrl --task=Isaac-Cartpole --distributed --ml_framework jax
-
-For more details on multi-node training with PyTorch, please visit the
-`PyTorch documentation <https://pytorch.org/tutorials/intermediate/ddp_series_multinode.html>`_.
-For more details on multi-node training with JAX, please visit the
-`skrl documentation <https://skrl.readthedocs.io/en/latest/api/utils/distributed.html>`_ and the
-`JAX documentation <https://jax.readthedocs.io/en/latest/multi_process.html>`_.
-
-.. note::
-
-    As mentioned in the PyTorch documentation, "multi-node training is bottlenecked by inter-node communication
-    latencies". When this latency is high, it is possible multi-node training will perform worse than running on
-    a single node instance.
-
-.. _train-multigpu-command:
-
-``train_multigpu`` Command (Experimental)
------------------------------------------
+   Multi-GPU and multi-node training requires Linux and NVIDIA NCCL. Windows is
+   not supported.
 
 .. warning::
 
-   This command is experimental and subject to change in future releases.
+   ``train_multigpu`` is experimental and may change in a future release.
 
-Isaac Lab provides a ``train_multigpu`` convenience script that wraps the distributed launchers,
-adds ``--distributed`` automatically, and forwards remaining arguments to the selected training library.
-It defaults to ``rsl_rl`` and uses ``torch.distributed.run`` for torch-based workflows.
+Start a multi-GPU training run
+------------------------------
 
-Single-node training (defaults to all available GPUs):
+First, verify that the task trains on one GPU. This separates task or
+configuration problems from distributed-launch problems:
 
-.. tab-set::
-    :sync-group: launcher
+.. code-block:: bash
 
-    .. tab-item:: isaaclab.sh
-        :sync: isaaclab
+   uv run isaaclab train --task Isaac-Cartpole
 
-        .. tab-set::
+Then run the same task on every visible GPU:
 
-           .. tab-item:: uv (Recommended)
+.. code-block:: bash
 
-              .. code-block:: bash
+   uv run isaaclab train_multigpu --task Isaac-Cartpole
 
-                  uv run python scripts/reinforcement_learning/train_multigpu.py \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+That is the complete transition from a single-GPU run. ``train_multigpu`` adds
+``--distributed`` and selects the distributed launcher automatically. All other
+arguments are the same arguments accepted by ``train``:
 
-           .. tab-item:: isaaclab.sh / isaaclab.bat
+.. code-block:: bash
 
-              .. code-block:: bash
+   uv run isaaclab train_multigpu \
+      --task Isaac-Reorient-KukaAllegro \
+      --num_envs 4096 \
+      --max_iterations 100
 
-                  ./isaaclab.sh -p scripts/reinforcement_learning/train_multigpu.py \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+``--num_envs`` is the number of environments **on each GPU**. With four GPUs and
+``--num_envs 4096``, the job collects experience from 16,384 environments in
+total.
 
-    .. tab-item:: uv run
-        :sync: uv
+.. tip::
 
-        .. code-block:: bash
+   Add ``--dry_run`` to print the resolved launcher command without starting
+   training. This is useful when checking GPU counts, rendezvous options, or
+   forwarded training arguments.
 
-            uv run isaaclab train_multigpu \
-               --task Isaac-Reorient-KukaAllegro \
-               --num_envs 4096 --max_iterations 100
+Choose the GPUs
+~~~~~~~~~~~~~~~
 
-Override the GPU count or torchrun settings when needed:
+By default, the launcher uses every visible GPU. Set ``--num_gpus`` when you want
+a specific worker count:
 
-.. tab-set::
-    :sync-group: launcher
+.. code-block:: bash
 
-    .. tab-item:: isaaclab.sh
-        :sync: isaaclab
+   uv run isaaclab train_multigpu --num_gpus 2 --task Isaac-Cartpole
 
-        .. tab-set::
+Use ``CUDA_VISIBLE_DEVICES`` to choose the physical devices. The launcher sees
+only the devices in that list:
 
-           .. tab-item:: uv (Recommended)
+.. code-block:: bash
 
-              .. code-block:: bash
+   CUDA_VISIBLE_DEVICES=1,3 uv run isaaclab train_multigpu \
+      --num_gpus 2 --task Isaac-Cartpole
 
-                  uv run python scripts/reinforcement_learning/train_multigpu.py \
-                     --num_gpus 4 --master_port 29504 \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+Run ``nvidia-smi`` before launching to confirm that the expected devices are
+available and have enough free memory.
 
-           .. tab-item:: isaaclab.sh / isaaclab.bat
+Choose an RL library
+~~~~~~~~~~~~~~~~~~~~
 
-              .. code-block:: bash
+Multi-GPU training supports RSL-RL, RL-Games, and skrl. RSL-RL is the default
+for most core tasks.
 
-                  ./isaaclab.sh -p scripts/reinforcement_learning/train_multigpu.py \
-                     --num_gpus 4 --master_port 29504 \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+.. list-table::
+   :header-rows: 1
+   :widths: 18 22 60
 
-    .. tab-item:: uv run
-        :sync: uv
+   * - Library
+     - Distributed backend
+     - Command
+   * - RSL-RL
+     - PyTorch
+     - ``uv run isaaclab train_multigpu --rl_library rsl_rl ...``
+   * - RL-Games
+     - PyTorch
+     - ``uv run --extra rl-games isaaclab train_multigpu --rl_library rl_games ...``
+   * - skrl
+     - PyTorch
+     - ``uv run --extra skrl isaaclab train_multigpu --rl_library skrl ...``
+   * - skrl
+     - JAX
+     - ``uv run --extra skrl isaaclab train_multigpu --rl_library skrl --ml_framework jax ...``
 
-        .. code-block:: bash
+skrl with JAX uses skrl's distributed launcher instead of ``torchrun``. Pass an
+integer ``--num_gpus`` and use ``--coordinator_address`` to configure its
+coordinator:
 
-            uv run isaaclab train_multigpu --num_gpus 4 --master_port 29504 \
-               --task Isaac-Reorient-KukaAllegro \
-               --num_envs 4096 --max_iterations 100
+.. code-block:: bash
 
-Use ``--rl_library`` to select other distributed-capable libraries (``rsl_rl``, ``rl_games``, or ``skrl``).
-For skrl JAX training, pass an integer GPU count and the ``--coordinator_address``:
+   uv run --extra skrl isaaclab train_multigpu \
+      --rl_library skrl --ml_framework jax --num_gpus 4 \
+      --coordinator_address localhost:5000 \
+      --task Isaac-Cartpole
 
-.. tab-set::
-    :sync-group: launcher
+Measure scaling with the three multi-GPU benchmarks
+---------------------------------------------------
 
-    .. tab-item:: isaaclab.sh
-        :sync: isaaclab
+Use the benchmark commands when the goal is to measure performance rather than
+train a policy for later use. Isaac Lab provides three multi-GPU workflows:
 
-        .. tab-set::
+.. list-table::
+   :header-rows: 1
+   :widths: 24 38 38
 
-           .. tab-item:: uv (Recommended)
+   * - Benchmark
+     - What it measures
+     - Use it to answer
+   * - ``startup_multigpu``
+     - Startup time for rank 0 while every GPU starts the same workload.
+     - How does a fully occupied node affect startup?
+   * - ``runtime_multigpu``
+     - Simulation throughput for rank 0 while every GPU runs independently.
+     - How does host contention affect environment stepping?
+   * - ``training_multigpu``
+     - Global, synchronized training throughput across every rank.
+     - How well does end-to-end learning scale across GPUs?
 
-              .. code-block:: bash
+Run each benchmark with the same launcher options used by ``train_multigpu``:
 
-                  uv run --extra skrl python scripts/reinforcement_learning/train_multigpu.py \
-                     --rl_library skrl --ml_framework jax --num_gpus 4 \
-                     --coordinator_address localhost:5000 \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+.. code-block:: bash
 
-           .. tab-item:: isaaclab.sh / isaaclab.bat
+   uv run isaaclab benchmark startup_multigpu \
+      --num_gpus 2 --task Isaac-Cartpole
 
-              .. code-block:: bash
+   uv run isaaclab benchmark runtime_multigpu \
+      --num_gpus 2 --task Isaac-Cartpole --num_envs 4096
 
-                  ./isaaclab.sh -p scripts/reinforcement_learning/train_multigpu.py \
-                     --rl_library skrl --ml_framework jax --num_gpus 4 \
-                     --coordinator_address localhost:5000 \
-                     --task Isaac-Reorient-KukaAllegro \
-                     --num_envs 4096 --max_iterations 100
+   uv run isaaclab benchmark training_multigpu \
+      --rl_library rsl_rl --num_gpus 2 \
+      --task Isaac-Cartpole --num_envs 4096 --max_iterations 100
 
-    .. tab-item:: uv run
-        :sync: uv
+``training_multigpu`` supports RSL-RL, RL-Games, and skrl with PyTorch. It does
+not support skrl with JAX or SB3. It also rejects ``--video``,
+``--capture_env_sensors``, and ``--check_success``, which do not produce a
+meaningful aggregate result across ranks.
 
-        .. code-block:: bash
+For multi-node benchmarks, pass the same ``--nnodes``, ``--node_rank``, and
+rendezvous options described in :ref:`multi-node-training` on every node.
 
-            uv run --extra skrl isaaclab train_multigpu --rl_library skrl --ml_framework jax --num_gpus 4 \
-               --coordinator_address localhost:5000 \
-               --task Isaac-Reorient-KukaAllegro \
-               --num_envs 4096 --max_iterations 100
+Read multi-GPU benchmark results
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For multi-node torch jobs, pass torchrun settings such as ``--nnodes``, ``--node_rank``,
-``--rdzv_backend``, ``--rdzv_endpoint``, and ``--rdzv_id`` before the training arguments. For
-skrl JAX multi-node jobs, pass ``--nnodes``, ``--node_rank``, and ``--coordinator_address``.
+Only global rank 0 writes a result bundle. The ``extra`` fields record the rank
+layout and clarify which measurements the bundle covers:
 
-To measure aggregate throughput and timing rather than to train a policy, use the multi-GPU
-benchmark workflows instead; see :ref:`testing_benchmarks_multigpu`. They take the same launcher
-options and support RSL-RL, RL-Games, and skrl with Torch.
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - ``extra`` field
+     - Meaning
+   * - ``world_size``, ``local_world_size``, ``num_nodes``
+     - Rank layout of the job.
+   * - ``num_envs_per_rank``
+     - Environments hosted by each rank.
+   * - ``workload_scope``
+     - ``global`` for ``training_multigpu`` because ranks train in lockstep.
+       ``rank0`` for ``startup_multigpu`` and ``runtime_multigpu`` because each
+       rank runs independently and only rank 0 is measured.
+   * - ``measurement_scope``
+     - ``rank0_process``: timings, learning curves, CPU, and RAM come from rank
+       0 alone.
+   * - ``gpu_measurement_scope``
+     - ``rank0_node``: ``resources.devices`` reports every GPU visible to rank
+       0. GPU utilization and memory values remain scoped to rank 0's device.
+
+When comparing one GPU with multiple GPUs, keep ``--num_envs`` constant **per
+rank**. An N-GPU job processes N times as many environments as the one-GPU job
+at the same per-rank setting. Compare the global throughput of
+``training_multigpu`` against N times the single-GPU throughput. Do not treat
+``startup_multigpu`` or ``runtime_multigpu`` as aggregate rates; they measure
+rank 0 while the other ranks create host contention.
+
+How multi-GPU training works
+----------------------------
+
+For PyTorch workflows, ``train_multigpu`` wraps
+`torchrun <https://docs.pytorch.org/docs/stable/elastic/run.html>`_. It launches
+one process per GPU. Each process owns:
+
+* one Isaac Lab application and its vectorized environments,
+* one copy of the policy,
+* one rollout buffer, and
+* one GPU selected by its local rank.
+
+The processes collect experience independently and synchronize gradients during
+policy updates with
+`DistributedDataParallel <https://docs.pytorch.org/docs/stable/notes/ddp.html>`_.
+Simulation does not move between GPUs, so available host CPU, RAM, and I/O can
+become limiting factors as the GPU count grows.
+
+.. image:: ../_static/multi-gpu-rl/a3c-light.svg
+   :class: only-light
+   :align: center
+   :alt: One training process and simulation workload per GPU
+   :width: 80%
+
+.. image:: ../_static/multi-gpu-rl/a3c-dark.svg
+   :class: only-dark
+   :align: center
+   :alt: One training process and simulation workload per GPU
+   :width: 80%
+
+Read logs from distributed runs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every rank produces similar startup messages, warnings, and model summaries.
+The launcher shows local rank 0 by default so the console remains readable.
+Training metrics already come from global rank 0, and a crash on any hidden rank
+still reports the failing rank and its traceback.
+
+Show output from every rank when processes appear to disagree:
+
+.. code-block:: bash
+
+   uv run isaaclab train_multigpu \
+      --task Isaac-Cartpole --log_all_ranks
+
+For a clean console and complete per-rank logs on disk, use ``torchrun`` log
+redirection:
+
+.. code-block:: bash
+
+   uv run isaaclab train_multigpu \
+      --task Isaac-Cartpole --tee 3 --log_dir /tmp/isaaclab-rank-logs
+
+The log filtering options apply to PyTorch workflows. skrl with JAX writes every
+rank to the console.
+
+.. _multi-node-training:
+
+Train across multiple nodes
+---------------------------
+
+Every node must have the same Isaac Lab checkout, dependencies, task
+configuration, and access to training assets. The nodes must also be able to
+reach one another on the rendezvous port.
+
+Choose one node as the rendezvous host. For a two-node PyTorch job with four GPUs
+per node, run the following on the first node:
+
+.. code-block:: bash
+
+   uv run isaaclab train_multigpu \
+      --nnodes 2 --node_rank 0 --num_gpus 4 \
+      --master_addr 10.0.0.10 --master_port 29500 \
+      --task Isaac-Cartpole
+
+Run the same command on the second node with its own rank:
+
+.. code-block:: bash
+
+   uv run isaaclab train_multigpu \
+      --nnodes 2 --node_rank 1 --num_gpus 4 \
+      --master_addr 10.0.0.10 --master_port 29500 \
+      --task Isaac-Cartpole
+
+The total world size is ``nnodes * num_gpus``: eight ranks in this example. You
+can also use ``--rdzv_backend``, ``--rdzv_endpoint``, and ``--rdzv_id`` for an
+elastic ``torchrun`` rendezvous. Add ``--dry_run`` first to verify the command on
+each node.
+
+For skrl with JAX, pass ``--nnodes``, ``--node_rank``, an integer
+``--num_gpus``, and the same ``--coordinator_address`` on every node. Do not pass
+the PyTorch rendezvous options to a JAX launch.
+
+Multi-node scaling depends heavily on the network between nodes. A multi-node
+job can be slower than a single-node job when gradient synchronization dominates
+the training iteration.
+
+Troubleshoot distributed training
+---------------------------------
+
+Start with the smallest useful diagnosis:
+
+#. Confirm that the same task, backend, and training arguments work with
+   ``isaaclab train`` on one GPU.
+#. Add ``--dry_run`` and check the selected GPU and node counts.
+#. Retry at world sizes 2, 3, and 4. A failure at only one world size often
+   points to the communication transport rather than the task.
+#. Check GPU placement and interconnects with ``nvidia-smi topo -m``.
+#. Set ``NCCL_DEBUG=INFO`` to see which NCCL transport was selected.
+#. Apply one workaround at a time and verify that the failure returns when the
+   workaround is removed.
+
+.. _multi-gpu-nccl-troubleshooting:
+
+NCCL hangs and errors
+~~~~~~~~~~~~~~~~~~~~~
+
+A run that stops without a traceback while every participating GPU remains at
+100% utilization is usually stalled in an NCCL collective. The following
+workarounds address known system-specific transport problems:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 55 45
+
+   * - Symptom
+     - Try
+   * - World size 2 hangs on a PCIe system without NVLink.
+     - ``NCCL_P2P_DISABLE=1`` or ``NCCL_P2P_LEVEL=LOC``
+   * - ``illegal memory access`` appears in ``ProcessGroupNCCL``.
+     - ``NCCL_SHM_DISABLE=1``
+   * - A rendered job fails because CUDA and the renderer enumerate GPUs in
+       different orders.
+     - ``CUDA_DEVICE_ORDER=PCI_BUS_ID``
+   * - A rendered job times out across NUMA nodes during ``BROADCAST`` or
+       ``ALLREDUCE``.
+     - ``NCCL_CUMEM_HOST_ENABLE=0``; if needed, try ``NCCL_CUMEM_ENABLE=0``.
+   * - Communicator initialization or transport failures persist.
+     - ``NCCL_IB_DISABLE=1`` or ``NCCL_ALGO=Ring``.
+
+For example, test the first workaround without changing a shared configuration:
+
+.. code-block:: bash
+
+   NCCL_P2P_DISABLE=1 uv run isaaclab train_multigpu \
+      --num_gpus 2 --task Isaac-Cartpole
+
+These variables can reduce communication performance and should be scoped to
+the affected machine. Set either ``NCCL_P2P_DISABLE=1`` or
+``NCCL_P2P_LEVEL=LOC``, not both. Each prevents direct P2P communication and
+can reduce bandwidth by forcing NCCL to select another transport. Do not commit
+a workaround into a task or launcher unless it is required by every supported
+system. Use ``nvidia-smi --query-gpu=name,pci.bus_id`` to inspect GPU bus IDs
+before setting ``CUDA_DEVICE_ORDER=PCI_BUS_ID``.
+
+.. dropdown:: Isolate a hang from Isaac Lab
+
+   Run a minimal NCCL collective at the world size that hangs. Save this as
+   ``nccl_probe.py``:
+
+   .. code-block:: python
+
+      import os
+
+      import torch
+      import torch.distributed as dist
+
+      local_rank = int(os.environ["LOCAL_RANK"])
+      torch.cuda.set_device(local_rank)
+      dist.init_process_group("nccl")
+      tensor = torch.ones(1024, device=f"cuda:{local_rank}")
+      dist.all_reduce(tensor)
+      torch.cuda.synchronize()
+      print(f"rank {dist.get_rank()} ok", flush=True)
+      dist.destroy_process_group()
+
+   Launch the probe with the same rank count:
+
+   .. code-block:: bash
+
+      uv run python -m torch.distributed.run --nproc_per_node 2 nccl_probe.py
+
+   If this probe also hangs, the problem is in NCCL or the system topology, not
+   in Isaac Lab, the task, or the RL library.

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -300,11 +300,12 @@ Benchmark a task
    * - ``play``
      - Trained-policy rollout throughput. Requires ``--rl_library`` and
        ``--checkpoint``.
-   * - ``-multigpu``
-     - Run ``startup``, ``runtime``, or ``training`` across multiple GPUs by adding the suffix ``-multigpu``. For example, ``runtime-multigpu``.
+   * - ``_multigpu``
+     - Run ``startup``, ``runtime``, or ``training`` across multiple GPUs by
+       adding the suffix ``_multigpu``. For example, ``runtime_multigpu``.
 
-See :ref:`testing_benchmarks` for warm-up, formatters, multi-GPU details, and
-how to read results.
+See :ref:`testing_benchmarks` for benchmark fundamentals and
+:ref:`train_multigpu-command` for multi-GPU training and benchmarks.
 
 Next steps
 ----------

--- a/docs/source/testing/benchmarks.rst
+++ b/docs/source/testing/benchmarks.rst
@@ -32,7 +32,7 @@ Choose A Workflow
    * - Launch, import, configuration, scene creation, or first-step latency
      - ``startup``
    * - Any of the above across several GPUs
-     - ``<workflow>-multigpu``
+     - ``<workflow>_multigpu``
    * - One asset or sensor operation
      - :ref:`testing_micro_benchmarks`
 
@@ -343,90 +343,10 @@ they established final policy quality.
 Multi-GPU
 ---------
 
-Use It When
-~~~~~~~~~~~
-
-Append ``-multigpu`` to ``startup``, ``runtime``, or ``training`` to run the same
-workflow with one rank per GPU. Use it to measure synchronized multi-GPU training
-throughput, or to measure how much a workflow slows down when every GPU on the
-node is busy.
-
-Command
-~~~~~~~
-
-.. code-block:: bash
-
-   ./isaaclab.sh benchmark training-multigpu \
-       --rl_library rsl_rl \
-       --num_gpus 2 \
-       --task Isaac-Cartpole-Direct \
-       --num_envs 4096 \
-       --max_iterations 100 \
-       --seed 42 \
-       --visualizer none \
-       --output_path ./benchmark_results/multigpu \
-       physics=isaacsim_physx
-
-The launcher accepts ``--num_gpus``, ``--nnodes``, ``--node_rank``, and the
-``torchrun`` rendezvous options, exactly like :ref:`train-multigpu-command`. Every
-other argument is forwarded to the single-GPU workflow unchanged. Add ``--dry_run``
-to print the ``torchrun`` command without running it, and ``--log_all_ranks`` to
-show console output from every rank instead of local rank 0 only.
-
-For a multi-node run, issue the same command on every node with a distinct
-``--node_rank``:
-
-.. code-block:: bash
-
-   ./isaaclab.sh benchmark training-multigpu \
-       --rl_library rsl_rl --nnodes 2 --node_rank 0 --num_gpus 8 \
-       --rdzv_backend c10d --rdzv_endpoint host0:29400 --rdzv_id bench \
-       --task Isaac-Cartpole-Direct
-
-``training-multigpu`` supports ``rsl_rl``, ``rl_games``, and ``skrl`` with Torch. It
-does not support skrl JAX or SB3, and it rejects ``--video``,
-``--capture_env_sensors``, and ``--check_success``, none of which are meaningful
-across ranks. Use :ref:`train-multigpu-command` for general distributed training.
-
-Read The Result
-~~~~~~~~~~~~~~~
-
-``--num_envs`` is the number of environments **per rank**, and each rank creates its
-own Isaac Lab instance on its own GPU. Only global rank 0 writes a bundle. What that
-bundle covers depends on the workflow, and ``extra`` records it:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 70
-
-   * - ``extra`` field
-     - Meaning
-   * - ``world_size``, ``local_world_size``, ``num_nodes``
-     - Rank layout of the job.
-   * - ``num_envs_per_rank``
-     - Environments hosted by each rank.
-   * - ``workload_scope``
-     - ``global`` for ``training-multigpu``: ranks train in lockstep, so ``run.num_envs``,
-       ``runtime.steps_per_iteration``, and every FPS field cover all ranks.
-       ``rank0`` for ``startup-multigpu`` and ``runtime-multigpu``: those ranks run
-       independent workloads, so the reported values are rank 0's own, measured while
-       the other ranks contend for the same host.
-   * - ``measurement_scope``
-     - ``rank0_process`` — timings, learning curves, CPU, and RAM come from rank 0 alone.
-   * - ``gpu_measurement_scope``
-     - ``rank0_node`` — ``resources.devices`` reports every GPU visible to rank 0, so a
-       single-node run shows all ranks. ``resources.gpu_util_pct`` and
-       ``resources.gpu_mem_gb`` remain scoped to rank 0's own device.
-
-Do Not Infer
-~~~~~~~~~~~~
-
-Do not compare a multi-GPU result against a single-GPU result at the same
-``--num_envs``: the multi-GPU run has ``world_size`` times as many environments. To
-measure scaling, compare the global throughput of an ``N``-GPU run against ``N``
-times the throughput of a single-GPU run at the same per-rank environment count. Do
-not read ``startup-multigpu`` or ``runtime-multigpu`` throughput as a global rate;
-their ``workload_scope`` is ``rank0``, and the other ranks were not measured.
+Append ``_multigpu`` to ``startup``, ``runtime``, or ``training`` to run one
+benchmark rank per GPU. The :ref:`train_multigpu-command` guide is the canonical
+reference for the three workflows, launcher options, multi-node setup, supported
+RL libraries, and result interpretation.
 
 Startup Profiling
 -----------------

--- a/source/isaaclab/changelog.d/mh-train-multigpu-docs.rst
+++ b/source/isaaclab/changelog.d/mh-train-multigpu-docs.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Standardized multi-GPU benchmark commands on the underscore suffix. Replace
+  ``startup-multigpu``, ``runtime-multigpu``, and ``training-multigpu`` with
+  ``startup_multigpu``, ``runtime_multigpu``, and ``training_multigpu``. The hyphenated forms
+  remain available as deprecated aliases.

--- a/source/isaaclab/isaaclab/benchmark/dispatch.py
+++ b/source/isaaclab/isaaclab/benchmark/dispatch.py
@@ -70,7 +70,7 @@ def run_benchmark_request(request: BenchmarkRequest) -> BenchmarkResult:
 def run_benchmark_cli(argv: list[str] | None = None) -> int:
     """Run a runtime, startup, training, or play benchmark from CLI arguments.
 
-    Appending ``-multigpu`` to a workflow name runs it across several GPUs; see
+    Appending ``_multigpu`` to a workflow name runs it across several GPUs; see
     :mod:`isaaclab.benchmark.entrypoints.multigpu`.
     """
     from .entrypoints import multigpu
@@ -79,13 +79,26 @@ def run_benchmark_cli(argv: list[str] | None = None) -> int:
         argv = sys.argv[1:]
     argv = _fuse_kit_args(argv)
     multigpu_workflows = tuple(f"{name}{multigpu.MULTIGPU_SUFFIX}" for name in multigpu.MULTIGPU_WORKFLOWS)
+    legacy_multigpu_workflows = tuple(
+        f"{name}{multigpu.LEGACY_MULTIGPU_SUFFIX}" for name in multigpu.MULTIGPU_WORKFLOWS
+    )
     parser = argparse.ArgumentParser(description="Run an Isaac Lab benchmark.")
-    parser.add_argument("workflow", choices=(*WORKFLOW_MODULES, *_RL_WORKFLOW_MODULES, *multigpu_workflows))
+    parser.add_argument(
+        "workflow",
+        choices=(*WORKFLOW_MODULES, *_RL_WORKFLOW_MODULES, *multigpu_workflows, *legacy_multigpu_workflows),
+    )
     if not argv or argv[0] in ("-h", "--help"):
         parser.parse_args(argv)
     selected = parser.parse_args(argv[:1])
     if selected.workflow in multigpu_workflows:
         workflow = selected.workflow[: -len(multigpu.MULTIGPU_SUFFIX)]
+        return multigpu.run_multigpu_benchmark_cli(workflow, argv[1:])
+    if selected.workflow in legacy_multigpu_workflows:
+        workflow = selected.workflow[: -len(multigpu.LEGACY_MULTIGPU_SUFFIX)]
+        print(
+            f"'{selected.workflow}' is deprecated. Use '{workflow}{multigpu.MULTIGPU_SUFFIX}' instead.",
+            file=sys.stderr,
+        )
         return multigpu.run_multigpu_benchmark_cli(workflow, argv[1:])
     if selected.workflow in _RL_WORKFLOW_MODULES:
         return _run_rl_cli(selected.workflow, argv[1:])

--- a/source/isaaclab/isaaclab/benchmark/distributed.py
+++ b/source/isaaclab/isaaclab/benchmark/distributed.py
@@ -59,7 +59,7 @@ class DistributedContext:
         if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
             raise ValueError(
                 "--distributed was requested but no distributed launcher exported RANK and WORLD_SIZE."
-                f" Launch the benchmark with `isaaclab benchmark {workflow}-multigpu`."
+                f" Launch the benchmark with `isaaclab benchmark {workflow}_multigpu`."
             )
         return cls(
             enabled=True,
@@ -164,7 +164,7 @@ def add_distributed_arg(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help=(
-            "Run as one rank of a distributed launch. Set automatically by `isaaclab benchmark <workflow>-multigpu`."
+            "Run as one rank of a distributed launch. Set automatically by `isaaclab benchmark <workflow>_multigpu`."
         ),
     )
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/multigpu.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/multigpu.py
@@ -15,12 +15,12 @@ Every rank creates its own Isaac Lab instance, so ``--num_envs`` is the number o
 
 Usage example::
 
-    uv run isaaclab benchmark startup-multigpu \\
+    uv run isaaclab benchmark startup_multigpu \\
         --task Isaac-Cartpole-Direct \\
         --num_gpus 2 \\
         presets=newton_mjwarp
 
-    uv run isaaclab benchmark training-multigpu \\
+    uv run isaaclab benchmark training_multigpu \\
         --rl_library rsl_rl \\
         --num_gpus 2 \\
         --task Isaac-Cartpole-Direct \\
@@ -36,8 +36,11 @@ from isaaclab.cli.multigpu import MultiGpuLauncherCfg, run_multigpu_cli
 
 WORKER_SCRIPT = str(Path(__file__).resolve())
 
-MULTIGPU_SUFFIX = "-multigpu"
+MULTIGPU_SUFFIX = "_multigpu"
 """Suffix that turns a benchmark workflow name into its multi-GPU variant."""
+
+LEGACY_MULTIGPU_SUFFIX = "-multigpu"
+"""Deprecated suffix retained for command-line compatibility."""
 
 MULTIGPU_WORKFLOWS = ("startup", "runtime", "training")
 """Benchmark workflows that offer a multi-GPU variant."""

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/runtime.py
@@ -18,7 +18,7 @@ Usage example::
         --num_envs 16 --num_steps 1000 --warmup_steps 50 \\
         presets=newton_mjwarp --visualizer none
 
-Use ``isaaclab benchmark runtime-multigpu`` to measure rank 0 while every GPU steps an
+Use ``isaaclab benchmark runtime_multigpu`` to measure rank 0 while every GPU steps an
 independent workload; see :mod:`isaaclab.benchmark.entrypoints.multigpu`.
 """
 

--- a/source/isaaclab/isaaclab/benchmark/entrypoints/startup.py
+++ b/source/isaaclab/isaaclab/benchmark/entrypoints/startup.py
@@ -25,7 +25,7 @@ Usage example::
         --num_envs 16 \\
         presets=newton_mjwarp
 
-Use ``isaaclab benchmark startup-multigpu`` to profile rank 0 while every GPU launches
+Use ``isaaclab benchmark startup_multigpu`` to profile rank 0 while every GPU launches
 concurrently; see :mod:`isaaclab.benchmark.entrypoints.multigpu`.
 """
 

--- a/source/isaaclab/isaaclab/cli/__init__.py
+++ b/source/isaaclab/isaaclab/cli/__init__.py
@@ -149,7 +149,7 @@ def cli() -> None:
         epilog=(
             "commands:\n"
             "  benchmark       Run a runtime, startup, training, or play benchmark\n"
-            "                  (append -multigpu to a workflow to run it across GPUs)\n"
+            "                  (append _multigpu to a workflow to run it across GPUs)\n"
             "  microbenchmark  Run a component micro-benchmark\n"
             "  train           Train an RL policy\n"
             "  train_multigpu  Train an RL policy across multiple GPUs\n"

--- a/source/isaaclab/test/benchmark/test_distributed.py
+++ b/source/isaaclab/test/benchmark/test_distributed.py
@@ -45,7 +45,7 @@ def test_context_names_the_launcher_when_run_outside_one(monkeypatch: pytest.Mon
     monkeypatch.delenv("RANK", raising=False)
     monkeypatch.delenv("WORLD_SIZE", raising=False)
 
-    with pytest.raises(ValueError, match="isaaclab benchmark runtime-multigpu"):
+    with pytest.raises(ValueError, match="isaaclab benchmark runtime_multigpu"):
         DistributedContext.from_env(enabled=True, workflow="runtime")
 
 

--- a/source/isaaclab/test/benchmark/test_multigpu_launcher.py
+++ b/source/isaaclab/test/benchmark/test_multigpu_launcher.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Tests for the ``<workflow>-multigpu`` benchmark launcher command building."""
+"""Tests for the ``<workflow>_multigpu`` benchmark launcher command building."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import sys
 
 import pytest
 
+from isaaclab.benchmark import dispatch
 from isaaclab.benchmark.entrypoints import multigpu
 from isaaclab.cli.multigpu import build_launch_command, parse_launcher_args
 
@@ -83,3 +84,30 @@ def test_dry_run_prints_a_shell_parsable_command(capsys: pytest.CaptureFixture[s
     assert status == 0
     tokens = shlex.split(capsys.readouterr().out)
     assert tokens == _command("startup", ["--num_gpus", "2", "--task", "X"])
+
+
+def test_underscore_workflow_dispatches_to_multigpu_launcher(monkeypatch: pytest.MonkeyPatch):
+    """The canonical underscore suffix selects the requested multi-GPU workflow."""
+    received: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        multigpu,
+        "run_multigpu_benchmark_cli",
+        lambda workflow, argv: received.append((workflow, argv)) or 0,
+    )
+
+    assert dispatch.run_benchmark_cli(["runtime_multigpu", "--task", "X"]) == 0
+    assert received == [("runtime", ["--task", "X"])]
+
+
+def test_hyphenated_workflow_warns_and_dispatches(monkeypatch: pytest.MonkeyPatch, capsys):
+    """The former hyphen suffix remains available as a deprecated compatibility alias."""
+    received: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        multigpu,
+        "run_multigpu_benchmark_cli",
+        lambda workflow, argv: received.append((workflow, argv)) or 0,
+    )
+
+    assert dispatch.run_benchmark_cli(["runtime-multigpu", "--task", "X"]) == 0
+    assert received == [("runtime", ["--task", "X"])]
+    assert "'runtime-multigpu' is deprecated. Use 'runtime_multigpu' instead." in capsys.readouterr().err


### PR DESCRIPTION
## Description

Backports #7182 to `release/3.0.0` by cherry-picking merged commit `c1b0cbd25c488d3c30d070636f8b402e9cbcdc17`.

This consolidates the multi-GPU guide, standardizes benchmark workflows on `startup_multigpu`, `runtime_multigpu`, and `training_multigpu`, and retains the hyphenated forms as deprecated compatibility aliases.

No new dependencies.

## Type of change

- Documentation update
- Non-breaking benchmark CLI change with deprecated compatibility aliases

## Release backport

Not applicable; this PR targets the active release branch.

## Validation

- [x] Focused benchmark tests: 22 passed
- [x] `uv run isaaclab -f` equivalent with `ISAACLAB_CHANGELOG_BASE_REF=release/3.0.0`: passed
- [x] Warning-as-error docs build: passed
- [x] Backport patch ID matches merged #7182

The host was macOS, while the project lock and `ovstage` wheel support Linux/Windows. Validation therefore used a temporary uv-managed Python 3.12 environment; Sphinx autodoc mocked only the unavailable Linux `ovstage` module.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the canonical and compatibility command dispatch
- [x] I have included the original changelog fragment for the touched package
- [x] The original author already exists in `CONTRIBUTORS.md`