### PR TITLE
[Backport release/3.0.0] Consolidate and clean migration guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -212,6 +212,7 @@ exclude_patterns = [
     "plans",
     # Include-only fragments (pulled in via ``.. include::``; not standalone pages).
     "source/setup/installation/include/*",
+    "source/migration/include/*",
 ]
 
 # Mock out modules that are not available on RTD

--- a/docs/source/migration/include/comparing_simulation_isaacgym.rst
+++ b/docs/source/migration/include/comparing_simulation_isaacgym.rst
@@ -1,7 +1,6 @@
 .. _migrating-from-isaacgymenvs-comparing-simulation:
 
-Comparing Simulations Between Isaac Gym and Isaac Lab
-=====================================================
+.. rubric:: Comparing Simulations Between Isaac Gym and Isaac Lab
 
 
 When migrating simulations from Isaac Gym to Isaac Lab, it is sometimes helpful to compare
@@ -18,8 +17,7 @@ engine for both Isaac Gym and Isaac Lab, albeit with different versions.
    the Isaac Sim OmniPVD recording workflow described on this page.
 
 
-Recording to PXD2 in Isaac Gym Preview Release
-----------------------------------------------
+**Recording to PXD2 in Isaac Gym Preview Release**
 
 Simulation traces in Isaac Gym can be recorded using the built-in PhysX Visual Debugger (PVD)
 file output feature. Set the operating system environment variable ``GYM_PVD_FILE`` to the
@@ -36,8 +34,7 @@ For detailed instructions, refer to the tuning documentation included with Isaac
     This file reference is provided because Isaac Gym does not have its documentation available online.
 
 
-Recording to OVD in Isaac Lab
------------------------------
+**Recording to OVD in Isaac Lab**
 
 To record an OVD simulation trace file in Isaac Lab, you must set the appropriate Isaac Sim Kit
 arguments. It is important that the ``omniPvdOvdRecordingDirectory`` variable is set **before**
@@ -56,8 +53,7 @@ Do not edit Isaac Sim's installed ``SimulationApp`` sources to set these values.
 ``--kit_args`` so the command remains reproducible across Isaac Sim installations.
 
 
-Inspecting PXD2 and OVD Files
------------------------------
+**Inspecting PXD2 and OVD Files**
 
 By opening the PXD2 file in a PVD viewer and the OVD file in OmniPVD (a Kit extension), you can
 manually compare the two simulation runs and their respective parameters.
@@ -93,22 +89,19 @@ extension loaded to inspect OVD files.
 .. image:: ../_static/migration/ovd_pvd_comparison.jpg
 
 
-Parameters to Verify During Simulation Comparison
--------------------------------------------------
+**Parameters to Verify During Simulation Comparison**
 
 For PhysX articulations, each attribute is useful to inspect because it reveals how the link or shape
 will actually behave in contact, under drives, and at constraints. Below, each attribute is expanded
 with why it matters for debugging and tuning simulations.
 
 
-PxArticulationLink
-^^^^^^^^^^^^^^^^^^
+**PxArticulationLink**
 
 Each link behaves like a rigid body with mass properties, damping, velocity limits, and contact-resolution
 limits. Inspecting these helps explain stability issues, jitter, and odd responses to forces.
 
-Mass Properties
-"""""""""""""""
+**Mass Properties**
 
 **Mass**
     Determines how strongly the link accelerates under forces and how it shares impulses in collisions
@@ -130,8 +123,7 @@ Mass Properties
     *When to inspect:* Links are too easy or too hard to spin relative to their mass, which affects joint
     drive tuning and impact responses.
 
-Damping Properties
-""""""""""""""""""
+**Damping Properties**
 
 **Linear Damping**
     Models velocity-proportional drag on translation; higher values make links lose linear speed faster.
@@ -145,8 +137,7 @@ Damping Properties
     *When to inspect:* Links keep spinning after impacts or motor drives (too low), or joints feel "sticky"
     and fail to swing freely under gravity (too high).
 
-Velocity Properties
-"""""""""""""""""""
+**Velocity Properties**
 
 **Linear Velocity**
     Instantaneous world-space translational velocity of the link.
@@ -173,8 +164,7 @@ Velocity Properties
     *When to inspect:* Links spin unrealistically fast after collisions or drives (value too large), or
     rotation looks unnaturally limited, especially for wheels or rotors that should rotate quickly (value too small).
 
-Contact Resolution Properties
-"""""""""""""""""""""""""""""
+**Contact Resolution Properties**
 
 **Max Depenetration Velocity**
     Limits how much corrective velocity the solver may add in one step to resolve penetrations at contacts.
@@ -190,8 +180,7 @@ Contact Resolution Properties
     too rigid (sharp impulses causing ringing or bouncing), or when tuning "soft collisions" like rubber or
     skin-like surfaces.
 
-State and Behavior Flags
-""""""""""""""""""""""""
+**State and Behavior Flags**
 
 **Kinematic vs Dynamic flag / Disable gravity**
     Indicates whether a link is driven kinematically or fully simulated, and whether gravity affects it.
@@ -206,14 +195,12 @@ State and Behavior Flags
     and causing low-amplitude jitter).
 
 
-PxArticulationJoint
-^^^^^^^^^^^^^^^^^^^
+**PxArticulationJoint**
 
 The inbound joint defines relative motion between a link and its parent. Inspecting motion and related
 parameters explains limits, constraints, and how drives shape articulation pose and stability.
 
-Joint Configuration
-"""""""""""""""""""
+**Joint Configuration**
 
 **Motion**
     Per-axis setting (locked, limited, free) that defines which degrees of freedom the joint allows and
@@ -234,8 +221,7 @@ Joint Configuration
     *When to inspect:* Joints hyper-extend, clip through geometry, or suddenly snap at boundaries; mis-set
     limits cause popping and instability.
 
-Drive Properties
-""""""""""""""""
+**Drive Properties**
 
 **Drive target position (orientation) and target velocity**
     Desired relative pose and relative velocity that drives the articulation, often using spring-damper models.
@@ -255,14 +241,12 @@ Drive Properties
     *When to inspect:* Passive joints keep swinging too long, or appear stuck even without drives.
 
 
-PxShape
-^^^^^^^
+**PxShape**
 
 Shapes attached to links determine collision representation and contact behavior. Even if they are internal
 in OmniPhysics, their properties have a strong impact on stability, contact timing, and visual alignment.
 
-Collision Offsets
-"""""""""""""""""
+**Collision Offsets**
 
 **Rest Offset**
     Distance at which two shapes come to rest; sum of their rest offsets defines the separation where they "settle".
@@ -279,8 +263,7 @@ Collision Offsets
     contact count) or "too late" (tunneling or jitter). The difference between contact and rest offsets is
     crucial for predictive, stable contacts.
 
-Geometry and Materials
-""""""""""""""""""""""
+**Geometry and Materials**
 
 **Geometry type and dimensions**
     Box, sphere, capsule, convex, mesh, and the associated size parameters.
@@ -294,8 +277,7 @@ Geometry and Materials
     *When to inspect:* An articulation foot skids too easily, sticks to the ground, or bounces unexpectedly.
     Wrong materials can make mechanisms unstable or unresponsive.
 
-Shape Flags
-"""""""""""
+**Shape Flags**
 
 **Flag for simulation / query / trigger**
     Whether the shape participates in simulation contacts, raycasts only, or trigger events.
@@ -310,16 +292,14 @@ Shape Flags
     reduces performance.
 
 
-PxRigidDynamic
-^^^^^^^^^^^^^^
+**PxRigidDynamic**
 
 ``PxRigidDynamic`` is the core simulated rigid body type in PhysX, so inspecting its attributes is crucial
 for understanding individual object behavior, stability, and performance in the scene. Many attributes
 mirror ``PxArticulationLink``, but a rigid dynamic is not constrained by articulation joints and can also
 be used in kinematic mode.
 
-Mass and Mass-Related Properties
-""""""""""""""""""""""""""""""""
+**Mass and Mass-Related Properties**
 
 **Mass**
     Controls translational response to forces and impulses; for the same impulse, lower mass gives higher
@@ -341,8 +321,7 @@ Mass and Mass-Related Properties
     small hits), or when anisotropic behavior is needed (e.g., wheels that spin easily around one axis but
     resist others).
 
-Damping and Velocity Limits
-"""""""""""""""""""""""""""
+**Damping and Velocity Limits**
 
 **Linear Damping**
     Adds velocity-proportional drag on translation.
@@ -380,8 +359,7 @@ Damping and Velocity Limits
     *When to inspect:* Thin or small bodies spin so fast they destabilize the scene (value too high), or
     spinning elements such as wheels, propellers, or debris appear artificially capped (value too low).
 
-Contact Resolution and Impulses
-"""""""""""""""""""""""""""""""
+**Contact Resolution and Impulses**
 
 **Max Depenetration Velocity**
     Limits the corrective velocity the solver may introduce in one step to resolve interpenetrations.
@@ -396,8 +374,7 @@ Contact Resolution and Impulses
     *When to inspect:* Create softer contacts (lower limit) or very rigid, almost unyielding bodies (high or
     default limit); objects sink into each other or bounce unrealistically.
 
-Sleep and Activation Behavior
-"""""""""""""""""""""""""""""""
+**Sleep and Activation Behavior**
 
 **Sleep Threshold**
     Mass-normalized kinetic energy below which a body becomes a candidate for sleeping.
@@ -411,8 +388,7 @@ Sleep and Activation Behavior
     *When to inspect:* Bodies refuse to wake up on interactions or wake too easily. Bad sleep behavior can
     make scenes feel "dead" or too noisy.
 
-Kinematic Mode and Locking
-""""""""""""""""""""""""""
+**Kinematic Mode and Locking**
 
 **Kinematic Flag (PxRigidBodyFlag::eKINEMATIC)**
     When set, the body is moved by ``setKinematicTarget`` and ignores forces and gravity, while still
@@ -435,8 +411,7 @@ Kinematic Mode and Locking
     *When to inspect:* Objects float in mid-air or drop unexpectedly. A common source of confusion in
     mixed setups with some gravity-less bodies.
 
-Forces and Solver Overrides
-"""""""""""""""""""""""""""
+**Forces and Solver Overrides**
 
 **Applied force and torque (accumulated per step)**
     Net forces/torques that will be integrated into velocity.
@@ -451,8 +426,7 @@ Forces and Solver Overrides
     stability or more accurate stacking. Low iterations can cause jitter and penetration; too high wastes
     performance.
 
-Shape-Related Aspects
-"""""""""""""""""""""
+**Shape-Related Aspects**
 
 While not properties of ``PxRigidDynamic`` itself, the shapes attached to it heavily influence behavior.
 
@@ -469,8 +443,7 @@ While not properties of ``PxRigidDynamic`` itself, the shapes attached to it hea
     is material configuration rather than mass or damping.
 
 
-Summary: What to Inspect and Why
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Summary: What to Inspect and Why**
 
 The table below summarizes the key inspection areas for each PhysX component:
 

--- a/docs/source/migration/include/deformables.rst
+++ b/docs/source/migration/include/deformables.rst
@@ -1,7 +1,7 @@
 .. _migrating-deformables:
 
 Migration of Deformables
-========================
+------------------------
 
 .. currentmodule:: isaaclab
 
@@ -19,8 +19,7 @@ configurations live in ``isaaclab_newton.sim``.
   `release notes`_ for any changes in the future releases.
 
 
-Surface and Volume Deformables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Surface and Volume Deformables
 
 With the new Omni Physics API, deformable bodies are split into two distinct types, as described in the
 `Omni Physics documentation`_:
@@ -42,11 +41,9 @@ The type of deformable is determined by the **physics material** assigned to the
   **surface** deformable.
 
 
-Migration from the Old API
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Migration from the Old API
 
-Import Changes
-^^^^^^^^^^^^^^
+**Import Changes**
 
 Deformable object cfgs remain in ``isaaclab.assets``. Deformable schema and material cfgs should be imported
 from the physics backend package:
@@ -72,8 +69,7 @@ from the physics backend package:
    * - ``from isaaclab_physx.assets import DeformableObjectCfg``
      - ``from isaaclab.assets import DeformableObjectCfg``
 
-Removed Properties
-^^^^^^^^^^^^^^^^^^
+**Removed Properties**
 
 The following properties have been **removed** from
 :class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg`:
@@ -93,8 +89,7 @@ The following properties have been **removed** from
   mesh, so authoring them on the body prim never reached the solver. Set them on the mesh spawner's
   ``collision_props`` instead: ``collision_props=[PhysxCollisionCfg(rest_offset=0.0005, contact_offset=0.005)]``.
 
-Added Properties
-^^^^^^^^^^^^^^^^
+**Added Properties**
 
 The following properties have been **added** to
 :class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg`:
@@ -114,8 +109,7 @@ The following properties have been **added** to
 For a full description of all available properties, refer to the `PhysX deformable schema`_ and
 `OmniPhysics deformable schema`_ documentation.
 
-Material Changes
-^^^^^^^^^^^^^^^^
+**Material Changes**
 
 The deformable material hierarchy is now split by backend:
 
@@ -134,18 +128,15 @@ The deformable material hierarchy is now split by backend:
 
 The old ``damping_scale`` property has been removed. Use ``elasticity_damping`` directly instead.
 
-DeformableObject View Change
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**DeformableObject View Change**
 
 The internal PhysX view type has changed from ``physx.SoftBodyView`` to ``physx.DeformableBodyView``.
 The property ``root_physx_view`` has been deprecated in favor of ``root_view``.
 
 
-Code Examples
-~~~~~~~~~~~~~
+.. rubric:: Code Examples
 
-Volume Deformable (Before and After)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+**Volume Deformable (Before and After)**
 
 **Before**:
 
@@ -186,8 +177,7 @@ Volume Deformable (Before and After)
    )
    cube_object = DeformableObject(cfg=cfg)
 
-Surface Deformable (New)
-^^^^^^^^^^^^^^^^^^^^^^^^
+**Surface Deformable (New)**
 
 Surface deformables use :class:`~isaaclab.sim.spawners.meshes.MeshRectangleCfg` for 2D meshes, combined with
 :class:`~isaaclab_physx.sim.PhysxSurfaceDeformableBodyMaterialCfg`:
@@ -210,8 +200,7 @@ Surface deformables use :class:`~isaaclab.sim.spawners.meshes.MeshRectangleCfg` 
    )
    cloth_object = DeformableObject(cfg=cfg)
 
-USD File Deformable
-^^^^^^^^^^^^^^^^^^^
+**USD File Deformable**
 
 Deformable properties can also be applied to imported USD assets using
 :class:`~isaaclab.sim.spawners.from_files.UsdFileCfg`:
@@ -236,8 +225,7 @@ Deformable properties can also be applied to imported USD assets using
    teddy_object = DeformableObject(cfg=cfg)
 
 
-Limitations
-~~~~~~~~~~~
+.. rubric:: Limitations
 
 - **Kinematic targets are volume-only.** Calling
   :meth:`~isaaclab.assets.DeformableObject.write_nodal_kinematic_target_to_sim_index` on a surface

--- a/docs/source/migration/include/from_isaacgymenvs.rst
+++ b/docs/source/migration/include/from_isaacgymenvs.rst
@@ -1,15 +1,15 @@
 .. _migrating-from-isaacgymenvs:
 
-From IsaacGymEnvs
-=================
+Migration from Isaac Gym and IsaacGymEnvs
+------------------------------------------
 
 .. currentmodule:: isaaclab
 
 .. seealso::
 
-   This page is the source of truth for the ``isaaclab-migrating-from-isaac-gym`` agent skill
+   This section is the source of truth for the ``isaaclab-migrating-from-isaac-gym`` agent skill
    (`skills/user/migrate-from-isaac-gym/ <../../../skills/user/migrate-from-isaac-gym/SKILL.md>`__).
-   When you change this page, update the skill so agent guidance stays in sync. See
+   When you change this section, update the skill so agent guidance stays in sync. See
    :doc:`/source/overview/developer-guide/agent_skills`.
 
 
@@ -20,9 +20,19 @@ Preview Release and Isaac Sim. The maintained
 :isaaclab-source:`Cartpole direct environment <source/isaaclab_tasks/isaaclab_tasks/core/cartpole>` is the canonical
 complete example for the patterns used in this guide.
 
+For the smoothest migration, work through this section in order:
 
-Task Config Setup
-~~~~~~~~~~~~~~~~~
+1. Translate the task and simulation configuration to Python config classes.
+2. Recreate the scene and actors in a direct-workflow environment.
+3. Map simulation state access, paying particular attention to quaternion and joint ordering.
+4. Port actions, resets, observations, rewards, and termination logic.
+5. Smoke-test the environment before moving the training and inference commands.
+
+Use :ref:`migrating-from-isaacgymenvs-comparing-simulation` when the migrated task runs but its
+behavior does not match Isaac Gym.
+
+
+.. rubric:: Task Config Setup
 
 In IsaacGymEnvs, task config files were defined in ``.yaml`` format. With Isaac Lab, configs are now specified using
 a specialized Python class :class:`~isaaclab.utils.configclass`. The :class:`~isaaclab.utils.configclass`
@@ -58,8 +68,7 @@ Below is an example skeleton of a task config class:
       # task-specific parameters
       ...
 
-Simulation Config
------------------
+**Simulation Config**
 
 Simulation related parameters are defined as part of the :class:`~isaaclab.sim.SimulationCfg` class,
 which is a :class:`~isaaclab.utils.configclass` module that holds simulation parameters such as ``dt``,
@@ -142,8 +151,7 @@ has been validated for those solvers:
 Select a validated physics preset when launching the task, for example ``physics=physx`` or
 ``physics=newton_mjwarp``. A preset name is available only when the environment defines it.
 
-Scene Config
-------------
+**Scene Config**
 
 The :class:`~isaaclab.scene.InteractiveSceneCfg` class can be used to specify parameters related to the scene,
 such as the number of environments and the spacing between environments. Each task config must have a variable named
@@ -159,8 +167,7 @@ such as the number of environments and the spacing between environments. Each ta
 |    envSpacing: 4.0                                           |    env_spacing=4.0)                                               |
 +--------------------------------------------------------------+-------------------------------------------------------------------+
 
-Task Config
------------
+**Task Config**
 
 Each environment should specify its own config class that holds task specific parameters, such as the dimensions of the
 observation and action buffers. Reward term scaling parameters can also be specified in the config class.
@@ -180,8 +187,7 @@ in IsaacGymEnvs. To convert between step count to seconds, use the equation:
 ``episode_length_s = dt * decimation * num_steps``
 
 
-RL Config Setup
-~~~~~~~~~~~~~~~
+.. rubric:: RL Config Setup
 
 RL config files for the rl_games library can continue to be defined in ``.yaml`` files in Isaac Lab.
 Most of the content of the config file can be copied directly from IsaacGymEnvs.
@@ -205,8 +211,7 @@ they should be moved to the RL config file in Isaac Lab.
 |                          |     clip_actions: 1.0      |
 +--------------------------+----------------------------+
 
-Environment Creation
-~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Environment Creation
 
 In IsaacGymEnvs, environment creation generally included four components: creating the sim object with ``create_sim()``,
 creating the ground plane, importing the assets from MJCF or URDF files, and finally creating the environments
@@ -241,8 +246,7 @@ adding any other optional objects into the scene, such as lights.
 +------------------------------------------------------------------------------+------------------------------------------------------------------------+
 
 
-Ground Plane
-------------
+**Ground Plane**
 
 For a simple plane, spawn the ground directly in ``_setup_scene()``:
 
@@ -257,8 +261,7 @@ Use :class:`~terrains.TerrainImporterCfg` instead when the task needs generated 
 single plane.
 
 
-Actors
-------
+**Actors**
 
 Isaac Lab and Isaac Sim both use the `USD (Universal Scene Description) <https://github.com/PixarAnimationStudios/OpenUSD>`_
 library for describing the scene. Assets defined in MJCF and URDF formats can be imported to USD using importer
@@ -289,8 +292,7 @@ be added to the :class:`~scene.InteractiveScene` by calling ``self.scene.articul
 so that the :class:`~scene.InteractiveScene` can traverse through actors in the scene for writing values to the
 simulation and resetting.
 
-Simulation Parameters for Actors
-""""""""""""""""""""""""""""""""
+**Simulation Parameters for Actors**
 
 Some simulation parameters related to Rigid Bodies and Articulations may have different
 default values between Isaac Gym Preview Release and Isaac Sim.
@@ -344,8 +346,7 @@ For more details on performing thorough simulation comparisons between Isaac Gym
 please refer to the :ref:`migrating-from-isaacgymenvs-comparing-simulation` section.
 
 
-Cloner
-------
+**Cloner**
 
 Isaac Lab provides :mod:`isaaclab.cloner` for replication during the scene creation process.
 In IsaacGymEnvs, scenes had to be created by looping through the number of environments.
@@ -374,8 +375,7 @@ The scene creation process is as follow:
        self.scene.filter_collisions(global_prim_paths=[])
 
 
-Accessing States from Simulation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Accessing States from Simulation
 
 APIs for accessing physics states in Isaac Lab require the creation of an :class:`~assets.Articulation` or :class:`~assets.RigidObject`
 object. Multiple objects can be initialized for different articulations or rigid bodies in the scene by defining
@@ -425,8 +425,7 @@ avoids reading or rewriting state components that did not change.
 |       gymtorch.unwrap_tensor(env_ids_int32), len(env_ids_int32))          |       velocity=joint_vel, env_ids=env_ids)                    |
 +---------------------------------------------------------------------------+---------------------------------------------------------------+
 
-Quaternion Convention
----------------------
+**Quaternion Convention**
 
 .. warning::
 
@@ -458,8 +457,7 @@ IsaacGymEnvs, older Isaac Lab snippets, or USD examples without first confirming
 boundary.
 
 
-Articulation Joint Order
-------------------------
+**Articulation Joint Order**
 
 Physics simulation in Isaac Sim and Isaac Lab assumes a breadth-first
 ordering for the joints in a given kinematic tree.
@@ -470,8 +468,7 @@ In Isaac Lab, retrieve the ordered names from ``Articulation.joint_names`` and r
 :meth:`~assets.Articulation.find_joints`. Do not carry positional joint indices over from IsaacGymEnvs.
 
 
-Creating a New Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Creating a New Environment
 
 Each environment in Isaac Lab should be in its own directory following this structure:
 
@@ -511,8 +508,7 @@ Each environment in Isaac Lab should be in its own directory following this stru
 * ``my_environment/my_env_cfg.py`` defines the environment, simulation preset, scene, and asset configurations.
 
 
-Task Logic
-~~~~~~~~~~
+.. rubric:: Task Logic
 
 In Isaac Lab, the ``post_physics_step`` function has been moved to the framework in the base class.
 Tasks are not required to implement this method, but can choose to override it if a different workflow is desired.
@@ -555,16 +551,14 @@ We have also performed some renamings of APIs:
 * In addition, Isaac Lab requires ``_get_dones(self)``, which returns the ``terminated`` and ``time_out`` buffers.
 
 
-Putting It All Together
-~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Putting It All Together
 
 The following sections compare the IsaacGymEnvs Cartpole with the current Isaac Lab implementation. For the complete,
 executable source, use the maintained
 :isaaclab-source:`Cartpole environment configuration <source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py>`
 and :isaaclab-source:`Cartpole environment <source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env.py>`.
 
-Task Config
------------
+**Task Config**
 
 +--------------------------------------------------------+---------------------------------------------------------------------+
 | IsaacGymEnvs                                           | Isaac Lab                                                           |
@@ -618,8 +612,7 @@ Task Config
 
 
 
-Task Setup
-----------
+**Task Setup**
 
 Isaac Lab no longer requires pre-initialization of buffers through the ``acquire_*`` APIs that were used in IsaacGymEnvs.
 It is also no longer necessary to ``wrap`` and ``unwrap`` tensors.
@@ -659,8 +652,7 @@ It is also no longer necessary to ``wrap`` and ``unwrap`` tensors.
 
 
 
-Scene Setup
------------
+**Scene Setup**
 
 Scene setup is now done through the ``Cloner`` API and by specifying actor attributes in config objects.
 This eliminates the need to loop through the number of environments to set up the environments and avoids
@@ -756,8 +748,7 @@ the need to set simulation parameters for actors in the task implementation.
 +------------------------------------------------------------------------+---------------------------------------------------------------------+
 
 
-Pre and Post Physics Step
--------------------------
+**Pre and Post Physics Step**
 
 In IsaacGymEnvs, due to limitations of the GPU APIs, observations had stale data when environments had to perform resets.
 This restriction has been eliminated in Isaac Lab, and thus, tasks follow the correct workflow of applying actions, stepping simulation,
@@ -793,8 +784,7 @@ However, individual tasks can override the ``step()`` API to control the workflo
 +------------------------------------------------------------------+-------------------------------------------------------------+
 
 
-Dones and Resets
-----------------
+**Dones and Resets**
 
 In Isaac Lab, ``dones`` are computed in the ``_get_dones()`` method and should return two variables: ``resets`` and ``time_out``.
 Tracking of the ``progress_buf`` has been moved to the base class and is now automatically incremented and reset by the framework.
@@ -853,8 +843,7 @@ The ``progress_buf`` variable has also been renamed to ``episode_length_buf``.
 +-----------------------------------------------------------------------+---------------------------------------------------------------------------+
 
 
-Observations
-------------
+**Observations**
 
 In Isaac Lab, the ``_get_observations()`` API should now return a dictionary containing the ``policy`` key with the observation
 buffer as the value.
@@ -882,8 +871,7 @@ For asymmetric policies, the dictionary should also include a ``critic`` key tha
 +--------------------------------------------------------------------------+---------------------------------------------------------------------------------------+
 
 
-Rewards
--------
+**Rewards**
 
 In Isaac Lab, the reward method ``_get_rewards`` should return the reward buffer as a return value.
 Similar to IsaacGymEnvs, computations in the reward function can also be performed using pytorch jit
@@ -938,8 +926,7 @@ by adding the ``@torch.jit.script`` annotation.
 
 
 
-Launching Training
-~~~~~~~~~~~~~~~~~~
+.. rubric:: Launching Training
 
 To launch a training in Isaac Lab, use the command:
 
@@ -957,8 +944,7 @@ To launch a training in Isaac Lab, use the command:
 
          ./isaaclab.sh train --rl_library rl_games --task=Isaac-Cartpole-Direct physics=physx
 
-Running Inference
-~~~~~~~~~~~~~~~~~
+.. rubric:: Running Inference
 
 To run a trained policy in Isaac Lab, use the command:
 
@@ -978,15 +964,6 @@ To run a trained policy in Isaac Lab, use the command:
 
          ./isaaclab.sh play --rl_library rl_games --task=Isaac-Cartpole-Direct --num_envs=25 \
              --checkpoint=<path/to/checkpoint> physics=physx
-
-
-Additional Resources
-~~~~~~~~~~~~~~~~~~~~
-
-.. toctree::
-   :maxdepth: 1
-
-   comparing_simulation_isaacgym
 
 
 .. _IsaacGymEnvs: https://github.com/isaac-sim/IsaacGymEnvs

--- a/docs/source/migration/migrating_to_isaaclab_3-0.rst
+++ b/docs/source/migration/migrating_to_isaaclab_3-0.rst
@@ -1,310 +1,124 @@
 .. _migrating-to-isaaclab-3-0:
 
-Migrating to Isaac Lab 3.0
-==========================
+Migrating To 3.0
+================
 
 .. currentmodule:: isaaclab
 
+Choose the path that matches the code you are starting from. The Isaac Lab 2.x path is organized in
+the order most projects should migrate: install the new release, configure a backend, update task APIs,
+then move training and visualization workflows.
+
+**Choose your starting point:**
+
+* :ref:`Migration from Isaac Lab 2.x to 3.0 <migrating-from-isaaclab-2-x>` -- update an existing
+  Isaac Lab project for the new installation, APIs, and multi-backend architecture.
+* :ref:`Migration from Isaac Gym and IsaacGymEnvs <migrating-from-isaacgymenvs>` -- port an Isaac Gym
+  task, simulation configuration, or training workflow to Isaac Lab.
+* :ref:`Migration of deformables <migrating-deformables>` -- move from the old soft-body API to
+  surface and volume deformables.
+
+.. contents:: On this page
+   :local:
+   :depth: 1
+   :backlinks: top
+
+
+.. _migrating-from-isaaclab-2-x:
+
+.. rubric:: Migration from Isaac Lab 2.x to 3.0
+
+Isaac Lab 3.0 separates backend-specific simulation code from the core API and introduces unified
+commands for common workflows. Work through the following sections in order; skip a section only when
+your project does not use that feature.
+
 .. seealso::
 
-   This page is the source of truth for the ``isaaclab-migrating-2x-to-3x`` agent skill
+   This part of the page is the source of truth for the ``isaaclab-migrating-2x-to-3x`` agent skill
    (`skills/user/migrate-2x-to-3x/ <../../../skills/user/migrate-2x-to-3x/SKILL.md>`__).
-   When you change this page, update the skill so agent guidance stays in sync. See
+   When you change it, update the skill so agent guidance stays in sync. See
    :doc:`/source/overview/developer-guide/agent_skills`.
 
-Isaac Lab 3.0 introduces a multi-backend architecture that separates simulation backend-specific code
-from the core Isaac Lab API. This allows for future support of different physics backends while
-maintaining a consistent user-facing API.
 
-This guide covers the main breaking changes and deprecations you need to address when migrating
-from Isaac Lab 2.x to Isaac Lab 3.0.
+Installation
+------------
 
-.. toctree::
-   :hidden:
-   :maxdepth: 1
+Start from a fresh Isaac Lab 3.0 checkout and Python 3.12 environment instead of upgrading the
+packages inside an existing 2.x environment. The recommended workflow now uses ``uv`` to resolve the
+project environment and optional integrations when a command runs. The ``isaaclab.sh`` installer is
+still available for manually managed environments, but it is no longer the default path.
 
-   migrating_from_isaacgymenvs
-   migrating_deformables
+.. grid:: 2
+   :gutter: 2
 
+   .. grid-item-card:: Isaac Lab 2.x
 
-.. _actuators-solver-limit-migration:
-
-Actuator effort and joint-limit names
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Actuator configurations now use joint-qualified names for solver limits. Update active
-configurations to the canonical fields below. The former names remain accepted with a
-``DeprecationWarning`` through the 3.x release line and will be removed in 4.0.
-
-.. list-table:: Actuator limit migration
-   :header-rows: 1
-   :widths: 38 38 24
-
-   * - Deprecated configuration field
-     - Canonical configuration field
-     - Runtime owner
-   * - ``effort_limit``
-     - ``actuator_effort_limit``
-     - Actuator model (rated limit)
-   * - ``effort_limit_sim``
-     - ``joint_effort_limit``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_effort_limits`
-   * - ``velocity_limit_sim``
-     - ``joint_velocity_limit``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_vel_limits`
-
-``actuator_effort_limit`` clips explicit actuator-model output. ``joint_effort_limit`` and
-``joint_velocity_limit`` are construction-time joint-property overrides selected by an actuator
-group's joint expression. The deprecated aliases ``effort_limit``, ``velocity_limit``,
-``effort_limit_sim``, and ``velocity_limit_sim`` remain accepted through 3.x. ``effort_limit``
-resolves to the rated ``actuator_effort_limit`` for every actuator type. For an implicit group
-without a separately configured solver clamp, the rated value also populates
-``joint_effort_limit`` for backward compatibility; configure both fields to author distinct
-rated and solver limits. The runtime ``effort_limit`` and ``velocity_limit`` group properties
-follow the same mapping and are also deprecated.
-``actuator_velocity_limit`` describes rated speed or an implicit soft-limit snapshot.
-``joint_velocity_limit`` only requests solver enforcement, which is backend-dependent. See
-:ref:`actuators-joint-property-ownership` for the full ownership model.
-
-**Behavior change — explicit groups keep the solver effort limit.** Isaac Lab previously raised the
-solver effort limit to ``1.0e9`` on joints driven by an explicit actuator so that only the model
-clipped the effort. The solver now keeps the authored or configured ``joint_effort_limit``, so
-effort submitted by an explicit model is clipped a second time by the solver. If your asset authors
-a tight joint effort limit and your policy relies on the model limit alone, set
-``joint_effort_limit`` at least as large as ``actuator_effort_limit`` in the actuator
-configuration.
-
-The runtime group properties listed below were removed. Read their live values from articulation
-data and use the corresponding indexed articulation writer:
-
-.. list-table:: Removed group-property migration
-   :header-rows: 1
-   :widths: 26 38 36
-
-   * - Removed runtime group property
-     - Read
-     - Write
-   * - ``effort_limit_sim``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_effort_limits`
-     - :meth:`~isaaclab.assets.Articulation.write_joint_effort_limit_to_sim_index`
-   * - ``velocity_limit_sim``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_vel_limits`
-     - :meth:`~isaaclab.assets.Articulation.write_joint_velocity_limit_to_sim_index`
-   * - ``armature``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_armature`
-     - :meth:`~isaaclab.assets.Articulation.write_joint_armature_to_sim_index`
-   * - ``friction``
-     - :attr:`~isaaclab.assets.ArticulationData.joint_friction_coeff`
-     - :meth:`~isaaclab.assets.Articulation.write_joint_friction_coefficient_to_sim_index`
-   * - ``dynamic_friction``
-     - ``data.joint_dynamic_friction_coeff`` (PhysX and OVPhysX)
-     - ``write_joint_dynamic_friction_coefficient_to_sim_index`` (PhysX and OVPhysX)
-   * - ``viscous_friction``
-     - ``data.joint_viscous_friction_coeff``
-     - ``write_joint_viscous_friction_coefficient_to_sim_index``
-
-The dynamic-friction view and writer are backend-specific; Newton has no corresponding joint
-property.
-
-**Custom actuator models.** The protected helper ``ActuatorBase._parse_joint_parameter`` was
-removed together with the constructor rework. Custom actuator subclasses that parsed configuration
-fields with it should call :func:`~isaaclab.actuators.resolve_joint_parameter`, which applies the
-same resolution semantics as a standalone function:
-
-.. code-block:: python
-
-   from isaaclab.actuators import ActuatorBase, resolve_joint_parameter
-
-
-   class MyActuator(ActuatorBase):
-       def __init__(self, cfg, joint_names, joint_ids, num_envs, device, **kwargs):
-           super().__init__(cfg, joint_names, joint_ids, num_envs, device, **kwargs)
-           # before: self.my_gain = self._parse_joint_parameter(cfg.my_gain, 0.0)
-           self.my_gain = resolve_joint_parameter(cfg.my_gain, 0.0, joint_names, num_envs, device)
-
-The backend articulation methods ``write_actuator_stiffness_to_sim`` and
-``write_actuator_damping_to_sim`` are deprecated. Use
-:func:`~isaaclab.envs.mdp.events.randomize_actuator_gains` for managed gain randomization; it
-updates actuator-owned gains, implicit solver drives, or native-controller parameters as
-appropriate. For direct writes to a Newton-executed group's controller, use
-:func:`~isaaclab.actuators.newton.write_group_parameter`.
-
-Named regular-expression groups retain their configuration behavior. If both a deprecated name and
-its canonical replacement are present in the same group, use only the canonical name; equivalent
-values warn and select the canonical value, whereas conflicting values raise :class:`ValueError`.
-
-
-Visualizer CLI and Headless Behavior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In Isaac Lab 3.0, use ``--visualizer`` / ``--viz`` to determine whether viewer apps are launched
-with an Isaac Lab command. Without a visualizer, commands run headless by default.
-
-Visualizers are lightweight viewer apps for monitoring, debugging, and recording workflows
-(see :doc:`/source/overview/core-concepts/visualization`).
-
-The details below describe how CLI visualizer arguments resolve together with
-``SimulationCfg.visualizer_cfgs``.
-
-- ``--viz`` accepts **comma-separated** values (for example ``--viz kit,newton_gl``).
-  ``"newton"`` is a deprecated alias for ``"newton_gl"``; prefer ``"newton_gl"`` or ``"newton_rtx"``.
-- If omitted, visualizers are resolved from ``SimulationCfg.visualizer_cfgs``.
-- ``--viz none`` explicitly disables all visualizers, including config-defined ones.
-
-For the full behavior of visualizer resolution with the visualizer CLI argument and visualizer configs,
-see :ref:`visualization-common-modes`.
-
-**Breaking change — ``--headless`` no longer suppresses visualizers.**
-
-In Isaac Lab 2.x, passing ``--headless`` disabled all visualizers regardless of ``--viz``.
-In Isaac Lab 3.0, ``--headless`` and ``--viz`` are independent:
-
-- ``--headless`` controls the simulation rendering pipeline (Kit app mode, GPU context).
-- ``--viz <type>`` controls which visualizer backends to launch.
-
-Passing ``--viz kit --headless`` now launches a Kit visualizer in headless mode using the
-Replicator offscreen renderer (no display window required).  Passing ``--viz newton_gl --headless``
-launches a Newton GL visualizer using pyglet's EGL headless backend.  To disable all visualizers
-explicitly, use ``--viz none``.
-
-.. list-table:: Headless visualizer requirements
-   :header-rows: 1
-   :widths: 20 25 55
-
-   * - Visualizer
-     - Headless mechanism
-     - Extra requirement
-   * - ``kit``
-     - Replicator offscreen renderer (no display)
-     - Must also pass ``--enable_cameras``; without it, ``render_rgb_array()`` returns
-       black frames. ``--video`` sets this automatically.
-   * - ``newton_gl``
-     - pyglet EGL backend (no display)
-     - None — ``NewtonGLVisualizer`` auto-detects a missing ``$DISPLAY`` and selects EGL.
-   * - ``newton_rtx``
-     - Not supported headlessly
-     - ``render_rgb_array()`` returns ``None``; frame capture requires a display.
-
-**Headless video recording (``--video`` without ``--viz``).**
-
-In Isaac Lab 2.x, ``--video`` alone would use the Kit Replicator pipeline implicitly.
-In Isaac Lab 3.0, the equivalent is:
-
-.. code-block:: bash
-
-   # Record from Kit viewport headlessly (equivalent to 2.x --video behaviour)
-   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct \
-       --viz kit --enable_cameras --headless --video
-
-As a convenience, passing ``--video`` without ``--viz`` still works: Isaac Lab
-auto-creates a headless Kit visualizer (falling back to Newton GL if Kit is unavailable)
-and sets ``source="visualizer:kit"`` on the default recorder, printing:
-
-.. code-block:: text
-
-   [INFO] --video specified without --viz: auto-creating a headless Kit visualizer
-   for video recording. Pass --viz <type> to choose a different visualizer, or
-   set video_recorders in your env config to record from a scene sensor instead.
-
-
-Reinforcement Learning CLI Entrypoints
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Isaac Lab 3.0 provides unified reinforcement learning entrypoints for training
-and play. Instead of launching library-specific scripts under
-``scripts/reinforcement_learning/<library>/``, select the library with
-``--rl_library``.
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
+      Create and activate an environment, install every extension, then launch a library-specific script.
 
       .. code-block:: bash
 
-         # Isaac Lab 3.0
-         uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole
+         conda create -n env_isaaclab python=3.11
+         conda activate env_isaaclab
+         ./isaaclab.sh --install rsl_rl
+         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+            --task Isaac-Cartpole
 
-   .. tab-item:: isaaclab.sh / isaaclab.bat
+   .. grid-item-card:: Isaac Lab 3.0
 
-      .. code-block:: bash
-
-         # Isaac Lab 3.0
-         ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole
-
-The same pattern applies to the play workflow:
-
-.. tab-set::
-
-   .. tab-item:: uv (Recommended)
+      Install ``uv`` once; ``uv run`` creates or synchronizes the project environment and launches the
+      unified command. Select optional runtimes with ``--extra`` before ``isaaclab``.
 
       .. code-block:: bash
 
-         uv run isaaclab play --rl_library rsl_rl --task Isaac-Cartpole --checkpoint /PATH/TO/model.pt
+         curl -LsSf https://astral.sh/uv/install.sh | sh
+         uv run --extra isaacsim isaaclab train \
+            --rl_library rsl_rl --task Isaac-Cartpole \
+            physics=isaacsim_physx
 
-   .. tab-item:: isaaclab.sh / isaaclab.bat
-
-      .. code-block:: bash
-
-         ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Cartpole --checkpoint /PATH/TO/model.pt
-
-Supported reinforcement learning libraries are ``rsl_rl``, ``rl_games``, ``skrl``,
-``sb3``, and ``rlinf``. Backend-local ``train.py`` and ``play.py`` scripts were removed; use these
-unified commands instead.
-
-For distributed launchers that execute a Python script directly, use the unified
-script path and pass ``--rl_library`` to it:
-
-.. code-block:: bash
-
-   python -m torch.distributed.run --nproc_per_node=2 scripts/reinforcement_learning/train.py \
-      --rl_library rsl_rl --task Isaac-Cartpole --distributed
+Use ``uv run isaaclab ...`` for Newton-only workflows, ``--extra ovphysx`` for OV PhysX, and
+``--extra isaacsim`` for full Isaac Sim support. See :ref:`installation-method-uv` for platform-specific
+setup, the complete extras list, and manually managed environment options.
 
 
-Unified Checkpoint and Iteration Arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Multi-Backend Architecture and Presets
+--------------------------------------
 
-RL entrypoints now use ``--checkpoint`` consistently to select a checkpoint
-for training, resuming, or play. Update scripts that use the removed arguments
-as follows:
+Understand the new package boundaries first, then make environment configuration backend-selectable.
 
-.. list-table:: RL command migration
-   :header-rows: 1
-   :widths: 28 32 40
+.. grid:: 2
+   :gutter: 2
 
-   * - Previous command
-     - Isaac Lab 3.0 command
-     - Notes
-   * - RSL-RL ``--resume --load_run <run>``
-     - ``--checkpoint <path>``, ``--checkpoint latest``, or ``--checkpoint best``
-     - Pass a checkpoint path or select one from a compatible recorded run.
-   * - ``--use_pretrained_checkpoint``
-     - ``--checkpoint pretrained``
-     - Use this for play with RL-Games, RSL-RL, skrl, or Stable-Baselines3.
-   * - RLinf ``--rl_model_path <checkpoint-dir>`` or ``--resume_dir <checkpoint-dir>``
-     - ``--checkpoint <checkpoint-dir>``
-     - The directory must contain the RLinf ``full_weights.pt`` checkpoint.
-   * - RLinf ``--max_epochs <N>``
-     - ``--max_iterations <N>``
-     - This is the common training-iteration argument used by the unified API.
+   .. grid-item-card:: Isaac Lab 2.x
 
-For RLinf, ``--model_path`` now identifies the pretrained base VLA model, not
-the RL-finetuned weights. Supply both arguments when evaluating a finetuned
-policy:
+      Physics-specific configuration and implementations were exposed through the core package, and
+      environments typically configured one PhysX backend directly.
 
-.. code-block:: bash
+      .. code-block:: python
 
-   uv run --extra rlinf isaaclab play --rl_library rlinf \
-      --config_name isaaclab_ppo_gr00t_assemble_trocar \
-      --model_path /path/to/base_model \
-      --checkpoint /path/to/rlinf_checkpoint
+         import isaaclab.sim as sim_utils
 
-``latest`` and ``best`` select checkpoints from the newest compatible run for
-RL-Games, RSL-RL, skrl, Stable-Baselines3, and RLinf. ``pretrained`` selects a
-published policy where one is available; RLinf does not support this selector.
+         self.sim.physics = sim_utils.PhysxCfg(...)
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      Core assets dispatch to the selected backend. Import backend-owned configuration explicitly and
+      use a preset when an environment supports multiple backends.
+
+      .. code-block:: python
+
+         from isaaclab.utils.configclass import configclass
+         from isaaclab_physx.physics import PhysxCfg
+         from isaaclab_tasks.utils import PresetCfg
+
+         @configclass
+         class PhysicsPresets(PresetCfg):
+             isaacsim_physx: PhysxCfg = PhysxCfg(...)
+             default: PhysxCfg = isaacsim_physx
+
+         self.sim.physics = PhysicsPresets()
 
 
-Multi-Backend Architecture
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Multi-Backend Architecture
 
 Isaac Lab 3.0 introduces a **factory-based multi-backend architecture** that allows asset classes
 to be backed by different physics engines — currently **PhysX** and **Newton**.
@@ -324,17 +138,15 @@ The factory works by convention: for a class defined in ``isaaclab.assets.articu
 imports the matching class from the active backend package. The ``isaaclab_physx``,
 ``isaaclab_newton``, and ``isaaclab_ov`` packages mirror the ``isaaclab`` module structure.
 
-.. note::
-
-   The backend is currently set to ``"physx"`` by default. Newton backend support is being
-   actively developed. When backend selection is fully configurable, you will be able to
-   switch backends without changing any asset import paths.
+The concrete default remains task-specific so launching without an override stays predictable.
+Tasks can expose alternatives such as ``physics=physx``, ``physics=ovphysx``, or
+``physics=newton_mjwarp`` without changing their asset import paths.
 
 For a comprehensive overview of the factory pattern, backend selection, and how to add a new
 backend, see :doc:`/source/overview/core-concepts/multi_backend_architecture`.
 
-New ``isaaclab_physx`` and ``isaaclab_newton`` Extensions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: New ``isaaclab_physx`` and ``isaaclab_newton`` Extensions
 
 Two new backend extensions have been introduced:
 
@@ -368,10 +180,79 @@ The following classes have been moved to ``isaaclab_physx``:
    installation steps are required.
 
 
+.. rubric:: Backend-Neutral Imports
+
+The following asset classes remain in the ``isaaclab`` package and can still be imported as before:
+
+- :class:`~isaaclab.assets.Articulation`, :class:`~isaaclab.assets.ArticulationCfg`, :class:`~isaaclab.assets.ArticulationData`
+- :class:`~isaaclab.assets.RigidObject`, :class:`~isaaclab.assets.RigidObjectCfg`, :class:`~isaaclab.assets.RigidObjectData`
+- :class:`~isaaclab.assets.RigidObjectCollection`, :class:`~isaaclab.assets.RigidObjectCollectionCfg`, :class:`~isaaclab.assets.RigidObjectCollectionData`
+
+These classes now inherit from new abstract base classes but maintain full backward compatibility.
+
+The following sensor classes also remain in the ``isaaclab`` package with unchanged imports:
+
+- :class:`~isaaclab.sensors.ContactSensor`, :class:`~isaaclab.sensors.ContactSensorCfg`, :class:`~isaaclab.sensors.ContactSensorData`
+- :class:`~isaaclab.sensors.Imu`, :class:`~isaaclab.sensors.ImuCfg`, :class:`~isaaclab.sensors.ImuData`
+- :class:`~isaaclab.sensors.Pva`, :class:`~isaaclab.sensors.PvaCfg`, :class:`~isaaclab.sensors.PvaData`
+- :class:`~isaaclab.sensors.FrameTransformer`, :class:`~isaaclab.sensors.FrameTransformerCfg`, :class:`~isaaclab.sensors.FrameTransformerData`
+- :class:`~isaaclab.sensors.JointWrenchSensor`, :class:`~isaaclab.sensors.JointWrenchSensorCfg`,
+  :class:`~isaaclab.sensors.JointWrenchSensorData`
+
+These sensor classes now use factory patterns that automatically instantiate the appropriate backend
+implementation (PhysX by default), maintaining full backward compatibility.
+
+.. note::
+
+   The ``Imu`` sensor in Isaac Lab 3.0 is **not** the same as the ``Imu`` sensor in 2.x.
+   The old ``Imu`` (full state sensor) has been renamed to :class:`~isaaclab.sensors.Pva`.
+   The new :class:`~isaaclab.sensors.Imu` is a lightweight sensor that only provides angular velocity
+   and linear acceleration. See :ref:`imu-to-pva-migration` below for details.
+
+If you need to import the PhysX sensor implementations directly (e.g., for type hints or subclassing),
+you can import from ``isaaclab_physx.sensors``:
+
+.. code-block:: python
+
+   # Direct PhysX implementation imports
+   from isaaclab_physx.sensors import ContactSensor, ContactSensorData
+   from isaaclab_physx.sensors import Imu, ImuData
+   from isaaclab_physx.sensors import Pva, PvaData
+   from isaaclab_physx.sensors import FrameTransformer, FrameTransformerData
+   from isaaclab_physx.sensors import JointWrenchSensor, JointWrenchSensorData
+
+
+.. rubric:: Newton Backend Implementations
+
+A new extension ``isaaclab_newton`` provides Newton physics backend implementations for:
+
+- :class:`~isaaclab_newton.assets.Articulation` and :class:`~isaaclab_newton.assets.ArticulationData`
+- :class:`~isaaclab_newton.assets.RigidObject` and :class:`~isaaclab_newton.assets.RigidObjectData`
+- :class:`~isaaclab_newton.sensors.JointWrenchSensor` and
+  :class:`~isaaclab_newton.sensors.JointWrenchSensorData`
+
+These classes implement the same base interfaces as their PhysX counterparts
+(:class:`~isaaclab.assets.BaseArticulation`, :class:`~isaaclab.assets.BaseRigidObject`),
+ensuring a consistent API across backends. They use the same warp-based data conventions
+(``wp.array`` with structured types, ``_index`` / ``_mask`` write methods).
+
+.. note::
+
+   The ``isaaclab_newton`` extension requires the ``newton`` package and its dependencies
+   (``mujoco``, ``mujoco-warp``). These are installed automatically when installing the
+   ``isaaclab_newton`` package.
+
+If you need to import Newton implementations directly (e.g., for type hints or subclassing):
+
+.. code-block:: python
+
+   from isaaclab_newton.assets import Articulation as NewtonArticulation
+   from isaaclab_newton.assets import RigidObject as NewtonRigidObject
+
+
 .. _schemas-cfg-refactor:
 
-Schema Configuration Class Refactor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Schema Configuration Class Refactor
 
 In Isaac Lab 3.0, the spawner schema cfg classes are split into solver-common
 **base classes** (in ``isaaclab.sim.schemas``) and **backend-specific subclasses**
@@ -529,331 +410,14 @@ For complete tables of which fields live on which class and where each lands in
 USD, see :ref:`schema-cfgs`.
 
 
-Renaming of ``XformPrimView`` to ``FrameView``
------------------------------------------------
-
-Isaac Lab's ``XformPrimView`` and related classes have been renamed to ``FrameView`` to
-better reflect their purpose and avoid confusion with Isaac Sim's ``XFormPrim`` class
-hierarchy. The old ``XformPrimView`` name is kept as a deprecated alias.
-
-The rename applies across all backends:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 50 50
-
-   * - Isaac Lab 2.x
-     - Isaac Lab 3.0
-   * - ``BaseXformPrimView``
-     - :class:`~isaaclab.sim.views.BaseFrameView`
-   * - ``UsdXformPrimView``
-     - :class:`~isaaclab.sim.views.UsdFrameView`
-   * - ``XformPrimView``
-     - :class:`~isaaclab.sim.views.FrameView`
-   * - ``FabricXformPrimView``
-     - :class:`~isaaclab_physx.sim.views.FabricFrameView`
-   * - ``NewtonSiteXformPrimView``
-     - :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`
-
-For most users, the only change needed is updating imports:
-
-.. code-block:: python
-
-   # Before
-   from isaaclab.sim.views import XformPrimView
-
-   # After
-   from isaaclab.sim.views import FrameView
-
-The :class:`~isaaclab.sim.views.FrameView` factory automatically dispatches to the correct
-backend (:class:`~isaaclab_physx.sim.views.FabricFrameView` for PhysX,
-:class:`~isaaclab_newton.sim.views.NewtonSiteFrameView` for Newton) based on the active
-physics backend. The deprecated ``XformPrimView`` alias continues to work but will be
-removed in a future release.
-
-
-Unchanged Imports
------------------
-
-The following asset classes remain in the ``isaaclab`` package and can still be imported as before:
-
-- :class:`~isaaclab.assets.Articulation`, :class:`~isaaclab.assets.ArticulationCfg`, :class:`~isaaclab.assets.ArticulationData`
-- :class:`~isaaclab.assets.RigidObject`, :class:`~isaaclab.assets.RigidObjectCfg`, :class:`~isaaclab.assets.RigidObjectData`
-- :class:`~isaaclab.assets.RigidObjectCollection`, :class:`~isaaclab.assets.RigidObjectCollectionCfg`, :class:`~isaaclab.assets.RigidObjectCollectionData`
-
-These classes now inherit from new abstract base classes but maintain full backward compatibility.
-
-The following sensor classes also remain in the ``isaaclab`` package with unchanged imports:
-
-- :class:`~isaaclab.sensors.ContactSensor`, :class:`~isaaclab.sensors.ContactSensorCfg`, :class:`~isaaclab.sensors.ContactSensorData`
-- :class:`~isaaclab.sensors.Imu`, :class:`~isaaclab.sensors.ImuCfg`, :class:`~isaaclab.sensors.ImuData`
-- :class:`~isaaclab.sensors.Pva`, :class:`~isaaclab.sensors.PvaCfg`, :class:`~isaaclab.sensors.PvaData`
-- :class:`~isaaclab.sensors.FrameTransformer`, :class:`~isaaclab.sensors.FrameTransformerCfg`, :class:`~isaaclab.sensors.FrameTransformerData`
-- :class:`~isaaclab.sensors.JointWrenchSensor`, :class:`~isaaclab.sensors.JointWrenchSensorCfg`,
-  :class:`~isaaclab.sensors.JointWrenchSensorData`
-
-These sensor classes now use factory patterns that automatically instantiate the appropriate backend
-implementation (PhysX by default), maintaining full backward compatibility.
-
-.. note::
-
-   The ``Imu`` sensor in Isaac Lab 3.0 is **not** the same as the ``Imu`` sensor in 2.x.
-   The old ``Imu`` (full state sensor) has been renamed to :class:`~isaaclab.sensors.Pva`.
-   The new :class:`~isaaclab.sensors.Imu` is a lightweight sensor that only provides angular velocity
-   and linear acceleration. See :ref:`imu-to-pva-migration` below for details.
-
-If you need to import the PhysX sensor implementations directly (e.g., for type hints or subclassing),
-you can import from ``isaaclab_physx.sensors``:
-
-.. code-block:: python
-
-   # Direct PhysX implementation imports
-   from isaaclab_physx.sensors import ContactSensor, ContactSensorData
-   from isaaclab_physx.sensors import Imu, ImuData
-   from isaaclab_physx.sensors import Pva, PvaData
-   from isaaclab_physx.sensors import FrameTransformer, FrameTransformerData
-   from isaaclab_physx.sensors import JointWrenchSensor, JointWrenchSensorData
-
-
-New ``isaaclab_newton`` Extension
----------------------------------
-
-A new extension ``isaaclab_newton`` provides Newton physics backend implementations for:
-
-- :class:`~isaaclab_newton.assets.Articulation` and :class:`~isaaclab_newton.assets.ArticulationData`
-- :class:`~isaaclab_newton.assets.RigidObject` and :class:`~isaaclab_newton.assets.RigidObjectData`
-- :class:`~isaaclab_newton.sensors.JointWrenchSensor` and
-  :class:`~isaaclab_newton.sensors.JointWrenchSensorData`
-
-These classes implement the same base interfaces as their PhysX counterparts
-(:class:`~isaaclab.assets.BaseArticulation`, :class:`~isaaclab.assets.BaseRigidObject`),
-ensuring a consistent API across backends. They use the same warp-based data conventions
-(``wp.array`` with structured types, ``_index`` / ``_mask`` write methods).
-
-.. note::
-
-   The ``isaaclab_newton`` extension requires the ``newton`` package and its dependencies
-   (``mujoco``, ``mujoco-warp``). These are installed automatically when installing the
-   ``isaaclab_newton`` package.
-
-If you need to import Newton implementations directly (e.g., for type hints or subclassing):
-
-.. code-block:: python
-
-   from isaaclab_newton.assets import Articulation as NewtonArticulation
-   from isaaclab_newton.assets import RigidObject as NewtonRigidObject
-
-
-Deformable Object API Changes
-------------------------------
-
-Isaac Lab 3.0 updates the deformable body API to align with the current Omni Physics 110.0
-release. The old soft body API has been deprecated and replaced by two distinct deformable
-types: **volume deformables** (3D FEM tetrahedral meshes) and **surface deformables** (2D
-triangle cloth meshes). The deformable type is determined by the physics material assigned:
-
-- :class:`~isaaclab_physx.sim.PhysxDeformableBodyMaterialCfg` for PhysX volume deformables.
-- :class:`~isaaclab_physx.sim.PhysxSurfaceDeformableBodyMaterialCfg` for PhysX surface deformables.
-- :class:`~isaaclab_newton.sim.spawners.materials.NewtonDeformableBodyMaterialCfg` for Newton volume deformables.
-- :class:`~isaaclab_newton.sim.spawners.materials.NewtonSurfaceDeformableBodyMaterialCfg` for Newton surface
-  deformables.
-
-Deformable property and material cfgs are backend-specific. Several properties on
-:class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg` have been removed or added to
-match the new Omni Physics schema. The common
-:class:`~isaaclab.sim.DeformableBodyPropertiesBaseCfg` is now empty; OmniPhysics
-deformable body fields are owned by :class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg`.
-
-For a comprehensive guide covering the full deformable API migration — including removed and
-added properties, material changes, code examples for both volume and surface deformables, and
-current limitations — see :ref:`migrating-deformables`.
-
-
-.. _imu-to-pva-migration:
-
-IMU Sensor Renamed to PVA; New Lightweight IMU Sensor
------------------------------------------------------
-
-The old ``Imu`` sensor has been renamed to **PVA** (Pose Velocity Acceleration) because it provided
-full pose, velocity, and acceleration data — far more than a real inertial measurement unit measures.
-A new lightweight **IMU** sensor has been introduced that only provides the two physical quantities
-a real IMU measures: angular velocity (gyroscope) and linear acceleration (accelerometer).
-
-If you were using the old ``Imu`` sensor, you need to decide which new sensor to use:
-
-- Use :class:`~isaaclab.sensors.Pva` / :class:`~isaaclab.sensors.PvaCfg` if you need full state
-  data (pose, linear velocity, angular velocity, linear and angular acceleration, projected gravity).
-- Use :class:`~isaaclab.sensors.Imu` / :class:`~isaaclab.sensors.ImuCfg` if you only need angular
-  velocity and linear acceleration (as a real IMU provides).
-
-For configuration and data access examples, see the :ref:`overview_sensors_pva`.
-
-**Import changes:**
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x) — the old IMU provided full state
-   from isaaclab.sensors import Imu, ImuCfg, ImuData
-
-   # After (Isaac Lab 3.x) — use PVA for the same full-state sensor
-   from isaaclab.sensors import Pva, PvaCfg, PvaData
-
-   # Or use the new lightweight IMU for angular velocity + linear acceleration only
-   from isaaclab.sensors import Imu, ImuCfg, ImuData
-
-**Configuration changes:**
-
-The ``gravity_bias`` configuration parameter has been removed from both sensors:
-
-- **PVA** reports raw kinematic acceleration (no gravity contribution), as the acceleration
-  is derived from finite differencing of velocities which do not include gravity.
-- **IMU** unconditionally includes gravity in its accelerometer readings, matching the behavior
-  of a real accelerometer. The gravity vector is automatically queried from the simulation.
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   imu_cfg = ImuCfg(
-       prim_path="{ENV_REGEX_NS}/Robot/base",
-       gravity_bias=(0.0, 0.0, 9.81),  # had to be configured manually
-   )
-
-   # After (Isaac Lab 3.x) — PVA (no gravity in acceleration)
-   pva_cfg = PvaCfg(prim_path="{ENV_REGEX_NS}/Robot/base")
-
-   # After (Isaac Lab 3.x) — IMU (gravity always included automatically)
-   imu_cfg = ImuCfg(prim_path="{ENV_REGEX_NS}/Robot/base")
-
-**Observation function changes:**
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   from isaaclab.envs.mdp import imu_orientation, imu_projected_gravity
-
-   # After (Isaac Lab 3.x)
-   from isaaclab.envs.mdp import pva_orientation, pva_projected_gravity
-
-**Data property changes:**
-
-The new ``ImuData`` only provides ``ang_vel_b`` and ``lin_acc_b``. If you were accessing other
-properties (``pos_w``, ``quat_w``, ``lin_vel_b``, ``ang_acc_b``, ``projected_gravity_b``), switch
-to :class:`~isaaclab.sensors.PvaData` which provides all of them.
-
-
-Sensor Pose Properties Deprecation
-----------------------------------
-
-The ``pose_w``, ``pos_w``, and ``quat_w`` properties on :class:`~isaaclab.sensors.ContactSensorData`
-are deprecated and will be removed in a future release.
-
-If you need to track sensor poses in world frame, please use a dedicated sensor such as
-:class:`~isaaclab.sensors.FrameTransformer` instead.
-
-**Before (deprecated):**
-
-.. code-block:: python
-
-   # Using pose properties directly on sensor data
-   sensor_pos = contact_sensor.data.pos_w
-   sensor_quat = contact_sensor.data.quat_w
-
-**After (recommended):**
-
-.. code-block:: python
-
-   # Use FrameTransformer to track sensor pose
-   frame_transformer = FrameTransformer(FrameTransformerCfg(
-       prim_path="{ENV_REGEX_NS}/Robot/base",
-       target_frames=[
-           FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/sensor_link"),
-       ],
-   ))
-   sensor_pos = frame_transformer.data.target_pos_w
-   sensor_quat = frame_transformer.data.target_quat_w
-
-
-Articulation Joint Wrench Data Moved to ``JointWrenchSensor``
--------------------------------------------------------------
-
-The ``ArticulationData.body_incoming_joint_wrench_b`` property has been removed. In
-Isaac Lab 3.0, incoming joint reaction wrenches are exposed through
-:class:`~isaaclab.sensors.JointWrenchSensor`, which has PhysX and Newton backend
-implementations and returns separate force [N] and torque [N·m] buffers.
-The sensor reports wrenches in the child-side incoming joint frame, with torque
-referenced at the child-side joint anchor.
-
-For configuration and data access examples, see the :ref:`overview_sensors_joint_wrench`.
-
-**Before (Isaac Lab 2.x):**
-
-.. code-block:: python
-
-   wrench_b = robot.data.body_incoming_joint_wrench_b.torch[:, body_ids]
-
-**After (Isaac Lab 3.x):**
-
-.. code-block:: python
-
-   import torch
-   from isaaclab.scene import InteractiveSceneCfg
-   from isaaclab.sensors import JointWrenchSensorCfg
-
-   class MySceneCfg(InteractiveSceneCfg):
-       robot = ROBOT_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-       joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
-
-   sensor = env.scene.sensors["joint_wrench"]
-   data = sensor.data
-   wrench_j = torch.cat(
-       (
-           data.force.torch[:, body_ids],
-           data.torque.torch[:, body_ids],
-       ),
-       dim=-1,
-   )
-
-Use :attr:`~isaaclab.sensors.BaseJointWrenchSensor.body_names` or
-:meth:`~isaaclab.sensors.BaseJointWrenchSensor.find_bodies` to map sensor entries to
-articulation body names. PhysX reports one entry for every link, including the articulation
-root link. Newton reports the child bodies of reportable incoming joints.
-
-For manager-based environments, update observations that used the articulation data property to
-depend on the joint-wrench sensor instead:
-
-.. code-block:: python
-
-   import isaaclab.envs.mdp as mdp
-   from isaaclab.managers import SceneEntityCfg
-   from isaaclab.managers import ObservationTermCfg as ObsTerm
-   from isaaclab.scene import InteractiveSceneCfg
-   from isaaclab.sensors import JointWrenchSensorCfg
-
-   class MySceneCfg(InteractiveSceneCfg):
-       robot = ROBOT_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-       joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
-
-   feet_body_forces = ObsTerm(
-       func=mdp.body_incoming_wrench,
-       params={
-           "sensor_cfg": SceneEntityCfg(
-               "joint_wrench",
-               body_names=["left_foot", "right_foot"],
-           )
-       },
-   )
-
-
-Multi-Backend Support: PresetCfg Pattern
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Multi-Backend Support: PresetCfg Pattern
 
 Isaac Lab 3.0 introduces a **PresetCfg pattern** for writing environment configurations
 that work with both the PhysX and Newton backends. Instead of hard-coding a single
 physics config, environments declare named configuration variants. The active variant
 is selected at launch via a Hydra CLI override.
 
-What is PresetCfg?
-------------------
+**What is PresetCfg?**
 
 :class:`~isaaclab_tasks.utils.PresetCfg` is a base ``@configclass`` whose typed fields
 represent named variants of a configuration section. The field named ``default`` is used
@@ -875,8 +439,7 @@ when no CLI override is given. Other fields are named presets selectable with
        default: PhysxCfg = isaacsim_physx  # used when no override is given
        newton_mjwarp:  NewtonCfg = NewtonCfg(...)  # selected by physics=newton_mjwarp
 
-Selecting a preset at launch
------------------------------
+**Selecting a preset at launch**
 
 Pass ``physics=newton_mjwarp`` on the CLI to swap the entire config section.
 Use ``physics=physx`` to opt into automatic PhysX-family selection. The legacy
@@ -892,8 +455,7 @@ Use ``physics=physx`` to opt into automatic PhysX-family selection. The legacy
    uv run --extra isaacsim isaaclab train --rl_library rsl_rl \
        --task Isaac-Open-Drawer-Franka-Direct
 
-Adding Multi-Backend Support to an Environment
------------------------------------------------
+**Adding Multi-Backend Support to an Environment**
 
 **Step 1 — Physics config**
 
@@ -1017,8 +579,464 @@ Then change the ``events`` field in your env cfg from ``EventCfg`` to ``EnvEvent
        events: EnvEventCfg = EnvEventCfg()  # was: EventCfg = EventCfg()
 
 
-RigidObjectCollection API Renaming
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Isaac Sim API Compatibility
+
+In Isaac Sim 6.0, the legacy ``isaacsim.core.*``, ``isaacsim.sensors.*``, and
+``isaacsim.robot.wheeled_robots`` Python module paths are **deprecated** in favor of their
+``isaacsim.core.experimental.*`` (and ``*.experimental.*``) equivalents. Isaac Lab 3.0 has
+been migrated off the deprecated paths so that Isaac Lab continues to load and run when
+those modules are removed in a future Isaac Sim release.
+
+This is mostly a transparent change for users — Isaac Lab's own public Python API
+(:mod:`isaaclab`, :mod:`isaaclab_physx`, :mod:`isaaclab_tasks`, :mod:`isaaclab_teleop`,
+:mod:`isaaclab_mimic`) is unchanged. The migration is only user-visible if you:
+
+1. Import Isaac Sim symbols **directly** in your project, or
+2. Maintain a custom Kit experience (``.kit`` file) that lists Isaac Sim extension
+   dependencies, or
+3. Imported ``SimulationManager`` from ``isaacsim.core.simulation_manager`` in your own
+   PhysX-backed code.
+
+
+**Python module renames**
+
+Update direct imports in your own code as follows. **Where Isaac Lab provides an in-tree
+replacement, prefer the Isaac Lab API** over the ``isaacsim.core.experimental.*`` fallback:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Deprecated Isaac Sim path
+     - Recommended replacement
+   * - ``isaacsim.core.utils.stage``
+     - :mod:`isaaclab.sim.utils.stage` (e.g. ``get_current_stage``,
+       ``create_new_stage``, ``open_stage``, ``save_stage``, ``close_stage``,
+       ``clear_stage``, ``update_stage``, ``use_stage``)
+   * - ``isaacsim.core.utils.prims``
+     - :mod:`isaaclab.sim.utils.prims` (e.g. ``create_prim``, ``delete_prim``,
+       ``change_prim_property``, ``bind_visual_material``,
+       ``bind_physics_material``, ``add_usd_reference``)
+   * - ``isaacsim.core.utils.queries``
+     - :mod:`isaaclab.sim.utils.queries` (e.g. ``find_matching_prims``,
+       ``find_matching_prim_paths``, ``get_first_matching_child_prim``)
+   * - ``isaacsim.core.utils.transforms``
+     - :mod:`isaaclab.sim.utils.transforms`
+   * - ``isaacsim.core.utils.semantics``
+     - :mod:`isaaclab.sim.utils.semantics`
+   * - ``isaacsim.core.utils.extensions.enable_extension``
+     - :func:`isaaclab.sim.utils.enable_extension`
+   * - ``isaacsim.core.utils.viewports.set_camera_view``
+     - ``isaacsim.core.rendering_manager.ViewportManager.set_camera_view`` (or
+       ``omni.kit.viewport.utility.camera_state.ViewportCameraState`` for lower-level control)
+   * - ``isaacsim.core.prims.XFormPrim`` / ``XFormPrimView``
+     - :class:`~isaaclab.sim.views.FrameView` (Isaac Lab in-tree view; see
+       :ref:`migrating-to-isaaclab-3-0` ``Renaming of XformPrimView to FrameView`` above).
+       For ``Articulation`` / ``RigidPrim`` use ``isaacsim.core.experimental.prims``.
+   * - ``isaacsim.core.simulation_manager.SimulationManager``
+     - :class:`isaaclab_physx.physics.PhysxManager` (PhysX backend) or
+       ``isaaclab_newton.physics.NewtonManager`` (Newton backend); see local-alias
+       pattern below.
+   * - ``isaacsim.core.cloner``
+     - :mod:`isaaclab.cloner` (Isaac Lab in-tree cloner)
+   * - ``isaacsim.replicator.mobility_gen``
+     - ``isaacsim.replicator.experimental.mobility_gen``
+   * - ``isaacsim.sensors.<name>``
+     - ``isaacsim.sensors.experimental.<name>``
+   * - ``isaacsim.robot.wheeled_robots``
+     - ``isaacsim.robot.experimental.wheeled_robots`` (and
+       ``isaacsim.robot.wheeled_robots.nodes`` for OmniGraph nodes)
+
+To keep call-site code symmetric across backends when migrating off
+``isaacsim.core.simulation_manager.SimulationManager``, use the local-alias pattern:
+
+.. code-block:: python
+
+   from isaaclab_physx.physics import PhysxManager as SimulationManager
+   # or, for the Newton backend
+   from isaaclab_newton.physics import NewtonManager as SimulationManager
+
+**Isaac Sim extension modules must be explicitly enabled before direct import**
+
+Isaac Lab 3.0 no longer automatically initializes Isaac Sim extensions only to
+make their Python modules importable. Stock Isaac Lab Kit experiences now load a
+smaller set of extensions so unused Isaac Sim packages do not pull in
+unnecessary dependencies or deprecated aliases.
+
+If your project imports an Isaac Sim extension module directly, enable the
+extension after the Kit application has started and before importing from that
+module:
+
+.. code-block:: python
+
+   from isaaclab.sim.utils import enable_extension
+
+   enable_extension("isaacsim.core.experimental.prims")
+   from isaacsim.core.experimental.prims import XformPrim
+
+This is especially important for migration replacements such as
+``isaacsim.core.experimental.*`` and ``isaacsim.sensors.experimental.*``. Do not
+import ``enable_extension`` from ``isaacsim.core.experimental.utils.app`` unless
+that extension is already enabled; use :func:`isaaclab.sim.utils.enable_extension`
+from Isaac Lab instead. The helper requires a running Kit application and raises
+``RuntimeError`` if called from plain Python before Kit is launched.
+
+
+**Kit experience (``.kit``) updates**
+
+If you maintain a custom Kit experience derived from one of the Isaac Lab apps under
+``apps/``:
+
+* **Stop registering deprecated extension search paths.** The ``extsDeprecated`` search
+  path entry has been removed from all stock Isaac Lab Kit experiences (headless,
+  rendering, XR variants). Mirror that change in your own experience.
+* **Switch explicit Isaac Sim extension dependencies** to the non-deprecated equivalents
+  listed above (``isaacsim.core.experimental.*``, ``isaacsim.sensors.experimental.*``,
+  ``isaacsim.robot.experimental.wheeled_robots``).
+* **Do not rely on stock Isaac Lab apps to preload Isaac Sim extensions** that your
+  project imports directly. Either add those extensions to your custom ``.kit`` file
+  or enable them with :func:`isaaclab.sim.utils.enable_extension` before importing
+  their Python modules.
+* **Remove unused Isaac Sim extensions that pull in** ``isaacsim.core.api`` — Isaac Lab
+  no longer depends on those, and keeping them resurrects the deprecated stack.
+
+
+**``SimulationManager`` is no longer re-exported**
+
+Earlier internal previews of this migration briefly exposed
+``isaaclab_physx.physics.SimulationManager`` as a public alias of
+:class:`~isaaclab_physx.physics.PhysxManager`. **That alias has been removed**; use
+:class:`~isaaclab_physx.physics.PhysxManager` directly (with ``as SimulationManager`` at
+the import site if you want backend-agnostic call-site code, as shown above).
+
+
+**Retired standalone reproducers**
+
+A handful of legacy reproducers under ``source/isaaclab/test/deps/isaacsim`` that
+depended on the deprecated Isaac Sim core extensions have been retired:
+``check_camera.py``, ``check_floating_base_made_fixed.py``,
+``check_legged_robot_clone.py``, ``check_rep_texture_randomizer.py``, and
+``check_ref_count.py``. Use :mod:`isaaclab.sim` together with the new
+``isaacsim.core.experimental.*`` APIs for the same debugging workflows.
+
+
+.. rubric:: PhysX Tensors API Module Path
+
+Recent Isaac Sim releases removed the internal ``impl`` submodule of
+``omni.physics.tensors`` and now expose the PhysX Tensor API types
+(``ArticulationView``, ``RigidBodyView``, ``SimulationView``, etc.) directly
+under ``omni.physics.tensors.api``. Importing from the old path raises
+``ModuleNotFoundError: No module named 'omni.physics.tensors.impl'`` at import
+time.
+
+Isaac Lab has been updated to import from the new path. Downstream code
+(custom assets, sensors, or scripts) that imported from the old path must be
+updated:
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x / older Isaac Sim)
+   import omni.physics.tensors.impl.api as physx
+
+   # After (Isaac Lab 3.x / current Isaac Sim)
+   import omni.physics.tensors.api as physx
+
+The class identities are unchanged — only the module path moved. Type hints
+referencing the old path (``omni.physics.tensors.impl.api.ArticulationView``)
+should be similarly updated to ``omni.physics.tensors.api.ArticulationView``.
+
+
+Assets, Actuators, and Sensors
+------------------------------
+
+Update asset-facing APIs after the backend configuration is in place. This includes renamed views, actuator ownership, and sensor replacements.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Isaac Lab 2.x
+
+      .. code-block:: python
+
+         from isaaclab.sim.views import XformPrimView
+         from isaaclab.sensors import ImuCfg
+
+         view = XformPrimView(...)
+         wrench = robot.data.body_incoming_joint_wrench_b
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      .. code-block:: python
+
+         from isaaclab.sim.views import FrameView
+         from isaaclab.sensors import JointWrenchSensorCfg, PvaCfg
+
+         view = FrameView(...)
+         wrench = env.scene.sensors["joint_wrench"].data.force.torch
+
+
+.. rubric:: Renaming of ``XformPrimView`` to ``FrameView``
+
+Isaac Lab's ``XformPrimView`` and related classes have been renamed to ``FrameView`` to
+better reflect their purpose and avoid confusion with Isaac Sim's ``XFormPrim`` class
+hierarchy. The old ``XformPrimView`` name is kept as a deprecated alias.
+
+The rename applies across all backends:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Isaac Lab 2.x
+     - Isaac Lab 3.0
+   * - ``BaseXformPrimView``
+     - :class:`~isaaclab.sim.views.BaseFrameView`
+   * - ``UsdXformPrimView``
+     - :class:`~isaaclab.sim.views.UsdFrameView`
+   * - ``XformPrimView``
+     - :class:`~isaaclab.sim.views.FrameView`
+   * - ``FabricXformPrimView``
+     - :class:`~isaaclab_physx.sim.views.FabricFrameView`
+   * - ``NewtonSiteXformPrimView``
+     - :class:`~isaaclab_newton.sim.views.NewtonSiteFrameView`
+
+For most users, the only change needed is updating imports:
+
+.. code-block:: python
+
+   # Before
+   from isaaclab.sim.views import XformPrimView
+
+   # After
+   from isaaclab.sim.views import FrameView
+
+The :class:`~isaaclab.sim.views.FrameView` factory automatically dispatches to the correct
+backend (:class:`~isaaclab_physx.sim.views.FabricFrameView` for PhysX,
+:class:`~isaaclab_newton.sim.views.NewtonSiteFrameView` for Newton) based on the active
+physics backend. The deprecated ``XformPrimView`` alias continues to work but will be
+removed in a future release.
+
+
+.. _actuators-solver-limit-migration:
+
+.. rubric:: Actuator effort and joint-limit names
+
+Actuator configurations now use joint-qualified names for solver limits. Update active
+configurations to the canonical fields below. The former names remain accepted with a
+``DeprecationWarning`` through the 3.x release line and will be removed in 4.0.
+
+.. list-table:: Actuator limit migration
+   :header-rows: 1
+   :widths: 38 38 24
+
+   * - Deprecated configuration field
+     - Canonical configuration field
+     - Runtime owner
+   * - ``effort_limit``
+     - ``actuator_effort_limit``
+     - Actuator model (rated limit)
+   * - ``effort_limit_sim``
+     - ``joint_effort_limit``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_effort_limits`
+   * - ``velocity_limit_sim``
+     - ``joint_velocity_limit``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_vel_limits`
+
+``actuator_effort_limit`` clips explicit actuator-model output. ``joint_effort_limit`` and
+``joint_velocity_limit`` are construction-time joint-property overrides selected by an actuator
+group's joint expression. The deprecated aliases ``effort_limit``, ``velocity_limit``,
+``effort_limit_sim``, and ``velocity_limit_sim`` remain accepted through 3.x. ``effort_limit``
+resolves to the rated ``actuator_effort_limit`` for every actuator type. For an implicit group
+without a separately configured solver clamp, the rated value also populates
+``joint_effort_limit`` for backward compatibility; configure both fields to author distinct
+rated and solver limits. The runtime ``effort_limit`` and ``velocity_limit`` group properties
+follow the same mapping and are also deprecated.
+``actuator_velocity_limit`` describes rated speed or an implicit soft-limit snapshot.
+``joint_velocity_limit`` only requests solver enforcement, which is backend-dependent. See
+:ref:`actuators-joint-property-ownership` for the full ownership model.
+
+**Behavior change — explicit groups keep the solver effort limit.** Isaac Lab previously raised the
+solver effort limit to ``1.0e9`` on joints driven by an explicit actuator so that only the model
+clipped the effort. The solver now keeps the authored or configured ``joint_effort_limit``, so
+effort submitted by an explicit model is clipped a second time by the solver. If your asset authors
+a tight joint effort limit and your policy relies on the model limit alone, set
+``joint_effort_limit`` at least as large as ``actuator_effort_limit`` in the actuator
+configuration.
+
+The runtime group properties listed below were removed. Read their live values from articulation
+data and use the corresponding indexed articulation writer:
+
+.. list-table:: Removed group-property migration
+   :header-rows: 1
+   :widths: 26 38 36
+
+   * - Removed runtime group property
+     - Read
+     - Write
+   * - ``effort_limit_sim``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_effort_limits`
+     - :meth:`~isaaclab.assets.Articulation.write_joint_effort_limit_to_sim_index`
+   * - ``velocity_limit_sim``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_vel_limits`
+     - :meth:`~isaaclab.assets.Articulation.write_joint_velocity_limit_to_sim_index`
+   * - ``armature``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_armature`
+     - :meth:`~isaaclab.assets.Articulation.write_joint_armature_to_sim_index`
+   * - ``friction``
+     - :attr:`~isaaclab.assets.ArticulationData.joint_friction_coeff`
+     - :meth:`~isaaclab.assets.Articulation.write_joint_friction_coefficient_to_sim_index`
+   * - ``dynamic_friction``
+     - ``data.joint_dynamic_friction_coeff`` (PhysX and OVPhysX)
+     - ``write_joint_dynamic_friction_coefficient_to_sim_index`` (PhysX and OVPhysX)
+   * - ``viscous_friction``
+     - ``data.joint_viscous_friction_coeff``
+     - ``write_joint_viscous_friction_coefficient_to_sim_index``
+
+The dynamic-friction view and writer are backend-specific; Newton has no corresponding joint
+property.
+
+**Custom actuator models.** The protected helper ``ActuatorBase._parse_joint_parameter`` was
+removed together with the constructor rework. Custom actuator subclasses that parsed configuration
+fields with it should call :func:`~isaaclab.actuators.resolve_joint_parameter`, which applies the
+same resolution semantics as a standalone function:
+
+.. code-block:: python
+
+   from isaaclab.actuators import ActuatorBase, resolve_joint_parameter
+
+
+   class MyActuator(ActuatorBase):
+       def __init__(self, cfg, joint_names, joint_ids, num_envs, device, **kwargs):
+           super().__init__(cfg, joint_names, joint_ids, num_envs, device, **kwargs)
+           # before: self.my_gain = self._parse_joint_parameter(cfg.my_gain, 0.0)
+           self.my_gain = resolve_joint_parameter(cfg.my_gain, 0.0, joint_names, num_envs, device)
+
+The backend articulation methods ``write_actuator_stiffness_to_sim`` and
+``write_actuator_damping_to_sim`` are deprecated. Use
+:func:`~isaaclab.envs.mdp.events.randomize_actuator_gains` for managed gain randomization; it
+updates actuator-owned gains, implicit solver drives, or native-controller parameters as
+appropriate. For direct writes to a Newton-executed group's controller, use
+:func:`~isaaclab.actuators.newton.write_group_parameter`.
+
+Named regular-expression groups retain their configuration behavior. If both a deprecated name and
+its canonical replacement are present in the same group, use only the canonical name; equivalent
+values warn and select the canonical value, whereas conflicting values raise :class:`ValueError`.
+
+
+.. rubric:: Actuator API Moves to ``ActuatorCollection``
+
+In Isaac Lab 3.x, actuator ownership moves from :class:`~isaaclab.assets.Articulation` to a
+backend-neutral :class:`~isaaclab.actuators.ActuatorCollection`, available as
+:attr:`~isaaclab.assets.Articulation.actuators`. Actuator command setters and per-joint actuator
+telemetry now live on the collection, so the same code path drives every physics backend. The
+collection setters are keyword-only.
+
+
+**Method Relocations**
+
+The following methods on :class:`~isaaclab.assets.Articulation` move to the actuator collection.
+The old methods are deprecated and will be removed in a future release:
+
++-------------------------------------------------------------+------------------------------------------------------+
+| Deprecated                                                  | New                                                  |
++=============================================================+======================================================+
+| ``set_joint_position_target``                               | ``actuators.target_command.set_position_index``      |
++-------------------------------------------------------------+------------------------------------------------------+
+| ``set_joint_velocity_target``                               | ``actuators.target_command.set_velocity_index``      |
++-------------------------------------------------------------+------------------------------------------------------+
+| ``set_joint_effort_target``                                 | ``actuators.target_command.set_effort_index``        |
++-------------------------------------------------------------+------------------------------------------------------+
+| ``set_joint_{position,velocity,effort}_target_index/_mask`` | ``actuators.target_command.set_{position,velocity,`` |
+|                                                             | ``effort}_index/_mask``                              |
++-------------------------------------------------------------+------------------------------------------------------+
+
+**Property Relocations (Data Class)**
+
+The following properties on :class:`~isaaclab.assets.ArticulationData` move to the actuator
+collection under the command view. The old properties are deprecated and will be removed in a
+future release:
+
++------------------------------+---------------------------------------+
+| Deprecated                   | New                                   |
++==============================+=======================================+
+| ``data.joint_pos_target``    | ``actuators.target_command.position`` |
++------------------------------+---------------------------------------+
+| ``data.joint_vel_target``    | ``actuators.target_command.velocity`` |
++------------------------------+---------------------------------------+
+| ``data.joint_effort_target`` | ``actuators.target_command.effort``   |
++------------------------------+---------------------------------------+
+| ``data.computed_torque``     | ``actuators.computed_effort``         |
++------------------------------+---------------------------------------+
+| ``data.applied_torque``      | ``actuators.applied_effort``          |
++------------------------------+---------------------------------------+
+
+.. note::
+
+   All deprecated methods and properties are forwarders that emit a :class:`DeprecationWarning`
+   when used. Your existing code will continue to work, but you should migrate to the new API to
+   avoid issues in future releases.
+
+   :attr:`~isaaclab.assets.ArticulationData.soft_joint_vel_limits` remains on
+   :class:`~isaaclab.assets.ArticulationData`; do not migrate it to the actuator collection.
+   ``ArticulationData.gear_ratio`` was removed: it was legacy :class:`~isaaclab.actuators.DCMotor`
+   telemetry that was no longer updated and always read one. Gear ratios are an actuator
+   configuration input, not simulation output; read them from your actuator configuration.
+
+.. important::
+
+   LEAPP-exported action terms are a temporary exception. The collection command setters do not
+   yet carry LEAPP output annotations, so exportable terms must continue to call the deprecated,
+   annotated ``Articulation.set_joint_*_target_index`` or ``*_mask`` methods until collection
+   setters are supported by the exporter. Runtime code that is not exported should use the
+   collection API.
+
+Actuator group topology is configuration-time state. Add or remove a group on
+:attr:`~isaaclab.assets.ArticulationCfg.actuators` before creating the articulation:
+
+.. code-block:: python
+
+   robot_cfg.actuators["gripper"] = ImplicitActuatorCfg(...)
+   robot = Articulation(robot_cfg)
+
+At runtime, assignment to or deletion from ``robot.actuators`` raises :class:`TypeError`. Group
+membership, joint coverage, native binding, execution slices, and cached launches are
+construction-time invariants. Continue to use the public named groups and collection views; private
+execution and compatibility-projection details are not migration targets.
+
+
+**Migration Example**
+
+Here's a complete example showing how to update your code:
+
+**Before (Isaac Lab 2.x):**
+
+.. code-block:: python
+
+   # Setting joint targets on the articulation (deprecated)
+   robot = scene["robot"]
+   robot.set_joint_effort_target(efforts, joint_ids=joint_ids)
+
+   # Reading actuator telemetry from the data class (deprecated)
+   applied = robot.data.applied_torque
+   pos_target = robot.data.joint_pos_target
+
+**After (Isaac Lab 3.0):**
+
+.. code-block:: python
+
+   # Sending actuator commands expressed in joint-side coordinates (keyword-only)
+   robot = scene["robot"]
+   robot.actuators.target_command.set_effort_index(value=efforts, joint_ids=joint_ids)
+
+   # Reading actuator telemetry from the collection
+   applied = robot.actuators.applied_effort.torch
+   position_command = robot.actuators.target_command.position.torch
+
+For the full runtime API of the actuator collection -- command setters and telemetry buffers --
+see :ref:`actuators-runtime-api`.
+
+
+.. rubric:: RigidObjectCollection API Renaming
 
 The :class:`~isaaclab_physx.assets.RigidObjectCollection` and
 :class:`~isaaclab_physx.assets.RigidObjectCollectionData` classes have undergone an API rename
@@ -1026,8 +1044,7 @@ to provide consistency with other asset classes. The ``object_*`` naming convent
 deprecated in favor of ``body_*``.
 
 
-Method Renames
---------------
+**Method Renames**
 
 The following methods have been renamed. The old methods are deprecated and will be removed in a
 future release:
@@ -1055,8 +1072,7 @@ future release:
 +------------------------------------------+------------------------------------------+
 
 
-Property Renames (Data Class)
------------------------------
+**Property Renames (Data Class)**
 
 The following properties on :class:`~isaaclab_physx.assets.RigidObjectCollectionData` have been
 renamed. The old properties are deprecated and will be removed in a future release:
@@ -1147,8 +1163,7 @@ renamed. The old properties are deprecated and will be removed in a future relea
    code will continue to work, but you should migrate to the new API to avoid issues in future releases.
 
 
-Migration Example
------------------
+**Migration Example**
 
 Here's a complete example showing how to update your code:
 
@@ -1194,125 +1209,350 @@ and OvPhysX bindings use different access methods. See
 before using ``root_view`` in backend-portable code.
 
 
-Actuator API Moves to ``ActuatorCollection``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Deformable Object API Changes
 
-In Isaac Lab 3.x, actuator ownership moves from :class:`~isaaclab.assets.Articulation` to a
-backend-neutral :class:`~isaaclab.actuators.ActuatorCollection`, available as
-:attr:`~isaaclab.assets.Articulation.actuators`. Actuator command setters and per-joint actuator
-telemetry now live on the collection, so the same code path drives every physics backend. The
-collection setters are keyword-only.
+Isaac Lab 3.0 updates the deformable body API to align with the current Omni Physics 110.0
+release. The old soft body API has been deprecated and replaced by two distinct deformable
+types: **volume deformables** (3D FEM tetrahedral meshes) and **surface deformables** (2D
+triangle cloth meshes). The deformable type is determined by the physics material assigned:
+
+- :class:`~isaaclab_physx.sim.PhysxDeformableBodyMaterialCfg` for PhysX volume deformables.
+- :class:`~isaaclab_physx.sim.PhysxSurfaceDeformableBodyMaterialCfg` for PhysX surface deformables.
+- :class:`~isaaclab_newton.sim.spawners.materials.NewtonDeformableBodyMaterialCfg` for Newton volume deformables.
+- :class:`~isaaclab_newton.sim.spawners.materials.NewtonSurfaceDeformableBodyMaterialCfg` for Newton surface
+  deformables.
+
+Deformable property and material cfgs are backend-specific. Several properties on
+:class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg` have been removed or added to
+match the new Omni Physics schema. The common
+:class:`~isaaclab.sim.DeformableBodyPropertiesBaseCfg` is now empty; OmniPhysics
+deformable body fields are owned by :class:`~isaaclab_physx.sim.PhysxDeformableBodyPropertiesCfg`.
+
+For a comprehensive guide covering the full deformable API migration — including removed and
+added properties, material changes, code examples for both volume and surface deformables, and
+current limitations — see :ref:`migrating-deformables`.
 
 
-Method Relocations
-------------------
+.. _imu-to-pva-migration:
 
-The following methods on :class:`~isaaclab.assets.Articulation` move to the actuator collection.
-The old methods are deprecated and will be removed in a future release:
+.. rubric:: IMU Sensor Renamed to PVA; New Lightweight IMU Sensor
 
-+-------------------------------------------------------------+------------------------------------------------------+
-| Deprecated                                                  | New                                                  |
-+=============================================================+======================================================+
-| ``set_joint_position_target``                               | ``actuators.target_command.set_position_index``      |
-+-------------------------------------------------------------+------------------------------------------------------+
-| ``set_joint_velocity_target``                               | ``actuators.target_command.set_velocity_index``      |
-+-------------------------------------------------------------+------------------------------------------------------+
-| ``set_joint_effort_target``                                 | ``actuators.target_command.set_effort_index``        |
-+-------------------------------------------------------------+------------------------------------------------------+
-| ``set_joint_{position,velocity,effort}_target_index/_mask`` | ``actuators.target_command.set_{position,velocity,`` |
-|                                                             | ``effort}_index/_mask``                              |
-+-------------------------------------------------------------+------------------------------------------------------+
+The old ``Imu`` sensor has been renamed to **PVA** (Pose Velocity Acceleration) because it provided
+full pose, velocity, and acceleration data — far more than a real inertial measurement unit measures.
+A new lightweight **IMU** sensor has been introduced that only provides the two physical quantities
+a real IMU measures: angular velocity (gyroscope) and linear acceleration (accelerometer).
 
-Property Relocations (Data Class)
----------------------------------
+If you were using the old ``Imu`` sensor, you need to decide which new sensor to use:
 
-The following properties on :class:`~isaaclab.assets.ArticulationData` move to the actuator
-collection under the command view. The old properties are deprecated and will be removed in a
-future release:
+- Use :class:`~isaaclab.sensors.Pva` / :class:`~isaaclab.sensors.PvaCfg` if you need full state
+  data (pose, linear velocity, angular velocity, linear and angular acceleration, projected gravity).
+- Use :class:`~isaaclab.sensors.Imu` / :class:`~isaaclab.sensors.ImuCfg` if you only need angular
+  velocity and linear acceleration (as a real IMU provides).
 
-+------------------------------+---------------------------------------+
-| Deprecated                   | New                                   |
-+==============================+=======================================+
-| ``data.joint_pos_target``    | ``actuators.target_command.position`` |
-+------------------------------+---------------------------------------+
-| ``data.joint_vel_target``    | ``actuators.target_command.velocity`` |
-+------------------------------+---------------------------------------+
-| ``data.joint_effort_target`` | ``actuators.target_command.effort``   |
-+------------------------------+---------------------------------------+
-| ``data.computed_torque``     | ``actuators.computed_effort``         |
-+------------------------------+---------------------------------------+
-| ``data.applied_torque``      | ``actuators.applied_effort``          |
-+------------------------------+---------------------------------------+
+For configuration and data access examples, see the :ref:`overview_sensors_pva`.
 
-.. note::
-
-   All deprecated methods and properties are forwarders that emit a :class:`DeprecationWarning`
-   when used. Your existing code will continue to work, but you should migrate to the new API to
-   avoid issues in future releases.
-
-   :attr:`~isaaclab.assets.ArticulationData.soft_joint_vel_limits` remains on
-   :class:`~isaaclab.assets.ArticulationData`; do not migrate it to the actuator collection.
-   ``ArticulationData.gear_ratio`` was removed: it was legacy :class:`~isaaclab.actuators.DCMotor`
-   telemetry that was no longer updated and always read one. Gear ratios are an actuator
-   configuration input, not simulation output; read them from your actuator configuration.
-
-.. important::
-
-   LEAPP-exported action terms are a temporary exception. The collection command setters do not
-   yet carry LEAPP output annotations, so exportable terms must continue to call the deprecated,
-   annotated ``Articulation.set_joint_*_target_index`` or ``*_mask`` methods until collection
-   setters are supported by the exporter. Runtime code that is not exported should use the
-   collection API.
-
-Actuator group topology is configuration-time state. Add or remove a group on
-:attr:`~isaaclab.assets.ArticulationCfg.actuators` before creating the articulation:
+**Import changes:**
 
 .. code-block:: python
 
-   robot_cfg.actuators["gripper"] = ImplicitActuatorCfg(...)
-   robot = Articulation(robot_cfg)
+   # Before (Isaac Lab 2.x) — the old IMU provided full state
+   from isaaclab.sensors import Imu, ImuCfg, ImuData
 
-At runtime, assignment to or deletion from ``robot.actuators`` raises :class:`TypeError`. Group
-membership, joint coverage, native binding, execution slices, and cached launches are
-construction-time invariants. Continue to use the public named groups and collection views; private
-execution and compatibility-projection details are not migration targets.
+   # After (Isaac Lab 3.x) — use PVA for the same full-state sensor
+   from isaaclab.sensors import Pva, PvaCfg, PvaData
+
+   # Or use the new lightweight IMU for angular velocity + linear acceleration only
+   from isaaclab.sensors import Imu, ImuCfg, ImuData
+
+**Configuration changes:**
+
+The ``gravity_bias`` configuration parameter has been removed from both sensors:
+
+- **PVA** reports raw kinematic acceleration (no gravity contribution), as the acceleration
+  is derived from finite differencing of velocities which do not include gravity.
+- **IMU** unconditionally includes gravity in its accelerometer readings, matching the behavior
+  of a real accelerometer. The gravity vector is automatically queried from the simulation.
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   imu_cfg = ImuCfg(
+       prim_path="{ENV_REGEX_NS}/Robot/base",
+       gravity_bias=(0.0, 0.0, 9.81),  # had to be configured manually
+   )
+
+   # After (Isaac Lab 3.x) — PVA (no gravity in acceleration)
+   pva_cfg = PvaCfg(prim_path="{ENV_REGEX_NS}/Robot/base")
+
+   # After (Isaac Lab 3.x) — IMU (gravity always included automatically)
+   imu_cfg = ImuCfg(prim_path="{ENV_REGEX_NS}/Robot/base")
+
+**Observation function changes:**
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   from isaaclab.envs.mdp import imu_orientation, imu_projected_gravity
+
+   # After (Isaac Lab 3.x)
+   from isaaclab.envs.mdp import pva_orientation, pva_projected_gravity
+
+**Data property changes:**
+
+The new ``ImuData`` only provides ``ang_vel_b`` and ``lin_acc_b``. If you were accessing other
+properties (``pos_w``, ``quat_w``, ``lin_vel_b``, ``ang_acc_b``, ``projected_gravity_b``), switch
+to :class:`~isaaclab.sensors.PvaData` which provides all of them.
 
 
-Migration Example
------------------
+.. rubric:: Sensor Pose Properties Deprecation
 
-Here's a complete example showing how to update your code:
+The ``pose_w``, ``pos_w``, and ``quat_w`` properties on :class:`~isaaclab.sensors.ContactSensorData`
+are deprecated and will be removed in a future release.
+
+If you need to track sensor poses in world frame, please use a dedicated sensor such as
+:class:`~isaaclab.sensors.FrameTransformer` instead.
+
+**Before (deprecated):**
+
+.. code-block:: python
+
+   # Using pose properties directly on sensor data
+   sensor_pos = contact_sensor.data.pos_w
+   sensor_quat = contact_sensor.data.quat_w
+
+**After (recommended):**
+
+.. code-block:: python
+
+   # Use FrameTransformer to track sensor pose
+   frame_transformer = FrameTransformer(FrameTransformerCfg(
+       prim_path="{ENV_REGEX_NS}/Robot/base",
+       target_frames=[
+           FrameTransformerCfg.FrameCfg(prim_path="{ENV_REGEX_NS}/Robot/sensor_link"),
+       ],
+   ))
+   sensor_pos = frame_transformer.data.target_pos_w
+   sensor_quat = frame_transformer.data.target_quat_w
+
+
+.. rubric:: Articulation Joint Wrench Data Moved to ``JointWrenchSensor``
+
+The ``ArticulationData.body_incoming_joint_wrench_b`` property has been removed. In
+Isaac Lab 3.0, incoming joint reaction wrenches are exposed through
+:class:`~isaaclab.sensors.JointWrenchSensor`, which has PhysX and Newton backend
+implementations and returns separate force [N] and torque [N·m] buffers.
+The sensor reports wrenches in the child-side incoming joint frame, with torque
+referenced at the child-side joint anchor.
+
+For configuration and data access examples, see the :ref:`overview_sensors_joint_wrench`.
 
 **Before (Isaac Lab 2.x):**
 
 .. code-block:: python
 
-   # Setting joint targets on the articulation (deprecated)
-   robot = scene["robot"]
-   robot.set_joint_effort_target(efforts, joint_ids=joint_ids)
+   wrench_b = robot.data.body_incoming_joint_wrench_b.torch[:, body_ids]
 
-   # Reading actuator telemetry from the data class (deprecated)
-   applied = robot.data.applied_torque
-   pos_target = robot.data.joint_pos_target
-
-**After (Isaac Lab 3.0):**
+**After (Isaac Lab 3.x):**
 
 .. code-block:: python
 
-   # Sending actuator commands expressed in joint-side coordinates (keyword-only)
-   robot = scene["robot"]
-   robot.actuators.target_command.set_effort_index(value=efforts, joint_ids=joint_ids)
+   import torch
+   from isaaclab.scene import InteractiveSceneCfg
+   from isaaclab.sensors import JointWrenchSensorCfg
 
-   # Reading actuator telemetry from the collection
-   applied = robot.actuators.applied_effort.torch
-   position_command = robot.actuators.target_command.position.torch
+   class MySceneCfg(InteractiveSceneCfg):
+       robot = ROBOT_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+       joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
 
-For the full runtime API of the actuator collection -- command setters and telemetry buffers --
-see :ref:`actuators-runtime-api`.
+   sensor = env.scene.sensors["joint_wrench"]
+   data = sensor.data
+   wrench_j = torch.cat(
+       (
+           data.force.torch[:, body_ids],
+           data.torque.torch[:, body_ids],
+       ),
+       dim=-1,
+   )
+
+Use :attr:`~isaaclab.sensors.BaseJointWrenchSensor.body_names` or
+:meth:`~isaaclab.sensors.BaseJointWrenchSensor.find_bodies` to map sensor entries to
+articulation body names. PhysX reports one entry for every link, including the articulation
+root link. Newton reports the child bodies of reportable incoming joints.
+
+For manager-based environments, update observations that used the articulation data property to
+depend on the joint-wrench sensor instead:
+
+.. code-block:: python
+
+   import isaaclab.envs.mdp as mdp
+   from isaaclab.managers import SceneEntityCfg
+   from isaaclab.managers import ObservationTermCfg as ObsTerm
+   from isaaclab.scene import InteractiveSceneCfg
+   from isaaclab.sensors import JointWrenchSensorCfg
+
+   class MySceneCfg(InteractiveSceneCfg):
+       robot = ROBOT_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+       joint_wrench = JointWrenchSensorCfg(prim_path="{ENV_REGEX_NS}/Robot")
+
+   feet_body_forces = ObsTerm(
+       func=mdp.body_incoming_wrench,
+       params={
+           "sensor_cfg": SceneEntityCfg(
+               "joint_wrench",
+               body_names=["left_foot", "right_foot"],
+           )
+       },
+   )
 
 
-Quaternion Format
-~~~~~~~~~~~~~~~~~~~
+.. rubric:: Ray Caster Warp Backend
+
+The :class:`~isaaclab.sensors.RayCaster`, :class:`~isaaclab.sensors.RayCasterCamera`,
+:class:`~isaaclab.sensors.MultiMeshRayCaster`, and
+:class:`~isaaclab.sensors.MultiMeshRayCasterCamera` sensors have been transitioned from a
+PyTorch/USD-based backend to a native Warp kernel pipeline. This improves performance by
+eliminating per-step tensor allocations and torch-to-warp conversions, but introduces several
+breaking changes.
+
+
+**RayCasterData Return Types**
+
+The :attr:`~isaaclab.sensors.RayCasterData.pos_w`,
+:attr:`~isaaclab.sensors.RayCasterData.quat_w`, and
+:attr:`~isaaclab.sensors.RayCasterData.ray_hits_w` properties now return
+:class:`~isaaclab.utils.warp.ProxyArray` instead of ``torch.Tensor``. This follows the same
+pattern as the general ProxyArray backend migration described above.
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   ray_hits = ray_caster.data.ray_hits_w        # torch.Tensor
+   sensor_pos = ray_caster.data.pos_w            # torch.Tensor
+
+   # After (Isaac Lab 3.x)
+   ray_hits = ray_caster.data.ray_hits_w         # ProxyArray
+   sensor_pos = ray_caster.data.pos_w            # ProxyArray
+
+   # To use with torch operations, access .torch
+   ray_hits_torch = ray_caster.data.ray_hits_w.torch
+   sensor_pos_torch = ray_caster.data.pos_w.torch
+
+
+**Ray Alignment Configuration**
+
+The ``attach_yaw_only`` boolean parameter on :class:`~isaaclab.sensors.RayCasterCfg` has been
+deprecated in favor of the new ``ray_alignment`` parameter, which accepts one of three string
+values:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Old (2.x)
+     - New (3.0)
+     - Behavior
+   * - ``attach_yaw_only=False``
+     - ``ray_alignment="base"``
+     - Rays follow the full sensor orientation.
+   * - ``attach_yaw_only=True``
+     - ``ray_alignment="yaw"``
+     - Rays follow only the yaw component of the sensor orientation.
+   * - *(not available)*
+     - ``ray_alignment="world"``
+     - Rays are always cast in the world frame (no rotation applied).
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   cfg = RayCasterCfg(attach_yaw_only=True, ...)
+
+   # After (Isaac Lab 3.x)
+   cfg = RayCasterCfg(ray_alignment="yaw", ...)
+
+
+**Raycasting Kernel Signature Change**
+
+The :func:`~isaaclab.utils.warp.kernels.raycast_dynamic_meshes_kernel` Warp kernel now requires
+an ``env_mask`` parameter as its first argument. This is a ``wp.array(dtype=wp.bool)`` that
+controls which environments are updated. The public Python wrapper
+:func:`~isaaclab.utils.warp.ops.raycast_dynamic_meshes` has been updated to inject an all-True
+mask automatically, so code using the wrapper is unaffected.
+
+If you call the kernel directly, update your launch call:
+
+.. code-block:: python
+
+   import warp as wp
+
+   # Before (Isaac Lab 2.x)
+   wp.launch(
+       raycast_dynamic_meshes_kernel,
+       dim=(num_meshes, num_envs, num_rays),
+       inputs=[ray_starts, ray_directions, mesh_ids, ...],
+   )
+
+   # After (Isaac Lab 3.x) -- env_mask is now the first input
+   env_mask = wp.ones(num_envs, dtype=wp.bool, device=device)
+   wp.launch(
+       raycast_dynamic_meshes_kernel,
+       dim=(num_meshes, num_envs, num_rays),
+       inputs=[env_mask, ray_starts, ray_directions, mesh_ids, ...],
+   )
+
+
+**RayCaster.meshes Cache Key**
+
+The :attr:`~isaaclab.sensors.RayCaster.meshes` class variable, which caches warp meshes across
+all :class:`~isaaclab.sensors.RayCaster` instances, is now keyed by ``(prim_path, device)`` tuples
+instead of by ``prim_path`` alone. This prevents a mesh that was built on one device (e.g. CPU)
+from being reused by a sensor running on a different device (e.g. CUDA), which caused illegal
+memory accesses on systems without unified memory.
+
+Code that reads or writes this cache directly must update both the type annotation and the key:
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   meshes: ClassVar[dict[str, wp.Mesh]] = {}
+   wp_mesh = RayCaster.meshes[prim_path]
+
+   # After (Isaac Lab 3.x)
+   meshes: ClassVar[dict[tuple[str, str], wp.Mesh]] = {}
+   wp_mesh = RayCaster.meshes[(prim_path, device)]
+
+
+Data Access and Math
+--------------------
+
+Migrate tensor access, indexed writes, buffers, and quaternion conventions before validating task behavior.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Isaac Lab 2.x
+
+      Data properties behaved like Torch tensors, quaternions used WXYZ order, and one write method
+      accepted either indices or masks.
+
+      .. code-block:: python
+
+         identity = (1.0, 0.0, 0.0, 0.0)
+         root_pos = robot.data.root_pos_w
+         robot.write_root_pose_to_sim(pose, env_ids)
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      Data properties use ``ProxyArray``, quaternions use XYZW order, and writes distinguish index and
+      mask selection explicitly.
+
+      .. code-block:: python
+
+         identity = (0.0, 0.0, 0.0, 1.0)
+         root_pos = robot.data.root_pos_w.torch
+         robot.write_root_pose_to_sim_index(pose, env_ids)
+
+
+.. rubric:: Quaternion Format
 
 **The quaternion format changed from WXYZ to XYZW.**
 
@@ -1325,8 +1565,7 @@ Quaternion Format
 +------------------+----------------------------------+----------------------------------+
 
 
-Why This Change?
-----------------
+**Why This Change?**
 
 The new XYZW format aligns with:
 
@@ -1338,8 +1577,7 @@ This alignment removes the need for internal quaternion conversions, making the 
 faster, and less error-prone.
 
 
-What You Need to Update
------------------------
+**What You Need to Update**
 
 Any hard-coded quaternion values in your code need to be converted from WXYZ to XYZW.
 This includes:
@@ -1352,8 +1590,7 @@ This includes:
 Also, if you were relying on the :func:`~isaaclab.utils.math.convert_quat` function to convert quaternions, this should
 no longer be needed. (This would happen if you were pulling values from the views directly.)
 
-Example: Updating Asset Configuration
--------------------------------------
+**Example: Updating Asset Configuration**
 
 **Before (WXYZ):**
 
@@ -1382,8 +1619,7 @@ Example: Updating Asset Configuration
    )
 
 
-Using the Quaternion Finder Tool
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Using the Quaternion Finder Tool
 
 We provide a tool to help you find and fix quaternions in your codebase automatically. This is not a bulletproof tool,
 but it should help you find most of the quaternions that need to be updated. You *should* review the results manually.
@@ -1393,8 +1629,7 @@ but it should help you find most of the quaternions that need to be updated. You
   instance) it will find all the quaternions that we already converted. This tool is only meant to be used on your own
   codebase with no overlap with our own packages.
 
-Finding Quaternions
--------------------
+**Finding Quaternions**
 
 Run the tool to scan your code for potential quaternions:
 
@@ -1420,8 +1655,7 @@ The tool will show you:
 - Whether the format is likely WXYZ (``LIKELY_WXYZ``)
 
 
-Understanding the Output
-------------------------
+**Understanding the Output**
 
 .. code-block:: text
 
@@ -1438,8 +1672,7 @@ This tells you:
 - **Source**: The line of code for context
 
 
-Filtering Results
------------------
+**Filtering Results**
 
 Focus on specific types of quaternions:
 
@@ -1455,8 +1688,7 @@ Focus on specific types of quaternions:
    python scripts/tools/find_quaternions.py --all-quats
 
 
-Fixing Quaternions Automatically
---------------------------------
+**Fixing Quaternions Automatically**
 
 The tool can automatically convert quaternions from WXYZ to XYZW:
 
@@ -1475,8 +1707,7 @@ The tool can automatically convert quaternions from WXYZ to XYZW:
    python scripts/tools/find_quaternions.py --fix --force
 
 
-Interactive Fix Example
------------------------
+**Interactive Fix Example**
 
 When running with ``--fix``, you'll see something like:
 
@@ -1503,8 +1734,7 @@ Options:
 - **q** (quit): Stop fixing
 
 
-How the Tool Works
-------------------
+**How the Tool Works**
 
 The tool uses several techniques to find quaternions:
 
@@ -1528,29 +1758,7 @@ To determine if it's in WXYZ format:
 - Is the pattern consistent with first-element being the scalar part?
 
 
-Best Practices for Migration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. **Start with a clean git state** - Commit your work before running fixes.
-
-2. **Run the tool first without ``--fix``** - Review what will be changed.
-
-3. **Fix identity quaternions first** - They're the most common and safest:
-
-   .. code-block:: bash
-
-      python scripts/tools/find_quaternions.py --fix-identity-only
-
-4. **Review non-identity quaternions manually** - Some 4-element lists might
-   not be quaternions (e.g., RGBA colors, bounding boxes).
-
-5. **Test your code** - Run your simulations to verify everything works correctly.
-
-6. **Check documentation** - Update any docs or comments that mention quaternion format.
-
-
-Using the Runtime Quaternion Access Detector
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Using the Runtime Quaternion Access Detector
 
 The quaternion finder tool above covers hard-coded values in source files,
 but it cannot see quaternions that are *read* from asset/sensor data at
@@ -1609,11 +1817,9 @@ warp uses ``(x, y, z, w)`` natively and so a warp-side read is unaffected
 by the convention change.
 
 
-API Changes
-~~~~~~~~~~~
+.. rubric:: Quaternion Utility API Changes
 
-The ``convert_quat`` function has been removed
-----------------------------------------------
+**The ``convert_quat`` function has been removed**
 
 Previously, IsaacLab had a utility function to convert between quaternion formats:
 
@@ -1627,8 +1833,7 @@ Since everything now uses XYZW natively, this function is no longer needed.
 If you were using it, simply remove the conversion calls.
 
 
-Math utility functions now expect XYZW
---------------------------------------
+**Math utility functions now expect XYZW**
 
 All quaternion functions in :mod:`isaaclab.utils.math` now expect and return
 quaternions in XYZW format:
@@ -1642,8 +1847,27 @@ quaternions in XYZW format:
 - And all other quaternion utilities
 
 
-ProxyArray Backend for Asset and Sensor Data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Quaternion Migration Checklist
+
+1. **Start with a clean git state** - Commit your work before running fixes.
+
+2. **Run the tool first without ``--fix``** - Review what will be changed.
+
+3. **Fix identity quaternions first** - They're the most common and safest:
+
+   .. code-block:: bash
+
+      python scripts/tools/find_quaternions.py --fix-identity-only
+
+4. **Review non-identity quaternions manually** - Some 4-element lists might
+   not be quaternions (e.g., RGBA colors, bounding boxes).
+
+5. **Test your code** - Run your simulations to verify everything works correctly.
+
+6. **Check documentation** - Update any docs or comments that mention quaternion format.
+
+
+.. rubric:: ProxyArray Backend for Asset and Sensor Data
 
 All ``.data.*`` properties on asset and sensor classes now return
 :class:`~isaaclab.utils.warp.ProxyArray` instead of ``torch.Tensor``. ``ProxyArray`` wraps
@@ -1734,129 +1958,60 @@ Common patterns that need updating:
    future release; prefer ``.torch`` in new code.
 
 
-Ray Caster Warp Backend
-~~~~~~~~~~~~~~~~~~~~~~~
+.. _torcharray-migration:
 
-The :class:`~isaaclab.sensors.RayCaster`, :class:`~isaaclab.sensors.RayCasterCamera`,
-:class:`~isaaclab.sensors.MultiMeshRayCaster`, and
-:class:`~isaaclab.sensors.MultiMeshRayCasterCamera` sensors have been transitioned from a
-PyTorch/USD-based backend to a native Warp kernel pipeline. This improves performance by
-eliminating per-step tensor allocations and torch-to-warp conversions, but introduces several
-breaking changes.
+.. rubric:: ProxyArray Interop and Temporary Compatibility
 
-
-RayCasterData Return Types
---------------------------
-
-The :attr:`~isaaclab.sensors.RayCasterData.pos_w`,
-:attr:`~isaaclab.sensors.RayCasterData.quat_w`, and
-:attr:`~isaaclab.sensors.RayCasterData.ray_hits_w` properties now return
-:class:`~isaaclab.utils.warp.ProxyArray` instead of ``torch.Tensor``. This follows the same
-pattern as the general ProxyArray backend migration described above.
+Asset and sensor data class properties return :class:`~isaaclab.utils.warp.ProxyArray`, a
+lightweight wrapper with explicit ``.torch`` and ``.warp`` accessors:
 
 .. code-block:: python
 
-   # Before (Isaac Lab 2.x)
-   ray_hits = ray_caster.data.ray_hits_w        # torch.Tensor
-   sensor_pos = ray_caster.data.pos_w            # torch.Tensor
+   # BEFORE (2.x) — properties returned torch.Tensor directly
+   joint_pos = robot.data.joint_pos          # torch.Tensor
+   root_pos = robot.data.root_pos_w          # torch.Tensor
 
-   # After (Isaac Lab 3.x)
-   ray_hits = ray_caster.data.ray_hits_w         # ProxyArray
-   sensor_pos = ray_caster.data.pos_w            # ProxyArray
+   # AFTER (3.0) — properties return ProxyArray, use .torch for the tensor
+   joint_pos = robot.data.joint_pos.torch    # cached zero-copy torch.Tensor
+   root_pos = robot.data.root_pos_w.torch    # cached zero-copy torch.Tensor
+   joint_pos_warp = robot.data.joint_pos.warp  # the underlying warp.array
 
-   # To use with torch operations, access .torch
-   ray_hits_torch = ray_caster.data.ray_hits_w.torch
-   sensor_pos_torch = ray_caster.data.pos_w.torch
+**Automatic interop — in many cases, no changes are needed:**
 
+- **Warp kernels:** ``ProxyArray`` implements ``__cuda_array_interface__``, so it can be passed
+  directly to ``wp.launch()`` without calling ``.warp``:
 
-Ray Alignment Configuration
-----------------------------
+  .. code-block:: python
 
-The ``attach_yaw_only`` boolean parameter on :class:`~isaaclab.sensors.RayCasterCfg` has been
-deprecated in favor of the new ``ray_alignment`` parameter, which accepts one of three string
-values:
+     # Just works — no .warp needed
+     wp.launch(my_kernel, inputs=[robot.data.joint_pos], ...)
 
-.. list-table::
-   :header-rows: 1
-   :widths: 30 30 40
+- **Torch functions:** ``ProxyArray`` implements ``__torch_function__``, so ``torch.*`` operations
+  accept it directly. During the deprecation period this emits a one-time warning, but works:
 
-   * - Old (2.x)
-     - New (3.0)
-     - Behavior
-   * - ``attach_yaw_only=False``
-     - ``ray_alignment="base"``
-     - Rays follow the full sensor orientation.
-   * - ``attach_yaw_only=True``
-     - ``ray_alignment="yaw"``
-     - Rays follow only the yaw component of the sensor orientation.
-   * - *(not available)*
-     - ``ray_alignment="world"``
-     - Rays are always cast in the world frame (no rotation applied).
+  .. code-block:: python
 
-.. code-block:: python
+     # Works (emits DeprecationWarning once, then silent)
+     mean_pos = torch.mean(robot.data.joint_pos, dim=1)
+     clipped = torch.clamp(robot.data.joint_pos, -3.14, 3.14)
 
-   # Before (Isaac Lab 2.x)
-   cfg = RayCasterCfg(attach_yaw_only=True, ...)
+**What to change:**
 
-   # After (Isaac Lab 3.x)
-   cfg = RayCasterCfg(ray_alignment="yaw", ...)
+1. Append ``.torch`` where you need an explicit ``torch.Tensor`` (e.g., for indexing, slicing,
+   or passing to non-torch libraries).
+2. Warp kernel calls need no changes — ``ProxyArray`` works transparently.
+3. If you need the underlying ``warp.array`` (e.g., for ``ptr``, ``strides``), use ``.warp``.
+4. Replace legacy ``wp.to_torch(proxy_array)`` calls with ``proxy_array.torch``.
+
+.. note::
+
+   The ``__torch_function__`` bridge and the temporary ``wp.to_torch(proxy_array)`` shim will
+   be removed in a future release. We recommend migrating to explicit ``.torch`` access now.
+
+For a complete guide, see :doc:`/source/how-to/proxy_array`.
 
 
-Raycasting Kernel Signature Change
------------------------------------
-
-The :func:`~isaaclab.utils.warp.kernels.raycast_dynamic_meshes_kernel` Warp kernel now requires
-an ``env_mask`` parameter as its first argument. This is a ``wp.array(dtype=wp.bool)`` that
-controls which environments are updated. The public Python wrapper
-:func:`~isaaclab.utils.warp.ops.raycast_dynamic_meshes` has been updated to inject an all-True
-mask automatically, so code using the wrapper is unaffected.
-
-If you call the kernel directly, update your launch call:
-
-.. code-block:: python
-
-   import warp as wp
-
-   # Before (Isaac Lab 2.x)
-   wp.launch(
-       raycast_dynamic_meshes_kernel,
-       dim=(num_meshes, num_envs, num_rays),
-       inputs=[ray_starts, ray_directions, mesh_ids, ...],
-   )
-
-   # After (Isaac Lab 3.x) -- env_mask is now the first input
-   env_mask = wp.ones(num_envs, dtype=wp.bool, device=device)
-   wp.launch(
-       raycast_dynamic_meshes_kernel,
-       dim=(num_meshes, num_envs, num_rays),
-       inputs=[env_mask, ray_starts, ray_directions, mesh_ids, ...],
-   )
-
-
-RayCaster.meshes Cache Key
---------------------------
-
-The :attr:`~isaaclab.sensors.RayCaster.meshes` class variable, which caches warp meshes across
-all :class:`~isaaclab.sensors.RayCaster` instances, is now keyed by ``(prim_path, device)`` tuples
-instead of by ``prim_path`` alone. This prevents a mesh that was built on one device (e.g. CPU)
-from being reused by a sensor running on a different device (e.g. CUDA), which caused illegal
-memory accesses on systems without unified memory.
-
-Code that reads or writes this cache directly must update both the type annotation and the key:
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   meshes: ClassVar[dict[str, wp.Mesh]] = {}
-   wp_mesh = RayCaster.meshes[prim_path]
-
-   # After (Isaac Lab 3.x)
-   meshes: ClassVar[dict[tuple[str, str], wp.Mesh]] = {}
-   wp_mesh = RayCaster.meshes[(prim_path, device)]
-
-
-Write Method Index/Mask Split
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: Write Method Index/Mask Split
 
 All asset write methods have been split into two explicit variants:
 
@@ -1943,8 +2098,7 @@ The previous ``write_*_to_sim(data, env_ids)`` methods have been removed.
      - ``write_body_link_velocity_to_sim_index`` / ``write_body_link_velocity_to_sim_mask``
 
 
-TimestampedBufferWarp
-~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: TimestampedBufferWarp
 
 If you have custom asset or sensor data classes that subclass the Isaac Lab base data classes,
 note that internal buffers have changed from :class:`~isaaclab.utils.buffers.TimestampedBuffer`
@@ -1965,8 +2119,427 @@ wp_dtype)`` as constructor arguments instead of a ``torch.Tensor``:
    )
 
 
-URDF Importer
-~~~~~~~~~~~~~
+Reinforcement Learning
+----------------------
+
+Move training and inference workflows to the unified entrypoints after the environment imports and steps correctly.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Isaac Lab 2.x
+
+      Launch a framework-specific script and use framework-specific resume arguments.
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/reinforcement_learning/rsl_rl/train.py \
+            --task Isaac-Cartpole --resume --load_run RUN
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      Select the framework through the unified command and use ``--checkpoint`` consistently.
+
+      .. code-block:: bash
+
+         uv run isaaclab train --rl_library rsl_rl \
+            --task Isaac-Cartpole --checkpoint RUN/model.pt
+
+
+.. rubric:: Reinforcement Learning CLI Entrypoints
+
+Isaac Lab 3.0 provides unified reinforcement learning entrypoints for training
+and play. Instead of launching library-specific scripts under
+``scripts/reinforcement_learning/<library>/``, select the library with
+``--rl_library``.
+
+.. tab-set::
+
+   .. tab-item:: uv (Recommended)
+
+      .. code-block:: bash
+
+         # Isaac Lab 3.0
+         uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code-block:: bash
+
+         # Isaac Lab 3.0
+         ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole
+
+The same pattern applies to the play workflow:
+
+.. tab-set::
+
+   .. tab-item:: uv (Recommended)
+
+      .. code-block:: bash
+
+         uv run isaaclab play --rl_library rsl_rl --task Isaac-Cartpole --checkpoint /PATH/TO/model.pt
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code-block:: bash
+
+         ./isaaclab.sh play --rl_library rsl_rl --task Isaac-Cartpole --checkpoint /PATH/TO/model.pt
+
+Supported reinforcement learning libraries are ``rsl_rl``, ``rl_games``, ``skrl``,
+``sb3``, and ``rlinf``. Backend-local ``train.py`` and ``play.py`` scripts were removed; use these
+unified commands instead.
+
+For distributed launchers that execute a Python script directly, use the unified
+script path and pass ``--rl_library`` to it:
+
+.. code-block:: bash
+
+   python -m torch.distributed.run --nproc_per_node=2 scripts/reinforcement_learning/train.py \
+      --rl_library rsl_rl --task Isaac-Cartpole --distributed
+
+
+.. rubric:: Unified Checkpoint and Iteration Arguments
+
+RL entrypoints now use ``--checkpoint`` consistently to select a checkpoint
+for training, resuming, or play. Update scripts that use the removed arguments
+as follows:
+
+.. list-table:: RL command migration
+   :header-rows: 1
+   :widths: 28 32 40
+
+   * - Previous command
+     - Isaac Lab 3.0 command
+     - Notes
+   * - RSL-RL ``--resume --load_run <run>``
+     - ``--checkpoint <path>``, ``--checkpoint latest``, or ``--checkpoint best``
+     - Pass a checkpoint path or select one from a compatible recorded run.
+   * - ``--use_pretrained_checkpoint``
+     - ``--checkpoint pretrained``
+     - Use this for play with RL-Games, RSL-RL, skrl, or Stable-Baselines3.
+   * - RLinf ``--rl_model_path <checkpoint-dir>`` or ``--resume_dir <checkpoint-dir>``
+     - ``--checkpoint <checkpoint-dir>``
+     - The directory must contain the RLinf ``full_weights.pt`` checkpoint.
+   * - RLinf ``--max_epochs <N>``
+     - ``--max_iterations <N>``
+     - This is the common training-iteration argument used by the unified API.
+
+For RLinf, ``--model_path`` now identifies the pretrained base VLA model, not
+the RL-finetuned weights. Supply both arguments when evaluating a finetuned
+policy:
+
+.. code-block:: bash
+
+   uv run --extra rlinf isaaclab play --rl_library rlinf \
+      --config_name isaaclab_ppo_gr00t_assemble_trocar \
+      --model_path /path/to/base_model \
+      --checkpoint /path/to/rlinf_checkpoint
+
+``latest`` and ``best`` select checkpoints from the newest compatible run for
+RL-Games, RSL-RL, skrl, Stable-Baselines3, and RLinf. ``pretrained`` selects a
+published policy where one is available; RLinf does not support this selector.
+
+
+Visualizers, Cameras, and Recording
+-----------------------------------
+
+Update interactive viewing, headless rendering, camera configuration, and video capture together because they now share the visualizer abstraction.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Isaac Lab 2.x
+
+      ``--headless`` controlled viewer creation, viewport pose lived on ``env_cfg.viewer``, and video
+      wrapped the environment with Gymnasium's recorder.
+
+      .. code-block:: python
+
+         env_cfg.viewer.eye = (7.5, 7.5, 7.5)
+         env = gym.wrappers.RecordVideo(env, "videos")
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      ``--viz`` selects visualizers independently of headless rendering. Configure the default viewer
+      and recorders through ``SimulationCfg`` and the environment config.
+
+      .. code-block:: python
+
+         sim.default_visualizer_cfg.eye = (7.5, 7.5, 7.5)
+         env_cfg.video_recorders = [VideoRecorderCfg(...)]
+
+
+.. rubric:: Visualizer CLI and Headless Behavior
+
+In Isaac Lab 3.0, use ``--visualizer`` / ``--viz`` to determine whether viewer apps are launched
+with an Isaac Lab command. Without a visualizer, commands run headless by default.
+
+Visualizers are lightweight viewer apps for monitoring, debugging, and recording workflows
+(see :doc:`/source/overview/core-concepts/visualization`).
+
+The details below describe how CLI visualizer arguments resolve together with
+``SimulationCfg.visualizer_cfgs``.
+
+- ``--viz`` accepts **comma-separated** values (for example ``--viz kit,newton_gl``).
+  ``"newton"`` is a deprecated alias for ``"newton_gl"``; prefer ``"newton_gl"`` or ``"newton_rtx"``.
+- If omitted, visualizers are resolved from ``SimulationCfg.visualizer_cfgs``.
+- ``--viz none`` explicitly disables all visualizers, including config-defined ones.
+
+For the full behavior of visualizer resolution with the visualizer CLI argument and visualizer configs,
+see :ref:`visualization-common-modes`.
+
+**Breaking change — ``--headless`` no longer suppresses visualizers.**
+
+In Isaac Lab 2.x, passing ``--headless`` disabled all visualizers regardless of ``--viz``.
+In Isaac Lab 3.0, ``--headless`` and ``--viz`` are independent:
+
+- ``--headless`` controls the simulation rendering pipeline (Kit app mode, GPU context).
+- ``--viz <type>`` controls which visualizer backends to launch.
+
+Passing ``--viz kit --headless`` now launches a Kit visualizer in headless mode using the
+Replicator offscreen renderer (no display window required).  Passing ``--viz newton_gl --headless``
+launches a Newton GL visualizer using pyglet's EGL headless backend.  To disable all visualizers
+explicitly, use ``--viz none``.
+
+.. list-table:: Headless visualizer requirements
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Visualizer
+     - Headless mechanism
+     - Extra requirement
+   * - ``kit``
+     - Replicator offscreen renderer (no display)
+     - Must also pass ``--enable_cameras``; without it, ``render_rgb_array()`` returns
+       black frames. ``--video`` sets this automatically.
+   * - ``newton_gl``
+     - pyglet EGL backend (no display)
+     - None — ``NewtonGLVisualizer`` auto-detects a missing ``$DISPLAY`` and selects EGL.
+   * - ``newton_rtx``
+     - Not supported headlessly
+     - ``render_rgb_array()`` returns ``None``; frame capture requires a display.
+
+**Headless video recording (``--video`` without ``--viz``).**
+
+In Isaac Lab 2.x, ``--video`` alone would use the Kit Replicator pipeline implicitly.
+In Isaac Lab 3.0, the equivalent is:
+
+.. code-block:: bash
+
+   # Record from Kit viewport headlessly (equivalent to 2.x --video behaviour)
+   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct \
+       --viz kit --enable_cameras --headless --video
+
+As a convenience, passing ``--video`` without ``--viz`` still works: Isaac Lab
+auto-creates a headless Kit visualizer (falling back to Newton GL if Kit is unavailable)
+and sets ``source="visualizer:kit"`` on the default recorder, printing:
+
+.. code-block:: text
+
+   [INFO] --video specified without --viz: auto-creating a headless Kit visualizer
+   for video recording. Pass --viz <type> to choose a different visualizer, or
+   set video_recorders in your env config to record from a scene sensor instead.
+
+
+.. rubric:: Viewport Camera Configuration (``ViewerCfg`` deprecated)
+
+The ``viewer`` field (type :class:`~isaaclab.envs.common.ViewerCfg`) is deprecated on
+:class:`~isaaclab.envs.DirectRLEnvCfg`, :class:`~isaaclab.envs.ManagerBasedEnvCfg`, and
+:class:`~isaaclab.envs.DirectMARLEnvCfg`.  A backward-compatibility shim re-routes
+``viewer.*`` assignments for one release, but the field will be removed in a future version.
+Configure the viewport camera through :attr:`~isaaclab.sim.SimulationCfg.default_visualizer_cfg`
+on the sim config instead.
+
+Similarly, :class:`~isaaclab.envs.ui.ViewportCameraController` is deprecated.  A shim class
+remains so existing imports do not break, but it raises a :class:`DeprecationWarning` at
+construction.  Camera tracking is now handled directly by
+:class:`~isaaclab_visualizers.kit.KitVisualizer` via ``origin_type`` and
+``origin_track_path`` on :class:`~isaaclab_visualizers.kit.KitVisualizerCfg`.
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   env_cfg.viewer.eye = (4.5, 0.0, 6.0)
+   env_cfg.viewer.lookat = (0.0, 0.0, 2.0)
+
+   # After (Isaac Lab 3.x)
+   from isaaclab.visualizers import VisualizerCfg
+   env_cfg.sim.default_visualizer_cfg = VisualizerCfg(eye=(4.5, 0.0, 6.0), lookat=(0.0, 0.0, 2.0))
+
+For asset-body tracking (previously ``origin_type="asset_root"`` / ``"asset_body"``), use
+:class:`~isaaclab_visualizers.kit.KitVisualizerCfg` with ``origin_type="asset"`` and
+``origin_track_path``:
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   env_cfg.viewer.origin_type = "asset_root"
+   env_cfg.viewer.asset_name = "robot"
+
+   # After (Isaac Lab 3.x)
+   from isaaclab_visualizers.kit import KitVisualizerCfg
+   env_cfg.sim.visualizer_cfgs = [KitVisualizerCfg(origin_type="asset", origin_track_path="robot")]
+
+The :class:`~isaaclab.envs.ui.ViewportCameraController` class is also deprecated; camera
+tracking is handled directly by :class:`~isaaclab_visualizers.kit.KitVisualizer`.
+
+
+.. rubric:: Streaming Camera View (``tiled_cam_*`` fields removed)
+
+The ``tiled_cam_*`` configuration fields on visualizer configs (e.g. ``tiled_cam_view``,
+``tiled_cam_num``, ``tiled_cam_prim_path``) have been removed and replaced by the unified
+``streaming_*`` API available on all four visualizer backends.  A one-release deprecation
+shim forwards each removed field to its ``streaming_*`` equivalent and emits
+:class:`DeprecationWarning`; the shim will be removed in the next major release.
+
+.. list-table:: Field rename reference
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Old field (removed)
+     - New field
+     - Notes
+   * - ``tiled_cam_view``
+     - ``streaming_view``
+     - Default is now ``False`` (opt-in)
+   * - ``tiled_cam_num``
+     - ``streaming_envs``
+     - Accepts ``int`` or ``list[int]``
+   * - ``tiled_cam_prim_path``
+     - ``streaming_sensor_prim_path``
+     - Existing sensor path; takes priority over auto-created camera
+   * - ``tiled_cam_eye``
+     - ``streaming_cam_eye``
+     -
+   * - ``tiled_cam_renderer``
+     - ``streaming_cam_renderer``
+     - Accepts ``"newton_warp"``, ``"ovrtx"``, ``"isaac_rtx"``, or ``None``
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   from isaaclab_visualizers.newton import NewtonVisualizerCfg
+   cfg = NewtonVisualizerCfg(
+       tiled_cam_view=True,
+       tiled_cam_num=16,
+       tiled_cam_prim_path="/World/envs/env_.*/Camera",
+   )
+
+   # After (Isaac Lab 3.x)
+   from isaaclab_visualizers.newton import NewtonGLVisualizerCfg
+   cfg = NewtonGLVisualizerCfg(
+       streaming_view=True,
+       streaming_envs=16,
+       streaming_sensor_prim_path="/World/envs/env_.*/Camera",
+   )
+
+.. note::
+   :class:`~isaaclab_visualizers.newton.NewtonVisualizerCfg` is deprecated in this release.
+   Use :class:`~isaaclab_visualizers.newton.NewtonGLVisualizerCfg` (OpenGL rasterizer) or
+   :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizerCfg` (OVRTX path tracer) instead.
+
+
+.. rubric:: Newton Visualizer Type Split (``newton`` → ``newton_gl`` / ``newton_rtx``)
+
+The single ``NewtonVisualizerCfg`` (``visualizer_type="newton"``) has been split into two
+dedicated configs with separate type identifiers:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Old (removed / deprecated)
+     - New
+     - Notes
+   * - ``NewtonVisualizerCfg`` (``visualizer_type="newton"``)
+     - :class:`~isaaclab_visualizers.newton.NewtonGLVisualizerCfg` (``visualizer_type="newton_gl"``)
+     - OpenGL rasterizer; default Newton visualizer
+   * - —
+     - :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizerCfg` (``visualizer_type="newton_rtx"``)
+     - OVRTX path tracer (experimental)
+
+The ``--viz newton`` CLI argument remains as a **deprecated alias** for ``--viz newton_gl``.
+Update scripts and config files to use the explicit form:
+
+.. code-block:: bash
+
+   # Before (Isaac Lab 2.x)
+   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole --viz newton
+
+   # After (Isaac Lab 3.x)
+   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole --viz newton_gl
+
+Similarly, when importing the config class directly:
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   from isaaclab_visualizers.newton import NewtonVisualizerCfg
+   cfg = NewtonVisualizerCfg()
+
+   # After (Isaac Lab 3.x)
+   from isaaclab_visualizers.newton import NewtonGLVisualizerCfg  # or NewtonRTXVisualizerCfg
+   cfg = NewtonGLVisualizerCfg()
+
+The ``source="visualizer:newton"`` string in :class:`~isaaclab.envs.utils.video_recorder_cfg.VideoRecorderCfg`
+continues to work as a backward-compatible alias for ``"visualizer:newton_gl"``, but
+``"visualizer:newton_gl"`` and ``"visualizer:newton_rtx"`` are now the canonical source strings.
+
+
+.. rubric:: Video Recording (``gym.wrappers.RecordVideo`` replaced)
+
+The ``gym.wrappers.RecordVideo`` pattern is no longer supported.  Video recording is now driven
+internally by :class:`~isaaclab.envs.utils.video_recorder_cfg.VideoRecorderCfg` entries on the
+environment config, sourcing frames from the active visualizer or a scene sensor.
+
+.. code-block:: python
+
+   # Before (Isaac Lab 2.x)
+   env = gym.make(task, cfg=env_cfg, render_mode="rgb_array")
+   env = gym.wrappers.RecordVideo(env, video_folder="videos/", step_trigger=lambda s: s == 0)
+
+   # After (Isaac Lab 3.x)
+   from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+   env_cfg.video_recorders = [
+       VideoRecorderCfg(source="visualizer", output_dir="videos/", video_length=200)
+   ]
+   env = gym.make(task, cfg=env_cfg)
+
+Available sources: ``"visualizer"`` (auto-pick), ``"visualizer:kit"``, ``"visualizer:newton_gl"``,
+``"visualizer:newton_rtx"``, ``"visualizer:newton_gl:tiled"``, ``"sensor:<name>"``.
+``"visualizer:newton"`` and ``"visualizer:newton:tiled"`` remain as deprecated backward-compatible
+aliases for ``"visualizer:newton_gl"`` and ``"visualizer:newton_gl:tiled"`` respectively.
+The ``eye`` and ``lookat`` fields have been removed from ``VideoRecorderCfg``; position the
+camera via ``sim.default_visualizer_cfg`` instead.
+
+The ``isaaclab.envs.utils.recording_hooks`` module has been removed.  Physics-backend recording
+hooks are now registered via :meth:`~isaaclab.sim.SimulationContext.add_render_callback`.
+
+
+Tools and Integrations
+----------------------
+
+Finish by updating importers, benchmarks, and optional integrations used around the migrated task.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Isaac Lab 2.x
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/benchmarks/benchmark_rsl_rl.py \
+            --task Isaac-Cartpole
+
+   .. grid-item-card:: Isaac Lab 3.0
+
+      .. code-block:: bash
+
+         uv run isaaclab benchmark training --rl_library rsl_rl \
+            --task Isaac-Cartpole physics=physx
+
+
+.. rubric:: URDF Importer
 
 The URDF importer in Isaac Sim was rewritten to version 3.0, using the ``urdf-usd-converter``
 library and the ``isaacsim.asset.transformer.rules`` extension to produce structured USD output.
@@ -1986,8 +2559,7 @@ restructures the output.
    version of the extension is available in your Isaac Sim installation.
 
 
-Deprecated Settings
--------------------
+**Deprecated Settings**
 
 The following :class:`~sim.converters.UrdfConverterCfg` settings are **deprecated** because
 the new URDF importer 3.0 no longer supports them. They are kept for backward compatibility
@@ -2020,8 +2592,7 @@ The :attr:`~sim.converters.AssetConverterBaseCfg.make_instanceable` setting from
 is also no longer supported and will be ignored. Assets will be made instanceable by default.
 
 
-Updated CLI Tool
-----------------
+**Updated CLI Tool**
 
 The ``convert_urdf.py`` script has been updated. The ``usd_file_name`` is now determined
 automatically by the importer based on the robot name and cannot be overridden.
@@ -2084,8 +2655,7 @@ automatically by the importer based on the robot name and cannot be overridden.
    step to merge fixed joints.
 
 
-Updated Python API
-------------------
+**Updated Python API**
 
 If you use :class:`~sim.converters.UrdfConverter` or :class:`~sim.converters.UrdfConverterCfg`
 directly in your code, note the following changes:
@@ -2140,8 +2710,7 @@ directly in your code, note the following changes:
    )
 
 
-MJCF Importer
-~~~~~~~~~~~~~
+.. rubric:: MJCF Importer
 
 The MJCF importer in Isaac Sim was rewritten to use the ``mujoco-usd-converter`` library.
 The old C++ binding-based API (using Kit commands ``MJCFCreateAsset``/``MJCFCreateImportConfig``
@@ -2157,8 +2726,7 @@ and ``MJCFImporterConfig`` dataclass.
    If you have downstream logic that traverses the USD structure of MJCF-imported assets,
    verify that it handles nested rigid body prims correctly.
 
-Removed Settings
-----------------
+**Removed Settings**
 
 The following :class:`~sim.converters.MjcfConverterCfg` settings have been **removed** because
 the new converter handles them automatically based on the MJCF file content:
@@ -2172,8 +2740,7 @@ The :attr:`~sim.converters.AssetConverterBaseCfg.make_instanceable` setting from
 is also no longer supported and will be ignored.
 
 
-New Settings
-------------
+**New Settings**
 
 The following new settings were added to :class:`~sim.converters.MjcfConverterCfg`:
 
@@ -2189,8 +2756,7 @@ The following new settings were added to :class:`~sim.converters.MjcfConverterCf
 +-----------------------------------------------------------------+------------------------------------------------------+
 
 
-Renamed Settings
-----------------
+**Renamed Settings**
 
 +------------------------------------------+------------------------------------------+
 | Old (2.x)                                | New (3.0)                                |
@@ -2205,8 +2771,7 @@ Renamed Settings
    for backward compatibility and maps it to the new name internally.
 
 
-Updated CLI Tool
-----------------
+**Updated CLI Tool**
 
 The ``convert_mjcf.py`` script has been updated to match the new importer settings.
 Old command-line flags (``--fix-base``, ``--make-instanceable``, ``--import-sites``)
@@ -2265,8 +2830,7 @@ are no longer available.
 New flags: ``--merge-mesh``, ``--collision-from-visuals``, ``--collision-type``, ``--self-collision``.
 
 
-Updated Python API
-------------------
+**Updated Python API**
 
 If you use :class:`~sim.converters.MjcfConverter` or :class:`~sim.converters.MjcfConverterCfg`
 directly in your code, update your configuration:
@@ -2300,17 +2864,14 @@ directly in your code, update your configuration:
    )
 
 
-Benchmark Workflows
-~~~~~~~~~~~~~~~~~~~
+.. rubric:: Benchmark Workflows
 
 Isaac Lab 3.0 consolidates the per-backend environment benchmark entry points and their
-wrapper shell runners into library-owned, backend-agnostic workflows. The physics
-backend is now selected at launch time through the ``presets=`` system — the same pattern
-used for environment configurations (see "Multi-Backend Support: PresetCfg Pattern" above)
-— rather than by choosing a backend-specific script.
+wrapper shell runners into library-owned, backend-agnostic workflows. Select the physics
+configuration at launch with ``physics=NAME`` — the same preset mechanism used by environments —
+rather than choosing a backend-specific script.
 
-What Changed
-------------
+**What Changed**
 
 The environment benchmark entry points are now exposed through ``isaaclab benchmark`` and
 the typed :mod:`isaaclab.benchmark` Python API:
@@ -2348,8 +2909,7 @@ module and unified command.
    ``benchmark_hydra_resolve.py`` — are independent of the unified suite and likewise
    unaffected.
 
-Script and Command Mapping
---------------------------
+**Script and Command Mapping**
 
 Map each old invocation to its replacement:
 
@@ -2379,8 +2939,7 @@ through the same ``--rl_library`` dispatch on ``isaaclab benchmark training``. `
 3.0: it benchmarks inference of a checkpoint trained by the training workflow for any of the four
 RL libraries.
 
-Running Benchmarks
-------------------
+**Running Benchmarks**
 
 The physics (and rendering) backend is selected with Hydra preset tokens — ``presets=``,
 exactly as for the training workflow. There is no ``--physics`` or ``--render`` flag; pass
@@ -2438,8 +2997,7 @@ exactly as for the training workflow. There is no ``--physics`` or ``--render`` 
    # Startup profiling
    uv run isaaclab benchmark startup --task Isaac-Cartpole-Direct presets=newton_mjwarp
 
-Output Format
--------------
+**Output Format**
 
 The output format is controlled by ``--benchmark_formatter``, which is independent of the
 physics backend. It defaults to ``schema`` (the typed benchmark bundle) and accepts a
@@ -2453,8 +3011,7 @@ comma-separated list to emit several formats at once. Supported values are ``sch
    uv run isaaclab benchmark runtime --task Isaac-Cartpole-Direct \
        --benchmark_formatter schema,omniperf
 
-Migration Steps
----------------
+**Migration Steps**
 
 If you have custom benchmark scripts or CI based on Isaac Lab 2.x:
 
@@ -2484,8 +3041,7 @@ For a complete guide to multi-backend support, see the "Multi-Backend Support: P
 Pattern" section above.
 
 
-XR Teleoperation: Isaac Teleop Integration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. rubric:: XR Teleoperation: Isaac Teleop Integration
 
 The native XR teleoperation stack in ``isaaclab.devices.openxr`` has been deprecated and replaced
 by `Isaac Teleop <https://github.com/NVIDIA/IsaacTeleop>`_, integrated via the ``isaaclab_teleop``
@@ -2495,8 +3051,7 @@ plugin support is now in Isaac Teleop.
 For full documentation on the new stack, see :ref:`isaac-teleop-feature`.
 
 
-Installation Requirement
-------------------------
+**Installation Requirement**
 
 Isaac Teleop must now be installed in your Isaac Lab environment:
 
@@ -2507,8 +3062,7 @@ Isaac Teleop must now be installed in your Isaac Lab environment:
 See :ref:`install-isaac-teleop` for complete installation instructions.
 
 
-Import Changes
---------------
+**Import Changes**
 
 .. list-table::
    :header-rows: 1
@@ -2530,8 +3084,7 @@ Import Changes
      - ``from isaacteleop.retargeters import Se3AbsRetargeter``
 
 
-Environment Configuration Changes
-----------------------------------
+**Environment Configuration Changes**
 
 The ``teleop_devices`` field with ``OpenXRDeviceCfg`` has been replaced by the ``isaac_teleop``
 field with ``IsaacTeleopCfg`` and a pipeline builder callable.
@@ -2611,8 +3164,7 @@ field with ``IsaacTeleopCfg`` and a pipeline builder callable.
            )
 
 
-Backward Compatibility
-----------------------
+**Backward Compatibility**
 
 The old classes still exist and will issue ``DeprecationWarning`` when used:
 
@@ -2624,418 +3176,25 @@ Deprecated retargeters have been moved to ``isaaclab_teleop.deprecated.openxr.re
 compatibility. These will be removed in a future release.
 
 
-.. _torcharray-migration:
+Getting Help
+------------
 
-ProxyArray Interop and Temporary Compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use these resources when a migration issue remains after the relevant comparison and validation steps above.
 
-Asset and sensor data class properties return :class:`~isaaclab.utils.warp.ProxyArray`, a
-lightweight wrapper with explicit ``.torch`` and ``.warp`` accessors:
 
-.. code-block:: python
-
-   # BEFORE (2.x) — properties returned torch.Tensor directly
-   joint_pos = robot.data.joint_pos          # torch.Tensor
-   root_pos = robot.data.root_pos_w          # torch.Tensor
-
-   # AFTER (3.0) — properties return ProxyArray, use .torch for the tensor
-   joint_pos = robot.data.joint_pos.torch    # cached zero-copy torch.Tensor
-   root_pos = robot.data.root_pos_w.torch    # cached zero-copy torch.Tensor
-   joint_pos_warp = robot.data.joint_pos.warp  # the underlying warp.array
-
-**Automatic interop — in many cases, no changes are needed:**
-
-- **Warp kernels:** ``ProxyArray`` implements ``__cuda_array_interface__``, so it can be passed
-  directly to ``wp.launch()`` without calling ``.warp``:
-
-  .. code-block:: python
-
-     # Just works — no .warp needed
-     wp.launch(my_kernel, inputs=[robot.data.joint_pos], ...)
-
-- **Torch functions:** ``ProxyArray`` implements ``__torch_function__``, so ``torch.*`` operations
-  accept it directly. During the deprecation period this emits a one-time warning, but works:
-
-  .. code-block:: python
-
-     # Works (emits DeprecationWarning once, then silent)
-     mean_pos = torch.mean(robot.data.joint_pos, dim=1)
-     clipped = torch.clamp(robot.data.joint_pos, -3.14, 3.14)
-
-**What to change:**
-
-1. Append ``.torch`` where you need an explicit ``torch.Tensor`` (e.g., for indexing, slicing,
-   or passing to non-torch libraries).
-2. Warp kernel calls need no changes — ``ProxyArray`` works transparently.
-3. If you need the underlying ``warp.array`` (e.g., for ``ptr``, ``strides``), use ``.warp``.
-4. Replace legacy ``wp.to_torch(proxy_array)`` calls with ``proxy_array.torch``.
-
-.. note::
-
-   The ``__torch_function__`` bridge and the temporary ``wp.to_torch(proxy_array)`` shim will
-   be removed in a future release. We recommend migrating to explicit ``.torch`` access now.
-
-For a complete guide, see :doc:`/source/how-to/proxy_array`.
-
-
-Migration off Deprecated Isaac Sim APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In Isaac Sim 6.0, the legacy ``isaacsim.core.*``, ``isaacsim.sensors.*``, and
-``isaacsim.robot.wheeled_robots`` Python module paths are **deprecated** in favor of their
-``isaacsim.core.experimental.*`` (and ``*.experimental.*``) equivalents. Isaac Lab 3.0 has
-been migrated off the deprecated paths so that Isaac Lab continues to load and run when
-those modules are removed in a future Isaac Sim release.
-
-This is mostly a transparent change for users — Isaac Lab's own public Python API
-(:mod:`isaaclab`, :mod:`isaaclab_physx`, :mod:`isaaclab_tasks`, :mod:`isaaclab_teleop`,
-:mod:`isaaclab_mimic`) is unchanged. The migration is only user-visible if you:
-
-1. Import Isaac Sim symbols **directly** in your project, or
-2. Maintain a custom Kit experience (``.kit`` file) that lists Isaac Sim extension
-   dependencies, or
-3. Imported ``SimulationManager`` from ``isaacsim.core.simulation_manager`` in your own
-   PhysX-backed code.
-
-
-Python module renames
----------------------
-
-Update direct imports in your own code as follows. **Where Isaac Lab provides an in-tree
-replacement, prefer the Isaac Lab API** over the ``isaacsim.core.experimental.*`` fallback:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
-
-   * - Deprecated Isaac Sim path
-     - Recommended replacement
-   * - ``isaacsim.core.utils.stage``
-     - :mod:`isaaclab.sim.utils.stage` (e.g. ``get_current_stage``,
-       ``create_new_stage``, ``open_stage``, ``save_stage``, ``close_stage``,
-       ``clear_stage``, ``update_stage``, ``use_stage``)
-   * - ``isaacsim.core.utils.prims``
-     - :mod:`isaaclab.sim.utils.prims` (e.g. ``create_prim``, ``delete_prim``,
-       ``change_prim_property``, ``bind_visual_material``,
-       ``bind_physics_material``, ``add_usd_reference``)
-   * - ``isaacsim.core.utils.queries``
-     - :mod:`isaaclab.sim.utils.queries` (e.g. ``find_matching_prims``,
-       ``find_matching_prim_paths``, ``get_first_matching_child_prim``)
-   * - ``isaacsim.core.utils.transforms``
-     - :mod:`isaaclab.sim.utils.transforms`
-   * - ``isaacsim.core.utils.semantics``
-     - :mod:`isaaclab.sim.utils.semantics`
-   * - ``isaacsim.core.utils.extensions.enable_extension``
-     - :func:`isaaclab.sim.utils.enable_extension`
-   * - ``isaacsim.core.utils.viewports.set_camera_view``
-     - ``isaacsim.core.rendering_manager.ViewportManager.set_camera_view`` (or
-       ``omni.kit.viewport.utility.camera_state.ViewportCameraState`` for lower-level control)
-   * - ``isaacsim.core.prims.XFormPrim`` / ``XFormPrimView``
-     - :class:`~isaaclab.sim.views.FrameView` (Isaac Lab in-tree view; see
-       :ref:`migrating-to-isaaclab-3-0` ``Renaming of XformPrimView to FrameView`` above).
-       For ``Articulation`` / ``RigidPrim`` use ``isaacsim.core.experimental.prims``.
-   * - ``isaacsim.core.simulation_manager.SimulationManager``
-     - :class:`isaaclab_physx.physics.PhysxManager` (PhysX backend) or
-       ``isaaclab_newton.physics.NewtonManager`` (Newton backend); see local-alias
-       pattern below.
-   * - ``isaacsim.core.cloner``
-     - :mod:`isaaclab.cloner` (Isaac Lab in-tree cloner)
-   * - ``isaacsim.replicator.mobility_gen``
-     - ``isaacsim.replicator.experimental.mobility_gen``
-   * - ``isaacsim.sensors.<name>``
-     - ``isaacsim.sensors.experimental.<name>``
-   * - ``isaacsim.robot.wheeled_robots``
-     - ``isaacsim.robot.experimental.wheeled_robots`` (and
-       ``isaacsim.robot.wheeled_robots.nodes`` for OmniGraph nodes)
-
-To keep call-site code symmetric across backends when migrating off
-``isaacsim.core.simulation_manager.SimulationManager``, use the local-alias pattern:
-
-.. code-block:: python
-
-   from isaaclab_physx.physics import PhysxManager as SimulationManager
-   # or, for the Newton backend
-   from isaaclab_newton.physics import NewtonManager as SimulationManager
-
-Isaac Sim extension modules must be explicitly enabled before direct import
------------------------------------------------------------------------------
-
-Isaac Lab 3.0 no longer automatically initializes Isaac Sim extensions only to
-make their Python modules importable. Stock Isaac Lab Kit experiences now load a
-smaller set of extensions so unused Isaac Sim packages do not pull in
-unnecessary dependencies or deprecated aliases.
-
-If your project imports an Isaac Sim extension module directly, enable the
-extension after the Kit application has started and before importing from that
-module:
-
-.. code-block:: python
-
-   from isaaclab.sim.utils import enable_extension
-
-   enable_extension("isaacsim.core.experimental.prims")
-   from isaacsim.core.experimental.prims import XformPrim
-
-This is especially important for migration replacements such as
-``isaacsim.core.experimental.*`` and ``isaacsim.sensors.experimental.*``. Do not
-import ``enable_extension`` from ``isaacsim.core.experimental.utils.app`` unless
-that extension is already enabled; use :func:`isaaclab.sim.utils.enable_extension`
-from Isaac Lab instead. The helper requires a running Kit application and raises
-``RuntimeError`` if called from plain Python before Kit is launched.
-
-
-Kit experience (``.kit``) updates
----------------------------------
-
-If you maintain a custom Kit experience derived from one of the Isaac Lab apps under
-``apps/``:
-
-* **Stop registering deprecated extension search paths.** The ``extsDeprecated`` search
-  path entry has been removed from all stock Isaac Lab Kit experiences (headless,
-  rendering, XR variants). Mirror that change in your own experience.
-* **Switch explicit Isaac Sim extension dependencies** to the non-deprecated equivalents
-  listed above (``isaacsim.core.experimental.*``, ``isaacsim.sensors.experimental.*``,
-  ``isaacsim.robot.experimental.wheeled_robots``).
-* **Do not rely on stock Isaac Lab apps to preload Isaac Sim extensions** that your
-  project imports directly. Either add those extensions to your custom ``.kit`` file
-  or enable them with :func:`isaaclab.sim.utils.enable_extension` before importing
-  their Python modules.
-* **Remove unused Isaac Sim extensions that pull in** ``isaacsim.core.api`` — Isaac Lab
-  no longer depends on those, and keeping them resurrects the deprecated stack.
-
-
-``SimulationManager`` is no longer re-exported
-----------------------------------------------
-
-Earlier internal previews of this migration briefly exposed
-``isaaclab_physx.physics.SimulationManager`` as a public alias of
-:class:`~isaaclab_physx.physics.PhysxManager`. **That alias has been removed**; use
-:class:`~isaaclab_physx.physics.PhysxManager` directly (with ``as SimulationManager`` at
-the import site if you want backend-agnostic call-site code, as shown above).
-
-
-Retired standalone reproducers
-------------------------------
-
-A handful of legacy reproducers under ``source/isaaclab/test/deps/isaacsim`` that
-depended on the deprecated Isaac Sim core extensions have been retired:
-``check_camera.py``, ``check_floating_base_made_fixed.py``,
-``check_legged_robot_clone.py``, ``check_rep_texture_randomizer.py``, and
-``check_ref_count.py``. Use :mod:`isaaclab.sim` together with the new
-``isaacsim.core.experimental.*`` APIs for the same debugging workflows.
-
-
-PhysX Tensors API Module Path
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Recent Isaac Sim releases removed the internal ``impl`` submodule of
-``omni.physics.tensors`` and now expose the PhysX Tensor API types
-(``ArticulationView``, ``RigidBodyView``, ``SimulationView``, etc.) directly
-under ``omni.physics.tensors.api``. Importing from the old path raises
-``ModuleNotFoundError: No module named 'omni.physics.tensors.impl'`` at import
-time.
-
-Isaac Lab has been updated to import from the new path. Downstream code
-(custom assets, sensors, or scripts) that imported from the old path must be
-updated:
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x / older Isaac Sim)
-   import omni.physics.tensors.impl.api as physx
-
-   # After (Isaac Lab 3.x / current Isaac Sim)
-   import omni.physics.tensors.api as physx
-
-The class identities are unchanged — only the module path moved. Type hints
-referencing the old path (``omni.physics.tensors.impl.api.ArticulationView``)
-should be similarly updated to ``omni.physics.tensors.api.ArticulationView``.
-
-
-Viewport Camera Configuration (``ViewerCfg`` deprecated)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``viewer`` field (type :class:`~isaaclab.envs.common.ViewerCfg`) is deprecated on
-:class:`~isaaclab.envs.DirectRLEnvCfg`, :class:`~isaaclab.envs.ManagerBasedEnvCfg`, and
-:class:`~isaaclab.envs.DirectMARLEnvCfg`.  A backward-compatibility shim re-routes
-``viewer.*`` assignments for one release, but the field will be removed in a future version.
-Configure the viewport camera through :attr:`~isaaclab.sim.SimulationCfg.default_visualizer_cfg`
-on the sim config instead.
-
-Similarly, :class:`~isaaclab.envs.ui.ViewportCameraController` is deprecated.  A shim class
-remains so existing imports do not break, but it raises a :class:`DeprecationWarning` at
-construction.  Camera tracking is now handled directly by
-:class:`~isaaclab_visualizers.kit.KitVisualizer` via ``origin_type`` and
-``origin_track_path`` on :class:`~isaaclab_visualizers.kit.KitVisualizerCfg`.
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   env_cfg.viewer.eye = (4.5, 0.0, 6.0)
-   env_cfg.viewer.lookat = (0.0, 0.0, 2.0)
-
-   # After (Isaac Lab 3.x)
-   from isaaclab.visualizers import VisualizerCfg
-   env_cfg.sim.default_visualizer_cfg = VisualizerCfg(eye=(4.5, 0.0, 6.0), lookat=(0.0, 0.0, 2.0))
-
-For asset-body tracking (previously ``origin_type="asset_root"`` / ``"asset_body"``), use
-:class:`~isaaclab_visualizers.kit.KitVisualizerCfg` with ``origin_type="asset"`` and
-``origin_track_path``:
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   env_cfg.viewer.origin_type = "asset_root"
-   env_cfg.viewer.asset_name = "robot"
-
-   # After (Isaac Lab 3.x)
-   from isaaclab_visualizers.kit import KitVisualizerCfg
-   env_cfg.sim.visualizer_cfgs = [KitVisualizerCfg(origin_type="asset", origin_track_path="robot")]
-
-The :class:`~isaaclab.envs.ui.ViewportCameraController` class is also deprecated; camera
-tracking is handled directly by :class:`~isaaclab_visualizers.kit.KitVisualizer`.
-
-
-Streaming Camera View (``tiled_cam_*`` fields removed)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``tiled_cam_*`` configuration fields on visualizer configs (e.g. ``tiled_cam_view``,
-``tiled_cam_num``, ``tiled_cam_prim_path``) have been removed and replaced by the unified
-``streaming_*`` API available on all four visualizer backends.  A one-release deprecation
-shim forwards each removed field to its ``streaming_*`` equivalent and emits
-:class:`DeprecationWarning`; the shim will be removed in the next major release.
-
-.. list-table:: Field rename reference
-   :header-rows: 1
-   :widths: 40 40 20
-
-   * - Old field (removed)
-     - New field
-     - Notes
-   * - ``tiled_cam_view``
-     - ``streaming_view``
-     - Default is now ``False`` (opt-in)
-   * - ``tiled_cam_num``
-     - ``streaming_envs``
-     - Accepts ``int`` or ``list[int]``
-   * - ``tiled_cam_prim_path``
-     - ``streaming_sensor_prim_path``
-     - Existing sensor path; takes priority over auto-created camera
-   * - ``tiled_cam_eye``
-     - ``streaming_cam_eye``
-     -
-   * - ``tiled_cam_renderer``
-     - ``streaming_cam_renderer``
-     - Accepts ``"newton_warp"``, ``"ovrtx"``, ``"isaac_rtx"``, or ``None``
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   from isaaclab_visualizers.newton import NewtonVisualizerCfg
-   cfg = NewtonVisualizerCfg(
-       tiled_cam_view=True,
-       tiled_cam_num=16,
-       tiled_cam_prim_path="/World/envs/env_.*/Camera",
-   )
-
-   # After (Isaac Lab 3.x)
-   from isaaclab_visualizers.newton import NewtonGLVisualizerCfg
-   cfg = NewtonGLVisualizerCfg(
-       streaming_view=True,
-       streaming_envs=16,
-       streaming_sensor_prim_path="/World/envs/env_.*/Camera",
-   )
-
-.. note::
-   :class:`~isaaclab_visualizers.newton.NewtonVisualizerCfg` is deprecated in this release.
-   Use :class:`~isaaclab_visualizers.newton.NewtonGLVisualizerCfg` (OpenGL rasterizer) or
-   :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizerCfg` (OVRTX path tracer) instead.
-
-
-Newton Visualizer Type Split (``newton`` → ``newton_gl`` / ``newton_rtx``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The single ``NewtonVisualizerCfg`` (``visualizer_type="newton"``) has been split into two
-dedicated configs with separate type identifiers:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 30 40
-
-   * - Old (removed / deprecated)
-     - New
-     - Notes
-   * - ``NewtonVisualizerCfg`` (``visualizer_type="newton"``)
-     - :class:`~isaaclab_visualizers.newton.NewtonGLVisualizerCfg` (``visualizer_type="newton_gl"``)
-     - OpenGL rasterizer; default Newton visualizer
-   * - —
-     - :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizerCfg` (``visualizer_type="newton_rtx"``)
-     - OVRTX path tracer (experimental)
-
-The ``--viz newton`` CLI argument remains as a **deprecated alias** for ``--viz newton_gl``.
-Update scripts and config files to use the explicit form:
-
-.. code-block:: bash
-
-   # Before (Isaac Lab 2.x)
-   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole --viz newton
-
-   # After (Isaac Lab 3.x)
-   uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole --viz newton_gl
-
-Similarly, when importing the config class directly:
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   from isaaclab_visualizers.newton import NewtonVisualizerCfg
-   cfg = NewtonVisualizerCfg()
-
-   # After (Isaac Lab 3.x)
-   from isaaclab_visualizers.newton import NewtonGLVisualizerCfg  # or NewtonRTXVisualizerCfg
-   cfg = NewtonGLVisualizerCfg()
-
-The ``source="visualizer:newton"`` string in :class:`~isaaclab.envs.utils.video_recorder_cfg.VideoRecorderCfg`
-continues to work as a backward-compatible alias for ``"visualizer:newton_gl"``, but
-``"visualizer:newton_gl"`` and ``"visualizer:newton_rtx"`` are now the canonical source strings.
-
-
-Video Recording (``gym.wrappers.RecordVideo`` replaced)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``gym.wrappers.RecordVideo`` pattern is no longer supported.  Video recording is now driven
-internally by :class:`~isaaclab.envs.utils.video_recorder_cfg.VideoRecorderCfg` entries on the
-environment config, sourcing frames from the active visualizer or a scene sensor.
-
-.. code-block:: python
-
-   # Before (Isaac Lab 2.x)
-   env = gym.make(task, cfg=env_cfg, render_mode="rgb_array")
-   env = gym.wrappers.RecordVideo(env, video_folder="videos/", step_trigger=lambda s: s == 0)
-
-   # After (Isaac Lab 3.x)
-   from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
-   env_cfg.video_recorders = [
-       VideoRecorderCfg(source="visualizer", output_dir="videos/", video_length=200)
-   ]
-   env = gym.make(task, cfg=env_cfg)
-
-Available sources: ``"visualizer"`` (auto-pick), ``"visualizer:kit"``, ``"visualizer:newton_gl"``,
-``"visualizer:newton_rtx"``, ``"visualizer:newton_gl:tiled"``, ``"sensor:<name>"``.
-``"visualizer:newton"`` and ``"visualizer:newton:tiled"`` remain as deprecated backward-compatible
-aliases for ``"visualizer:newton_gl"`` and ``"visualizer:newton_gl:tiled"`` respectively.
-The ``eye`` and ``lookat`` fields have been removed from ``VideoRecorderCfg``; position the
-camera via ``sim.default_visualizer_cfg`` instead.
-
-The ``isaaclab.envs.utils.recording_hooks`` module has been removed.  Physics-backend recording
-hooks are now registered via :meth:`~isaaclab.sim.SimulationContext.add_render_callback`.
-
-
-Need Help?
-~~~~~~~~~~
+.. rubric:: Support Resources
 
 If you encounter issues during migration:
 
 1. Check the `IsaacLab GitHub Issues <https://github.com/isaac-sim/IsaacLab/issues>`_
 2. Review the `CHANGELOG <https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/docs/CHANGELOG.rst>`_
 3. Join the community on `Discord <https://discord.gg/nvidiaomniverse>`_
+
+
+.. include:: include/from_isaacgymenvs.rst
+
+
+.. include:: include/comparing_simulation_isaacgym.rst
+
+
+.. include:: include/deformables.rst

--- a/skills/user/migrate-2x-to-3x/SKILL.md
+++ b/skills/user/migrate-2x-to-3x/SKILL.md
@@ -18,9 +18,9 @@ Do not copy migration tables into answers from memory. Read the official migrati
 ## Workflow
 
 1. Read the official migration guide in `docs/source/migration/migrating_to_isaaclab_3-0.rst`.
-2. Identify which migration area applies: visualization CLI, backend packages, schema cfgs, actuator collection
-   ownership and runtime topology, quaternion order, `ProxyArray`, asset views, RSL-RL config, Isaac Sim extension
-   enablement, or project-specific scripts.
+2. Identify which migration area applies: installation, backend packages and presets, asset and actuator APIs,
+   sensors, quaternion order, `ProxyArray`, RL entrypoints, visualizers and recording, importers, Isaac Sim
+   extension enablement, or project-specific scripts.
 3. Search the downstream project for old API symbols before editing.
 4. For user code that imports Isaac Sim extension modules directly:
    - Prefer an Isaac Lab in-tree API when the migration guide lists one.

--- a/skills/user/migrate-from-isaac-gym/SKILL.md
+++ b/skills/user/migrate-from-isaac-gym/SKILL.md
@@ -60,7 +60,7 @@ uv run --no-project python tools/skills/cli.py check
 
 ## Maintenance
 
-Keep this skill synchronized with `docs/source/migration/migrating_from_isaacgymenvs.rst`, `docs/source/setup/installation/index.rst`, `docs/source/overview/core-concepts/task_workflows.rst`, `docs/source/overview/core-concepts/multi_backend_architecture.rst`, `docs/source/overview/core-concepts/schema_cfgs.rst`, the direct environment tutorial, and direct task examples such as `source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/`, `source/isaaclab_tasks/isaaclab_tasks/contrib/anymal_c_direct/`, and `source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/`. If the migration requires documentation-level details, update `docs/source/` or the maintained examples first and keep this skill as a workflow router.
+Keep this skill synchronized with the Isaac Gym section in `docs/source/migration/migrating_to_isaaclab_3-0.rst`, `docs/source/setup/installation/index.rst`, `docs/source/overview/core-concepts/task_workflows.rst`, `docs/source/overview/core-concepts/multi_backend_architecture.rst`, `docs/source/overview/core-concepts/schema_cfgs.rst`, the direct environment tutorial, and direct task examples such as `source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/`, `source/isaaclab_tasks/isaaclab_tasks/contrib/anymal_c_direct/`, and `source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/`. If the migration requires documentation-level details, update `docs/source/` or the maintained examples first and keep this skill as a workflow router.
 
 ## References
 
@@ -70,7 +70,7 @@ Keep this skill synchronized with `docs/source/migration/migrating_from_isaacgym
 - [Initial Ant smoke validation](validation-ant-fresh-agent.md)
 - [Evaluations](evaluations.md)
 - [Direct to manager conversion skill](../convert-direct-to-manager/SKILL.md)
-- [IsaacGymEnvs migration guide](../../../docs/source/migration/migrating_from_isaacgymenvs.rst)
+- [Migration guide: Isaac Gym section](../../../docs/source/migration/migrating_to_isaaclab_3-0.rst#migration-from-isaac-gym-and-isaacgymenvs)
 - [Task workflows](../../../docs/source/overview/core-concepts/task_workflows.rst)
 - [Multi-backend architecture](../../../docs/source/overview/core-concepts/multi_backend_architecture.rst)
 - [Schema cfgs](../../../docs/source/overview/core-concepts/schema_cfgs.rst)


### PR DESCRIPTION
# Description

Backports #7428 onto `release/3.0.0` by cherry-picking the merged squash commit (`9055a1e5e9a77141ee2188aa7e636bdf6193acab`).

This consolidates the Isaac Lab migration guides and updates the related repository skills. The backport patch ID matches the original commit.

## Type of change

- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run isaaclab -f`
- `uv run --no-project python tools/skills/cli.py check` (21 skills validated)
- `uv run --isolated --extra test -- make -C docs current-docs` equivalent dependency-isolated Sphinx build (succeeded with no warnings; `ovstage` was mocked because it is unavailable on macOS)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: documentation and skill routing only)
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (not applicable: no source package changed)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there