### PR TITLE
[Docs] Update multi-asset guide for Newton

### DIFF
--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -40,8 +40,8 @@ a fixed base robot. This guide goes over the various considerations and steps to
 Spawning Multiple Assets
 ------------------------
 
-This guide explains how to import and configure different assets in each environment. This is
-useful when you want to create diverse environments with different objects.
+This guide explains how to batch rigid objects into a collection and configure different asset
+variants across environments.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/how-to/multi_asset_spawning.rst
+++ b/docs/source/how-to/multi_asset_spawning.rst
@@ -4,20 +4,14 @@ Spawning Multiple Assets
 
 .. currentmodule:: isaaclab
 
-Typical spawning configurations (introduced in the :ref:`tutorial-spawn-prims` tutorial) copy the same
-asset (or USD primitive) across the different resolved prim paths from the expressions.
-For instance, if the user specifies to spawn the asset at "/World/Table\_.*/Object", the same
-asset is created at the paths "/World/Table_0/Object", "/World/Table_1/Object" and so on.
+Typical spawning configurations (introduced in the :ref:`tutorial-spawn-prims` tutorial) copy one asset across all
+prim paths resolved from an expression. Multi-asset workflows cover two related composition needs:
 
-However, we also support multi-asset spawning with two mechanisms:
+1. A rigid object collection batches several rigid objects in every environment behind one data and command API.
+2. A multi-asset spawner declares several variants for one scene asset binding, allowing environments to contain
+   different geometry or robot variants.
 
-1. Rigid object collections. This allows the user to spawn multiple rigid objects in each environment and access/modify
-   them with a unified API, improving performance.
-
-2. Spawning different assets under the same prim path. This allows the user to create diverse simulations, where each
-   environment has a different asset.
-
-This guide describes how to use these two mechanisms.
+This guide demonstrates both mechanisms and explains how their execution differs between PhysX and Newton.
 
 The sample script ``multi_asset.py`` is used as a reference, located in the
 ``IsaacLab/scripts/demos`` directory.
@@ -27,106 +21,138 @@ The sample script ``multi_asset.py`` is used as a reference, located in the
 
    .. literalinclude:: ../../../scripts/demos/multi_asset.py
       :language: python
-      :emphasize-lines: 109-131, 135-179, 184-203
       :linenos:
 
-This script creates multiple environments, where each environment has:
+With the default PhysX configuration, this script creates multiple environments containing:
 
-* a rigid object collection containing a cone, a cube, and a sphere
-* a rigid object that is either a cone, a cube, or a sphere, chosen at random
-* an articulation that is either the ANYmal-C or ANYmal-D robot, chosen at random
+* a rigid object collection containing a sphere, a cube, and a cylinder
+* a rigid object selected from nine geometry and material variants by the clone plan
+* an articulation selected from the ANYmal-C and ANYmal-D variants by the clone plan
 
 .. image:: ../_static/demos/multi_asset.jpg
   :width: 100%
   :alt: result of multi_asset.py
 
 
-Rigid Object Collections
+Rigid object collections
 ------------------------
 
-Multiple rigid objects can be spawned in each environment and accessed/modified with a unified ``(env_ids, obj_ids)`` API.
-While the user could also create multiple rigid objects by spawning them individually, the API is more user-friendly and
-more efficient since it uses a single physics view under the hood to handle all the objects.
+Use a rigid object collection when every environment contains the same set of independently moving rigid bodies and you
+want to access them as one batch. The collection exposes data with an ``(env, object, ...)`` layout and accepts
+``(env_ids, obj_ids)`` selections for commands. Compared with managing each object separately, the collection uses one
+batched physics view.
 
 .. literalinclude:: ../../../scripts/demos/multi_asset.py
    :language: python
-   :lines: 135-179
-   :dedent:
+   :start-at: object_collection: RigidObjectCollectionCfg = RigidObjectCollectionCfg(
+   :end-before: # articulation
+   :dedent: 4
 
-The configuration :class:`~assets.RigidObjectCollectionCfg` is used to create the collection. It's attribute :attr:`~assets.RigidObjectCollectionCfg.rigid_objects`
-is a dictionary containing :class:`~assets.RigidObjectCfg` objects. The keys serve as unique identifiers for each
-rigid object in the collection.
+The :class:`~assets.RigidObjectCollectionCfg` configuration owns a dictionary of :class:`~assets.RigidObjectCfg`
+instances. Each dictionary key is the object's stable identifier within the collection.
 
-
-Spawning different assets under the same prim path
---------------------------------------------------
-
-It is possible to spawn different assets and USDs under the same prim path in each environment using the spawners
-:class:`~sim.spawners.wrappers.MultiAssetSpawnerCfg` and :class:`~sim.spawners.wrappers.MultiUsdFileCfg`:
-
-* We set the spawn configuration in :class:`~assets.RigidObjectCfg` to be
-  :class:`~sim.spawners.wrappers.MultiAssetSpawnerCfg`:
-
-  .. literalinclude:: ../../../scripts/demos/multi_asset.py
-     :language: python
-     :lines: 107-133
-     :dedent:
-
-  This function allows you to define a list of different assets that can be spawned as rigid objects.
-  When :attr:`~sim.spawners.wrappers.MultiAssetSpawnerCfg.random_choice` is set to True, one asset from the list
-  is randomly selected and spawned at the specified prim path.
-
-* Similarly, we set the spawn configuration in :class:`~assets.ArticulationCfg` to be
-  :class:`~sim.spawners.wrappers.MultiUsdFileCfg`:
-
-  .. literalinclude:: ../../../scripts/demos/multi_asset.py
-     :language: python
-     :lines: 182-215
-     :dedent:
-
-  Similar to before, this configuration allows the selection of different USD files representing articulated assets.
-
-
-Things to Note
-~~~~~~~~~~~~~~
-
-Similar asset structuring
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-While spawning and handling multiple assets using the same physics interface (the rigid object or articulation classes),
-it is essential to have the assets at all the prim locations follow a similar structure. In case of an articulation,
-this means that they all must have the same number of links and joints, the same number of collision bodies and
-the same names for them. If that is not the case, the physics parsing of the prims can get affected and fail.
-
-The main purpose of this functionality is to enable the user to create randomized versions of the same asset,
-for example robots with different link lengths, or rigid objects with different collider shapes.
-
-Physics replication in interactive scene
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, the flag :attr:`scene.InteractiveScene.replicate_physics` is set to True. This flag informs the physics
-engine that the simulation environments are copies of one another so it just needs to parse the first environment
-to understand the entire simulation scene. This helps speed up the simulation scene parsing.
-
-However, in the case of spawning different assets in different environments, this assumption does not hold
-anymore. Hence the flag :attr:`scene.InteractiveScene.replicate_physics` must be disabled when the spawned assets
-do not share the same structure.
-For a full guide on the template-based cloning system including strategies and collision filtering,
-see :doc:`cloning`.
+The demo resets all collection members through the same API used by both physics backends:
 
 .. literalinclude:: ../../../scripts/demos/multi_asset.py
    :language: python
-   :lines: 247-251
-   :dedent:
+   :start-at: default_pose_w = rigid_object_collection.data.default_body_pose.torch.clone()
+   :end-at: rigid_object_collection.write_body_com_velocity_to_sim_index(body_velocities=default_vel_w)
+   :dedent: 12
 
-The Code Execution
-------------------
 
-To execute the script with multiple environments and randomized assets, use the following command:
+Spawning variants for one scene asset
+-------------------------------------
 
-.. code-block:: bash
+Use :class:`~sim.spawners.wrappers.MultiAssetSpawnerCfg` and :class:`~sim.spawners.wrappers.MultiUsdFileCfg` to declare
+the available variants for one scene asset binding. :class:`~scene.InteractiveScene` includes these variants in its clone
+plan and assigns one valid prototype combination to each environment.
 
-   uv run --extra isaacsim python scripts/demos/multi_asset.py --num_envs 2048
+For configuration-based assets, assign :class:`~sim.spawners.wrappers.MultiAssetSpawnerCfg` to the
+:class:`~assets.RigidObjectCfg` spawn configuration:
 
-This command runs the simulation with 2048 environments, each with randomly selected assets.
+.. literalinclude:: ../../../scripts/demos/multi_asset.py
+   :language: python
+   :start-at: object: RigidObjectCfg = RigidObjectCfg(
+   :end-before: # object collection
+   :dedent: 4
+
+The ``assets_cfg`` list defines the prototypes available to the clone plan. Variant assignment is controlled by
+:attr:`~cloner.CloneCfg.clone_strategy`; the default :func:`~cloner.sequential` strategy assigns combinations in
+round-robin order. To sample combinations randomly instead, set the strategy before constructing the scene:
+
+.. code-block:: python
+
+   from isaaclab import cloner
+
+   scene_cfg.clone_cfg.clone_strategy = cloner.random
+
+For USD assets, assign :class:`~sim.spawners.wrappers.MultiUsdFileCfg` to the
+:class:`~assets.ArticulationCfg` spawn configuration:
+
+.. literalinclude:: ../../../scripts/demos/multi_asset.py
+   :language: python
+   :start-at: robot: ArticulationCfg = ArticulationCfg(
+   :end-before: ##
+   :dedent: 4
+
+Variant compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+All variants behind one batched asset interface must have a compatible structure. Articulation variants must have the
+same links, joints, collision-body count, and names. Rigid object variants can differ in geometry and material while
+retaining a compatible rigid-body layout. Model structurally different assets as separate scene bindings.
+
+Clone planning and physics replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`~scene.InteractiveScene` represents multi-asset variants as clone-plan prototypes. It can therefore keep
+:attr:`~scene.InteractiveSceneCfg.replicate_physics` enabled and replicate each prototype only to its assigned
+environments. Do not disable physics replication merely because a scene uses a multi-asset spawner. Reserve
+``replicate_physics=False`` for per-environment stage differences that cannot be represented as clone variants; that
+mode is not supported by the Newton backend.
+
+The demo keeps physics replication enabled. For Newton, it also narrows the standalone object and articulation to one
+variant because their batched Newton views currently require a uniform body layout across worlds:
+
+.. literalinclude:: ../../../scripts/demos/multi_asset.py
+   :language: python
+   :start-at: scene_cfg = MultiObjectSceneCfg(num_envs=args_cli.num_envs
+   :end-at: scene_cfg.robot.spawn.usd_path = scene_cfg.robot.spawn.usd_path[0]
+   :dedent: 8
+
+For more detail on prototype assignment and replication, see :doc:`cloning`.
+
+Run the demo
+------------
+
+The physics backend and visualizer are selected independently. Run one of these commands from the repository root:
+
+.. tab-set::
+
+   .. tab-item:: PhysX with Kit
+
+      .. code-block:: bash
+
+         uv run --extra isaacsim python scripts/demos/multi_asset.py --num_envs 2048
+
+   .. tab-item:: Newton MJWarp with Kit
+
+      .. code-block:: bash
+
+         uv run --extra isaacsim python scripts/demos/multi_asset.py \
+             --physics newton_mjwarp --num_envs 2048
+
+   .. tab-item:: Newton MJWarp with Newton GL
+
+      .. code-block:: bash
+
+         uv run python scripts/demos/multi_asset.py \
+             --physics newton_mjwarp --visualizer newton_gl --num_envs 2048
+
+The Newton commands exercise the same :class:`~assets.RigidObjectCollectionCfg` and ``(env_ids, obj_ids)`` APIs as the
+PhysX command. They do not demonstrate per-environment object or articulation variants because of the uniform-layout
+restriction described above; use the PhysX command to inspect that part of the example. See the
+:doc:`Newton installation guide </source/overview/core-concepts/physical-backends/newton/installation>` before running
+the kitless command.
+
 To stop the simulation, you can close the window, or press ``Ctrl+C`` in the terminal.

--- a/scripts/demos/multi_asset.py
+++ b/scripts/demos/multi_asset.py
@@ -10,14 +10,14 @@
     # Usage with default PhysX physics and default kit visualizer.
     uv run --extra isaacsim python scripts/demos/multi_asset.py --num_envs 1024
 
-    # Usage with Newton visualizer and default PhysX physics.
-    uv run --extra isaacsim python scripts/demos/multi_asset.py --visualizer newton --num_envs 1024
+    # Usage with Newton GL visualizer and default PhysX physics.
+    uv run --extra isaacsim python scripts/demos/multi_asset.py --visualizer newton_gl --num_envs 1024
 
     # Usage with Newton (MJWarp) physics and default kit visualizer.
     uv run --extra isaacsim python scripts/demos/multi_asset.py --physics newton_mjwarp --num_envs 1024
 
-    # Usage with Newton visualizer and Newton (MJWarp) physics.
-    uv run python scripts/demos/multi_asset.py --visualizer newton --physics newton_mjwarp --num_envs 1024
+    # Usage with Newton GL visualizer and Newton (MJWarp) physics.
+    uv run python scripts/demos/multi_asset.py --visualizer newton_gl --physics newton_mjwarp --num_envs 1024
 
 """
 


### PR DESCRIPTION
# Description

Keep the Spawning Multiple Assets how-to as the discoverable guide for both `RigidObjectCollection` and multi-variant spawning, and align it with the current demo and cloning architecture.

- Show both collection configuration and the `(env_ids, obj_ids)` runtime API.
- Replace stale line-number excerpts with content-anchored literal includes.
- Explain that clone strategies own variant assignment and that the default is sequential.
- Correct the physics-replication guidance for clone-plan prototypes.
- Add PhysX and Newton MJWarp launch commands for Kit and Newton GL.
- Document that the Newton path exercises the shared collection API but currently pins the standalone object and articulation to uniform variants.
- Replace the deprecated `newton` visualizer alias in the demo usage examples with `newton_gl`.

No dependencies are added.

## Type of change

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this updates guide content and command examples.

## Testing

- `uv run --isolated --extra test -- pytest -q source/isaaclab/test/app/test_standalone_scripts.py` (`44 passed, 380 skipped`)
- `SKIP=check-changelog-fragments uv run --frozen --project /home/zhengyuz/Projects/IsaacLab.wt/pbt-training-guide isaaclab -f` (all applicable hooks passed)
- Full dummy Sphinx read parsed the changed guide, literal includes, and cross-references without any warnings from the changed files. Current `develop` emits 15 unrelated duplicate API-object warnings under global `-W`.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run the focused standalone-script tests
- [x] No source package is touched, so no changelog fragment is required
- [x] My name already exists in `CONTRIBUTORS.md`
