### PR TITLE
Document that Isaac RTX enable_shadows cannot disable shadows

### DIFF
--- a/source/isaaclab_physx/changelog.d/mataylor-isaac-rtx-enable-shadows-no-op.rst
+++ b/source/isaaclab_physx/changelog.d/mataylor-isaac-rtx-enable-shadows-no-op.rst
@@ -2,7 +2,10 @@ Fixed
 ^^^^^
 
 * Fixed :attr:`~isaaclab_physx.renderers.IsaacRtxRendererGlobalSettingsCfg.enable_shadows`
-  documenting itself as a working shadow switch. It writes ``/rtx/shadows/enabled``, which the RTX
-  version shipped by Isaac Sim 6.0 registers but no render mode reads, so setting it to ``False``
-  leaves every camera output unchanged. The docstring now records the limitation and points at
-  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows`, which does take effect.
+  documenting itself as a working shadow switch. It writes ``/rtx/shadows/enabled``, the shadow
+  switch of the ``RaytracedLighting`` pipeline, which the RTX version shipped by Isaac Sim 6.0 no
+  longer offers; the render modes that remain do not read it, so setting the field to ``False``
+  leaves every camera output byte-identical. The docstring now records the limitation and points at
+  the ``albedo`` data type, ambient-only lighting, and
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows` as the shadow-free options that do
+  work.

--- a/source/isaaclab_physx/changelog.d/mataylor-isaac-rtx-enable-shadows-no-op.rst
+++ b/source/isaaclab_physx/changelog.d/mataylor-isaac-rtx-enable-shadows-no-op.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :attr:`~isaaclab_physx.renderers.IsaacRtxRendererGlobalSettingsCfg.enable_shadows`
+  documenting itself as a working shadow switch. It writes ``/rtx/shadows/enabled``, which the RTX
+  version shipped by Isaac Sim 6.0 registers but no render mode reads, so setting it to ``False``
+  leaves every camera output unchanged. The docstring now records the limitation and points at
+  :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows`, which does take effect.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_cfg.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_cfg.py
@@ -55,7 +55,20 @@ class IsaacRtxRendererGlobalSettingsCfg:
     """Direct lighting samples per pixel."""
 
     enable_shadows: bool | None = None
-    """Enable shadow rendering."""
+    """Enable shadow rendering. ``None`` preserves the launch-time setting.
+
+    .. warning::
+
+        This has no effect on the rendered image with the RTX version shipped by Isaac Sim 6.0.
+        It writes ``/rtx/shadows/enabled``, which RTX registers but no render mode reads: the
+        path-traced modes always cast shadows, and RTX Minimal exposes no shadow switch at all.
+        Setting this to ``False`` leaves every camera output unchanged, so shadows cannot
+        currently be turned off on this backend.
+
+        :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows` does work, because the
+        ``ovrtx`` runtime carries a newer RTX whose Minimal mode has an
+        ``omni:rtx:minimal:castShadows`` switch.
+    """
 
     enable_ambient_occlusion: bool | None = None
     """Enable ambient occlusion."""

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_cfg.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer_cfg.py
@@ -59,15 +59,24 @@ class IsaacRtxRendererGlobalSettingsCfg:
 
     .. warning::
 
-        This has no effect on the rendered image with the RTX version shipped by Isaac Sim 6.0.
-        It writes ``/rtx/shadows/enabled``, which RTX registers but no render mode reads: the
-        path-traced modes always cast shadows, and RTX Minimal exposes no shadow switch at all.
-        Setting this to ``False`` leaves every camera output unchanged, so shadows cannot
-        currently be turned off on this backend.
+        This has no effect on the rendered image with the RTX version shipped by Isaac Sim 6.0:
+        setting it to ``False`` leaves every camera output byte-identical.
 
-        :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows` does work, because the
-        ``ovrtx`` runtime carries a newer RTX whose Minimal mode has an
-        ``omni:rtx:minimal:castShadows`` switch.
+        It writes ``/rtx/shadows/enabled``, the shadow switch of the ``RaytracedLighting``
+        pipeline. That pipeline is no longer selectable -- requesting it reverts the render mode
+        to ``RealTimePathTracing`` -- and none of the three that remain read the setting:
+        ``RealTimePathTracing`` and ``PathTracing`` always cast shadows, and ``Minimal`` uses
+        ``omni:rtx:minimal:castShadows``, which this RTX version does not define.
+
+        Nothing above the renderer misbehaves, which is why this is easy to miss: the setting is
+        registered, mapped to ``OmniRtxDebugSettingsAPI_1.omni:rtx:shadows:enabled``, and reads
+        back the assigned value. Only its consumer is gone. Per-light ``UsdLux`` ``ShadowAPI``
+        (``inputs:shadow:enable``) is ignored for the same reason.
+
+        For a shadow-free output today, request the ``albedo`` data type, which is unlit, or light
+        the scene with ambient only (:attr:`ambient_light_intensity`) so nothing casts a shadow.
+        :attr:`~isaaclab_ov.renderers.OVRTXRendererCfg.enable_shadows` also works, because the
+        ``ovrtx`` runtime carries a newer RTX whose Minimal mode defines ``castShadows``.
     """
 
     enable_ambient_occlusion: bool | None = None


### PR DESCRIPTION
# Description

`IsaacRtxRendererGlobalSettingsCfg.enable_shadows` reads as a working shadow switch. It is not one,
and has not been since #5449. This documents the limitation and its cause.

Setting it to `False` leaves every camera output **byte-identical**.

## Root cause

`enable_shadows` writes `/rtx/shadows/enabled` — the shadow switch of the **`RaytracedLighting`**
pipeline. Isaac Lab used to pin that render mode (see #310, a workaround for its casing), so the
flag worked when it was added. #5449 switched the default to `RealTimePathTracing` for determinism,
and the flag became inert that day, silently.

`RaytracedLighting` is no longer selectable at all on Isaac Sim 6.0 — requesting it is rejected the
same way a nonsense token is:

| requested `/rtx/rendermode` | readback |
| --- | --- |
| `RaytracedLighting` | **`RealTimePathTracing`** ← rejected |
| `BogusMode123` | **`RealTimePathTracing`** ← rejected |
| `PathTracing` / `Minimal` / `MinimalRendering` / `RealTimePathTracing` | kept |

None of the three surviving pipelines reads the setting. `RealTimePathTracing` and `PathTracing`
always cast shadows by design; `Minimal` uses `omni:rtx:minimal:castShadows`, which Isaac Sim 6.0's
`OmniRtxSettingsMinimalAPI_1` does not define (it has `minimal:mode`, `minimal:constantColor` and
the two `sceneDb:ambientLight*` properties). The `ovrtx` runtime carries a newer RTX that does
define it, which is why `OVRTXRendererCfg.enable_shadows` works.

## Measurements

Slab, 1.2 m pillar, sphere, distant light at 45 degrees, 640x480, unmodified `Camera` /
`IsaacRtxRendererCfg`, reading the **color** buffer.

| attempt | applied | result |
| --- | --- | --- |
| `enable_shadows=False` | renderer init | identical |
| `settings.set("/rtx/shadows/enabled", False)` | runtime | identical |
| `--/rtx/shadows/enabled=false` | Kit startup | identical |
| `rtx.shadows.enabled = false` in the `.kit` file | app config | identical |
| per-light `UsdLux` `ShadowAPI` `inputs:shadow:enable=False` | before *and* after Fabric population | identical |
| `omni:rtx:minimal:castShadows=False`, incl. with `OmniRtxSettingsMinimalAPI_1` applied to the prim | 4 variants, in real Minimal mode | identical |

Every one reports success at the layer it touches — the carb setting reads back `False`, and the USD
attributes report `defined=True authored=True value=False`. Nothing above the renderer misbehaves;
only the consumer is missing.

## Shadow-free options that do work today

* Request the `albedo` data type. It is unlit, so there is nothing to shadow.
* Light the scene with ambient only (`ambient_light_intensity`), so no directional source casts.
* Use the OVRTX renderer with `OVRTXRendererCfg(enable_shadows=False)` in Minimal mode (#7454).

There is no way to keep RTPT or Minimal lighting *and* drop the cast shadows on this backend. That
needs an Isaac Sim RTX uplift to the build that defines `castShadows`.

## Note on test coverage

`test_isaac_rtx_global_settings` does cover this field, but asserts
`settings.get("/rtx/shadows/enabled") is True` against a fake settings object. It verifies that the
config field writes the carb key, never that the key does anything, so it passed unchanged through
the regression. Catching this class of bug needs a pixel comparison; the rendering suite's
`make_xfail_rendering_params` would be the natural home, as a non-strict xfail that reports
`XPASS (REVIEW XFAIL)` when a future Isaac Sim honours the setting. Happy to add that here or as a
follow-up.

## Type of change

- Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — docstring-only change; see the test-coverage note above
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
