### PR TITLE
Harden Git asset cache downloads

### DIFF
--- a/source/isaaclab/changelog.d/recover-git-asset-cache.rst
+++ b/source/isaaclab/changelog.d/recover-git-asset-cache.rst
@@ -1,4 +1,4 @@
 Fixed
 ^^^^^
 
-* Fixed interrupted, stale, and concurrent Git asset downloads leaving incomplete cache checkouts.
+* Fixed interrupted and concurrent Git asset downloads leaving incomplete cache checkouts.

--- a/source/isaaclab/changelog.d/recover-git-asset-cache.rst
+++ b/source/isaaclab/changelog.d/recover-git-asset-cache.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed interrupted, stale, and concurrent Git asset downloads leaving incomplete cache checkouts.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -20,7 +20,6 @@ import logging
 import os
 import posixpath
 import re
-import shutil
 import subprocess
 import tempfile
 import uuid
@@ -300,14 +299,13 @@ def _get_git_asset_dir(git_path: str, cache_dir: str | None = None, force_update
         elif os.path.exists(git_asset_dir):
             raise RuntimeError(f"Git asset cache exists but is not a git repository: {git_asset_dir}")
         else:
-            os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
-            temporary_path = git_asset_dir + ".partial"
-            shutil.rmtree(temporary_path, ignore_errors=True)
-            try:
+            cache_parent = os.path.dirname(git_asset_dir)
+            os.makedirs(cache_parent, exist_ok=True)
+            prefix = f".{os.path.basename(git_asset_dir)}."
+            with tempfile.TemporaryDirectory(prefix=prefix, dir=cache_parent) as temporary_dir:
+                temporary_path = os.path.join(temporary_dir, "checkout")
                 _run_git_command(["git", "clone", "--depth", "1", git_path, temporary_path])
                 os.replace(temporary_path, git_asset_dir)
-            finally:
-                shutil.rmtree(temporary_path, ignore_errors=True)
 
     return git_asset_dir
 

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -236,10 +236,9 @@ def retrieve_git_asset_path(
     """Return a local path for an asset stored in a git repository.
 
     Remote repositories are cached under :data:`GIT_ASSET_CACHE_DIR`. If the requested
-    asset is already cached, it is returned without running git. Otherwise, access to the
-    checkout is serialized and an existing checkout is updated before the asset is reported
-    as missing. New checkouts are published atomically so an interrupted clone cannot leave
-    an incomplete cache at the final path.
+    asset is already cached, it is returned without running git. Cache population is
+    serialized, and new checkouts are published atomically so an interrupted clone cannot
+    leave an incomplete cache at the final path.
 
     Args:
         git_path: Git repository URL, SSH path, or existing local checkout directory.
@@ -263,27 +262,20 @@ def retrieve_git_asset_path(
         if not force_update and os.path.exists(source_path):
             return source_path
 
-    git_asset_dir = _get_git_asset_dir(git_path, cache_dir, force_update, required_local_path=local_path)
+    git_asset_dir = _get_git_asset_dir(git_path, cache_dir, force_update)
     source_path = _resolve_git_asset_source_path(local_path, git_asset_dir)
     if not os.path.exists(source_path):
         raise FileNotFoundError(f"Unable to find git asset: {source_path}")
     return source_path
 
 
-def _get_git_asset_dir(
-    git_path: str,
-    cache_dir: str | None = None,
-    force_update: bool = False,
-    required_local_path: str | None = None,
-) -> str:
+def _get_git_asset_dir(git_path: str, cache_dir: str | None = None, force_update: bool = False) -> str:
     """Return a local checkout for a git asset repository.
 
     Args:
         git_path: Git repository URL, SSH path, or existing local checkout directory.
         cache_dir: Directory where remote repositories are cached.
         force_update: Whether to update an existing checkout.
-        required_local_path: Asset path that must exist in a remote checkout. When it is missing,
-            an existing checkout is updated and recovered before returning.
 
     Returns:
         Path to a local repository checkout.
@@ -301,61 +293,23 @@ def _get_git_asset_dir(
         return git_asset_dir
 
     git_asset_dir = _get_git_asset_cache_dir(git_path, cache_dir)
-    required_source_path = (
-        _resolve_git_asset_source_path(required_local_path, git_asset_dir) if required_local_path is not None else None
-    )
-
     with FileLock(git_asset_dir + ".lock"):
-        has_checkout = os.path.isdir(os.path.join(git_asset_dir, ".git"))
-        asset_is_missing = required_source_path is not None and not os.path.exists(required_source_path)
-
-        if has_checkout:
-            if force_update or asset_is_missing:
-                try:
-                    _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
-                except RuntimeError:
-                    _clone_git_asset_repo(git_path, git_asset_dir)
-            if required_source_path is not None and not os.path.exists(required_source_path):
-                # A clone interrupted during checkout can have a valid HEAD but still lack
-                # working-tree files. Restore the checkout without downloading the repository again.
-                try:
-                    _run_git_command(["git", "-C", git_asset_dir, "checkout", "HEAD", "--", "."])
-                except RuntimeError:
-                    _clone_git_asset_repo(git_path, git_asset_dir)
+        if os.path.isdir(os.path.join(git_asset_dir, ".git")):
+            if force_update:
+                _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
+        elif os.path.exists(git_asset_dir):
+            raise RuntimeError(f"Git asset cache exists but is not a git repository: {git_asset_dir}")
         else:
-            _clone_git_asset_repo(git_path, git_asset_dir)
+            os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
+            temporary_path = git_asset_dir + ".partial"
+            shutil.rmtree(temporary_path, ignore_errors=True)
+            try:
+                _run_git_command(["git", "clone", "--depth", "1", git_path, temporary_path])
+                os.replace(temporary_path, git_asset_dir)
+            finally:
+                shutil.rmtree(temporary_path, ignore_errors=True)
 
     return git_asset_dir
-
-
-def _clone_git_asset_repo(git_path: str, git_asset_dir: str) -> None:
-    """Clone a remote asset repository and atomically publish its checkout.
-
-    The caller must serialize access to :paramref:`git_asset_dir`. The existing cache is
-    preserved until the replacement clone completes successfully.
-
-    Args:
-        git_path: Git repository URL or SSH path.
-        git_asset_dir: Final cache directory for the checkout.
-    """
-    os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
-    temporary_path = git_asset_dir + ".partial"
-    _remove_git_asset_cache_path(temporary_path)
-    try:
-        _run_git_command(["git", "clone", "--depth", "1", git_path, temporary_path])
-        _remove_git_asset_cache_path(git_asset_dir)
-        os.replace(temporary_path, git_asset_dir)
-    finally:
-        _remove_git_asset_cache_path(temporary_path)
-
-
-def _remove_git_asset_cache_path(path: str) -> None:
-    """Remove a managed Git asset cache path if it exists."""
-    if os.path.isdir(path) and not os.path.islink(path):
-        shutil.rmtree(path)
-    else:
-        with contextlib.suppress(FileNotFoundError):
-            os.remove(path)
 
 
 def _get_git_asset_cache_dir(git_path: str, cache_dir: str | None = None) -> str:

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -20,6 +20,7 @@ import logging
 import os
 import posixpath
 import re
+import shutil
 import subprocess
 import tempfile
 import uuid
@@ -235,7 +236,10 @@ def retrieve_git_asset_path(
     """Return a local path for an asset stored in a git repository.
 
     Remote repositories are cached under :data:`GIT_ASSET_CACHE_DIR`. If the requested
-    asset is already cached, it is returned without running git.
+    asset is already cached, it is returned without running git. Otherwise, access to the
+    checkout is serialized and an existing checkout is updated before the asset is reported
+    as missing. New checkouts are published atomically so an interrupted clone cannot leave
+    an incomplete cache at the final path.
 
     Args:
         git_path: Git repository URL, SSH path, or existing local checkout directory.
@@ -259,20 +263,27 @@ def retrieve_git_asset_path(
         if not force_update and os.path.exists(source_path):
             return source_path
 
-    git_asset_dir = _get_git_asset_dir(git_path, cache_dir, force_update)
+    git_asset_dir = _get_git_asset_dir(git_path, cache_dir, force_update, required_local_path=local_path)
     source_path = _resolve_git_asset_source_path(local_path, git_asset_dir)
     if not os.path.exists(source_path):
         raise FileNotFoundError(f"Unable to find git asset: {source_path}")
     return source_path
 
 
-def _get_git_asset_dir(git_path: str, cache_dir: str | None = None, force_update: bool = False) -> str:
+def _get_git_asset_dir(
+    git_path: str,
+    cache_dir: str | None = None,
+    force_update: bool = False,
+    required_local_path: str | None = None,
+) -> str:
     """Return a local checkout for a git asset repository.
 
     Args:
         git_path: Git repository URL, SSH path, or existing local checkout directory.
         cache_dir: Directory where remote repositories are cached.
         force_update: Whether to update an existing checkout.
+        required_local_path: Asset path that must exist in a remote checkout. When it is missing,
+            an existing checkout is updated and recovered before returning.
 
     Returns:
         Path to a local repository checkout.
@@ -290,17 +301,61 @@ def _get_git_asset_dir(git_path: str, cache_dir: str | None = None, force_update
         return git_asset_dir
 
     git_asset_dir = _get_git_asset_cache_dir(git_path, cache_dir)
+    required_source_path = (
+        _resolve_git_asset_source_path(required_local_path, git_asset_dir) if required_local_path is not None else None
+    )
 
-    if os.path.isdir(os.path.join(git_asset_dir, ".git")):
-        if force_update:
-            _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
-    elif os.path.exists(git_asset_dir):
-        raise RuntimeError(f"Git asset cache exists but is not a git repository: {git_asset_dir}")
-    else:
-        os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
-        _run_git_command(["git", "clone", "--depth", "1", git_path, git_asset_dir])
+    with FileLock(git_asset_dir + ".lock"):
+        has_checkout = os.path.isdir(os.path.join(git_asset_dir, ".git"))
+        asset_is_missing = required_source_path is not None and not os.path.exists(required_source_path)
+
+        if has_checkout:
+            if force_update or asset_is_missing:
+                try:
+                    _run_git_command(["git", "-C", git_asset_dir, "pull", "--ff-only"])
+                except RuntimeError:
+                    _clone_git_asset_repo(git_path, git_asset_dir)
+            if required_source_path is not None and not os.path.exists(required_source_path):
+                # A clone interrupted during checkout can have a valid HEAD but still lack
+                # working-tree files. Restore the checkout without downloading the repository again.
+                try:
+                    _run_git_command(["git", "-C", git_asset_dir, "checkout", "HEAD", "--", "."])
+                except RuntimeError:
+                    _clone_git_asset_repo(git_path, git_asset_dir)
+        else:
+            _clone_git_asset_repo(git_path, git_asset_dir)
 
     return git_asset_dir
+
+
+def _clone_git_asset_repo(git_path: str, git_asset_dir: str) -> None:
+    """Clone a remote asset repository and atomically publish its checkout.
+
+    The caller must serialize access to :paramref:`git_asset_dir`. The existing cache is
+    preserved until the replacement clone completes successfully.
+
+    Args:
+        git_path: Git repository URL or SSH path.
+        git_asset_dir: Final cache directory for the checkout.
+    """
+    os.makedirs(os.path.dirname(git_asset_dir), exist_ok=True)
+    temporary_path = git_asset_dir + ".partial"
+    _remove_git_asset_cache_path(temporary_path)
+    try:
+        _run_git_command(["git", "clone", "--depth", "1", git_path, temporary_path])
+        _remove_git_asset_cache_path(git_asset_dir)
+        os.replace(temporary_path, git_asset_dir)
+    finally:
+        _remove_git_asset_cache_path(temporary_path)
+
+
+def _remove_git_asset_cache_path(path: str) -> None:
+    """Remove a managed Git asset cache path if it exists."""
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    else:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(path)
 
 
 def _get_git_asset_cache_dir(git_path: str, cache_dir: str | None = None) -> str:

--- a/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
+++ b/source/isaaclab/test/cli/test_test_orchestrator_result_handling.py
@@ -707,3 +707,15 @@ def test_hang_dump_plugin_is_inert_without_signal_support(monkeypatch) -> None:
     assert hang_dump.is_supported() is False
     assert hang_dump.register() is False
     hang_dump.pytest_configure(config=None)  # must not raise
+
+
+def test_external_git_asset_tests_receive_extended_startup_deadline():
+    """Environment discovery must allow a cold external Git asset clone to complete."""
+    orchestrator = _load_orchestrator_module()
+
+    startup_deadline = orchestrator._resolve_startup_deadline(
+        "test_environments_isaacsim_physx.py", timeout=10000, is_cold_cache_test=False
+    )
+
+    assert startup_deadline == orchestrator.test_settings.GIT_ASSET_STARTUP_TIMEOUT
+    assert orchestrator._resolve_startup_deadline("test_sample.py", timeout=10000, is_cold_cache_test=False) == 120

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -321,16 +321,21 @@ def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch
     """Test that git assets are pulled into the default asset cache directory."""
     git_commands = []
     git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "tmp" / "asset_cache"
+    partial_dir = cache_dir / "example-assets.partial"
+    partial_dir.mkdir(parents=True)
+    (partial_dir / "incomplete").write_text("stale clone", encoding="utf-8")
 
     def mock_run_git_command(command):
         git_commands.append(command)
         repo_dir = Path(command[-1])
+        assert not repo_dir.exists()
         asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
         asset_dir.mkdir(parents=True)
         (repo_dir / ".git").mkdir()
         (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
 
-    monkeypatch.setattr(assets_utils, "GIT_ASSET_CACHE_DIR", str(tmp_path / "tmp" / "asset_cache"))
+    monkeypatch.setattr(assets_utils, "GIT_ASSET_CACHE_DIR", str(cache_dir))
     monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
 
     asset_path = Path(assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot"))
@@ -389,84 +394,6 @@ def test_retrieve_git_asset_path_serializes_cold_cache_population(tmp_path, monk
     assert max_active_clones == 1
 
 
-def test_retrieve_git_asset_path_updates_checkout_for_missing_asset(tmp_path, monkeypatch):
-    """Test a cache miss updates an existing checkout before reporting the asset missing."""
-    git_path = "https://example.com/example-assets.git"
-    cache_dir = tmp_path / "asset_cache"
-    repo_dir = cache_dir / "example-assets"
-    (repo_dir / ".git").mkdir(parents=True)
-    git_commands = []
-
-    def mock_run_git_command(command):
-        git_commands.append(command)
-        asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
-        asset_dir.mkdir(parents=True)
-        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
-
-    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
-
-    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
-
-    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
-    assert git_commands == [["git", "-C", str(repo_dir), "pull", "--ff-only"]]
-
-
-def test_retrieve_git_asset_path_restores_incomplete_checkout(tmp_path, monkeypatch):
-    """Test a checkout still missing an asset after update restores its working tree."""
-    git_path = "https://example.com/example-assets.git"
-    cache_dir = tmp_path / "asset_cache"
-    repo_dir = cache_dir / "example-assets"
-    (repo_dir / ".git").mkdir(parents=True)
-    git_commands = []
-
-    def mock_run_git_command(command):
-        git_commands.append(command)
-        if "checkout" in command:
-            asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
-            asset_dir.mkdir(parents=True)
-            (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
-
-    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
-
-    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
-
-    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
-    assert git_commands == [
-        ["git", "-C", str(repo_dir), "pull", "--ff-only"],
-        ["git", "-C", str(repo_dir), "checkout", "HEAD", "--", "."],
-    ]
-    assert not Path(str(repo_dir) + ".partial").exists()
-
-
-def test_retrieve_git_asset_path_replaces_checkout_when_update_fails(tmp_path, monkeypatch):
-    """Test an unusable checkout is replaced only after a fresh clone succeeds."""
-    git_path = "https://example.com/example-assets.git"
-    cache_dir = tmp_path / "asset_cache"
-    repo_dir = cache_dir / "example-assets"
-    (repo_dir / ".git").mkdir(parents=True)
-    git_commands = []
-
-    def mock_run_git_command(command):
-        git_commands.append(command)
-        if "pull" in command:
-            raise RuntimeError("checkout is incomplete")
-        replacement_dir = Path(command[-1])
-        asset_dir = replacement_dir / "Robots" / "Disney" / "ExampleBot"
-        asset_dir.mkdir(parents=True)
-        (replacement_dir / ".git").mkdir()
-        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
-
-    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
-
-    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
-
-    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
-    assert git_commands == [
-        ["git", "-C", str(repo_dir), "pull", "--ff-only"],
-        ["git", "clone", "--depth", "1", git_path, str(repo_dir) + ".partial"],
-    ]
-
-
 def test_retrieve_git_asset_path_does_not_publish_failed_clone(tmp_path, monkeypatch):
     """Test a failed clone leaves neither a partial nor final cache checkout."""
     git_path = "https://example.com/example-assets.git"
@@ -506,6 +433,26 @@ def test_retrieve_git_asset_path_uses_cached_asset_without_git(tmp_path, monkeyp
 
     assert asset_path == asset_dir
     assert (asset_path / "example_bot.usd").read_text(encoding="utf-8") == "#usda 1.0\n"
+
+
+def test_retrieve_git_asset_path_preserves_non_repository_cache(tmp_path, monkeypatch):
+    """Test a missing asset never replaces a caller-managed cache directory."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    repo_dir = cache_dir / "example-assets"
+    repo_dir.mkdir(parents=True)
+    marker = repo_dir / "caller-managed.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    def fail_run_git_command(command):
+        raise AssertionError(f"git should not be called for a non-repository cache: {command}")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", fail_run_git_command)
+
+    with pytest.raises(RuntimeError, match="cache exists but is not a git repository"):
+        assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
 
 
 @pytest.mark.parametrize(

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -322,9 +322,6 @@ def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch
     git_commands = []
     git_path = "https://example.com/example-assets.git"
     cache_dir = tmp_path / "tmp" / "asset_cache"
-    partial_dir = cache_dir / "example-assets.partial"
-    partial_dir.mkdir(parents=True)
-    (partial_dir / "incomplete").write_text("stale clone", encoding="utf-8")
 
     def mock_run_git_command(command):
         git_commands.append(command)
@@ -342,16 +339,12 @@ def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch
 
     assert asset_path == tmp_path / "tmp" / "asset_cache" / "example-assets" / "Robots" / "Disney" / "ExampleBot"
     assert (asset_path / "example_bot.usd").read_text(encoding="utf-8") == "#usda 1.0\n"
-    assert git_commands == [
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            git_path,
-            str(tmp_path / "tmp" / "asset_cache" / "example-assets.partial"),
-        ]
-    ]
+    assert len(git_commands) == 1
+    assert git_commands[0][:-1] == ["git", "clone", "--depth", "1", git_path]
+    temporary_path = Path(git_commands[0][-1])
+    assert temporary_path.name == "checkout"
+    assert temporary_path.parent.parent == cache_dir
+    assert temporary_path.parent.name.startswith(".example-assets.")
 
 
 def test_retrieve_git_asset_path_serializes_cold_cache_population(tmp_path, monkeypatch):
@@ -411,7 +404,7 @@ def test_retrieve_git_asset_path_does_not_publish_failed_clone(tmp_path, monkeyp
         assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
 
     assert not repo_dir.exists()
-    assert not Path(str(repo_dir) + ".partial").exists()
+    assert not list(cache_dir.glob(".example-assets.*"))
 
 
 def test_retrieve_git_asset_path_uses_cached_asset_without_git(tmp_path, monkeypatch):

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -324,7 +324,7 @@ def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch
 
     def mock_run_git_command(command):
         git_commands.append(command)
-        repo_dir = tmp_path / "tmp" / "asset_cache" / "example-assets"
+        repo_dir = Path(command[-1])
         asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
         asset_dir.mkdir(parents=True)
         (repo_dir / ".git").mkdir()
@@ -344,9 +344,147 @@ def test_retrieve_git_asset_path_clones_default_repo_cache(tmp_path, monkeypatch
             "--depth",
             "1",
             git_path,
-            str(tmp_path / "tmp" / "asset_cache" / "example-assets"),
+            str(tmp_path / "tmp" / "asset_cache" / "example-assets.partial"),
         ]
     ]
+
+
+def test_retrieve_git_asset_path_serializes_cold_cache_population(tmp_path, monkeypatch):
+    """Test concurrent callers publish one complete Git asset checkout."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    clone_count = 0
+    active_clones = 0
+    max_active_clones = 0
+    counter_lock = threading.Lock()
+    start = threading.Barrier(2)
+
+    def mock_run_git_command(command):
+        nonlocal clone_count, active_clones, max_active_clones
+        with counter_lock:
+            clone_count += 1
+            active_clones += 1
+            max_active_clones = max(max_active_clones, active_clones)
+        time.sleep(0.05)
+        repo_dir = Path(command[-1])
+        asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
+        asset_dir.mkdir(parents=True)
+        (repo_dir / ".git").mkdir()
+        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+        with counter_lock:
+            active_clones -= 1
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    def retrieve() -> str:
+        start.wait()
+        return assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        retrieved = list(executor.map(lambda _: retrieve(), range(2)))
+
+    expected = str(cache_dir / "example-assets" / "Robots" / "Disney" / "ExampleBot")
+    assert retrieved == [expected, expected]
+    assert clone_count == 1
+    assert max_active_clones == 1
+
+
+def test_retrieve_git_asset_path_updates_checkout_for_missing_asset(tmp_path, monkeypatch):
+    """Test a cache miss updates an existing checkout before reporting the asset missing."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    repo_dir = cache_dir / "example-assets"
+    (repo_dir / ".git").mkdir(parents=True)
+    git_commands = []
+
+    def mock_run_git_command(command):
+        git_commands.append(command)
+        asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
+        asset_dir.mkdir(parents=True)
+        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
+    assert git_commands == [["git", "-C", str(repo_dir), "pull", "--ff-only"]]
+
+
+def test_retrieve_git_asset_path_restores_incomplete_checkout(tmp_path, monkeypatch):
+    """Test a checkout still missing an asset after update restores its working tree."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    repo_dir = cache_dir / "example-assets"
+    (repo_dir / ".git").mkdir(parents=True)
+    git_commands = []
+
+    def mock_run_git_command(command):
+        git_commands.append(command)
+        if "checkout" in command:
+            asset_dir = repo_dir / "Robots" / "Disney" / "ExampleBot"
+            asset_dir.mkdir(parents=True)
+            (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
+    assert git_commands == [
+        ["git", "-C", str(repo_dir), "pull", "--ff-only"],
+        ["git", "-C", str(repo_dir), "checkout", "HEAD", "--", "."],
+    ]
+    assert not Path(str(repo_dir) + ".partial").exists()
+
+
+def test_retrieve_git_asset_path_replaces_checkout_when_update_fails(tmp_path, monkeypatch):
+    """Test an unusable checkout is replaced only after a fresh clone succeeds."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    repo_dir = cache_dir / "example-assets"
+    (repo_dir / ".git").mkdir(parents=True)
+    git_commands = []
+
+    def mock_run_git_command(command):
+        git_commands.append(command)
+        if "pull" in command:
+            raise RuntimeError("checkout is incomplete")
+        replacement_dir = Path(command[-1])
+        asset_dir = replacement_dir / "Robots" / "Disney" / "ExampleBot"
+        asset_dir.mkdir(parents=True)
+        (replacement_dir / ".git").mkdir()
+        (asset_dir / "example_bot.usd").write_text("#usda 1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    asset_path = assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    assert asset_path == str(repo_dir / "Robots" / "Disney" / "ExampleBot")
+    assert git_commands == [
+        ["git", "-C", str(repo_dir), "pull", "--ff-only"],
+        ["git", "clone", "--depth", "1", git_path, str(repo_dir) + ".partial"],
+    ]
+
+
+def test_retrieve_git_asset_path_does_not_publish_failed_clone(tmp_path, monkeypatch):
+    """Test a failed clone leaves neither a partial nor final cache checkout."""
+    git_path = "https://example.com/example-assets.git"
+    cache_dir = tmp_path / "asset_cache"
+    repo_dir = cache_dir / "example-assets"
+
+    def mock_run_git_command(command):
+        partial_dir = Path(command[-1])
+        (partial_dir / ".git").mkdir(parents=True)
+        raise RuntimeError("clone failed")
+
+    monkeypatch.setattr(assets_utils, "_run_git_command", mock_run_git_command)
+
+    with pytest.raises(RuntimeError, match="clone failed"):
+        assets_utils.retrieve_git_asset_path(git_path, "Robots/Disney/ExampleBot", cache_dir=str(cache_dir))
+
+    assert not repo_dir.exists()
+    assert not Path(str(repo_dir) + ".partial").exists()
 
 
 def test_retrieve_git_asset_path_uses_cached_asset_without_git(tmp_path, monkeypatch):

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1344,8 +1344,7 @@ def run_individual_tests(test_files, workspace_root, ci_marker, test_node_ids_by
             cold_cache_applied = True
             logger.info(f"⏱️  Adding {COLD_CACHE_BUFFER}s cold-cache buffer (timeout now {timeout}s)")
 
-        extra = COLD_CACHE_BUFFER if is_cold_cache_test else 0
-        startup_deadline = min(timeout, STARTUP_DEADLINE + extra)
+        startup_deadline = _resolve_startup_deadline(file_name, timeout, is_cold_cache_test)
 
         pytest_targets = test_node_ids_by_file.get(os.path.normpath(test_file), [str(test_file)])
 
@@ -1399,6 +1398,13 @@ def run_individual_tests(test_files, workspace_root, ci_marker, test_node_ids_by
     logger.info("~~~~~~~~~~~~ Finished running all tests")
 
     return failed_tests, test_status, xml_reports
+
+
+def _resolve_startup_deadline(file_name: str, timeout: int, is_cold_cache_test: bool) -> int:
+    """Resolve the startup deadline for one independently launched test file."""
+    base_deadline = test_settings.PER_TEST_STARTUP_TIMEOUTS.get(file_name, STARTUP_DEADLINE)
+    cold_cache_extra = COLD_CACHE_BUFFER if is_cold_cache_test else 0
+    return min(timeout, base_deadline + cold_cache_extra)
 
 
 def _collect_test_files(

--- a/tools/test_settings.py
+++ b/tools/test_settings.py
@@ -73,6 +73,17 @@ PER_TEST_TIMEOUTS = {
 Note: Any tests not listed here will use the default timeout.
 """
 
+GIT_ASSET_STARTUP_TIMEOUT = 1000
+"""Startup timeout for tests that may populate the external Git asset cache."""
+
+PER_TEST_STARTUP_TIMEOUTS = {
+    "test_environments_isaacsim_physx.py": GIT_ASSET_STARTUP_TIMEOUT,
+    "test_environments_newton.py": GIT_ASSET_STARTUP_TIMEOUT,
+    "test_environments_ovphysx.py": GIT_ASSET_STARTUP_TIMEOUT,
+    "test_multi_agent_environments.py": GIT_ASSET_STARTUP_TIMEOUT,
+}
+"""Per-test startup timeouts for cold external asset downloads."""
+
 CUROBO_PLANNER_TESTS = [
     "test_curobo_planner_franka.py",
     "test_curobo_planner_cube_stack.py",


### PR DESCRIPTION
# Description

Isaac Sim CI can spend more than 120 seconds cloning the roughly 816 MB `newton-assets` repository while collecting environment tests. The test orchestrator previously treated that as a startup hang, killed the Git process, and left `/tmp/asset_cache/newton-assets` as a partial checkout. The retry then trusted the existing `.git` directory and failed when the Fourbar Pole USD was absent.

This change:

- Serializes remote Git asset cache population across concurrent test processes.
- Clones into a temporary sibling and atomically publishes only complete checkouts.
- Preserves the existing behavior and contents of already-published or caller-managed caches.
- Gives environment-discovery tests enough startup time to populate the external asset cache without disabling those tests.
- Adds regression coverage for concurrent and interrupted cold clones, non-repository cache preservation, and the per-test startup deadline.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

Not applicable.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTING.md) document.
- [x] I have run the pre-commit checks with `uv run isaaclab -f`.
- [x] I have made corresponding changes to the documentation where required.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the relevant changelog fragment.
- [x] My name is already in `CONTRIBUTORS.md`.

## Validation

- `uv run --frozen --extra test python -m pytest source/isaaclab/test/utils/test_assets.py source/isaaclab/test/cli/test_test_orchestrator_result_handling.py -q` (74 passed)
- `uv run --frozen isaaclab -f`
