### PR TITLE
Fix PhysX deformable and robot load CI tests

### DIFF
--- a/source/isaaclab/test/performance/test_robot_load_performance.py
+++ b/source/isaaclab/test/performance/test_robot_load_performance.py
@@ -34,12 +34,10 @@ SPACING = 2.0
 @pytest.mark.parametrize(
     "test_config,device",
     [
-        # TODO: regression - this used to be 10
-        ({"name": "Cartpole", "robot_cfg": CARTPOLE_CFG, "expected_load_time": 15.0}, "cuda:0"),
-        ({"name": "Cartpole", "robot_cfg": CARTPOLE_CFG, "expected_load_time": 15.0}, "cpu"),
-        # TODO: regression - this used to be 40
-        ({"name": "Anymal_D", "robot_cfg": ANYMAL_D_CFG, "expected_load_time": 60.0}, "cuda:0"),
-        ({"name": "Anymal_D", "robot_cfg": ANYMAL_D_CFG, "expected_load_time": 60.0}, "cpu"),
+        ({"name": "Cartpole", "robot_cfg": CARTPOLE_CFG, "expected_load_time": 10.0}, "cuda:0"),
+        ({"name": "Cartpole", "robot_cfg": CARTPOLE_CFG, "expected_load_time": 10.0}, "cpu"),
+        ({"name": "Anymal_D", "robot_cfg": ANYMAL_D_CFG, "expected_load_time": 40.0}, "cuda:0"),
+        ({"name": "Anymal_D", "robot_cfg": ANYMAL_D_CFG, "expected_load_time": 40.0}, "cpu"),
     ],
 )
 def test_robot_load_performance(test_config, device):

--- a/source/isaaclab_physx/changelog.d/codex-fix-ci-deformable-load-performance.rst
+++ b/source/isaaclab_physx/changelog.d/codex-fix-ci-deformable-load-performance.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed PhysX deformable initialization on CPU simulations to fail before entering the GPU-only backend.

--- a/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/deformable_object/deformable_object.py
@@ -578,6 +578,9 @@ class DeformableObject(AssetBase):
         return env_ids
 
     def _initialize_impl(self):
+        if not self.device.startswith("cuda"):
+            raise RuntimeError(f"PhysX deformables require a CUDA simulation device; received '{self.device}'.")
+
         # obtain global simulation view
         self._physics_sim_view = SimulationManager.get_physics_sim_view()
 

--- a/source/isaaclab_physx/test/assets/test_deformable_object.py
+++ b/source/isaaclab_physx/test/assets/test_deformable_object.py
@@ -36,10 +36,6 @@ import isaaclab.utils.math as math_utils
 from isaaclab.assets import DeformableObjectCfg
 from isaaclab.sim import build_simulation_context
 
-# Temporarily disabled: this suite intermittently aborts with SIGABRT on CI.
-# Re-enable once the underlying crash is fixed.
-pytestmark = pytest.mark.skip(reason="Temporarily disabled due to intermittent crash on CI.")
-
 
 def generate_cubes_scene(
     num_cubes: int = 1,
@@ -211,7 +207,7 @@ def test_initialization_on_device_cpu():
         assert sys.getrefcount(cube_object) < 10
 
         # Play sim
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="PhysX deformables require a CUDA simulation device; received 'cpu'."):
             sim.reset()
 
 


### PR DESCRIPTION
# Description

This change removes two temporary Isaac Sim 6.0 CI workarounds:

- Reject PhysX deformable initialization on non-CUDA simulation devices before creating a native deformable view. The CPU contract now raises a deterministic error, allowing `test_deformable_object.py` to run instead of skipping the entire suite.
- Restore the original robot-load regression limits of 10 seconds for Cartpole and 40 seconds for ANYmal-D. Startup, cloning, asset-loading, and articulation optimizations merged since the regression now make the relaxed 15/60-second limits obsolete.

Fixes isaac-sim/IsaacLab-Internal#872
Fixes isaac-sim/IsaacLab-Internal#873

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — test and runtime validation changes only.

## Validation

- `python -m py_compile` on all changed Python files
- Changelog fragment validation against `upstream/develop`
- All non-LFS pre-commit hooks passed locally; the repository's mandatory Git LFS pre-push hook also completed successfully
- Simulator-dependent tests are left to Linux CI because the repository lockfile excludes this macOS host

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the applicable pre-commit checks
- [x] Documentation changes are not required
- [x] My changes generate no new warnings
- [x] I have updated tests to prove the fix and restore the performance contracts
- [x] I have added changelog fragments for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`