### PR TITLE
[Docs] Fix command builder extras

### DIFF
--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -194,6 +194,7 @@
         task: "Isaac-Cartpole",
         benchmarkWorkload: "runtime",
     };
+    const rlLibraryExtras = {rl_games: "rl-games", sb3: "sb3", skrl: "skrl", rlinf: "rlinf"};
     let benchmarkRows = [];
 
     const categoryFor = (task) => {
@@ -311,10 +312,13 @@
         if (fields.physics.value === "isaacsim_physx" || fields.renderer.value === "isaacsim_rtx") {
             extras.push("isaacsim");
         }
+        if (rlLibraryExtras[fields.rl.value]) {
+            extras.push(rlLibraryExtras[fields.rl.value]);
+        }
 
         const parts = ["uv", "run"];
-        for (const extra of extras) {
-            parts.push("--extra", extra);
+        if (extras.length) {
+            parts.push("--extra", extras.join(","));
         }
         const task = selectedTask();
         const supportsRl = task.rl.length > 0;


### PR DESCRIPTION
# Description

Fixes the environments-page command builder so selecting an optional RL library adds its project extra. Backend and RL-library extras are emitted together as one comma-separated `--extra` value, including the `rl_games` to `rl-games` package-extra mapping.

No additional dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; the visible change is limited to the generated command text.

## Validation

- `uv run --frozen python -m pytest --confcutdir=tools/test tools/test/test_environ_docs.py` (26 passed)
- `uv run --isolated --extra test -- make -C docs current-docs` (passed with warnings treated as errors)
- `SKIP=check-changelog-fragments uv run --frozen isaaclab -f` (all applicable hooks passed; docs-only change)
- `node --check docs/source/_static/css/environment-browser.js`
- Verified in the built environments page:
  - Isaac Sim PhysX + SKRL emits `--extra isaacsim,skrl`
  - Isaac Sim PhysX + OVRTX emits `--extra ovrtx,isaacsim`
  - Isaac Sim PhysX + OVRTX + RL Games emits `--extra ovrtx,isaacsim,rl-games`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the applicable pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have verified the fix in the built documentation
- [x] No package changelog fragment is required for this docs-only change
- [x] My name already exists in `CONTRIBUTORS.md`
