### PR TITLE
Update China storage profile to Isaac Sim 6.1

### DIFF
--- a/docs/source/setup/installation/asset_caching_details.inc
+++ b/docs/source/setup/installation/asset_caching_details.inc
@@ -120,8 +120,8 @@ Isaac Lab launchers and asset helpers apply the profile automatically. A standal
 
 .. note::
    The China service mirrors a subset of the global asset set, and that subset can change between releases.
-   Check the `Isaac 6.0 asset availability manifest
-   <https://assets.simready.cn/manifests/isaac/6.0/asset-availability.csv>`__ before choosing an asset. The manifest lists
+   Check the `Isaac 6.1 asset availability manifest
+   <https://assets.simready.cn/manifests/isaac/6.1/asset-availability.csv>`__ before choosing an asset. The manifest lists
    service path records relative to the versioned ``Isaac`` folder. A path with no row is not mirrored, and a listed
    path must have an ``available`` status to load from the service. Use an available asset or a local asset pack when
    needed.

--- a/source/isaaclab/changelog.d/china-storage-profile-6-1.rst
+++ b/source/isaaclab/changelog.d/china-storage-profile-6-1.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated the China storage profile to the Isaac Sim 6.1 asset set. Check the 6.1 availability
+  manifest before using mirrored assets.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -52,7 +52,7 @@ _KIT_ASSET_ROOT_SETTINGS = ("default", "cloud")
 
 _STORAGE_PROFILE_ENV_VAR = "ISAACSIM_STORAGE_PROFILE"
 # Update this value when the China mirror moves to a new Isaac Sim asset release.
-_ISAAC_SIM_ASSET_RELEASE = "6.0"
+_ISAAC_SIM_ASSET_RELEASE = "6.1"
 _CHINA_STORAGE_ENDPOINT = "simready-cn.s3.oss-cn-shanghai.aliyuncs.com"
 
 


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Updates the China storage profile asset root and public availability manifest from Isaac Sim 6.0 to 6.1. This does not change profile routing or asset-loading behavior.

Validation:
- Confirmed the public 6.1 manifest is available and contains 26 Isaac Lab paths, all marked available.
- Confirmed all 26 paths resolve through profile-configured OmniClient.
- Passed 11 focused storage-profile and asset-root tests.
- Passed the full pre-commit suite and changelog validation.

No additional dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there