### PR TITLE
Fix external callback order in rsrl script

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-external-callback-order.rst
+++ b/source/isaaclab_rl/changelog.d/fix-external-callback-order.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed RSL-RL training resolving agent metadata before external task registration callbacks run.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -88,13 +88,18 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     cli_args.add_rsl_rl_args(parser)
     add_launcher_args(parser)
+
+    # Register external tasks before preset setup reads their Gym metadata.
+    registration_parser = argparse.ArgumentParser(add_help=False)
+    registration_parser.add_argument("--external_callback")
+    registration_args, _ = registration_parser.parse_known_args(argv)
+    remaining_args_env_registration = None
+    if registration_args.external_callback:
+        external_callback_function = string_to_callable(registration_args.external_callback, separator=".")
+        remaining_args_env_registration = external_callback_function()
+
     args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="rsl_rl")
     enable_cameras_for_video(args_cli)
-
-    remaining_args_env_registration = None
-    if args_cli.external_callback:
-        external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
-        remaining_args_env_registration = external_callback_function()
 
     set_hydra_args(list_intersection(remaining_args, remaining_args_env_registration))
     return args_cli

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -275,6 +275,39 @@ def test_failed_rsl_training_restores_torch_backend_state(monkeypatch) -> None:
     assert _torch_backend_state() == caller_state
 
 
+def test_rsl_training_registers_external_task_before_agent_discovery(monkeypatch) -> None:
+    """RSL-RL parses tasks registered by its external callback."""
+    from isaaclab_rl.entrypoints.backends import train_rsl_rl
+
+    task_name = "Isaac-ExternalCallbackOrderTest"
+    callback_module_name = "_external_callback_order_test"
+    callback_module = types.ModuleType(callback_module_name)
+
+    def register_task() -> list[str]:
+        gym.register(
+            id=task_name,
+            entry_point="dummy:Env",
+            kwargs={"rsl_rl_cfg_entry_point": "dummy:AgentCfg"},
+        )
+        return []
+
+    callback_module.register_task = register_task
+    monkeypatch.setitem(sys.modules, callback_module_name, callback_module)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train.py", "--task", task_name, "--external_callback", f"{callback_module_name}.register_task"],
+    )
+    gym.registry.pop(task_name, None)
+
+    try:
+        args = train_rsl_rl._parse_args(sys.argv[1:])
+    finally:
+        gym.registry.pop(task_name, None)
+
+    assert args.task == task_name
+
+
 def test_skrl_training_restores_jax_backend(monkeypatch) -> None:
     """SKRL training removes the JAX backend setting it created after an exception."""
     skrl = pytest.importorskip("skrl")


### PR DESCRIPTION
Fixes # (issue)

The unified RSL-RL trainer resolved task agent metadata before invoking `--external_callback`.
Externally registered tasks therefore failed because they were not yet present in the Gym registry.

This change invokes the external callback before preset and agent discovery while preserving the
existing Hydra argument handling. It also adds regression coverage for externally registered tasks.

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
