### PR TITLE
Refresh Fabric transforms for static prims after stage rebuild

### DIFF
--- a/source/isaaclab_physx/changelog.d/pv-fix-fabric-static-xforms-stage-rebuild.rst
+++ b/source/isaaclab_physx/changelog.d/pv-fix-fabric-static-xforms-stage-rebuild.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed static child prims (visual and collision meshes) being drawn at the world origin
+  after a stage is torn down and rebuilt in the same process. The rebuilt subtree was not
+  flagged dirty, so the Fabric hierarchy never recomposed its world transforms.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -30,7 +30,7 @@ import omni.physics.tensors
 import omni.physx
 import omni.timeline
 import omni.usd
-from pxr import Sdf, Usd, UsdPhysics, UsdUtils
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdUtils
 
 import isaaclab.sim as sim_utils
 from isaaclab.physics import CallbackHandle, PhysicsEvent, PhysicsManager
@@ -53,6 +53,29 @@ if TYPE_CHECKING:
 __all__ = ["IsaacEvents", "PhysxManager"]
 
 logger = logging.getLogger(__name__)
+
+_FABRIC_WORLD_MATRIX_ATTR = "omni:fabric:worldMatrix"
+_TRANSFORM_TOLERANCE = 1e-9
+
+
+def _is_identity_matrix(matrix) -> bool:
+    """Whether a 4x4 matrix equals identity within :data:`_TRANSFORM_TOLERANCE`.
+
+    Accepts any row-iterable 4x4 matrix, so both USD and Fabric matrix types work
+    without conversion.
+
+    Args:
+        matrix: Row-iterable 4x4 matrix.
+
+    Returns:
+        ``True`` when every component is within tolerance of identity.
+    """
+    for row_index, row in enumerate(matrix):
+        for column_index, value in enumerate(row):
+            expected = 1.0 if row_index == column_index else 0.0
+            if abs(float(value) - expected) > _TRANSFORM_TOLERANCE:
+                return False
+    return True
 
 
 class IsaacEvents(Enum):
@@ -481,6 +504,9 @@ class PhysxManager(PhysicsManager):
 
         if cls._view is not None:
             cls._view._backend.initialize_kinematic_bodies()
+
+        if not soft:
+            cls._refresh_fabric_static_xforms()
 
         cls.raise_callback_exception_if_any()
 
@@ -919,6 +945,81 @@ class PhysxManager(PhysicsManager):
                 "Could not re-attach fabric stage. Articulation visuals will be broken until next reset.",
                 exc_info=True,
             )
+
+    @classmethod
+    def _refresh_fabric_static_xforms(cls) -> None:
+        """Mark prims the fabric writer does not own as dirty so the Fabric hierarchy recomposes them.
+
+        The PhysX fabric writer publishes world transforms for rigid bodies and articulation
+        links. Static descendants such as visual and collision meshes instead get their world
+        transform composed by :class:`IFabricHierarchy`, which only visits prims flagged dirty.
+        Rebuilding a stage in the same process repopulates Fabric without flagging the new
+        subtree, so those descendants keep an identity world matrix and the render delegate
+        draws them at the world origin.
+
+        Re-asserting a prim's own local transform is a pure dirty-mark: the value is unchanged,
+        so world matrices stay owned by the hierarchy and physics-driven parents are never
+        recomposed from a stale local transform.
+
+        See: https://github.com/isaac-sim/IsaacLab/issues/7472
+        """
+        if cls._fabric is None:
+            return
+
+        import usdrt  # noqa: PLC0415
+
+        try:
+            from usdrt import hierarchy  # noqa: PLC0415
+        except ImportError:
+            logger.warning("usdrt.hierarchy unavailable; Fabric static transforms were not refreshed.")
+            return
+
+        from isaaclab.sim.utils.stage import get_current_stage, get_current_stage_id  # noqa: PLC0415
+
+        usd_stage = get_current_stage()
+        if usd_stage is None:
+            return
+
+        try:
+            fabric_stage = usdrt.Usd.Stage.Attach(get_current_stage_id())
+        except Exception:
+            logger.warning("Could not attach Fabric stage to refresh static transforms.")
+            return
+
+        fabric_hierarchy = hierarchy.IFabricHierarchy().get_fabric_hierarchy(
+            fabric_stage.GetFabricId(), fabric_stage.GetStageIdAsStageId()
+        )
+
+        xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+        dirtied = 0
+        for prim in usd_stage.Traverse():
+            if not prim.IsA(UsdGeom.Xformable):
+                continue
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI) or prim.HasAPI(UsdPhysics.ArticulationRootAPI):
+                continue
+
+            # Only prims USD places off the origin can be told apart from a legitimate identity.
+            if _is_identity_matrix(xform_cache.GetLocalToWorldTransform(prim)):
+                continue
+
+            path = prim.GetPath().pathString
+            rt_prim = fabric_stage.GetPrimAtPath(path)
+            if not rt_prim or not rt_prim.IsValid():
+                continue
+            attribute = rt_prim.GetAttribute(_FABRIC_WORLD_MATRIX_ATTR)
+            if not attribute or not attribute.IsValid():
+                continue
+            fabric_world = attribute.Get()
+            if fabric_world is None or not _is_identity_matrix(fabric_world):
+                continue
+
+            fabric_path = usdrt.Sdf.Path(path)
+            fabric_hierarchy.set_local_xform(fabric_path, fabric_hierarchy.get_local_xform(fabric_path))
+            dirtied += 1
+
+        if dirtied:
+            fabric_hierarchy.update_world_xforms()
+            logger.debug("Refreshed %d Fabric world transform(s) after stage build.", dirtied)
 
     @classmethod
     def _warmup_and_create_views(cls) -> None:

--- a/source/isaaclab_physx/test/sim/test_fabric_stage_rebuild.py
+++ b/source/isaaclab_physx/test/sim/test_fabric_stage_rebuild.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+"""Rest everything follows."""
+
+import pytest
+import torch
+
+import omni.timeline
+import omni.usd
+from pxr import Usd, UsdGeom
+
+from isaaclab.assets import Articulation
+from isaaclab.sim import SimulationCfg, SimulationContext
+from isaaclab.sim.utils.stage import get_current_stage_id
+
+from isaaclab_assets import FRANKA_PANDA_CFG  # isort: skip
+
+pytestmark = pytest.mark.isaacsim_ci
+
+TRANSFORM_TOLERANCE = 1e-4
+IDENTITY = (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+
+
+def _flatten(value) -> tuple[float, ...]:
+    if hasattr(value, "__len__"):
+        flat: list[float] = []
+        for item in value:
+            flat.extend(_flatten(item))
+        return tuple(flat)
+    return (float(value),)
+
+
+def _prims_left_at_identity_in_fabric() -> list[str]:
+    """Prims that USD places away from the origin but Fabric still reports at identity."""
+    import usdrt
+
+    usd_stage = omni.usd.get_context().get_stage()
+    xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+    usd_transforms: dict[str, tuple[float, ...]] = {}
+    for prim in usd_stage.Traverse():
+        if prim.IsA(UsdGeom.Xformable):
+            matrix = xform_cache.GetLocalToWorldTransform(prim)
+            usd_transforms[prim.GetPath().pathString] = tuple(v for row in matrix for v in row)
+
+    fabric_stage = usdrt.Usd.Stage.Attach(get_current_stage_id())
+    stale: list[str] = []
+    for prim in fabric_stage.Traverse():
+        usd_value = usd_transforms.get(str(prim.GetPath()))
+        if usd_value is None:
+            continue
+        attribute = prim.GetAttribute("omni:fabric:worldMatrix")
+        if not attribute or not attribute.IsValid():
+            continue
+        value = attribute.Get()
+        if value is None:
+            continue
+        fabric_value = _flatten(value)
+        if len(fabric_value) != 16:
+            continue
+        # Only prims USD places off the origin can be distinguished from identity.
+        if max(abs(v) for v in usd_value[12:15]) <= TRANSFORM_TOLERANCE:
+            continue
+        if max(abs(a - b) for a, b in zip(fabric_value, IDENTITY)) <= TRANSFORM_TOLERANCE:
+            stale.append(str(prim.GetPath()))
+    return stale
+
+
+def _build_step_and_collect(steps: int = 5) -> list[str]:
+    """Build a one-articulation stage, step it, and return prims Fabric left at identity."""
+    sim = SimulationContext(SimulationCfg(dt=1.0 / 120.0, device="cuda:0", use_fabric=True))
+    robot_cfg = FRANKA_PANDA_CFG.replace(prim_path="/World/Robot")
+    robot_cfg.init_state.pos = (0.0, 0.0, 0.5)
+    robot = Articulation(robot_cfg)
+
+    sim.reset()
+    for _ in range(steps):
+        robot.write_data_to_sim()
+        sim.step()
+        robot.update(sim.get_physics_dt())
+
+    stale = _prims_left_at_identity_in_fabric()
+
+    SimulationContext.clear_instance()
+    omni.timeline.get_timeline_interface().stop()
+    omni.usd.get_context().new_stage()
+    return stale
+
+
+def test_fabric_world_matrices_populated_after_stage_rebuild():
+    """Static child prims keep their Fabric world matrices when a stage is rebuilt in-process.
+
+    Regression test for https://github.com/isaac-sim/IsaacLab/issues/7472: the render delegate
+    reads ``omni:fabric:worldMatrix``, so children left at identity are drawn at the world origin.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    first_build = _build_step_and_collect()
+    assert not first_build, f"first build already left prims at identity: {first_build}"
+
+    second_build = _build_step_and_collect()
+    assert not second_build, (
+        f"{len(second_build)} prim(s) lost their Fabric world matrix after a stage rebuild: {second_build[:8]}"
+    )


### PR DESCRIPTION
# Description

Static descendants of articulation links and rigid bodies (the `visuals` and `collisions` meshes under each link) do not get their world transform from the PhysX fabric writer. It is composed by `IFabricHierarchy`, which only visits prims flagged dirty. Rebuilding a stage in the same process repopulates Fabric without flagging the new subtree, so those descendants keep an identity `omni:fabric:worldMatrix` and the render delegate draws them at the world origin.

The fix re-asserts the local transform of affected prims after a non-soft `reset()`, which marks them dirty, then asks the hierarchy to recompose. The written value is unchanged, so world matrices stay owned by the hierarchy and physics-driven parents are never recomposed from a stale local transform.

Fixes #7472

## Root cause evidence

Nothing is broken in the fabric writer, and this is not a missed notification or a timing problem. Measuring on `develop` (`1b92aad12`), counting prims that USD places off the origin but Fabric reports at identity after a rebuild:

| action taken on the stale prims | result |
|---|---|
| nothing (control) | 21 of 38 stale |
| `update_world_xforms()` alone | still stale |
| pump 10 `app.update()` frames | still stale |
| dirty each link's USD translate op | still stale |
| fabric `detach_stage()` + `attach_stage()` (the #4279 re-sync) | still stale |
| **re-assert each prim's own local xform, then `update_world_xforms()`** | **0 stale** |
| re-assert each parent link's local xform, then `update_world_xforms()` | 0 stale |
| re-assert each parent link's *world* xform | still stale |

So the hierarchy composes correctly the whole time; it simply never learns the rebuilt subtree needs recomposing. Re-asserting an unchanged local transform is sufficient, which is why frame pumping and a bare `update_world_xforms()` do nothing: with no dirty flag there is nothing to propagate.

`IFabricHierarchy` change tracking was verified enabled (`local=True world=True`) throughout the failing build, so this is not a paused-listener issue either.

## Scope

- Present on current `develop`, not only the 3.0 branches. Verified by running the added test at `1b92aad12` without the fix: it fails.
- Present on the newest released Isaac Sim. `pypi.nvidia.com` currently tops out at `isaacsim 6.0.1.0`, which is what this was measured on, so there is no newer runtime to defer to.
- The failure is deterministic, not a race: five independent processes each reported exactly the same stale path set. It only appears when several builds share one process, so a shell loop of single-build processes never shows it.
- Requires the `Articulation` wrapper: the same Franka USD spawned raw stays clean, as do procedurally authored articulations. That is what places the fix on the IsaacLab side.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

None. The regression is verified numerically by the added test rather than visually.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Notes for reviewers

`source/isaaclab_physx/test/sim/test_fabric_stage_rebuild.py` builds the same one-articulation stage twice in one process and asserts no prim is left at identity. Without the fix: `AssertionError: 22 prim(s) lost their Fabric world matrix after a stage rebuild`. With it, it passes.

It needs the real Franka USD plus `Articulation`, so it is a small integration test rather than a pure unit test.

Two things worth a reviewer's eye:

- The refresh traverses the USD stage once per non-soft `reset()`. Negligible for a single robot, but worth checking before it lands on very large multi-thousand-env stages. Restricting the traversal to articulation/rigid-body subtrees would be straightforward if that is a concern.
- The issue reports this as absent in `release/3.0.0-beta1` and present in `beta2`. That window also spans an Isaac Sim major bump (`beta1` pins `isaacsim==5.1.0`, `beta2` requires `>=6.0.0`), so the trigger for the missing dirty flag may sit in the runtime rather than in IsaacLab source. This change is the IsaacLab-side fix; identifying what stopped flagging the subtree is still open.
