### PR TITLE
Preserve authored scale in Newton Fabric sync

### DIFF
--- a/source/isaaclab_newton/changelog.d/newton-fabric-preserve-usd-scale.rst
+++ b/source/isaaclab_newton/changelog.d/newton-fabric-preserve-usd-scale.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Newton body pose synchronization dropping authored USD scale from Kit viewport and Isaac RTX
+  rendering, which caused scaled rigid assets to render at unit scale.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -136,21 +136,50 @@ logger = logging.getLogger(__name__)
 
 
 @wp.kernel(enable_backward=False)
+def _capture_fabric_scales(
+    fabric_transforms: wp.fabricarray(dtype=wp.mat44d),
+    newton_indices: wp.fabricarray(dtype=wp.uint32),
+    body_scales: wp.array(dtype=wp.vec3f),
+):
+    """Capture initialized Fabric world scales by Newton body index."""
+    i = int(wp.tid())
+    idx = int(newton_indices[i])
+    matrix = wp.mat44f(fabric_transforms[i])
+    body_scales[idx] = wp.vec3f(
+        wp.length(wp.vec3f(matrix[0, 0], matrix[0, 1], matrix[0, 2])),
+        wp.length(wp.vec3f(matrix[1, 0], matrix[1, 1], matrix[1, 2])),
+        wp.length(wp.vec3f(matrix[2, 0], matrix[2, 1], matrix[2, 2])),
+    )
+
+
+@wp.kernel(enable_backward=False)
 def _set_fabric_transforms(
     fabric_transforms: wp.fabricarray(dtype=wp.mat44d),
     newton_indices: wp.fabricarray(dtype=wp.uint32),
     newton_body_q: wp.array(ndim=1, dtype=wp.transformf),
+    body_scales: wp.array(dtype=wp.vec3f),
 ):
-    """Write Newton body transforms to Fabric world matrices.
+    """Write Newton body poses to Fabric world matrices with their initialized scale.
 
     For each Fabric prim at thread ``i``, reads the Newton body transform at
-    ``newton_body_q[newton_indices[i]]`` and stores it as a column-major
-    ``mat44d`` in ``fabric_transforms[i]``.
+    ``newton_body_q[newton_indices[i]]`` and combines its translation and rotation
+    with the corresponding scale captured from the initialized Fabric world matrix.
+    Newton transforms do not carry scale, so reapplying the captured value prevents
+    authored USD scale from being overwritten with unit scale during rendering sync.
     """
     i = int(wp.tid())
     idx = int(newton_indices[i])
     transform = newton_body_q[idx]
-    fabric_transforms[i] = wp.transpose(wp.mat44d(wp.transform_to_matrix(transform)))
+    scale = body_scales[idx]
+    fabric_transforms[i] = wp.mat44d(
+        wp.transpose(
+            wp.transform_compose(
+                wp.transform_get_translation(transform),
+                wp.transform_get_rotation(transform),
+                scale,
+            )
+        )
+    )
 
 
 @wp.kernel(enable_backward=False)
@@ -449,6 +478,8 @@ class NewtonManager(PhysicsManager):
     _newton_stage_path = None
     _usdrt_stage = None
     _newton_index_attr = "newton:index"
+    # Body-indexed world scales captured before Newton first overwrites Fabric transforms.
+    _fabric_body_scales: wp.array | None = None
     _clone_physics_only = False
     _transforms_dirty: bool = False
     _transforms_may_change_on_graph_replay: bool = False
@@ -643,8 +674,10 @@ class NewtonManager(PhysicsManager):
         frame rather than after every physics step.
 
         Uses ``wp.fabricarray`` directly (no ``isaacsim.physics.newton`` extension needed).
-        The Warp kernel reads ``state_0.body_q[newton_index[i]]`` and writes the
-        corresponding ``mat44d`` to ``omni:fabric:worldMatrix`` for each prim.
+        On the first successful sync, a Warp kernel captures each initialized Fabric
+        world scale by Newton body index. The pose kernel then combines that scale with
+        ``state_0.body_q[newton_index[i]]`` and writes the corresponding ``mat44d`` to
+        ``omni:fabric:worldMatrix`` for each prim.
 
         When ``IFabricHierarchy.update_world_xforms_gpu_with_options`` is
         available the method mirrors PhysX's ``DirectGpuHelper`` pattern: pause
@@ -713,10 +746,22 @@ class NewtonManager(PhysicsManager):
 
                 fabric_transforms = wp.fabricarray(selection, "omni:fabric:worldMatrix")
                 newton_indices = wp.fabricarray(selection, cls._newton_index_attr)
+                if cls._fabric_body_scales is None:
+                    NewtonManager._fabric_body_scales = wp.empty(
+                        cls._model.body_count,
+                        dtype=wp.vec3f,
+                        device=PhysicsManager._device,
+                    )
+                    wp.launch(
+                        _capture_fabric_scales,
+                        dim=newton_indices.shape[0],
+                        inputs=[fabric_transforms, newton_indices, cls._fabric_body_scales],
+                        device=PhysicsManager._device,
+                    )
                 wp.launch(
                     _set_fabric_transforms,
                     dim=newton_indices.shape[0],
-                    inputs=[fabric_transforms, newton_indices, cls._state_0.body_q],
+                    inputs=[fabric_transforms, newton_indices, cls._state_0.body_q, cls._fabric_body_scales],
                     device=PhysicsManager._device,
                 )
                 wp.synchronize_device(PhysicsManager._device)
@@ -1112,6 +1157,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._sensor_bvh_shape_flags = ShapeFlags.VISIBLE
         NewtonManager._newton_stage_path = None
         NewtonManager._usdrt_stage = None
+        NewtonManager._fabric_body_scales = None
         NewtonManager._transforms_dirty = False
         NewtonManager._transforms_may_change_on_graph_replay = False
         NewtonManager._particles_dirty = False
@@ -1588,6 +1634,7 @@ class NewtonManager(PhysicsManager):
         if not cls._clone_physics_only:
             import usdrt
 
+            NewtonManager._fabric_body_scales = None
             body_paths = list(cls._model.body_label)
             NewtonManager._usdrt_stage = get_current_stage(fabric=True)
             body_bindings = NewtonManager._cl_fabric_body_bindings

--- a/source/isaaclab_newton/test/physics/test_newton_fabric_body_sync.py
+++ b/source/isaaclab_newton/test/physics/test_newton_fabric_body_sync.py
@@ -17,6 +17,7 @@ import torch
 import warp as wp
 from isaaclab_newton.physics import NewtonCfg, NewtonManager, VBDSolverCfg, XPBDSolverCfg
 
+from pxr import Gf as UsdGf
 from pxr import UsdGeom
 from usdrt import Gf, Rt
 
@@ -68,6 +69,19 @@ def _fabric_position(body_path: str) -> torch.Tensor:
     assert world_matrix is not None, f"Fabric body prim has no world matrix: {body_path}"
     translation = world_matrix.ExtractTranslation()
     return torch.tensor([float(translation[i]) for i in range(3)])
+
+
+def _fabric_scale(body_path: str) -> torch.Tensor:
+    """Read the world scale consumed by Kit/RTX from the real Fabric stage."""
+    stage = sim_utils.get_current_stage(fabric=True)
+    assert stage is not None, "The rendering-side Fabric stage is unavailable"
+
+    prim = stage.GetPrimAtPath(body_path)
+    assert prim.IsValid(), f"Fabric body prim does not exist: {body_path}"
+    world_matrix = Rt.Xformable(prim).GetFabricHierarchyWorldMatrixAttr().Get()
+    assert world_matrix is not None, f"Fabric body prim has no world matrix: {body_path}"
+    scale = Gf.Transform(world_matrix).GetScale()
+    return torch.tensor([float(scale[i]) for i in range(3)])
 
 
 def _fabric_curve_points_world(curve_path: str) -> torch.Tensor:
@@ -321,6 +335,49 @@ def test_root_pose_write_is_visible_on_next_render_without_step():
                     rtol=0.0,
                     atol=1.0e-4,
                 )
+        finally:
+            sim.register_interactive_scene(None)
+
+
+@pytest.mark.isaacsim_ci
+@pytest.mark.skipif(not wp.get_cuda_device_count(), reason="CUDA is unavailable")
+def test_root_pose_sync_preserves_authored_scale():
+    """Newton body pose synchronization must preserve authored USD scale in Kit/RTX."""
+    device = "cuda:0"
+    sim_cfg = SimulationCfg(
+        device=device,
+        gravity=(0.0, 0.0, 0.0),
+        physics=NewtonCfg(solver_cfg=XPBDSolverCfg(), use_cuda_graph=False),
+    )
+
+    with build_simulation_context(sim_cfg=sim_cfg) as sim:
+        sim._app_control_on_stop_handle = None
+        scene = InteractiveScene(_RenderSceneCfg(num_envs=1, env_spacing=2.0))
+        sim.register_interactive_scene(scene)
+        try:
+            body_path = "/World/envs/env_0/Cube"
+            authored_scale = torch.tensor([0.25, 0.5, 0.75])
+            body_prim = sim_utils.get_current_stage().GetPrimAtPath(body_path)
+            body_prim.GetAttribute("xformOp:scale").Set(UsdGf.Vec3d(*authored_scale.tolist()))
+
+            sim.reset()
+            scene.reset()
+            sim.render()
+            wp.synchronize_device(device)
+
+            torch.testing.assert_close(_fabric_scale(body_path), authored_scale, rtol=0.0, atol=1.0e-5)
+
+            target_pose = torch.tensor(
+                [[1.5, -0.75, 2.0, 0.0, 0.0, 0.0, 1.0]],
+                dtype=torch.float32,
+                device=device,
+            )
+            scene["cube"].write_root_link_pose_to_sim_index(root_pose=target_pose)
+            sim.render()
+            wp.synchronize_device(device)
+
+            torch.testing.assert_close(_fabric_position(body_path), target_pose[0, :3].cpu(), rtol=0.0, atol=1.0e-4)
+            torch.testing.assert_close(_fabric_scale(body_path), authored_scale, rtol=0.0, atol=1.0e-5)
         finally:
             sim.register_interactive_scene(None)
 


### PR DESCRIPTION
# Description

Newton's Kit/RTX Fabric synchronization rebuilt every rigid-body world matrix from a Newton `transformf`, which contains translation and rotation but no scale. The first render sync therefore overwrote composed USD scale with unit scale, making scaled rigid assets appear oversized.

This change captures each body's initialized Fabric world scale by Newton body index and reapplies it when composing subsequent render matrices. It fixes the synchronization contract at the backend boundary, following the same root-fix approach used for OVRTX in #7010, and removes the need for the task-specific asset substitution proposed in #7476.

No new dependencies are required.

Related: #7010, #7476

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; the regression test checks the rendering-side Fabric world matrix directly.

## Validation

- Ruff format and lint passed for the changed Python files.
- `git diff --check` passed.
- The changelog gate passed against current `upstream/develop`.
- A Warp 1.16 CPU smoke test compiled and exercised the scale-capture and transform-composition kernels.
- The Isaac Sim/CUDA regression test was not run locally because this host is macOS/arm; it is marked for Isaac Sim CI.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the full pre-commit checks with `uv run isaaclab -f` (unsupported on this macOS/arm host)
- [x] No public API or documentation change is required
- [x] My changes generate no new warnings in the available local checks
- [x] I have added a regression test that proves the fix preserves non-uniform authored scale across pose synchronization
- [x] I have added a changelog fragment under `source/isaaclab_newton/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
