### PR TITLE
Keep search-path asset identifiers intact when resolving layer paths

### DIFF
--- a/source/isaaclab/changelog.d/jichuanh-mdl-search-path-asset-resolve.rst
+++ b/source/isaaclab/changelog.d/jichuanh-mdl-search-path-asset-resolve.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.sim.utils.resolve_paths` rewriting search-path asset identifiers, such as
+  the MDL module ``OmniPBR.mdl``, into paths relative to the process working directory. Assets
+  converted with ``--make-instanceable`` referenced a non-existent MDL module, so the renderer
+  logged ``MDLC comp error: C120 could not find module`` and left their materials unresolved.

--- a/source/isaaclab/isaaclab/sim/utils/stage.py
+++ b/source/isaaclab/isaaclab/sim/utils/stage.py
@@ -121,12 +121,17 @@ def resolve_paths(
         resolved = src_layer.ComputeAbsolutePath(asset_path)
         if resolved and _is_uri_path(resolved):
             return resolved
-        if store_relative_path and resolved and dst_dir:
+        # Search-path identifiers (e.g. the MDL module ``OmniPBR.mdl``) come back unchanged: they
+        # are resolved against the renderer's module path, not the layer's directory. Re-anchoring
+        # one would make it relative to the process working directory and point at nothing.
+        if not os.path.isabs(resolved):
+            return asset_path
+        if store_relative_path and dst_dir:
             try:
                 return os.path.relpath(resolved, dst_dir)
             except ValueError:
                 return resolved
-        return resolved or asset_path
+        return resolved
 
     UsdUtils.ModifyAssetPaths(dst_layer, _modify_path)
 

--- a/source/isaaclab/test/sim/test_utils_stage.py
+++ b/source/isaaclab/test/sim/test_utils_stage.py
@@ -321,6 +321,49 @@ def test_resolve_paths():
         assert cube_prim.GetTypeName() == "Cube"
 
 
+def test_resolve_paths_keeps_search_path_assets():
+    """Test resolve_paths leaves search-path asset identifiers untouched.
+
+    Identifiers such as the MDL module ``OmniPBR.mdl`` are resolved against the renderer's module
+    path rather than the layer's directory, so re-anchoring one to the destination layer yields a
+    path relative to the process working directory that resolves to nothing.
+    """
+    from pxr import Sdf, UsdShade
+
+    from isaaclab.sim.utils.stage import resolve_paths
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a mesh the source asset references through a directory-qualified relative path
+        mesh_path = Path(temp_dir) / "meshes" / "mesh.usda"
+        mesh_path.parent.mkdir(parents=True, exist_ok=True)
+        mesh_stage = Usd.Stage.CreateNew(str(mesh_path))
+        mesh_stage.GetRootLayer().Save()
+
+        # Create the source asset with a mesh reference and an MDL shader
+        source_path = Path(temp_dir) / "asset.usda"
+        source_stage = Usd.Stage.CreateNew(str(source_path))
+        world_prim = source_stage.DefinePrim("/World", "Xform")
+        world_prim.GetReferences().AddReference("./meshes/mesh.usda")
+        shader = UsdShade.Shader.Define(source_stage, "/World/Looks/red/red")
+        shader.SetSourceAsset(Sdf.AssetPath("OmniPBR.mdl"), "mdl")
+        source_stage.GetRootLayer().Save()
+
+        # Copy the layer one directory deeper, as export_prim_to_file does for instanceable meshes
+        dest_path = Path(temp_dir) / "Props" / "instanceable_meshes.usda"
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_layer = Sdf.Layer.CreateNew(str(dest_path))
+        dest_layer.TransferContent(source_stage.GetRootLayer())
+
+        resolve_paths(str(source_path), str(dest_path))
+        dest_layer.Save()
+
+        contents = dest_layer.ExportToString()
+        # the MDL module keeps its search-path identifier
+        assert "@OmniPBR.mdl@" in contents
+        # the mesh reference is re-anchored to the new location
+        assert "@../meshes/mesh.usda@" in contents
+
+
 def test_stage_context_tracking():
     """Test that stage context is properly tracked across operations."""
     # Create initial stage


### PR DESCRIPTION
# Description

`resolve_paths` passed the result of `Sdf.Layer.ComputeAbsolutePath` straight to `os.path.relpath`. USD returns *search-path* identifiers unchanged, so a non-absolute string such as the MDL module `OmniPBR.mdl` was anchored at the process working directory instead of the layer's location. `MeshConverter` routes every `--make-instanceable` export through this helper, so each MDL material in `Props/instanceable_meshes.usd` pointed at a module that does not exist.

Fixes NVBug 6675386, NVBug 6703374

## 1. Before / after

Converting `cube_multicolor.obj` with `--make-instanceable`, output under `source/isaaclab_assets/data/Props/CubeMultiColor/`:

| | `info:mdl:sourceAsset` in `Props/instanceable_meshes.usd` |
| --- | --- |
| Before | `@../../../../../../OmniPBR.mdl@` (six levels up = the process CWD) |
| After | `@OmniPBR.mdl@` |

The renderer then logged `MDLC comp error: C120 could not find module '::..::..::..::..::..::..::OmniPBR'` and `Unable to find SdrShaderNode` once per material.

## 2. Verified

QA's exact command (`--make-instanceable --collision-approximation convexDecomposition --mass 1.0 --visualizer kit,viser,rerun,newton_gl`), before and after, on the build the reports were filed against:

| Isaac Sim | `MDLC comp error: C120` | `Unable to find SdrShaderNode` |
| --- | --- | --- |
| 6.1.0rc17 (Kit 110.3.0+feature.370106), before | 1 | 6 |
| 6.1.0rc17, after | 0 | 0 |
| 6.0.0-rc.59 (Kit 110.1.1), before | 1 | 6 |
| 6.0.0-rc.59, after | 0 | 0 |

The added unit test fails on `develop` (`@../../../workspace/isaaclab/OmniPBR.mdl@`) and passes with the fix.

## 3. Design notes

Only paths that `ComputeAbsolutePath` actually resolved to an absolute location are re-anchored; anything else is returned as authored, for the renderer's module path to resolve. Genuine relative references still move with the layer — the added test asserts `@../meshes/mesh.usda@` alongside the untouched `@OmniPBR.mdl@`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
