### PR TITLE
Fix OVPhysX CPU-only property writes racing their pinned-host staging copies

### DIFF
--- a/source/isaaclab_ov/changelog.d/fix-malesiani-ovphysx_pinned_host_staging_sync.rst
+++ b/source/isaaclab_ov/changelog.d/fix-malesiani-ovphysx_pinned_host_staging_sync.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed OVPhysX CPU-only property writes (joint stiffness, damping, limits, armature, friction,
+  body mass, center of mass, and inertia) on GPU simulations consuming their pinned-host staging
+  buffers before the asynchronous device-to-host copy had completed. Environments could silently
+  receive stale (typically zero) property values, which made repeated training runs diverge.
+  Every pinned-host staging copy in :class:`~isaaclab_ov.assets.Articulation`,
+  :class:`~isaaclab_ov.assets.RigidObject`, and :class:`~isaaclab_ov.assets.RigidObjectCollection`
+  now waits for the device stream before the CPU setter runs.

--- a/source/isaaclab_ov/isaaclab_ov/assets/articulation/articulation.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/articulation/articulation.py
@@ -2334,6 +2334,7 @@ class Articulation(BaseArticulation):
         self._data._body_mass.timestamp = self._data._sim_timestamp
         cpu_env_ids = self._get_cpu_env_ids(env_ids, sim_env_ids)
         wp.copy(self.data._cpu_body_mass, body_mass_backend)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(TT.BODY_MASS, self.data._cpu_body_mass, indices=cpu_env_ids)
         self._data._reset_dynamics(mass_matrix=True, gravity_compensation=True)
 
@@ -2385,6 +2386,7 @@ class Articulation(BaseArticulation):
         )
         self._data._body_mass.timestamp = self._data._sim_timestamp
         wp.copy(self.data._cpu_body_mass, body_mass_backend)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(TT.BODY_MASS, self.data._cpu_body_mass, mask=self._get_cpu_env_mask(env_mask_wp))
         self._data._reset_dynamics(mass_matrix=True, gravity_compensation=True)
 
@@ -2480,6 +2482,7 @@ class Articulation(BaseArticulation):
             backend_staging.timestamp = validity
 
         wp.copy(self.data._cpu_body_coms, body_com_backend.view(wp.float32))
+        wp.synchronize_stream(self._device)
         if use_mask:
             self._root_view.set_attribute(
                 TT.BODY_COM_POSE, self.data._cpu_body_coms, mask=self._get_cpu_env_mask(env_sel)
@@ -2616,6 +2619,7 @@ class Articulation(BaseArticulation):
         self._data._body_inertia.timestamp = self._data._sim_timestamp
         cpu_env_ids = self._get_cpu_env_ids(env_ids, sim_env_ids)
         wp.copy(self.data._cpu_body_inertia, body_inertia_backend)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(TT.BODY_INERTIA, self.data._cpu_body_inertia, indices=cpu_env_ids)
         self._data._reset_dynamics(mass_matrix=True)
 
@@ -2668,6 +2672,7 @@ class Articulation(BaseArticulation):
         )
         self._data._body_inertia.timestamp = self._data._sim_timestamp
         wp.copy(self.data._cpu_body_inertia, body_inertia_backend)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(
             TT.BODY_INERTIA, self.data._cpu_body_inertia, mask=self._get_cpu_env_mask(env_mask_wp)
         )
@@ -3958,6 +3963,7 @@ class Articulation(BaseArticulation):
         # Pinned-host CPU staging for env ids/masks (PR #5329 pattern).
         self._cpu_env_ids_all = wp.zeros(N, dtype=wp.int32, device="cpu", pinned=True)
         wp.copy(self._cpu_env_ids_all, self._ALL_INDICES)
+        wp.synchronize_stream(device)
         self._cpu_env_ids = wp.empty(N, dtype=wp.int32, device="cpu", pinned=True)
         self._cpu_env_ids_views: dict[int, wp.array] = {}
         self._cpu_env_mask = wp.zeros(N, dtype=wp.bool, device="cpu", pinned=True)
@@ -4389,6 +4395,7 @@ class Articulation(BaseArticulation):
         inertia. Reuses the pre-allocated ``_cpu_env_mask`` pinned buffer.
         """
         wp.copy(self._cpu_env_mask, env_mask)
+        wp.synchronize_stream(env_mask.device)
         return self._cpu_env_mask
 
     def _get_cpu_env_ids(self, env_ids: wp.array | torch.Tensor, sim_env_ids: wp.array | None = None) -> wp.array:
@@ -4409,6 +4416,7 @@ class Articulation(BaseArticulation):
             return env_ids
         cpu_env_ids = self._cpu_env_ids_view(env_ids.shape[0])
         wp.copy(cpu_env_ids, env_ids)
+        wp.synchronize_stream(env_ids.device)
         return cpu_env_ids
 
     def _get_sim_env_ids(self, env_ids: wp.array | torch.Tensor, sim_env_ids: wp.array | None = None) -> wp.array:
@@ -4467,6 +4475,9 @@ class Articulation(BaseArticulation):
                     copy=False,
                 )
             wp.copy(cpu_buffer, source)
+            # The device-to-host copy into pinned memory is asynchronous; the CPU-only
+            # setter below reads the buffer immediately.
+            wp.synchronize_stream(source.device)
         if indices is not None:
             self._root_view.set_attribute(tensor_type, cpu_buffer, indices=indices)
         else:

--- a/source/isaaclab_ov/isaaclab_ov/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/rigid_object/rigid_object.py
@@ -723,6 +723,7 @@ class RigidObject(BaseRigidObject):
         # Push cache to the wheel via pinned-CPU staging (RIGID_BODY_MASS is CPU-only).
         cpu_env_ids = self._get_cpu_env_ids(env_ids, sim_env_ids)
         wp.copy(self._cpu_body_mass, self.data._body_mass)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(TT.RIGID_BODY_MASS, self._cpu_body_mass.flatten(), indices=cpu_env_ids)
 
     def set_masses_mask(
@@ -757,6 +758,7 @@ class RigidObject(BaseRigidObject):
             device=self._device,
         )
         wp.copy(self._cpu_body_mass, self.data._body_mass)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(
             TT.RIGID_BODY_MASS, self._cpu_body_mass.flatten(), mask=self._get_cpu_env_mask(env_mask_wp)
         )
@@ -800,6 +802,7 @@ class RigidObject(BaseRigidObject):
         # Push cache to the wheel via pinned-CPU staging (RIGID_BODY_COM_POSE is CPU-only).
         cpu_env_ids = self._get_cpu_env_ids(env_ids, sim_env_ids)
         wp.copy(self._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
+        wp.synchronize_stream(self._device)
         # Wheel binding shape is (N, 7); squeeze singleton body dim with a flat float32 view.
         self._root_view.set_attribute(
             TT.RIGID_BODY_COM_POSE, self._cpu_body_coms.reshape((self._num_instances, 7)), indices=cpu_env_ids
@@ -838,6 +841,7 @@ class RigidObject(BaseRigidObject):
         )
         self.data._reset_body_com_pose_b_dependents()
         wp.copy(self._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(
             TT.RIGID_BODY_COM_POSE,
             self._cpu_body_coms.reshape((self._num_instances, 7)),
@@ -881,6 +885,7 @@ class RigidObject(BaseRigidObject):
         # Push cache to the wheel via pinned-CPU staging (RIGID_BODY_INERTIA is CPU-only).
         cpu_env_ids = self._get_cpu_env_ids(env_ids, sim_env_ids)
         wp.copy(self._cpu_body_inertia, self.data._body_inertia)
+        wp.synchronize_stream(self._device)
         # Wheel binding shape is (N, 9); flatten the singleton body dim.
         self._root_view.set_attribute(
             TT.RIGID_BODY_INERTIA, self._cpu_body_inertia.reshape((self._num_instances, 9)), indices=cpu_env_ids
@@ -918,6 +923,7 @@ class RigidObject(BaseRigidObject):
             device=self._device,
         )
         wp.copy(self._cpu_body_inertia, self.data._body_inertia)
+        wp.synchronize_stream(self._device)
         self._root_view.set_attribute(
             TT.RIGID_BODY_INERTIA,
             self._cpu_body_inertia.reshape((self._num_instances, 9)),
@@ -1043,6 +1049,7 @@ class RigidObject(BaseRigidObject):
         # host memory enables DMA fast path and avoids per-call ``wp.clone`` allocation.
         self._cpu_env_ids_all = wp.zeros(N, dtype=wp.int32, device="cpu", pinned=True)
         wp.copy(self._cpu_env_ids_all, self._ALL_INDICES)
+        wp.synchronize_stream(self._device)
         self._cpu_env_ids = wp.empty(N, dtype=wp.int32, device="cpu", pinned=True)
         self._cpu_env_ids_views: dict[int, wp.array] = {}
         self._cpu_body_mass = wp.zeros((N, B), dtype=wp.float32, device="cpu", pinned=True)
@@ -1153,6 +1160,7 @@ class RigidObject(BaseRigidObject):
         ``_cpu_env_mask`` pinned buffer.
         """
         wp.copy(self._cpu_env_mask, env_mask)
+        wp.synchronize_stream(env_mask.device)
         return self._cpu_env_mask
 
     def _get_cpu_env_ids(self, env_ids: wp.array | torch.Tensor, sim_env_ids: wp.array | None = None) -> wp.array:
@@ -1173,6 +1181,7 @@ class RigidObject(BaseRigidObject):
             return env_ids
         cpu_env_ids = self._cpu_env_ids_view(env_ids.shape[0])
         wp.copy(cpu_env_ids, env_ids)
+        wp.synchronize_stream(env_ids.device)
         return cpu_env_ids
 
     def _cpu_env_ids_view(self, count: int) -> wp.array:

--- a/source/isaaclab_ov/isaaclab_ov/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/rigid_object_collection/rigid_object_collection.py
@@ -843,6 +843,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self._device,
         )
         wp.copy(self.data._cpu_body_mass, self.data._body_mass.data)
+        wp.synchronize_stream(self._device)
         self._binding_write(
             TT.BODY_MASS,
             self.data._cpu_body_mass,
@@ -888,6 +889,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self._device,
         )
         wp.copy(self.data._cpu_body_mass, self.data._body_mass.data)
+        wp.synchronize_stream(self._device)
         self._binding_write(TT.BODY_MASS, self.data._cpu_body_mass, env_ids=env_ids, device="cpu")
 
     def set_coms_index(
@@ -926,6 +928,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         )
         self.data._reset_body_com_pose_b_dependents()
         wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
+        wp.synchronize_stream(self._device)
         self._binding_write(
             TT.BODY_COM_POSE,
             self.data._cpu_body_coms,
@@ -973,6 +976,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         )
         self.data._reset_body_com_pose_b_dependents()
         wp.copy(self.data._cpu_body_coms, self.data._body_com_pose_b.data.view(wp.float32))
+        wp.synchronize_stream(self._device)
         self._binding_write(
             TT.BODY_COM_POSE,
             self.data._cpu_body_coms,
@@ -1018,6 +1022,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self._device,
         )
         wp.copy(self.data._cpu_body_inertia, self.data._body_inertia.data)
+        wp.synchronize_stream(self._device)
         self._binding_write(
             TT.BODY_INERTIA,
             self.data._cpu_body_inertia,
@@ -1066,6 +1071,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
             device=self._device,
         )
         wp.copy(self.data._cpu_body_inertia, self.data._body_inertia.data)
+        wp.synchronize_stream(self._device)
         self._binding_write(
             TT.BODY_INERTIA,
             self.data._cpu_body_inertia,
@@ -1176,6 +1182,7 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         self._sim_view_ids_views: dict[int, wp.array] = {}
         self._cpu_all_view_ids = wp.empty(num_view_ids, dtype=wp.int32, device="cpu", pinned=True)
         wp.copy(self._cpu_all_view_ids, self._ALL_VIEW_INDICES)
+        wp.synchronize_stream(self._device)
         self._cpu_view_ids = wp.empty(num_view_ids, dtype=wp.int32, device="cpu", pinned=True)
         self._cpu_view_ids_views: dict[int, wp.array] = {}
 

--- a/source/isaaclab_ov/test/assets/test_articulation.py
+++ b/source/isaaclab_ov/test/assets/test_articulation.py
@@ -3365,5 +3365,76 @@ def test_set_material_properties(sim, num_articulations, device, add_ground_plan
     torch.testing.assert_close(materials_check, materials)
 
 
+@wp.kernel
+def _occupy_stream_kernel(iterations: int, out: wp.array(dtype=wp.float32)):
+    total = float(0.0)
+    for i in range(iterations):
+        total += wp.sin(float(i))
+    out[0] = total
+
+
+@pytest.mark.parametrize("device", ["cuda:0"])
+def test_cpu_only_property_writes_wait_for_pinned_host_staging(sim, device):
+    """Land CPU-only property writes while the device stream is busy.
+
+    OVPhysX keeps joint and body properties on the host even for a GPU simulation, so the writers
+    stage the device-resident data, environment indices, and masks through pinned host buffers
+    before calling the CPU setter. Warp issues that device-to-host copy asynchronously on the
+    device stream, so a long kernel queued ahead of the copy must not let the setter consume the
+    previous contents of the pinned buffers.
+    """
+    articulation, _ = generate_articulation(
+        ArticulationCfg(
+            prim_path="/World/Robot",
+            spawn=sim_utils.UsdFileCfg(
+                usd_path=str(Path(__file__).parent / "data" / "articulation_ordering_branching.usda")
+            ),
+            actuators={},
+        ),
+        num_articulations=4,
+        device=device,
+    )
+    sim.reset()
+    num_envs, num_joints = articulation.num_instances, articulation.num_joints
+
+    stiffness_before = _read_binding_to_torch(articulation, TT.DOF_STIFFNESS, device)
+    damping_before = _read_binding_to_torch(articulation, TT.DOF_DAMPING, device)
+    masses_before = _read_binding_to_torch(articulation, TT.BODY_MASS, device)
+    joint_values = torch.arange(1, num_envs * num_joints + 1, device=device, dtype=torch.float32)
+    joint_values = joint_values.reshape(num_envs, num_joints)
+    env_ids = torch.tensor([1, 3], device=device)
+    env_mask = wp.array([False, True, False, True], dtype=wp.bool, device=device)
+    scratch = wp.zeros(1, dtype=wp.float32, device=device)
+
+    def occupy_device_stream(iterations: int = 500_000):
+        wp.launch(_occupy_stream_kernel, dim=1, inputs=[iterations], outputs=[scratch], device=device)
+
+    # Warm up every kernel involved so that module compilation cannot drain the stream
+    # between the writes below and the kernel that keeps it busy.
+    occupy_device_stream(iterations=1)
+    articulation.write_joint_stiffness_to_sim_index(stiffness=stiffness_before[env_ids], env_ids=env_ids)
+    articulation.write_joint_damping_to_sim_mask(damping=damping_before, env_mask=env_mask)
+    articulation.set_masses_mask(masses=masses_before, env_mask=env_mask)
+    wp.synchronize_device(device)
+
+    occupy_device_stream()
+    articulation.write_joint_stiffness_to_sim_index(stiffness=joint_values[env_ids], env_ids=env_ids)
+    occupy_device_stream()
+    articulation.write_joint_damping_to_sim_mask(damping=joint_values, env_mask=env_mask)
+    occupy_device_stream()
+    articulation.set_masses_mask(masses=masses_before * 2.0, env_mask=env_mask)
+    wp.synchronize_device(device)
+
+    expected_stiffness = stiffness_before.clone()
+    expected_stiffness[env_ids] = joint_values[env_ids]
+    expected_damping = damping_before.clone()
+    expected_damping[env_ids] = joint_values[env_ids]
+    expected_masses = masses_before.clone()
+    expected_masses[env_ids] = masses_before[env_ids] * 2.0
+    torch.testing.assert_close(_read_binding_to_torch(articulation, TT.DOF_STIFFNESS, device), expected_stiffness)
+    torch.testing.assert_close(_read_binding_to_torch(articulation, TT.DOF_DAMPING, device), expected_damping)
+    torch.testing.assert_close(_read_binding_to_torch(articulation, TT.BODY_MASS, device), expected_masses)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--maxfail=1"])


### PR DESCRIPTION
# Description

OVPhysX keeps joint and body properties (stiffness, damping, limits, armature, friction, mass, center of mass, inertia) on the host even when the simulation runs on the GPU, so the `isaaclab_ov` assets stage the GPU-resident caches, environment indices, and masks into pinned host buffers with `wp.copy` and then call the CPU-only `set_attribute`. Warp issues a device-to-host copy into pinned memory asynchronously on the device stream, so whenever that stream still has work queued ahead of the copy, the setter consumed whatever the pinned buffer held before the copy landed: zeros on first use, or the values of the previous write.

For `Isaac-Ant-Direct` on `physics=ovphysx` this hit the actuator setup writes during initialization. In a fraction of fresh processes some environments received all-zero joint properties, their first physics step diverged, and repeated seeded training runs stopped being reproducible. The race is timing dependent, which is why short validation series could pass while longer ones did not.

Two helpers already had the right pattern (`ArticulationData._binding_write` / `_stage_to_pinned_cpu` and `RigidObjectCollection._env_body_ids_to_view_ids` fence with `wp.synchronize_stream` right after the copy); the preallocated-buffer paths did not. This change makes every device-to-pinned-host staging copy consumed by CPU code wait for the device stream before the setter runs:

- `Articulation`: `_push_joint_property` (all joint property writers), `set_masses_*`, `_set_coms`, `set_inertias_*`, `_get_cpu_env_ids`, `_get_cpu_env_mask`, and the one-time `_cpu_env_ids_all` fill.
- `RigidObject`: the same mass, center of mass, inertia, index, and mask sites.
- `RigidObjectCollection`: the mass, center of mass, and inertia staging copies and the one-time `_cpu_all_view_ids` fill.

Host-to-device copies followed by kernels on the same stream are already stream ordered and are left untouched.

## Performance

Measured on an RTX A6000 with `Isaac-Ant-Direct`, 4096 environments, `physics=ovphysx`, 300 random-action steps per run:

| Scenario | Fence calls in the step loop | Fence cost | CPU setter cost | Step time |
| --- | --- | --- | --- | --- |
| Ant steady state (no property writes after init) | 0 | 0 | 0 | 8.7 ms/step, unchanged |
| Initialization (6 actuator property writes) | n/a | 0.10 to 0.15 ms total | 53 to 66 ms total | one-time |
| Stiffness and damping rewritten for 256 envs every step | 600 | about 19 us median per write, 11 to 13 ms total | 546 to 584 ms total | 11.7 to 11.9 ms/step before, 12.0 to 12.2 ms/step after (two runs each, within run-to-run noise) |
| Stiffness and damping rewritten for all 4096 envs every step | 600 | 11 ms total | 7.8 to 8.9 s total | 42 to 47 ms/step both ways |

The wait is bounded by the copy itself because the CPU-only setter cannot start before the data is on the host anyway; the setter's per-DOF PhysX calls dominate the write cost by roughly two orders of magnitude. Steady-state training is unaffected because these writers only run at initialization and during reset-time randomization.

## Test

`test_cpu_only_property_writes_wait_for_pinned_host_staging` warms up the writers, queues a long kernel on the device stream ahead of each write, and checks the values read back from OVPhysX. It fails on the previous code (the two selected environments keep their old stiffness) and passes with this change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

The defect also affects the current release branch with `ovphysx`; maintainers may want to tick the backport box.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
