### PR TITLE
Fix OSC singular task-space inertia inversion

### DIFF
--- a/source/isaaclab/changelog.d/maximiliank-fix-osc-singular-inertia.rst
+++ b/source/isaaclab/changelog.d/maximiliank-fix-osc-singular-inertia.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed operational-space inertial decoupling failing when an environment had a singular task-space mass matrix.

--- a/source/isaaclab/isaaclab/controllers/operational_space.py
+++ b/source/isaaclab/isaaclab/controllers/operational_space.py
@@ -21,6 +21,15 @@ if TYPE_CHECKING:
     from .operational_space_cfg import OperationalSpaceControllerCfg
 
 
+def _compute_task_space_mass_matrix(inverse_task_space_mass_matrix: torch.Tensor) -> torch.Tensor:
+    """Invert a task-space mass matrix, falling back to a pseudoinverse for singular batch elements."""
+    task_space_mass_matrix, info = torch.linalg.inv_ex(inverse_task_space_mass_matrix)
+    singular_mask = info != 0
+    if torch.any(singular_mask):
+        task_space_mass_matrix[singular_mask] = torch.linalg.pinv(inverse_task_space_mass_matrix[singular_mask])
+    return task_space_mass_matrix
+
+
 class OperationalSpaceController:
     """Operational-space controller.
 
@@ -432,17 +441,19 @@ class OperationalSpaceController:
                 self._mass_matrix_inv = torch.inverse(mass_matrix)
                 if self.cfg.partial_inertial_dynamics_decoupling:
                     # Fill in the translational and rotational parts of the inertia separately, ignoring their coupling
-                    self._os_mass_matrix_b[:, 0:3, 0:3] = torch.inverse(
+                    self._os_mass_matrix_b[:, 0:3, 0:3] = _compute_task_space_mass_matrix(
                         jacobian_b[:, 0:3] @ self._mass_matrix_inv @ jacobian_b[:, 0:3].mT
                     )
-                    self._os_mass_matrix_b[:, 3:6, 3:6] = torch.inverse(
+                    self._os_mass_matrix_b[:, 3:6, 3:6] = _compute_task_space_mass_matrix(
                         jacobian_b[:, 3:6] @ self._mass_matrix_inv @ jacobian_b[:, 3:6].mT
                     )
                 else:
                     # Calculate the operational space mass matrix fully accounting for the couplings
-                    self._os_mass_matrix_b[:] = torch.inverse(jacobian_b @ self._mass_matrix_inv @ jacobian_b.mT)
+                    self._os_mass_matrix_b[:] = _compute_task_space_mass_matrix(
+                        jacobian_b @ self._mass_matrix_inv @ jacobian_b.mT
+                    )
                 # (Generalized) operational space command forces
-                # F = (J M^(-1) J^T)^(-1) * \ddot(x_des) = M_task * \ddot(x_des)
+                # F = (J M^(-1) J^T)^+ * \ddot(x_des) = M_task * \ddot(x_des)
                 os_command_forces_b = self._os_mass_matrix_b @ des_ee_acc_b
             else:
                 # Task-space impedance control: command forces = \ddot(x_des).

--- a/source/isaaclab/test/controllers/test_operational_space_features.py
+++ b/source/isaaclab/test/controllers/test_operational_space_features.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+import torch
+
+from isaaclab.controllers import OperationalSpaceController, OperationalSpaceControllerCfg
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("partial_inertial_decoupling", [False, True])
+def test_inertial_decoupling_handles_singular_task_inertia(partial_inertial_decoupling: bool):
+    """Inertial decoupling produces finite efforts for rank-deficient Jacobians in a mixed batch."""
+    num_envs = 3
+    num_joints = 7
+    cfg = OperationalSpaceControllerCfg(
+        target_types=["pose_abs"],
+        inertial_dynamics_decoupling=True,
+        partial_inertial_dynamics_decoupling=partial_inertial_decoupling,
+    )
+    controller = OperationalSpaceController(cfg, num_envs=num_envs, device="cpu")
+
+    target_pose = torch.tensor([[0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]).repeat(num_envs, 1)
+    controller.set_command(target_pose)
+
+    jacobian = torch.zeros(num_envs, 6, num_joints)
+    jacobian[:, :6, :6] = torch.eye(6)
+    jacobian[1, 1] = 0.0  # singular translational task-space inertia
+    jacobian[2, 5] = 0.0  # singular rotational task-space inertia
+
+    current_pose = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]]).repeat(num_envs, 1)
+
+    joint_efforts = controller.compute(
+        jacobian_b=jacobian,
+        current_ee_pose_b=current_pose,
+        current_ee_vel_b=torch.zeros(num_envs, 6),
+        mass_matrix=torch.eye(num_joints).repeat(num_envs, 1, 1),
+    )
+
+    assert torch.isfinite(joint_efforts).all()
+    torch.testing.assert_close(
+        joint_efforts[:, 0],
+        torch.full((num_envs,), 10.0),
+    )
+    torch.testing.assert_close(
+        joint_efforts[:, 1:],
+        torch.zeros(num_envs, num_joints - 1),
+    )


### PR DESCRIPTION
# Description

Operational-space inertial decoupling currently applies a batched ordinary inverse to `J M^-1 J^T`. If one environment has a rank-deficient Jacobian, `torch.inverse` raises for that batch element and terminates every environment in the batch. This causes the `run_osc.py` tutorial to abort on Newton with a singular-matrix error.

This change uses `torch.linalg.inv_ex` to retain the ordinary inverse for full-rank batch elements and applies `torch.linalg.pinv` only to elements whose inversion failed. It covers full and partial inertial decoupling while intentionally leaving the positive-definite joint-space mass-matrix inverse unchanged.

A focused unit test uses a mixed batch containing full-rank, translationally singular, and rotationally singular Jacobians. No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- Confirmed the regression test fails without the controller fix with `torch._C._LinAlgError` on the singular batch element.
- `uv run --frozen --extra test pytest -q source/isaaclab/test/controllers/test_operational_space_features.py` — 2 passed.
- Existing full and partial simulator-backed OSC tests plus the regression cases — 4 passed.
- Official `Isaac-Reach-Franka-OSC` Newton MJWarp smoke test — passed.
- `Isaac-Reach-Franka-OSC` Newton/CUDA stress run with 128 environments for 1,000 control steps — passed.
- `run_osc.py` Newton/CUDA tutorial run with 128 environments for 1,500 steps across all target cycles — completed without a singular inversion failure. The finite step bound and current Newton backend selector were local test-only instrumentation and are not part of this PR.
- `./isaaclab.sh -f` — all hooks passed before commit and before push.

## Screenshots

Not applicable; this change fixes a controller computation failure.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] Documentation changes are not required for this internal controller fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`