### PR TITLE
Fix documentation link check for opensource.org 403s

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -97,6 +97,7 @@ jobs:
           --exclude 'graphics\.pixar\.com'
           --exclude 'openpbs\.org'
           --exclude 'docutils\.sourceforge\.io'
+          --exclude '^https://opensource\.org/'
           --exclude 'huggingface\.co/datasets/nvidia/PhysicalAI-Robotics-NuRec'
           --exclude 'huggingface\.co/nvidia/COMPASS'
           --exclude 'huggingface\.co/nvidia/X-Mobility'


### PR DESCRIPTION
# Description

The documentation link check began failing across pull requests and pushes because `opensource.org` returns HTTP 403 to GitHub-hosted runners, even with the configured browser user-agent. The affected URLs are valid license references rather than dead links.

Exclude only URLs under `https://opensource.org/` from Lychee. Other 403 responses remain failures.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- Full Lychee v0.24.2 scan: 1,082 total links and 0 errors.
- Applicable pre-commit hooks and `git diff --check` passed.
- `uv run isaaclab -f` could not start because the project lockfile does not support macOS/arm64.

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the full pre-commit checks with `./isaaclab.sh --format` (host platform unsupported; applicable hooks passed)
- [x] Documentation changes are not required for this workflow-only fix
- [x] My changes generate no new warnings
- [x] The full link-check command proves the fix is effective
- [x] No changelog fragment is required because no source package changed
- [x] My name already exists in `CONTRIBUTORS.md`