### PR TITLE
Make carb optional so teleop imports without Kit

### DIFF
--- a/source/isaaclab_teleop/changelog.d/rwiltz-teleop-optional-carb.rst
+++ b/source/isaaclab_teleop/changelog.d/rwiltz-teleop-optional-carb.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed ``from isaaclab_teleop import IsaacTeleopDevice`` raising ``ModuleNotFoundError: No module named 'carb'``
+  on hosts without Isaac Sim installed. :mod:`~isaaclab_teleop.xr_anchor_manager` now imports ``carb`` with the
+  same optional fallback it already used for ``omni.kit.xr.core``, so headless sessions that never start an XR
+  runtime can import the device. The XR render and anchor settings are skipped when Kit is absent; behavior with
+  Kit present is unchanged.

--- a/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
+++ b/source/isaaclab_teleop/isaaclab_teleop/xr_anchor_manager.py
@@ -13,12 +13,14 @@ import logging
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-import carb
-
 from .xr_anchor_utils import XrAnchorSynchronizer
 from .xr_cfg import XrCfg
 
-# Import XR components with fallback for testing
+# Import Kit components with fallback for sessions without Kit
+carb = None
+with contextlib.suppress(ModuleNotFoundError):
+    import carb
+
 XRCore = None
 XRCoreEventType = None
 with contextlib.suppress(ModuleNotFoundError):
@@ -116,7 +118,7 @@ class XrAnchorManager:
                 logger.warning(f"Failed to create XR anchor prim: {e}")
 
         # Configure carb settings for XR rendering
-        if hasattr(carb, "settings"):
+        if carb is not None and hasattr(carb, "settings"):
             carb.settings.get_settings().set_float("/persistent/xr/render/nearPlane", self._xr_cfg.near_plane)
             carb.settings.get_settings().set_string("/persistent/xr/anchorMode", "custom anchor")
             carb.settings.get_settings().set_string("/xrstage/customAnchor", self._xr_anchor_headset_path)


### PR DESCRIPTION
# Description
xr_anchor_manager imported carb at module scope, and isaac_teleop_device imports XrAnchorManager at module scope, so `from isaaclab_teleop import IsaacTeleopDevice` raised ModuleNotFoundError on hosts without Isaac Sim installed -- blocking headless sessions that never start an XR runtime.

carb is now imported with the same contextlib.suppress fallback the file already used for omni.kit.xr.core. Its only use site was already guarded, so the three XR render/anchor settings are skipped when Kit is absent, which is correct with no XR runtime to configure. Behavior with Kit present is unchanged.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there