### PR TITLE
Remove per-step host synchronizations from the environment hot path

### DIFF
--- a/source/isaaclab/changelog.d/perf-remove-hot-path-host-syncs.rst
+++ b/source/isaaclab/changelog.d/perf-remove-hot-path-host-syncs.rst
@@ -1,0 +1,12 @@
+Changed
+^^^^^^^
+
+* Removed per-step host-device synchronizations from the environment hot path: scalar index
+  assignments in reset paths (:class:`~isaaclab.utils.buffers.CircularBuffer`,
+  :class:`~isaaclab.managers.RewardManager`, :class:`~isaaclab.managers.EventManager`, joint action
+  terms, :class:`~isaaclab.sensors.SensorBase`, :class:`~isaaclab.envs.ManagerBasedRLEnv`) now use
+  device-side fills, :class:`~isaaclab.managers.TerminationManager` updates its last-episode bookkeeping
+  with a masked write instead of ``nonzero``, :class:`~isaaclab.markers.VisualizationMarkers` skips the
+  synchronizing environment-index validation when no visualizer backend consumes marker state, :class:`~isaaclab.sensors.Camera` skips the
+  device-to-host outdated-mask readback for sensors with ``update_period == 0``, and zero-range uniform
+  noise is treated as the identity.

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -447,7 +447,10 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         info = self.recorder_manager.reset(env_ids)
         self.extras["log"].update(info)
 
-        # reset the episode length buffer
-        self.episode_length_buf[env_ids] = 0
+        # reset the episode length buffer (device-side fill avoids a host scalar upload + stream sync)
+        if isinstance(env_ids, slice):
+            self.episode_length_buf[env_ids] = 0
+        else:
+            self.episode_length_buf.index_fill_(0, torch.as_tensor(env_ids, device=self.device).long(), 0)
 
         self.sim.render_context.reset_scene_state_cadence()

--- a/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
+++ b/source/isaaclab/isaaclab/envs/mdp/actions/joint_actions.py
@@ -179,7 +179,11 @@ class JointAction(ActionTerm):
             )
 
     def reset(self, env_ids: Sequence[int] | None = None) -> None:
-        self._raw_actions[env_ids] = 0.0
+        if env_ids is None or isinstance(env_ids, slice):
+            self._raw_actions[env_ids] = 0.0
+        else:
+            # device-side fill: a scalar index assignment synchronizes the stream on every call
+            self._raw_actions.index_fill_(0, torch.as_tensor(env_ids, device=self.device).long(), 0.0)
 
 
 class JointPositionAction(JointAction):

--- a/source/isaaclab/isaaclab/managers/event_manager.py
+++ b/source/isaaclab/isaaclab/managers/event_manager.py
@@ -255,8 +255,16 @@ class EventManager(ManagerBase):
                 # We bypass the trigger mechanism if min_step_count is zero, i.e. apply term on every reset call.
                 # This should avoid the overhead of checking the trigger condition.
                 if min_step_count == 0:
-                    self._reset_term_last_triggered_step_id[index][env_ids] = global_env_step_count
-                    self._reset_term_last_triggered_once[index][env_ids] = True
+                    # device-side fills: scalar index assignments synchronize the stream on every call
+                    if isinstance(env_ids, slice):
+                        self._reset_term_last_triggered_step_id[index].fill_(global_env_step_count)
+                        self._reset_term_last_triggered_once[index].fill_(True)
+                    else:
+                        env_ids_long = torch.as_tensor(env_ids, device=self.device).long()
+                        self._reset_term_last_triggered_step_id[index].index_fill_(
+                            0, env_ids_long, global_env_step_count
+                        )
+                        self._reset_term_last_triggered_once[index].index_fill_(0, env_ids_long, True)
 
                     # call the event term with the environment indices
                     term_cfg.func(self._env, env_ids, **term_cfg.params)

--- a/source/isaaclab/isaaclab/managers/reward_manager.py
+++ b/source/isaaclab/isaaclab/managers/reward_manager.py
@@ -118,8 +118,11 @@ class RewardManager(ManagerBase):
             # r_1 + r_2 + ... + r_n
             episodic_sum_avg = torch.mean(self._episode_sums[key][env_ids])
             extras["Episode_Reward/" + key] = episodic_sum_avg / self._env.max_episode_length_s
-            # reset episodic sum
-            self._episode_sums[key][env_ids] = 0.0
+            # reset episodic sum (device-side fill: a scalar assignment would synchronize the stream)
+            if isinstance(env_ids, slice):
+                self._episode_sums[key].fill_(0.0)
+            else:
+                self._episode_sums[key].index_fill_(0, torch.as_tensor(env_ids, device=self.device).long(), 0.0)
         # reset all the reward terms
         for term_cfg in self._class_term_cfgs:
             term_cfg.func.reset(env_ids=env_ids)

--- a/source/isaaclab/isaaclab/managers/termination_manager.py
+++ b/source/isaaclab/isaaclab/managers/termination_manager.py
@@ -176,9 +176,8 @@ class TerminationManager(ManagerBase):
             self._term_dones[:, i] = value
         # update last-episode dones once per compute: for any env where a term fired,
         # reflect exactly which term(s) fired this step and clear others
-        rows = self._term_dones.any(dim=1).nonzero(as_tuple=True)[0]
-        if rows.numel() > 0:
-            self._last_episode_dones[rows] = self._term_dones[rows]
+        fired = self._term_dones.any(dim=1, keepdim=True)
+        torch.where(fired, self._term_dones, self._last_episode_dones, out=self._last_episode_dones)
         # return combined termination signal
         return self._truncated_buf | self._terminated_buf
 

--- a/source/isaaclab/isaaclab/markers/visualization_markers.py
+++ b/source/isaaclab/isaaclab/markers/visualization_markers.py
@@ -229,7 +229,9 @@ class VisualizationMarkers:
             norm_marker_indices = norm_marker_indices.to(device=target_device)
         if norm_environment_ids is not None:
             norm_environment_ids = norm_environment_ids.to(device=target_device)
-            if torch.any(norm_environment_ids < 0):
+            # the device->host readback synchronizes the stream every call; only pay for it when a
+            # backend will consume the indices
+            if self._backends and torch.any(norm_environment_ids < 0):
                 raise ValueError("Expected `environment_ids` to contain non-negative indices.")
 
         marker_values = (norm_translations, norm_orientations, norm_scales, norm_marker_indices)

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -603,7 +603,10 @@ class Camera(SensorBase):
         self._create_buffers()
 
     def _update_buffers_impl(self, env_mask: wp.array):
-        if not self._env_mask_has_any(env_mask):
+        # With ``update_period == 0`` every ``update()`` marks all cameras outdated and the
+        # generation check in ``_update_outdated_buffers`` already skips redundant fetches, so the
+        # device->host mask readback (a full stream synchronization) is only needed for periodic sensors.
+        if self.cfg.update_period > 0 and not self._env_mask_has_any(env_mask):
             return
         # Increment frame count
         if self.cfg.update_latest_camera_pose:

--- a/source/isaaclab/isaaclab/sensors/sensor_base.py
+++ b/source/isaaclab/isaaclab/sensors/sensor_base.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+import torch
 import warp as wp
 
 import isaaclab.sim as sim_utils
@@ -428,7 +429,8 @@ class SensorBase(ABC):
             return env_mask
         else:
             self._reset_mask.zero_()
-            self._reset_mask_torch[env_ids] = True
+            # device-side fill: a scalar index assignment synchronizes the stream on every call
+            self._reset_mask_torch.index_fill_(0, torch.as_tensor(env_ids, device=self._device).long(), True)
             return self._reset_mask
 
     def _resolve_rigid_body_ancestor_expr(

--- a/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
+++ b/source/isaaclab/isaaclab/utils/buffers/circular_buffer.py
@@ -142,20 +142,22 @@ class CircularBuffer:
         # nothing to reset; arming the backfill would cost one full-buffer pass in append
         if batch_ids is not None and len(batch_ids) == 0:
             return
-        batch_ids_resolved: Sequence[int] | slice
+        # ``index_fill_`` instead of ``x[ids] = scalar``: the scalar assignment uploads a host scalar
+        # on every call, which synchronizes the stream; the fill runs fully on the device.
         if batch_ids is None:
-            batch_ids_resolved = slice(None)
+            self._num_pushes.fill_(0)
         else:
-            batch_ids_resolved = batch_ids
-        self._num_pushes[batch_ids_resolved] = 0
+            batch_ids_t = torch.as_tensor(batch_ids, device=self._device).long()
+            self._num_pushes.index_fill_(0, batch_ids_t, 0)
         self._need_reset = True
         if self._buffer is not None:
             # set buffer at batch_id reset indices to 0.0 so that the buffer() getter returns
             # the cleared circular buffer after reset.
-            if self._stack_dim_internal is None:
-                self._buffer[:, batch_ids_resolved] = 0.0
+            batch_dim = 1 if self._stack_dim_internal is None else 0
+            if batch_ids is None:
+                self._buffer.fill_(0.0)
             else:
-                self._buffer[batch_ids_resolved] = 0.0
+                self._buffer.index_fill_(batch_dim, batch_ids_t, 0.0)
 
     def append(self, data: torch.Tensor):
         """Append the data to the circular buffer.

--- a/source/isaaclab/isaaclab/utils/noise/noise_model.py
+++ b/source/isaaclab/isaaclab/utils/noise/noise_model.py
@@ -62,6 +62,11 @@ def uniform_noise(data: torch.Tensor, cfg: noise_cfg.UniformNoiseCfg) -> torch.T
         cfg.n_min = cfg.n_min.to(data.device)
 
     if cfg.operation == "add":
+        # a degenerate zero-width range (e.g. a curriculum that has not started ramping the noise yet)
+        # is the identity: skip the random draw and the add pass
+        if not isinstance(cfg.n_min, torch.Tensor) and not isinstance(cfg.n_max, torch.Tensor):
+            if cfg.n_min == 0.0 and cfg.n_max == 0.0:
+                return data
         return data + torch.rand_like(data) * (cfg.n_max - cfg.n_min) + cfg.n_min
     elif cfg.operation == "scale":
         return data * (torch.rand_like(data) * (cfg.n_max - cfg.n_min) + cfg.n_min)

--- a/source/isaaclab_newton/changelog.d/perf-remove-hot-path-host-syncs.rst
+++ b/source/isaaclab_newton/changelog.d/perf-remove-hot-path-host-syncs.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed :class:`~isaaclab_newton.physics.NewtonManager` to upload the sensor-graph task flags only
+  when they change, avoiding a synchronizing pageable host-to-device copy on every camera render.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -443,6 +443,7 @@ class NewtonManager(PhysicsManager):
     _sensor_state: State | None = None
     _sensor_state_dirty: bool = True
     _sensor_graph_capture_failed: bool = False
+    _sensor_flags_uploaded: np.ndarray | None = None
     _sensor_bvh_shape_flags: ShapeFlags = ShapeFlags.VISIBLE
 
     # USD/Fabric sync
@@ -2630,7 +2631,11 @@ class NewtonManager(PhysicsManager):
         task_names = tuple(cls._sensor_tasks)
         for name in names:
             cls._sensor_flags_host[1 + task_names.index(name)] = 1
-        cls._sensor_flags.assign(cls._sensor_flags_host)
+        # The host->device flag upload is a pageable copy that synchronizes the stream; the flags are
+        # identical on steady-state steps, so only upload when they differ from the last launch.
+        if cls._sensor_flags_uploaded is None or not np.array_equal(cls._sensor_flags_uploaded, cls._sensor_flags_host):
+            cls._sensor_flags.assign(cls._sensor_flags_host)
+            cls._sensor_flags_uploaded = cls._sensor_flags_host.copy()
         wp.capture_launch(cls._sensor_graph)
         cls._sensor_state_dirty = False
 
@@ -2678,6 +2683,7 @@ class NewtonManager(PhysicsManager):
         cls._sensor_graph = None
         cls._sensor_flags = None
         cls._sensor_flags_host = None
+        cls._sensor_flags_uploaded = None
         cls._sensor_graph_capture_failed = False
 
     @classmethod

--- a/source/isaaclab_tasks/changelog.d/perf-remove-hot-path-host-syncs.rst
+++ b/source/isaaclab_tasks/changelog.d/perf-remove-hot-path-host-syncs.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed the lift task progress rewards and ``object_ee_distance`` to use masked ``torch.where``
+  updates and a cached device index tensor instead of boolean-mask indexing and Python-list indexing,
+  removing five stream synchronizations per environment step, and fused the camera observation
+  normalization into a single conversion pass.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/observations.py
@@ -228,19 +228,26 @@ class vision_camera(ManagerTermBase):
         self, env: ManagerBasedRLEnv, sensor_cfg: SceneEntityCfg, normalize: bool = True
     ) -> torch.Tensor:  # obtain the input image
         images = self.sensor.data.output[self.sensor_type]
-        torch.nan_to_num_(images, nan=1e6)
+        if images.is_floating_point():
+            torch.nan_to_num_(images, nan=1e6)
         if normalize:
+            # one fused pass: NHWC (uint8 or float) -> NCHW float32, then normalize in place. Each
+            # extra elementwise pass over the 4096x3x64x64 batch is ~200 MB of traffic per step.
+            images = images.permute(0, 3, 1, 2).to(dtype=torch.float32, memory_format=torch.contiguous_format)
             images = self.norm_fn(images)
-            images = images.permute(0, 3, 1, 2).contiguous()
         return images
 
     def _rgb_norm(self, images: torch.Tensor) -> torch.Tensor:
-        return images.float() / 255.0 - 0.5
+        if images.dtype != torch.float32:
+            images = images.float()
+        return images.mul_(1.0 / 255.0).sub_(0.5)
 
     def _depth_norm(self, images: torch.Tensor) -> torch.Tensor:
         # same [-0.5, 0.5) span as the RGB normalization: a wider depth range doubles the
         # encoder's effective input scale and halves the stable learning-rate budget
-        return torch.tanh(images / 2) - 0.5
+        if images.dtype != torch.float32:
+            images = images.float()
+        return torch.tanh_(images.mul_(0.5)).sub_(0.5)
 
     def show_collage(self, images: torch.Tensor, save_path: str = "collage.png"):
         import matplotlib

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/mdp/rewards.py
@@ -47,7 +47,15 @@ def object_ee_distance(
     """
     asset: RigidObject = env.scene[asset_cfg.name]
     obj: RigidObject = env.scene[object_cfg.name]
-    asset_pos = asset.data.body_pos_w.torch[:, asset_cfg.body_ids]
+    # index with a cached device tensor: indexing with a Python list uploads it every call (a stream sync)
+    body_ids = asset_cfg.body_ids
+    if isinstance(body_ids, list):
+        body_ids_t = getattr(asset_cfg, "_body_ids_device", None)
+        if body_ids_t is None:
+            body_ids_t = torch.tensor(body_ids, dtype=torch.long, device=env.device)
+            asset_cfg._body_ids_device = body_ids_t
+        body_ids = body_ids_t
+    asset_pos = asset.data.body_pos_w.torch[:, body_ids]
     object_pos = obj.data.root_pos_w.torch
     distance = torch.linalg.norm(asset_pos - object_pos[:, None, :], dim=-1).max(dim=-1).values
     contact_bonus = contacts(env, contact_threshold, thumb_name, finger_names).float().clamp(0.1, 1.0)
@@ -252,6 +260,7 @@ class _ProgressReward(ManagerTermBase):
         super().__init__(cfg, env)
         # inf marks an environment whose bar has not been seeded yet against its current command
         self.best_error = torch.full((env.num_envs,), float("inf"), device=env.device)
+        self._inf = torch.full_like(self.best_error, float("inf"))
         self._prev_command: torch.Tensor | None = None
 
     def reset(self, env_ids: Sequence[int] | None = None):
@@ -275,15 +284,18 @@ class _ProgressReward(ManagerTermBase):
         """
         # a resampled command changes the error's reference, so the bar it was measured against no
         # longer applies; dropping it to inf re-seeds from the first error under the new command
+        # masked writes via torch.where: boolean-mask indexing (``x[mask] = v``) launches a nonzero and
+        # a host->device scalar copy, each of which synchronizes the stream every step
         if self._prev_command is None:
             self._prev_command = command.clone()
         else:
-            self.best_error[(self._prev_command != command).any(dim=1)] = float("inf")
+            resampled = (self._prev_command != command).any(dim=1)
+            torch.where(resampled, self._inf, self.best_error, out=self.best_error)
             self._prev_command.copy_(command)
         unseeded = torch.isinf(self.best_error)
-        self.best_error[unseeded] = error[unseeded]
+        torch.where(unseeded, error, self.best_error, out=self.best_error)
         improved = gate & (error < self.best_error - min_improvement)
-        self.best_error[improved] = error[improved]
+        torch.where(improved, error, self.best_error, out=self.best_error)
         return improved.float()
 
 


### PR DESCRIPTION
# Description

Profiling `Isaac-Lift-KukaAllegro-Camera` on Newton/MJWarp (4096 envs, Newton Warp tiled camera, RTX PRO 6000) showed that the env step is bound by a CPU-only tail (rewards, reset, commands, observation terms) that runs while the GPU idles, and that ~40 host-device synchronizations per step keep host work from overlapping device work. This PR removes the synchronizations that are pure integration overhead and keeps behavior unchanged:

- `isaaclab`: scalar index assignments (`x[ids] = scalar`, a host scalar upload + stream sync each) in `CircularBuffer.reset`, `RewardManager.reset`, `EventManager.apply` (reset mode), `JointAction.reset`, `SensorBase._resolve_indices_and_mask`, and the episode-length reset now use `index_fill_`; `TerminationManager.compute` updates last-episode bookkeeping with a masked `torch.where` instead of `nonzero`; `VisualizationMarkers.visualize` skips the synchronizing environment-index validation when no visualizer backend consumes marker state; `Camera` skips the device->host outdated-mask readback when `update_period == 0` (the generation check already dedupes fetches); zero-range uniform noise returns its input.
- `isaaclab_newton`: `NewtonManager._update_sensor_tasks` only uploads the sensor-graph flags when they change (the pageable host->device `assign` synchronized the stream on every render).
- `isaaclab_tasks` (lift task): the progress rewards use `torch.where(..., out=)` instead of boolean-mask writes (4 syncs per step, right after physics), `object_ee_distance` indexes with a cached device tensor instead of a Python list, and the camera observation converts/normalizes in one fused pass without a NaN scrub on uint8 images.

Measured with `uv run isaaclab benchmark runtime --task Isaac-Lift-KukaAllegro-Camera --num_envs 4096 --num_steps 500 --warmup_steps 50 --visualizer none` (sequential runs):

| build | 4096 envs | 8192 envs |
|---|---|---|
| develop @ 4f154633e | 148.6k FPS | 178.3k FPS |
| this PR | 155.1k FPS (+4.4%) | 199.1k FPS (+11.7%) |
| this PR + `sim.use_newton_actuators=True` | 156.2k FPS (+5.1%) | |

The reward-term change accounts for most of the 4096-env gain; the others are individually within measurement noise but remove ~25 stream synchronizations per step and are prerequisites for a fully asynchronous (mask-based reset) step, which a non-mergeable prototype measured at +19-22% (177k-181k FPS). A full breakdown (physics graph 12.2 ms wall / 8.0 ms kernels, render 7.3 ms, CPU tail ~7 ms) is available on request.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Existing tests run locally: `test_circular_buffer.py`, `test_noise.py`, `test_termination_manager.py`, `test_reward_manager.py`, `test_event_manager.py`, `test_visualization_markers.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
