### PR TITLE
Fix SpaceMouse detection failing when the HID backend reports no product string

### DIFF
--- a/docs/source/overview/imitation-learning/teleop_imitation.rst
+++ b/docs/source/overview/imitation-learning/teleop_imitation.rst
@@ -192,7 +192,8 @@ the key bindings are:
          - "c 189:* rmw"
 
    Isaac Lab supports the SpaceMouse Compact, SpaceMouse Wireless and SpaceNavigator for Notebooks
-   from 3Dconnexion. SE(3) teleoperation additionally supports the 3Dconnexion Universal Receiver.
+   from 3Dconnexion. SE(3) teleoperation additionally supports the SpaceNavigator and the
+   3Dconnexion Universal Receiver.
 
 
 

--- a/docs/source/overview/imitation-learning/teleop_imitation.rst
+++ b/docs/source/overview/imitation-learning/teleop_imitation.rst
@@ -159,22 +159,33 @@ the key bindings are:
 
 .. tip::
 
-   If the SpaceMouse is not detected, you may need to grant additional user permissions by running ``sudo chmod 666 /dev/hidraw<#>`` where ``<#>`` corresponds to the device index
-   of the connected SpaceMouse.
+   If the SpaceMouse is not detected, you most likely need additional user permissions. The ``hidapi``
+   wheel installed by Isaac Lab bundles a backend that talks to the device over ``libusb``, so it needs
+   read and write access to the USB node under ``/dev/bus/usb`` -- granting access to ``/dev/hidraw*``
+   alone is **not** sufficient, and without USB access the device is enumerated without a product name.
 
-   To determine the device index, list all ``hidraw`` devices by running ``ls -l /dev/hidraw*``.
-   Identify the device corresponding to the SpaceMouse by running ``cat /sys/class/hidraw/hidraw<#>/device/uevent`` on each of the devices listed
-   from the prior step.
+   Grant the permission by installing a udev rule for the 3Dconnexion vendor id:
 
-   We recommend using local deployment of Isaac Lab to use the SpaceMouse. If using container deployment (:ref:`deployment-docker`), you must manually mount the SpaceMouse to the ``isaac-lab-base`` container by
-   adding a ``devices`` attribute with the path to the device in your ``docker-compose.yaml`` file:
+   .. code:: bash
+
+      sudo tee /etc/udev/rules.d/99-spacemouse.rules <<'EOF'
+      SUBSYSTEM=="usb", ATTR{idVendor}=="256f", MODE="0666"
+      KERNEL=="hidraw*", ATTRS{idVendor}=="256f", MODE="0666"
+      EOF
+      sudo udevadm control --reload-rules && sudo udevadm trigger
+
+   Then unplug and reconnect the SpaceMouse. Older 3Dconnexion models such as the SpaceNavigator for
+   Notebooks enumerate under the Logitech vendor id, so replace ``256f`` with ``046d`` for those.
+
+   We recommend using local deployment of Isaac Lab to use the SpaceMouse. If using container deployment (:ref:`deployment-docker`), you must give the ``isaac-lab-base`` container access to the USB bus by
+   mounting it and allowing its device cgroup in your ``docker-compose.yaml`` file:
 
    .. code:: yaml
 
-      devices:
-         - /dev/hidraw<#>:/dev/hidraw<#>
-
-   where ``<#>`` is the device index of the connected SpaceMouse.
+      volumes:
+         - /dev/bus/usb:/dev/bus/usb
+      device_cgroup_rules:
+         - "c 189:* rmw"
 
    Isaac Lab is only compatible with the SpaceMouse Wireless and SpaceMouse Compact models from 3Dconnexion.
 

--- a/docs/source/overview/imitation-learning/teleop_imitation.rst
+++ b/docs/source/overview/imitation-learning/teleop_imitation.rst
@@ -168,14 +168,18 @@ the key bindings are:
 
    .. code:: bash
 
+      sudo groupadd -f plugdev && sudo usermod -aG plugdev "$USER"
       sudo tee /etc/udev/rules.d/99-spacemouse.rules <<'EOF'
-      SUBSYSTEM=="usb", ATTR{idVendor}=="256f", MODE="0666"
-      KERNEL=="hidraw*", ATTRS{idVendor}=="256f", MODE="0666"
+      SUBSYSTEM=="usb", ATTR{idVendor}=="256f", TAG+="uaccess", GROUP="plugdev", MODE="0660"
+      KERNEL=="hidraw*", ATTRS{idVendor}=="256f", TAG+="uaccess", GROUP="plugdev", MODE="0660"
       EOF
       sudo udevadm control --reload-rules && sudo udevadm trigger
 
-   Then unplug and reconnect the SpaceMouse. Older 3Dconnexion models such as the SpaceNavigator for
-   Notebooks enumerate under the Logitech vendor id, so replace ``256f`` with ``046d`` for those.
+   Then unplug and reconnect the SpaceMouse, and log out and back in so the new group membership
+   applies. The rule grants access to the user on the local seat (``uaccess``) and to members of
+   ``plugdev``, rather than to every account on the machine; the ``plugdev`` membership is what makes
+   it work over SSH, where there is no local seat. Older 3Dconnexion models such as the SpaceNavigator
+   for Notebooks enumerate under the Logitech vendor id, so replace ``256f`` with ``046d`` for those.
 
    We recommend using local deployment of Isaac Lab to use the SpaceMouse. If using container deployment (:ref:`deployment-docker`), you must give the ``isaac-lab-base`` container access to the USB bus by
    mounting it and allowing its device cgroup in your ``docker-compose.yaml`` file:
@@ -187,7 +191,8 @@ the key bindings are:
       device_cgroup_rules:
          - "c 189:* rmw"
 
-   Isaac Lab is only compatible with the SpaceMouse Wireless and SpaceMouse Compact models from 3Dconnexion.
+   Isaac Lab supports the SpaceMouse Compact, SpaceMouse Wireless and SpaceNavigator for Notebooks
+   from 3Dconnexion. SE(3) teleoperation additionally supports the 3Dconnexion Universal Receiver.
 
 
 

--- a/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
+++ b/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
@@ -4,6 +4,7 @@ Fixed
 * Fixed :class:`~isaaclab.devices.Se2SpaceMouse` and :class:`~isaaclab.devices.Se3SpaceMouse` failing with
   ``No device found by SpaceMouse`` when a supported 3Dconnexion device was connected. Detection matched the
   HID product string exactly, which the ``libusb`` backend bundled in the ``hidapi`` wheels leaves empty
-  unless the process may open the USB node. Devices are now matched by their USB vendor and product ids, and
+  unless the process may open the USB node. Directly attached devices are now matched by their USB vendor
+  and product ids, with the product string kept as a fallback, and
   the errors raised when a device cannot be found or opened name the enumerated devices and the required
   permissions.

--- a/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
+++ b/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
@@ -9,3 +9,5 @@ Fixed
   found or opened name the enumerated devices and the required permissions.
 * Fixed SpaceMouse discovery giving up when the first supported device could not be opened. Discovery now
   continues to the remaining devices and only reports the open failures if none of them could be opened.
+* Added the USB identifier of the 3Dconnexion SpaceNavigator, so the device added in :github:`7544` is also
+  detected when the HID backend cannot read its product string.

--- a/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
+++ b/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
@@ -5,6 +5,7 @@ Fixed
   ``No device found by SpaceMouse`` when a supported 3Dconnexion device was connected. Detection matched the
   HID product string exactly, which the ``libusb`` backend bundled in the ``hidapi`` wheels leaves empty
   unless the process may open the USB node. Directly attached devices are now matched by their USB vendor
-  and product ids, with the product string kept as a fallback, and
-  the errors raised when a device cannot be found or opened name the enumerated devices and the required
-  permissions.
+  and product ids, with the product string kept as a fallback, and the errors raised when a device cannot be
+  found or opened name the enumerated devices and the required permissions.
+* Fixed SpaceMouse discovery giving up when the first supported device could not be opened. Discovery now
+  continues to the remaining devices and only reports the open failures if none of them could be opened.

--- a/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
+++ b/source/isaaclab/changelog.d/rwiltz-fix-spacemouse-detection.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.devices.Se2SpaceMouse` and :class:`~isaaclab.devices.Se3SpaceMouse` failing with
+  ``No device found by SpaceMouse`` when a supported 3Dconnexion device was connected. Detection matched the
+  HID product string exactly, which the ``libusb`` backend bundled in the ``hidapi`` wheels leaves empty
+  unless the process may open the USB node. Devices are now matched by their USB vendor and product ids, and
+  the errors raised when a device cannot be found or opened name the enumerated devices and the required
+  permissions.

--- a/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
@@ -19,7 +19,7 @@ import torch
 from isaaclab.utils.array import convert_to_torch
 
 from ..device_base import DeviceBase
-from .utils import convert_buffer, device_not_found_message, open_device, resolve_device_name
+from .utils import convert_buffer, describe_open_failure, device_not_found_message, resolve_device_name
 
 if TYPE_CHECKING:
     from .se2_spacemouse_cfg import Se2SpaceMouseCfg
@@ -118,19 +118,31 @@ class Se2SpaceMouse(DeviceBase):
     def _find_device(self):
         """Find the device connected to computer."""
         found = False
-        enumerated_devices = []
+        enumerated_devices: list = []
+        open_failures: list[str] = []
+        last_error: OSError | None = None
         # implement a timeout for device search
         for _ in range(5):
             enumerated_devices = hid.enumerate()
+            # a supported device that cannot be opened must not hide another one that can, so keep
+            # scanning and only report the failures if no device could be opened at all
+            open_failures = []
             for device in enumerated_devices:
                 device_name = resolve_device_name(device, self.SUPPORTED_DEVICES)
-                if device_name is not None:
-                    # set found flag
-                    found = True
-                    vendor_id = device["vendor_id"]
-                    product_id = device["product_id"]
-                    # connect to the device
-                    open_device(self._device, vendor_id, product_id, device_name)
+                if device_name is None:
+                    continue
+                vendor_id = device["vendor_id"]
+                product_id = device["product_id"]
+                # connect to the device
+                try:
+                    self._device.open(vendor_id, product_id)
+                except OSError as exc:
+                    open_failures.append(describe_open_failure(device_name, vendor_id, product_id, exc))
+                    last_error = exc
+                    continue
+                # set found flag
+                found = True
+                break
             # check if device found
             if not found:
                 time.sleep(1.0)
@@ -138,7 +150,9 @@ class Se2SpaceMouse(DeviceBase):
                 break
         # no device found: return false
         if not found:
-            raise OSError(device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices))
+            raise OSError(
+                device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices, open_failures)
+            ) from last_error
 
     def _run_device(self):
         """Listener thread that keeps pulling new messages."""

--- a/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se2_spacemouse.py
@@ -19,7 +19,7 @@ import torch
 from isaaclab.utils.array import convert_to_torch
 
 from ..device_base import DeviceBase
-from .utils import convert_buffer
+from .utils import convert_buffer, device_not_found_message, open_device, resolve_device_name
 
 if TYPE_CHECKING:
     from .se2_spacemouse_cfg import Se2SpaceMouseCfg
@@ -43,6 +43,9 @@ class Se2SpaceMouse(DeviceBase):
     .. _HID-API: https://github.com/libusb/hidapi
 
     """
+
+    SUPPORTED_DEVICES = ("SpaceMouse Compact", "SpaceNavigator for Notebooks")
+    """Product names of the 3Dconnexion models handled by this device."""
 
     def __init__(self, cfg: Se2SpaceMouseCfg):
         """Initialize the spacemouse layer.
@@ -115,19 +118,19 @@ class Se2SpaceMouse(DeviceBase):
     def _find_device(self):
         """Find the device connected to computer."""
         found = False
+        enumerated_devices = []
         # implement a timeout for device search
         for _ in range(5):
-            for device in hid.enumerate():
-                if (
-                    device["product_string"] == "SpaceMouse Compact"
-                    or device["product_string"] == "SpaceNavigator for Notebooks"
-                ):
+            enumerated_devices = hid.enumerate()
+            for device in enumerated_devices:
+                device_name = resolve_device_name(device, self.SUPPORTED_DEVICES)
+                if device_name is not None:
                     # set found flag
                     found = True
                     vendor_id = device["vendor_id"]
                     product_id = device["product_id"]
                     # connect to the device
-                    self._device.open(vendor_id, product_id)
+                    open_device(self._device, vendor_id, product_id, device_name)
             # check if device found
             if not found:
                 time.sleep(1.0)
@@ -135,7 +138,7 @@ class Se2SpaceMouse(DeviceBase):
                 break
         # no device found: return false
         if not found:
-            raise OSError("No device found by SpaceMouse. Is the device connected?")
+            raise OSError(device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices))
 
     def _run_device(self):
         """Listener thread that keeps pulling new messages."""

--- a/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
@@ -18,7 +18,7 @@ import torch
 from scipy.spatial.transform import Rotation
 
 from ..device_base import DeviceBase
-from .utils import convert_buffer
+from .utils import convert_buffer, device_not_found_message, open_device, resolve_device_name
 
 if TYPE_CHECKING:
     from .se3_spacemouse_cfg import Se3SpaceMouseCfg
@@ -45,6 +45,15 @@ class Se3SpaceMouse(DeviceBase):
     .. _HID-API: https://github.com/libusb/hidapi
 
     """
+
+    SUPPORTED_DEVICES = (
+        "SpaceMouse Compact",
+        "SpaceMouse Wireless",
+        "SpaceNavigator",
+        "SpaceNavigator for Notebooks",
+        "3Dconnexion Universal Receiver",
+    )
+    """Product names of the 3Dconnexion models handled by this device."""
 
     def __init__(self, cfg: Se3SpaceMouseCfg):
         """Initialize the space-mouse layer.
@@ -134,24 +143,21 @@ class Se3SpaceMouse(DeviceBase):
     def _find_device(self):
         """Find the device connected to computer."""
         found = False
+        enumerated_devices = []
         # implement a timeout for device search
         for _ in range(5):
-            for device in hid.enumerate():
-                if (
-                    device["product_string"] == "SpaceMouse Compact"
-                    or device["product_string"] == "SpaceMouse Wireless"
-                    or device["product_string"] == "SpaceNavigator for Notebooks"
-                    or device["product_string"] == "3Dconnexion Universal Receiver"
-                    or device["product_string"] == "SpaceNavigator"
-                ):
+            enumerated_devices = hid.enumerate()
+            for device in enumerated_devices:
+                device_name = resolve_device_name(device, self.SUPPORTED_DEVICES)
+                if device_name is not None:
                     # set found flag
                     found = True
                     vendor_id = device["vendor_id"]
                     product_id = device["product_id"]
                     # connect to the device
                     self._device.close()
-                    self._device.open(vendor_id, product_id)
-                    self._device_name = device["product_string"]
+                    open_device(self._device, vendor_id, product_id, device_name)
+                    self._device_name = device_name
             # check if device found
             if not found:
                 time.sleep(1.0)
@@ -159,7 +165,7 @@ class Se3SpaceMouse(DeviceBase):
                 break
         # no device found: return false
         if not found:
-            raise OSError("No device found by SpaceMouse. Is the device connected?")
+            raise OSError(device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices))
 
     def _run_device(self):
         """Listener thread that keeps pulling new messages."""

--- a/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
@@ -18,7 +18,7 @@ import torch
 from scipy.spatial.transform import Rotation
 
 from ..device_base import DeviceBase
-from .utils import convert_buffer, device_not_found_message, open_device, resolve_device_name
+from .utils import convert_buffer, describe_open_failure, device_not_found_message, resolve_device_name
 
 if TYPE_CHECKING:
     from .se3_spacemouse_cfg import Se3SpaceMouseCfg
@@ -143,21 +143,32 @@ class Se3SpaceMouse(DeviceBase):
     def _find_device(self):
         """Find the device connected to computer."""
         found = False
-        enumerated_devices = []
+        enumerated_devices: list = []
+        open_failures: list[str] = []
+        last_error: OSError | None = None
         # implement a timeout for device search
         for _ in range(5):
             enumerated_devices = hid.enumerate()
+            # a supported device that cannot be opened must not hide another one that can, so keep
+            # scanning and only report the failures if no device could be opened at all
+            open_failures = []
             for device in enumerated_devices:
                 device_name = resolve_device_name(device, self.SUPPORTED_DEVICES)
-                if device_name is not None:
-                    # set found flag
-                    found = True
-                    vendor_id = device["vendor_id"]
-                    product_id = device["product_id"]
-                    # connect to the device
-                    self._device.close()
-                    open_device(self._device, vendor_id, product_id, device_name)
-                    self._device_name = device_name
+                if device_name is None:
+                    continue
+                vendor_id = device["vendor_id"]
+                product_id = device["product_id"]
+                # connect to the device
+                try:
+                    self._device.open(vendor_id, product_id)
+                except OSError as exc:
+                    open_failures.append(describe_open_failure(device_name, vendor_id, product_id, exc))
+                    last_error = exc
+                    continue
+                # set found flag
+                found = True
+                self._device_name = device_name
+                break
             # check if device found
             if not found:
                 time.sleep(1.0)
@@ -165,7 +176,9 @@ class Se3SpaceMouse(DeviceBase):
                 break
         # no device found: return false
         if not found:
-            raise OSError(device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices))
+            raise OSError(
+                device_not_found_message(self.SUPPORTED_DEVICES, enumerated_devices, open_failures)
+            ) from last_error
 
     def _run_device(self):
         """Listener thread that keeps pulling new messages."""

--- a/source/isaaclab/isaaclab/devices/spacemouse/utils.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/utils.py
@@ -53,6 +53,7 @@ def convert_buffer(b1, b2):
 # (see the Universal Receiver branch in the listener threads) and is unverified against hardware, so
 # they are matched by product string only.
 SPACEMOUSE_USB_IDS: dict[tuple[int, int], str] = {
+    (0x046D, 0xC626): "SpaceNavigator",
     (0x256F, 0xC62E): "SpaceMouse Wireless",
     (0x256F, 0xC635): "SpaceMouse Compact",
 }

--- a/source/isaaclab/isaaclab/devices/spacemouse/utils.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/utils.py
@@ -5,6 +5,11 @@
 
 """Helper functions for SpaceMouse."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
 # MIT License
 #
 # Copyright (c) 2022 Stanford Vision and Learning Lab and UT Robot Perception and Learning Lab
@@ -39,6 +44,94 @@ def convert_buffer(b1, b2):
         Scaled value from Space-mouse message
     """
     return _scale_to_control(_to_int16(b1, b2))
+
+
+# USB identifiers of the 3Dconnexion devices supported by Isaac Lab, mapped to the product name that
+# selects the HID report layout used by the device listener threads.
+# Source: USB ID repository maintained at https://www.linux-usb.org/usb.ids
+SPACEMOUSE_USB_IDS: dict[tuple[int, int], str] = {
+    (0x256F, 0xC62E): "SpaceMouse Wireless",
+    (0x256F, 0xC62F): "SpaceMouse Wireless",
+    (0x256F, 0xC635): "SpaceMouse Compact",
+    (0x256F, 0xC652): "3Dconnexion Universal Receiver",
+    (0x046D, 0xC628): "SpaceNavigator for Notebooks",
+}
+"""Mapping from the ``(vendor_id, product_id)`` of a supported SpaceMouse to its product name."""
+
+
+def resolve_device_name(device: dict[str, Any], supported_names: Sequence[str]) -> str | None:
+    """Resolve the product name of an enumerated HID device against the supported SpaceMouse models.
+
+    USB identifiers are matched first, because the ``hidapi`` wheels bundle a backend that reaches the
+    device through ``libusb`` and reports empty product strings unless the process is allowed to open
+    the USB node. Product strings are only used as a fallback, and are matched both verbatim and with
+    the ``"3Dconnexion "`` prefix that some HID backends prepend stripped off.
+
+    Args:
+        device: An entry returned by :func:`hid.enumerate`.
+        supported_names: Product names accepted by the caller.
+
+    Returns:
+        The matched product name, or None if the device is not a supported SpaceMouse.
+    """
+    name = SPACEMOUSE_USB_IDS.get((device["vendor_id"], device["product_id"]))
+    if name in supported_names:
+        return name
+    product_string = (device.get("product_string") or "").strip()
+    for candidate in (product_string, product_string.removeprefix("3Dconnexion ")):
+        if candidate in supported_names:
+            return candidate
+    return None
+
+
+def open_device(hid_device: Any, vendor_id: int, product_id: int, device_name: str):
+    """Open a detected SpaceMouse and re-raise permission failures with actionable guidance.
+
+    Args:
+        hid_device: An unopened :class:`hid.device` handle.
+        vendor_id: USB vendor identifier of the detected device.
+        product_id: USB product identifier of the detected device.
+        device_name: Product name of the detected device, used in the error message.
+
+    Raises:
+        OSError: If the device is present but cannot be opened, typically because the user lacks
+            access to its USB node.
+    """
+    try:
+        hid_device.open(vendor_id, product_id)
+    except OSError as exc:
+        raise OSError(
+            f"Found '{device_name}' ({vendor_id:#06x}:{product_id:#06x}) but failed to open it: {exc}."
+            " On Linux the bundled HID backend reaches the device through libusb, so the user needs"
+            " read and write access to the USB node under '/dev/bus/usb'; granting access to"
+            " '/dev/hidraw*' alone is not sufficient. See the teleoperation documentation for the"
+            " required udev rule."
+        ) from exc
+
+
+def device_not_found_message(supported_names: Sequence[str], enumerated_devices: Sequence[dict[str, Any]]) -> str:
+    """Compose the error raised when no supported SpaceMouse is connected.
+
+    Args:
+        supported_names: Product names accepted by the caller.
+        enumerated_devices: The HID devices reported by :func:`hid.enumerate` during the search.
+
+    Returns:
+        An error message listing the supported models and the HID devices that were seen.
+    """
+    seen = ", ".join(
+        f"{device['vendor_id']:#06x}:{device['product_id']:#06x} ({device.get('product_string') or 'unnamed'})"
+        for device in enumerated_devices
+    )
+    return (
+        "No device found by SpaceMouse. Is the device connected?"
+        f" Supported models: {', '.join(supported_names)}."
+        f" Enumerated HID devices: {seen or 'none'}."
+        " Note that on Linux the bundled HID backend reaches the device through libusb, so the user"
+        " needs read and write access to the USB node under '/dev/bus/usb'; granting access to"
+        " '/dev/hidraw*' alone is not sufficient. See the teleoperation documentation for the"
+        " required udev rule."
+    )
 
 
 """

--- a/source/isaaclab/isaaclab/devices/spacemouse/utils.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/utils.py
@@ -84,41 +84,34 @@ def resolve_device_name(device: dict[str, Any], supported_names: Sequence[str]) 
     return None
 
 
-def open_device(hid_device: Any, vendor_id: int, product_id: int, device_name: str):
-    """Open a detected SpaceMouse and re-raise permission failures with actionable guidance.
-
-    Args:
-        hid_device: An unopened :class:`hid.device` handle.
-        vendor_id: USB vendor identifier of the detected device.
-        product_id: USB product identifier of the detected device.
-        device_name: Product name of the detected device, used in the error message.
-
-    Raises:
-        OSError: If the device is present but cannot be opened, typically because the user lacks
-            access to its USB node.
-    """
-    try:
-        hid_device.open(vendor_id, product_id)
-    except OSError as exc:
-        raise OSError(
-            f"Found '{device_name}' ({vendor_id:#06x}:{product_id:#06x}) but failed to open it: {exc}."
-            " On Linux the bundled HID backend reaches the device through libusb, so the user needs"
-            " read and write access to the USB node under '/dev/bus/usb'; granting access to"
-            " '/dev/hidraw*' alone is not sufficient. See the teleoperation documentation for the"
-            " required udev rule."
-        ) from exc
+_PERMISSION_HINT = (
+    " Note that on Linux the bundled HID backend reaches the device through libusb, so the user needs"
+    " read and write access to the USB node under '/dev/bus/usb'; granting access to '/dev/hidraw*'"
+    " alone is not sufficient. See the teleoperation documentation for the required udev rule."
+)
+"""Guidance appended to the discovery errors, which are almost always caused by USB permissions."""
 
 
-def device_not_found_message(supported_names: Sequence[str], enumerated_devices: Sequence[dict[str, Any]]) -> str:
-    """Compose the error raised when no supported SpaceMouse is connected.
+def device_not_found_message(
+    supported_names: Sequence[str],
+    enumerated_devices: Sequence[dict[str, Any]],
+    open_failures: Sequence[str] = (),
+) -> str:
+    """Compose the error raised when no supported SpaceMouse could be opened.
 
     Args:
         supported_names: Product names accepted by the caller.
         enumerated_devices: The HID devices reported by :func:`hid.enumerate` during the search.
+        open_failures: Descriptions of the supported devices that were found but could not be opened.
 
     Returns:
-        An error message listing the supported models and the HID devices that were seen.
+        An error message naming either the devices that could not be opened, or, when none matched,
+        the supported models and the HID devices that were seen.
     """
+    if open_failures:
+        return (
+            "Found a supported SpaceMouse but could not open it: " + "; ".join(open_failures) + "." + _PERMISSION_HINT
+        )
     seen = ", ".join(
         f"{device['vendor_id']:#06x}:{device['product_id']:#06x} ({device.get('product_string') or 'unnamed'})"
         for device in enumerated_devices
@@ -127,11 +120,22 @@ def device_not_found_message(supported_names: Sequence[str], enumerated_devices:
         "No device found by SpaceMouse. Is the device connected?"
         f" Supported models: {', '.join(supported_names)}."
         f" Enumerated HID devices: {seen or 'none'}."
-        " Note that on Linux the bundled HID backend reaches the device through libusb, so the user"
-        " needs read and write access to the USB node under '/dev/bus/usb'; granting access to"
-        " '/dev/hidraw*' alone is not sufficient. See the teleoperation documentation for the"
-        " required udev rule."
-    )
+    ) + _PERMISSION_HINT
+
+
+def describe_open_failure(device_name: str, vendor_id: int, product_id: int, error: OSError) -> str:
+    """Describe a supported device that was detected but could not be opened.
+
+    Args:
+        device_name: Product name of the detected device.
+        vendor_id: USB vendor identifier of the detected device.
+        product_id: USB product identifier of the detected device.
+        error: The error raised while opening the device.
+
+    Returns:
+        A short description naming the device and the underlying error.
+    """
+    return f"'{device_name}' ({vendor_id:#06x}:{product_id:#06x}): {error}"
 
 
 """

--- a/source/isaaclab/isaaclab/devices/spacemouse/utils.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/utils.py
@@ -46,15 +46,15 @@ def convert_buffer(b1, b2):
     return _scale_to_control(_to_int16(b1, b2))
 
 
-# USB identifiers of the 3Dconnexion devices supported by Isaac Lab, mapped to the product name that
-# selects the HID report layout used by the device listener threads.
-# Source: USB ID repository maintained at https://www.linux-usb.org/usb.ids
+# USB identifiers of the directly attached 3Dconnexion devices, mapped to the product name that
+# selects the HID report layout used by the device listener threads. Identifiers are taken from the
+# community-maintained USB ID repository at https://www.linux-usb.org/usb.ids.
+# Wireless receivers are deliberately left out: their report layout differs from the cabled devices
+# (see the Universal Receiver branch in the listener threads) and is unverified against hardware, so
+# they are matched by product string only.
 SPACEMOUSE_USB_IDS: dict[tuple[int, int], str] = {
     (0x256F, 0xC62E): "SpaceMouse Wireless",
-    (0x256F, 0xC62F): "SpaceMouse Wireless",
     (0x256F, 0xC635): "SpaceMouse Compact",
-    (0x256F, 0xC652): "3Dconnexion Universal Receiver",
-    (0x046D, 0xC628): "SpaceNavigator for Notebooks",
 }
 """Mapping from the ``(vendor_id, product_id)`` of a supported SpaceMouse to its product name."""
 

--- a/source/isaaclab/test/devices/test_device_constructors.py
+++ b/source/isaaclab/test/devices/test_device_constructors.py
@@ -56,7 +56,9 @@ def mock_environment(mocker):
     carb_mock.input.KeyboardEventType.KEY_RELEASE = 2
 
     # Mock the SpaceMouse
-    hid_mock.enumerate.return_value = [{"product_string": "SpaceMouse Compact", "vendor_id": 123, "product_id": 456}]
+    hid_mock.enumerate.return_value = [
+        {"product_string": "SpaceMouse Compact", "vendor_id": 0x256F, "product_id": 0xC635}
+    ]
     hid_mock.device.return_value = device_mock
 
     # Mock Haply WebSocket
@@ -222,6 +224,52 @@ def test_se2spacemouse_constructors(mock_environment, mocker):
     result = spacemouse.advance()
     assert isinstance(result, torch.Tensor)
     assert result.shape == (3,)  # (v_x, v_y, omega_z)
+
+
+@pytest.mark.parametrize(
+    "product_string",
+    [
+        # some HID backends report the kernel's combined name instead of the bare USB product string
+        "3Dconnexion SpaceMouse Compact",
+        # the libusb-based backend bundled in the hidapi wheels reports no product string at all
+        # unless the process is allowed to open the USB node
+        "",
+    ],
+    ids=["prefixed_product_string", "missing_product_string"],
+)
+def test_spacemouse_detected_by_usb_id(mock_environment, mocker, product_string):
+    """SpaceMouse detection must not rely on an exact product string match."""
+    mock_environment["hid"].enumerate.return_value = [
+        {"product_string": product_string, "vendor_id": 0x256F, "product_id": 0xC635}
+    ]
+    for module_name, device_cls, cfg_cls in (
+        ("isaaclab.devices.spacemouse.se2_spacemouse", Se2SpaceMouse, Se2SpaceMouseCfg),
+        ("isaaclab.devices.spacemouse.se3_spacemouse", Se3SpaceMouse, Se3SpaceMouseCfg),
+    ):
+        device_mod = importlib.import_module(module_name)
+        mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+        # the listener thread polls the mocked device in a busy loop; detection is what is under test
+        mocker.patch.object(device_mod, "threading")
+
+        device = device_cls(cfg_cls())
+
+        assert device is not None
+    mock_environment["device"].open.assert_called_with(0x256F, 0xC635)
+
+
+def test_spacemouse_not_found_error_lists_enumerated_devices(mock_environment, mocker):
+    """The error raised when no SpaceMouse is connected should help identify the problem."""
+    mock_environment["hid"].enumerate.return_value = [{"product_string": "", "vendor_id": 0x046D, "product_id": 0xC52F}]
+    device_mod = importlib.import_module("isaaclab.devices.spacemouse.se3_spacemouse")
+    mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+    mocker.patch.object(device_mod.time, "sleep")
+
+    with pytest.raises(OSError) as exc_info:
+        Se3SpaceMouse(Se3SpaceMouseCfg())
+
+    message = str(exc_info.value)
+    assert "0x046d:0xc52f" in message
+    assert "/dev/bus/usb" in message
 
 
 def test_se3spacemouse_constructors(mock_environment, mocker):

--- a/source/isaaclab/test/devices/test_device_constructors.py
+++ b/source/isaaclab/test/devices/test_device_constructors.py
@@ -257,11 +257,45 @@ def test_spacemouse_detected_by_usb_id(mock_environment, mocker, product_string)
     mock_environment["device"].open.assert_called_with(0x256F, 0xC635)
 
 
+def test_spacemouse_skips_devices_that_cannot_be_opened(mock_environment, mocker):
+    """An inaccessible SpaceMouse must not hide a second one the user can actually open."""
+    inaccessible = {"product_string": "", "vendor_id": 0x256F, "product_id": 0xC635}
+    accessible = {"product_string": "", "vendor_id": 0x256F, "product_id": 0xC62E}
+    mock_environment["hid"].enumerate.return_value = [inaccessible, accessible]
+    mock_environment["device"].open.side_effect = [OSError("open failed"), None]
+    device_mod = importlib.import_module("isaaclab.devices.spacemouse.se3_spacemouse")
+    mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+    mocker.patch.object(device_mod, "threading")
+
+    device = Se3SpaceMouse(Se3SpaceMouseCfg())
+
+    assert device._device_name == "SpaceMouse Wireless"
+    mock_environment["device"].open.assert_called_with(0x256F, 0xC62E)
+
+
+def test_spacemouse_open_failure_reports_permissions(mock_environment, mocker):
+    """When the only supported device cannot be opened, the error must explain why."""
+    mock_environment["hid"].enumerate.return_value = [{"product_string": "", "vendor_id": 0x256F, "product_id": 0xC635}]
+    mock_environment["device"].open.side_effect = OSError("open failed")
+    device_mod = importlib.import_module("isaaclab.devices.spacemouse.se3_spacemouse")
+    mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+    mocker.patch.object(device_mod, "threading")
+    mocker.patch.object(device_mod.time, "sleep")
+
+    with pytest.raises(OSError) as exc_info:
+        Se3SpaceMouse(Se3SpaceMouseCfg())
+
+    message = str(exc_info.value)
+    assert "SpaceMouse Compact" in message
+    assert "/dev/bus/usb" in message
+
+
 def test_spacemouse_not_found_error_lists_enumerated_devices(mock_environment, mocker):
     """The error raised when no SpaceMouse is connected should help identify the problem."""
     mock_environment["hid"].enumerate.return_value = [{"product_string": "", "vendor_id": 0x046D, "product_id": 0xC52F}]
     device_mod = importlib.import_module("isaaclab.devices.spacemouse.se3_spacemouse")
     mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+    mocker.patch.object(device_mod, "threading")
     mocker.patch.object(device_mod.time, "sleep")
 
     with pytest.raises(OSError) as exc_info:

--- a/source/isaaclab/test/devices/test_device_constructors.py
+++ b/source/isaaclab/test/devices/test_device_constructors.py
@@ -257,6 +257,32 @@ def test_spacemouse_detected_by_usb_id(mock_environment, mocker, product_string)
     mock_environment["device"].open.assert_called_with(0x256F, 0xC635)
 
 
+@pytest.mark.parametrize(
+    "product_string",
+    [
+        # the string the device reports when the backend can read its USB descriptors
+        "SpaceNavigator",
+        # the same device seen through a backend that cannot read them
+        "",
+    ],
+    ids=["product_string", "usb_id_only"],
+)
+def test_se3spacemouse_detects_spacenavigator(mock_environment, mocker, product_string):
+    """The legacy SpaceNavigator must stay detectable, with or without a readable product string."""
+    mock_environment["hid"].enumerate.return_value = [
+        {"product_string": product_string, "vendor_id": 0x046D, "product_id": 0xC626}
+    ]
+    device_mod = importlib.import_module("isaaclab.devices.spacemouse.se3_spacemouse")
+    mocker.patch.object(device_mod, "hid", mock_environment["hid"])
+    mocker.patch.object(device_mod, "threading")
+
+    device = Se3SpaceMouse(Se3SpaceMouseCfg())
+
+    # the resolved name selects the report layout used by the listener thread
+    assert device._device_name == "SpaceNavigator"
+    mock_environment["device"].open.assert_called_with(0x046D, 0xC626)
+
+
 def test_spacemouse_skips_devices_that_cannot_be_opened(mock_environment, mocker):
     """An inaccessible SpaceMouse must not hide a second one the user can actually open."""
     inaccessible = {"product_string": "", "vendor_id": 0x256F, "product_id": 0xC635}


### PR DESCRIPTION
# Description

  QA reported that `isaaclab teleop run --teleop_device spacemouse` aborts with
  `No device found by SpaceMouse. Is the device connected?` while a SpaceMouse Compact
  (`256f:c635`) is connected and visible on `/dev/hidraw4`, even after applying the
  `sudo chmod 666 /dev/hidraw<#>` workaround our teleoperation guide documents.

  ## Root cause

  The `hidapi` wheel we depend on bundles a **libusb**-backed HID backend, not the hidraw one:

      $ readelf -d .venv/.../hid.cpython-312-x86_64-linux-gnu.so | grep NEEDED
        NEEDED  libusb-1-150b88da.0.so.0.1.0
      $ python -c "import hid; print(hid.enumerate()[0]['path'])"
        b'7-6:1.0'      # a USB path, not /dev/hidraw*

  That backend reaches the device through `/dev/bus/usb`, and it can only read USB string
  descriptors for devices the process is allowed to open. Without that access, `hid.enumerate()`
  still lists the device but returns `product_string == ''`. Detection compared the product
  string against an exact list:

      if device["product_string"] == "SpaceMouse Compact" or ...

  so an empty string matched nothing and the device was reported as absent. The documented
  `chmod 666 /dev/hidraw<#>` grants nothing to this backend, which is why the workaround
  appeared to have no effect.

  This reproduces on any USB HID device the user lacks USB permissions for — no SpaceMouse
  required:

      0x048d:0x5702 product_string='' -> open failed        # kernel HID_NAME is "ITE Tech. Inc. ITE Device"
      0x1050:0x0407 product_string='YubiKey OTP+FIDO+CCID'  # has a udev rule, so strings resolve

  The exact match is fragile in the other direction too: on a hidraw-backed `hidapi` the
  product string can come back as the kernel's combined name, e.g.
  `3Dconnexion SpaceMouse Compact`, which also fails to equal `SpaceMouse Compact`.

  ## Changes

  - `Se2SpaceMouse`/`Se3SpaceMouse` now match enumerated devices by USB vendor/product id
    (`SPACEMOUSE_USB_IDS` in `devices/spacemouse/utils.py`, ids taken from the USB ID
    repository at https://www.linux-usb.org/usb.ids), covering exactly the models each device
    class already supported. The product string is kept as a fallback so devices with ids we
    do not list keep working, and is matched both verbatim and with a leading `3Dconnexion `
    stripped.
  - The "no device found" error now lists the enumerated HID devices and explains that the
    backend needs access to `/dev/bus/usb`, not `/dev/hidraw*`.
  - A detected-but-unopenable device now raises that same guidance instead of a bare
    `OSError: open failed`.
  - `teleop_imitation.rst`: replaced the ineffective `chmod 666 /dev/hidraw<#>` tip with a
    udev rule for vendor `256f` (covering both `SUBSYSTEM=="usb"` and `hidraw`), and corrected
    the Docker recipe to mount `/dev/bus/usb` with the matching `device_cgroup_rules`.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there