### PR TITLE
Bug Fixes for Mimic-Cosmos Workflows

### DIFF
--- a/docs/source/overview/imitation-learning/augmented_imitation.rst
+++ b/docs/source/overview/imitation-learning/augmented_imitation.rst
@@ -93,11 +93,23 @@ The ``hdf5_to_mp4.py`` script converts camera frames stored in HDF5 demonstratio
 
 Example usage for the cube stacking task:
 
-.. code:: bash
+.. tab-set::
 
-    python scripts/tools/hdf5_to_mp4.py \
-    --input_file datasets/mimic_dataset_1k.hdf5 \
-    --output_dir datasets/mimic_dataset_1k_mp4
+   .. tab-item:: uv (Recommended)
+
+      .. code:: bash
+
+          uv run --extra mimic python scripts/tools/hdf5_to_mp4.py \
+          --input_file datasets/mimic_dataset_1k.hdf5 \
+          --output_dir datasets/mimic_dataset_1k_mp4
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code:: bash
+
+          ./isaaclab.sh -p scripts/tools/hdf5_to_mp4.py \
+          --input_file datasets/mimic_dataset_1k.hdf5 \
+          --output_dir datasets/mimic_dataset_1k_mp4
 
 .. _running-cosmos:
 
@@ -251,12 +263,25 @@ The ``mp4_to_hdf5.py`` script converts the visually augmented MP4 videos back to
 
 Example usage for the cube stacking task:
 
-.. code:: bash
+.. tab-set::
 
-    python scripts/tools/mp4_to_hdf5.py \
-    --input_file datasets/mimic_dataset_1k.hdf5 \
-    --videos_dir datasets/cosmos_dataset_1k_mp4 \
-    --output_file datasets/cosmos_dataset_1k.hdf5
+   .. tab-item:: uv (Recommended)
+
+      .. code:: bash
+
+          uv run --extra mimic python scripts/tools/mp4_to_hdf5.py \
+          --input_file datasets/mimic_dataset_1k.hdf5 \
+          --videos_dir datasets/cosmos_dataset_1k_mp4 \
+          --output_file datasets/cosmos_dataset_1k.hdf5
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code:: bash
+
+          ./isaaclab.sh -p scripts/tools/mp4_to_hdf5.py \
+          --input_file datasets/mimic_dataset_1k.hdf5 \
+          --videos_dir datasets/cosmos_dataset_1k_mp4 \
+          --output_file datasets/cosmos_dataset_1k.hdf5
 
 Pre-generated Dataset
 ^^^^^^^^^^^^^^^^^^^^^
@@ -291,11 +316,23 @@ The ``merge_hdf5_datasets.py`` script combines multiple HDF5 datasets into a sin
 
 Example usage for the cube stacking task:
 
-.. code:: bash
+.. tab-set::
 
-    python scripts/tools/merge_hdf5_datasets.py \
-    --input_files datasets/mimic_dataset_1k.hdf5 datasets/cosmos_dataset_1k.hdf5 \
-    --output_file datasets/mimic_cosmos_dataset.hdf5
+   .. tab-item:: uv (Recommended)
+
+      .. code:: bash
+
+          uv run --extra mimic python scripts/tools/merge_hdf5_datasets.py \
+          --input_files datasets/mimic_dataset_1k.hdf5 datasets/cosmos_dataset_1k.hdf5 \
+          --output_file datasets/mimic_cosmos_dataset.hdf5
+
+   .. tab-item:: isaaclab.sh / isaaclab.bat
+
+      .. code:: bash
+
+          ./isaaclab.sh -p scripts/tools/merge_hdf5_datasets.py \
+          --input_files datasets/mimic_dataset_1k.hdf5 datasets/cosmos_dataset_1k.hdf5 \
+          --output_file datasets/mimic_cosmos_dataset.hdf5
 
 Model Training and Evaluation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/overview/imitation-learning/augmented_imitation.rst
+++ b/docs/source/overview/imitation-learning/augmented_imitation.rst
@@ -54,6 +54,27 @@ requires.
 Cosmos Augmentation
 ~~~~~~~~~~~~~~~~~~~
 
+.. important::
+    The ``hdf5_to_mp4.py`` and ``mp4_to_hdf5.py`` scripts below read and write MP4 files through OpenCV's
+    video I/O, which requires ffmpeg support. Recent Isaac Sim releases ship an OpenCV build without ffmpeg,
+    so install the full OpenCV package into the environment before running these conversions:
+
+    .. tab-set::
+
+       .. tab-item:: uv (Recommended)
+
+          .. code:: bash
+
+              uv pip install opencv-python
+
+       .. tab-item:: isaaclab.sh / isaaclab.bat
+
+          .. code:: bash
+
+              ./isaaclab.sh -p -m pip install opencv-python
+
+    Without it, the conversion scripts fail to open or write the video files.
+
 HDF5 to MP4 Conversion
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scripts/imitation_learning/robomimic/play.py
+++ b/scripts/imitation_learning/robomimic/play.py
@@ -22,7 +22,9 @@ Args:
 
 import argparse
 
-from isaaclab.app import AppLauncher
+from isaaclab.app import AppLauncher, scan
+
+from isaaclab_tasks.utils import resolve_task_config
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Evaluate robomimic policy for Isaac Lab environment.")
@@ -47,9 +49,13 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_overrides = parser.parse_known_args()
 
 # launch omniverse app
-# Policy rollouts run camera-observation tasks and require an RTX renderer. Request
-# rendering support here so callers do not need a legacy CLI flag.
-app_launcher = AppLauncher(args_cli, enable_cameras=True)
+# Only enable rendering for tasks that actually declare Kit camera sensors: this script also
+# plays policies trained on low-dimensional observations, which should not pay for the RTX
+# renderer. ``resolve_task_config`` is safe to call before Kit is launched, and ``scan`` is the
+# same detection ``launch_simulation`` uses, so this matches how camera enabling is resolved
+# elsewhere now that the ``--enable_cameras`` flag is gone.
+env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "")
+app_launcher = AppLauncher(args_cli, enable_cameras=scan(env_cfg_for_scan, args_cli).has_kit_camera)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""

--- a/scripts/imitation_learning/robomimic/play.py
+++ b/scripts/imitation_learning/robomimic/play.py
@@ -47,7 +47,9 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_overrides = parser.parse_known_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(args_cli)
+# Policy rollouts run camera-observation tasks and require an RTX renderer. Request
+# rendering support here so callers do not need a legacy CLI flag.
+app_launcher = AppLauncher(args_cli, enable_cameras=True)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""

--- a/scripts/imitation_learning/robomimic/robust_eval.py
+++ b/scripts/imitation_learning/robomimic/robust_eval.py
@@ -28,7 +28,9 @@ Args:
 
 import argparse
 
-from isaaclab.app import AppLauncher
+from isaaclab.app import AppLauncher, scan
+
+from isaaclab_tasks.utils import resolve_task_config
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Evaluate robomimic policy for Isaac Lab environment.")
@@ -64,9 +66,13 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_overrides = parser.parse_known_args()
 
 # launch omniverse app
-# Evaluation rollouts run camera-observation tasks and require an RTX renderer. Request
-# rendering support here so callers do not need a legacy CLI flag.
-app_launcher = AppLauncher(args_cli, enable_cameras=True)
+# Only enable rendering for tasks that actually declare Kit camera sensors: this script also
+# evaluates policies trained on low-dimensional observations, which should not pay for the RTX
+# renderer. ``resolve_task_config`` is safe to call before Kit is launched, and ``scan`` is the
+# same detection ``launch_simulation`` uses, so this matches how camera enabling is resolved
+# elsewhere now that the ``--enable_cameras`` flag is gone.
+env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "")
+app_launcher = AppLauncher(args_cli, enable_cameras=scan(env_cfg_for_scan, args_cli).has_kit_camera)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""

--- a/scripts/imitation_learning/robomimic/robust_eval.py
+++ b/scripts/imitation_learning/robomimic/robust_eval.py
@@ -64,7 +64,9 @@ AppLauncher.add_app_launcher_args(parser)
 args_cli, hydra_overrides = parser.parse_known_args()
 
 # launch omniverse app
-app_launcher = AppLauncher(args_cli)
+# Evaluation rollouts run camera-observation tasks and require an RTX renderer. Request
+# rendering support here so callers do not need a legacy CLI flag.
+app_launcher = AppLauncher(args_cli, enable_cameras=True)
 simulation_app = app_launcher.app
 
 """Rest everything follows."""

--- a/source/isaaclab/changelog.d/shauryad-bug-fixes.rst
+++ b/source/isaaclab/changelog.d/shauryad-bug-fixes.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed the ``reshape_tiled_image`` Warp kernel to index the tiled image buffer as a 3D array
+  of shape (num_tiles_y * image_height, num_tiles_x * image_width, num_channels) instead of a
+  flattened 1D array. This keeps every array dimension within Warp's per-dimension size limit, so
+  large environment counts and camera resolutions no longer overflow a single flattened dimension.

--- a/source/isaaclab/isaaclab/utils/warp/kernels.py
+++ b/source/isaaclab/isaaclab/utils/warp/kernels.py
@@ -344,8 +344,14 @@ def reshape_tiled_image(
     is assumed to be tiled in the x and y directions. The output image is a batch of images with the
     specified height, width, and number of channels.
 
+    The tiled buffer is indexed as a 3D array rather than flattened to 1D so that the number of
+    cameras and the camera resolution are bounded per dimension instead of by their product. A
+    flattened view of a large tiled buffer can exceed the maximum size of a single Warp array
+    dimension, see https://nvidia.github.io/warp/stable/user_guide/limitations.html#arrays.
+
     Args:
-        tiled_image_buffer: The input image buffer. Shape is (height * width * num_channels * num_cameras,).
+        tiled_image_buffer: The input image buffer. Shape is
+            (num_tiles_y * image_height, num_tiles_x * image_width, num_channels).
         batched_image: The output image. Shape is (num_cameras, height, width, num_channels).
         image_width: The width of the image.
         image_height: The height of the image.
@@ -358,32 +364,29 @@ def reshape_tiled_image(
     # resolve the tile indices
     tile_x_id = camera_id % num_tiles_x
     tile_y_id = camera_id // num_tiles_x
-    # compute the start index of the pixel in the tiled image buffer
-    pixel_start = (
-        num_channels * num_tiles_x * image_width * (image_height * tile_y_id + height_id)
-        + num_channels * tile_x_id * image_width
-        + num_channels * width_id
-    )
+    # resolve the pixel position within the tiled image buffer
+    row = image_height * tile_y_id + height_id
+    col = image_width * tile_x_id + width_id
 
     # copy the pixel values into the batched image
     for i in range(num_channels):
-        batched_image[camera_id, height_id, width_id, i] = batched_image.dtype(tiled_image_buffer[pixel_start + i])
+        batched_image[camera_id, height_id, width_id, i] = batched_image.dtype(tiled_image_buffer[row, col, i])
 
 
 # uint32 -> int32 conversion is required for non-colored segmentation annotators
 wp.overload(
     reshape_tiled_image,
-    {"tiled_image_buffer": wp.array(dtype=wp.uint32), "batched_image": wp.array(dtype=wp.uint32, ndim=4)},
+    {"tiled_image_buffer": wp.array(dtype=wp.uint32, ndim=3), "batched_image": wp.array(dtype=wp.uint32, ndim=4)},
 )
 # uint8 is used for 4 channel annotators
 wp.overload(
     reshape_tiled_image,
-    {"tiled_image_buffer": wp.array(dtype=wp.uint8), "batched_image": wp.array(dtype=wp.uint8, ndim=4)},
+    {"tiled_image_buffer": wp.array(dtype=wp.uint8, ndim=3), "batched_image": wp.array(dtype=wp.uint8, ndim=4)},
 )
 # float32 is used for single channel annotators
 wp.overload(
     reshape_tiled_image,
-    {"tiled_image_buffer": wp.array(dtype=wp.float32), "batched_image": wp.array(dtype=wp.float32, ndim=4)},
+    {"tiled_image_buffer": wp.array(dtype=wp.float32, ndim=3), "batched_image": wp.array(dtype=wp.float32, ndim=4)},
 )
 
 ##

--- a/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
+++ b/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed ``IsaacRtxRenderer.render()`` crashing with ``RuntimeError: Invalid indexing in slice``
+  when an annotator's channel buffer has not warmed up yet (e.g. right after attach, at env
+  creation) for the ``motion_vectors``, ``normals``, simple-shading, and RGB HDR data types.
+* Added a pre-flight check in ``IsaacRtxRenderer.create_render_data()`` that raises a clear,
+  actionable error when the requested ``num_envs``/camera resolution would overflow Warp's
+  signed-32-bit-representable array shape limit, instead of an opaque ``ValueError`` raised deep
+  inside ``render()``.

--- a/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
+++ b/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
@@ -4,7 +4,10 @@ Fixed
 * Fixed ``IsaacRtxRenderer.render()`` crashing with ``RuntimeError: Invalid indexing in slice``
   when an annotator's channel buffer has not warmed up yet (e.g. right after attach, at env
   creation) for the ``motion_vectors``, ``normals``, simple-shading, and RGB HDR data types.
-* Added a pre-flight check in ``IsaacRtxRenderer.create_render_data()`` that raises a clear,
-  actionable error when the requested ``num_envs``/camera resolution would overflow Warp's
-  signed-32-bit-representable array shape limit, instead of an opaque ``ValueError`` raised deep
-  inside ``render()``.
+
+Changed
+^^^^^^^
+
+* Changed ``IsaacRtxRenderer.render()`` to pass the tiled annotator buffer to
+  ``reshape_tiled_image`` as a 3D array instead of flattening it to 1D. Large environment counts
+  and camera resolutions no longer overflow the maximum size of a single Warp array dimension.

--- a/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
+++ b/source/isaaclab_physx/changelog.d/shauryad-bug-fixes.rst
@@ -1,10 +1,3 @@
-Fixed
-^^^^^
-
-* Fixed ``IsaacRtxRenderer.render()`` crashing with ``RuntimeError: Invalid indexing in slice``
-  when an annotator's channel buffer has not warmed up yet (e.g. right after attach, at env
-  creation) for the ``motion_vectors``, ``normals``, simple-shading, and RGB HDR data types.
-
 Changed
 ^^^^^^^
 

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -618,17 +618,28 @@ class IsaacRtxRenderer(BaseRenderer):
 
             # For motion vectors, use specialized kernel that reads 4 channels but only writes 2
             # Note: Not doing this breaks the alignment of the data (check: https://github.com/isaac-sim/IsaacLab/issues/2003)
-            if data_type == "motion_vectors":
-                tiled_data_buffer = tiled_data_buffer[:, :, :2].contiguous()
-
             # For normals, we only require the first three channels of the tiled buffer
             # Note: Not doing this breaks the alignment of the data (check: https://github.com/isaac-sim/IsaacLab/issues/4239)
-            if data_type == "normals":
-                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
-            if data_type in SIMPLE_SHADING_MODES:
-                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
-            if data_type == str(RenderBufferKind.RGB_HDR):
-                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
+            trim_channels = None
+            if data_type == "motion_vectors":
+                trim_channels = 2
+            elif data_type == "normals" or data_type in SIMPLE_SHADING_MODES or data_type == str(RenderBufferKind.RGB_HDR):
+                trim_channels = 3
+
+            if trim_channels is not None:
+                # Immediately after an annotator is attached (e.g. during env creation, before the RTX
+                # renderer has warmed up), Replicator can momentarily hand back a buffer whose channel
+                # dimension is 0 instead of real image data. Warp's slice indexing rejects trimming an
+                # already-empty dimension (unlike NumPy, which allows it), so skip writing this data type
+                # for this frame rather than crashing; the next render() call will pick up valid data.
+                if tiled_data_buffer.shape[-1] < trim_channels:
+                    logger.debug(
+                        "Skipping '%s' this frame: annotator buffer not yet populated (channel dim=%d).",
+                        data_type,
+                        tiled_data_buffer.shape[-1],
+                    )
+                    continue
+                tiled_data_buffer = tiled_data_buffer[:, :, :trim_channels].contiguous()
 
             wp.launch(
                 kernel=reshape_tiled_image,

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -573,7 +573,7 @@ class IsaacRtxRenderer(BaseRenderer):
             rows = math.ceil(view_count / cols)
             return (cols, rows)
 
-        num_tiles_x = tiling_grid_shape()[0]
+        num_tiles_x, num_tiles_y = tiling_grid_shape()
 
         # Extract the flattened image buffer
         for data_type, annotator in render_data.annotators.items():
@@ -645,13 +645,18 @@ class IsaacRtxRenderer(BaseRenderer):
                     continue
                 tiled_data_buffer = tiled_data_buffer[:, :, :trim_channels].contiguous()
 
-            # ``reshape_tiled_image`` indexes the tiled buffer as (rows, cols, channels). Single-channel
-            # annotators (e.g. depth, non-colorized segmentation) hand back a 2D buffer, so add the
-            # trailing channel dimension. Passing the buffer in 3D rather than flattening it keeps every
-            # dimension well inside Warp's per-dimension array size limit, so large environment counts and
+            # ``reshape_tiled_image`` indexes the tiled buffer as
+            # (num_tiles_y * height, num_tiles_x * width, channels). Annotators hand this data back with
+            # varying shapes: 3D for multi-channel outputs, 2D for single-channel ones, and 2D
+            # ``(pixels, 4)`` for the colorized segmentation buffers reinterpreted above. Reshape to the
+            # documented tiled geometry rather than inferring it from ``ndim``, which silently mis-indexes
+            # the reinterpreted segmentation buffers. Reshaping instead of flattening keeps every
+            # dimension within Warp's per-dimension array size limit, so large environment counts and
             # camera resolutions no longer overflow a single flattened dimension.
-            if tiled_data_buffer.ndim == 2:
-                tiled_data_buffer = tiled_data_buffer.reshape((*tiled_data_buffer.shape, 1))
+            tile_height, tile_width, num_channels = (int(dim) for dim in buf_wp.shape[1:])
+            tiled_data_buffer = tiled_data_buffer.reshape(
+                (num_tiles_y * tile_height, num_tiles_x * tile_width, num_channels)
+            )
 
             wp.launch(
                 kernel=reshape_tiled_image,

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -631,16 +631,22 @@ class IsaacRtxRenderer(BaseRenderer):
                 tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
 
             # ``reshape_tiled_image`` indexes the tiled buffer as
-            # (num_tiles_y * height, num_tiles_x * width, channels). Annotators hand this data back with
-            # varying shapes: 3D for multi-channel outputs, 2D for single-channel ones, and 2D
-            # ``(pixels, 4)`` for the colorized segmentation buffers reinterpreted above. Reshape to the
-            # documented tiled geometry rather than inferring it from ``ndim``, which silently mis-indexes
-            # the reinterpreted segmentation buffers. Reshaping instead of flattening keeps every
-            # dimension within Warp's per-dimension array size limit, so large environment counts and
-            # camera resolutions no longer overflow a single flattened dimension.
+            # (num_tiles_y * height, num_tiles_x * width, channels), but annotators hand this data back
+            # with varying shapes: 3D for multi-channel outputs, 2D for single-channel ones, and — for the
+            # colorized segmentation types reinterpreted above — a descriptor that over-claims the backing
+            # memory when the raw buffer already carries a channel axis (e.g. (H, W, 4) becomes (H, W, 4, 4)).
+            # Build the view directly from the pointer rather than reshaping, so the extra claimed elements
+            # are ignored exactly as the previous flattened indexing ignored them. Keeping the view 3D
+            # instead of 1D also keeps every dimension within Warp's per-dimension array size limit, so
+            # large environment counts and camera resolutions no longer overflow a flattened dimension.
             tile_height, tile_width, num_channels = (int(dim) for dim in buf_wp.shape[1:])
-            tiled_data_buffer = tiled_data_buffer.reshape(
-                (num_tiles_y * tile_height, num_tiles_x * tile_width, num_channels)
+            # ``tiled_source`` must outlive the view below: the view does not own the annotator memory.
+            tiled_source = tiled_data_buffer
+            tiled_data_buffer = wp.array(
+                ptr=tiled_source.ptr,
+                shape=(num_tiles_y * tile_height, num_tiles_x * tile_width, num_channels),
+                dtype=tiled_source.dtype,
+                device=device,
             )
 
             wp.launch(

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -618,32 +618,17 @@ class IsaacRtxRenderer(BaseRenderer):
 
             # For motion vectors, use specialized kernel that reads 4 channels but only writes 2
             # Note: Not doing this breaks the alignment of the data (check: https://github.com/isaac-sim/IsaacLab/issues/2003)
+            if data_type == "motion_vectors":
+                tiled_data_buffer = tiled_data_buffer[:, :, :2].contiguous()
+
             # For normals, we only require the first three channels of the tiled buffer
             # Note: Not doing this breaks the alignment of the data (check: https://github.com/isaac-sim/IsaacLab/issues/4239)
-            trim_channels = None
-            if data_type == "motion_vectors":
-                trim_channels = 2
-            elif (
-                data_type == "normals"
-                or data_type in SIMPLE_SHADING_MODES
-                or data_type == str(RenderBufferKind.RGB_HDR)
-            ):
-                trim_channels = 3
-
-            if trim_channels is not None:
-                # Immediately after an annotator is attached (e.g. during env creation, before the RTX
-                # renderer has warmed up), Replicator can momentarily hand back a buffer whose channel
-                # dimension is 0 instead of real image data. Warp's slice indexing rejects trimming an
-                # already-empty dimension (unlike NumPy, which allows it), so skip writing this data type
-                # for this frame rather than crashing; the next render() call will pick up valid data.
-                if tiled_data_buffer.shape[-1] < trim_channels:
-                    logger.debug(
-                        "Skipping '%s' this frame: annotator buffer not yet populated (channel dim=%d).",
-                        data_type,
-                        tiled_data_buffer.shape[-1],
-                    )
-                    continue
-                tiled_data_buffer = tiled_data_buffer[:, :, :trim_channels].contiguous()
+            if data_type == "normals":
+                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
+            if data_type in SIMPLE_SHADING_MODES:
+                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
+            if data_type == str(RenderBufferKind.RGB_HDR):
+                tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
 
             # ``reshape_tiled_image`` indexes the tiled buffer as
             # (num_tiles_y * height, num_tiles_x * width, channels). Annotators hand this data back with

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -89,32 +89,6 @@ RTX_RENDER_MODE_ATTR = "omni:rtx:rendermode"
 RTX_MINIMAL_MODE_ATTR = "omni:rtx:minimal:mode"
 RTX_MINIMAL_RENDER_MODE = "Minimal"
 
-# Warp arrays require every dimension to fit in a signed 32-bit int (see
-# ``warp.types.array.__getitem__``/``check_array_shape``). ``render()`` flattens the whole
-# tiled buffer (all environments' camera tiles concatenated) into one Warp array per data
-# type, so this bounds how large ``num_envs * tile pixels`` can get before that call raises.
-_WARP_MAX_ARRAY_DIM = 2_147_483_647
-
-
-def _validate_tiled_buffer_size(spec: CameraRenderSpec) -> None:
-    """Raise a clear error if this camera's tiled buffer would overflow Warp's array shape limit.
-
-    Worst case is 4 elements per pixel: RGBA/HDR annotators return 4 channels directly, and
-    colorized segmentation annotators reinterpret a uint32 id as 4 uint8 channels.
-    """
-    num_tile_cols = math.ceil(math.sqrt(spec.view_count))
-    num_tile_rows = math.ceil(spec.view_count / num_tile_cols)
-    tiled_pixels = (num_tile_cols * spec.cfg.width) * (num_tile_rows * spec.cfg.height)
-    max_elements_per_pixel = 4
-    if tiled_pixels * max_elements_per_pixel > _WARP_MAX_ARRAY_DIM:
-        raise ValueError(
-            f"Camera '{spec.cfg.prim_path}' would allocate a tiled render buffer of up to"
-            f" {tiled_pixels * max_elements_per_pixel} elements ({spec.view_count} environments tiled into a"
-            f" {num_tile_cols}x{num_tile_rows} grid at {spec.cfg.width}x{spec.cfg.height} resolution), which"
-            f" exceeds Warp's signed-32-bit-representable array shape limit ({_WARP_MAX_ARRAY_DIM})."
-            " Reduce the number of environments (--num_envs) or the camera resolution for this task."
-        )
-
 
 def _camera_semantic_filter_predicate(semantic_filter: str | list[str]) -> str:
     """Build the instance-mapping semantics predicate from :attr:`isaaclab.sensors.camera.CameraCfg.semantic_filter`.
@@ -282,10 +256,6 @@ class IsaacRtxRenderer(BaseRenderer):
     def create_render_data(self, spec: CameraRenderSpec) -> IsaacRtxRenderData:
         """Create render product and annotators for the tiled camera.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
-        # Fail fast with an actionable error instead of a cryptic Warp ``ValueError`` raised deep
-        # inside render()'s ``.flatten()`` call once the annotators are already attached.
-        _validate_tiled_buffer_size(spec)
-
         import omni.replicator.core as rep
         from omni.syntheticdata import SyntheticData
         from pxr import UsdGeom
@@ -675,11 +645,19 @@ class IsaacRtxRenderer(BaseRenderer):
                     continue
                 tiled_data_buffer = tiled_data_buffer[:, :, :trim_channels].contiguous()
 
+            # ``reshape_tiled_image`` indexes the tiled buffer as (rows, cols, channels). Single-channel
+            # annotators (e.g. depth, non-colorized segmentation) hand back a 2D buffer, so add the
+            # trailing channel dimension. Passing the buffer in 3D rather than flattening it keeps every
+            # dimension well inside Warp's per-dimension array size limit, so large environment counts and
+            # camera resolutions no longer overflow a single flattened dimension.
+            if tiled_data_buffer.ndim == 2:
+                tiled_data_buffer = tiled_data_buffer.reshape((*tiled_data_buffer.shape, 1))
+
             wp.launch(
                 kernel=reshape_tiled_image,
                 dim=(view_count, cfg.height, cfg.width),
                 inputs=[
-                    tiled_data_buffer.flatten(),
+                    tiled_data_buffer,
                     buf_wp,
                     *list(buf_wp.shape[1:]),
                     num_tiles_x,

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -89,6 +89,12 @@ RTX_RENDER_MODE_ATTR = "omni:rtx:rendermode"
 RTX_MINIMAL_MODE_ATTR = "omni:rtx:minimal:mode"
 RTX_MINIMAL_RENDER_MODE = "Minimal"
 
+# Warp arrays require every dimension to fit in a signed 32-bit int (see
+# ``warp.types.array.__getitem__``/``check_array_shape``). ``render()`` flattens the whole
+# tiled buffer (all environments' camera tiles concatenated) into one Warp array per data
+# type, so this bounds how large ``num_envs * tile pixels`` can get before that call raises.
+_WARP_MAX_ARRAY_DIM = 2_147_483_647
+
 
 def _camera_semantic_filter_predicate(semantic_filter: str | list[str]) -> str:
     """Build the instance-mapping semantics predicate from :attr:`isaaclab.sensors.camera.CameraCfg.semantic_filter`.
@@ -256,6 +262,23 @@ class IsaacRtxRenderer(BaseRenderer):
     def create_render_data(self, spec: CameraRenderSpec) -> IsaacRtxRenderData:
         """Create render product and annotators for the tiled camera.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
+        # Fail fast with an actionable error instead of a cryptic Warp ``ValueError`` raised deep
+        # inside render()'s ``.flatten()`` call once the annotators are already attached. Worst case
+        # is 4 elements per pixel: RGBA/HDR annotators return 4 channels directly, and colorized
+        # segmentation annotators reinterpret a uint32 id as 4 uint8 channels.
+        num_tile_cols = math.ceil(math.sqrt(spec.view_count))
+        num_tile_rows = math.ceil(spec.view_count / num_tile_cols)
+        tiled_pixels = (num_tile_cols * spec.cfg.width) * (num_tile_rows * spec.cfg.height)
+        max_elements_per_pixel = 4
+        if tiled_pixels * max_elements_per_pixel > _WARP_MAX_ARRAY_DIM:
+            raise ValueError(
+                f"Camera '{spec.cfg.prim_path}' would allocate a tiled render buffer of up to"
+                f" {tiled_pixels * max_elements_per_pixel} elements ({spec.view_count} environments tiled into a"
+                f" {num_tile_cols}x{num_tile_rows} grid at {spec.cfg.width}x{spec.cfg.height} resolution), which"
+                f" exceeds Warp's signed-32-bit-representable array shape limit ({_WARP_MAX_ARRAY_DIM})."
+                " Reduce the number of environments (--num_envs) or the camera resolution for this task."
+            )
+
         import omni.replicator.core as rep
         from omni.syntheticdata import SyntheticData
         from pxr import UsdGeom

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -96,6 +96,26 @@ RTX_MINIMAL_RENDER_MODE = "Minimal"
 _WARP_MAX_ARRAY_DIM = 2_147_483_647
 
 
+def _validate_tiled_buffer_size(spec: CameraRenderSpec) -> None:
+    """Raise a clear error if this camera's tiled buffer would overflow Warp's array shape limit.
+
+    Worst case is 4 elements per pixel: RGBA/HDR annotators return 4 channels directly, and
+    colorized segmentation annotators reinterpret a uint32 id as 4 uint8 channels.
+    """
+    num_tile_cols = math.ceil(math.sqrt(spec.view_count))
+    num_tile_rows = math.ceil(spec.view_count / num_tile_cols)
+    tiled_pixels = (num_tile_cols * spec.cfg.width) * (num_tile_rows * spec.cfg.height)
+    max_elements_per_pixel = 4
+    if tiled_pixels * max_elements_per_pixel > _WARP_MAX_ARRAY_DIM:
+        raise ValueError(
+            f"Camera '{spec.cfg.prim_path}' would allocate a tiled render buffer of up to"
+            f" {tiled_pixels * max_elements_per_pixel} elements ({spec.view_count} environments tiled into a"
+            f" {num_tile_cols}x{num_tile_rows} grid at {spec.cfg.width}x{spec.cfg.height} resolution), which"
+            f" exceeds Warp's signed-32-bit-representable array shape limit ({_WARP_MAX_ARRAY_DIM})."
+            " Reduce the number of environments (--num_envs) or the camera resolution for this task."
+        )
+
+
 def _camera_semantic_filter_predicate(semantic_filter: str | list[str]) -> str:
     """Build the instance-mapping semantics predicate from :attr:`isaaclab.sensors.camera.CameraCfg.semantic_filter`.
 
@@ -263,21 +283,8 @@ class IsaacRtxRenderer(BaseRenderer):
         """Create render product and annotators for the tiled camera.
         See :meth:`~isaaclab.renderers.base_renderer.BaseRenderer.create_render_data`."""
         # Fail fast with an actionable error instead of a cryptic Warp ``ValueError`` raised deep
-        # inside render()'s ``.flatten()`` call once the annotators are already attached. Worst case
-        # is 4 elements per pixel: RGBA/HDR annotators return 4 channels directly, and colorized
-        # segmentation annotators reinterpret a uint32 id as 4 uint8 channels.
-        num_tile_cols = math.ceil(math.sqrt(spec.view_count))
-        num_tile_rows = math.ceil(spec.view_count / num_tile_cols)
-        tiled_pixels = (num_tile_cols * spec.cfg.width) * (num_tile_rows * spec.cfg.height)
-        max_elements_per_pixel = 4
-        if tiled_pixels * max_elements_per_pixel > _WARP_MAX_ARRAY_DIM:
-            raise ValueError(
-                f"Camera '{spec.cfg.prim_path}' would allocate a tiled render buffer of up to"
-                f" {tiled_pixels * max_elements_per_pixel} elements ({spec.view_count} environments tiled into a"
-                f" {num_tile_cols}x{num_tile_rows} grid at {spec.cfg.width}x{spec.cfg.height} resolution), which"
-                f" exceeds Warp's signed-32-bit-representable array shape limit ({_WARP_MAX_ARRAY_DIM})."
-                " Reduce the number of environments (--num_envs) or the camera resolution for this task."
-            )
+        # inside render()'s ``.flatten()`` call once the annotators are already attached.
+        _validate_tiled_buffer_size(spec)
 
         import omni.replicator.core as rep
         from omni.syntheticdata import SyntheticData
@@ -646,7 +653,11 @@ class IsaacRtxRenderer(BaseRenderer):
             trim_channels = None
             if data_type == "motion_vectors":
                 trim_channels = 2
-            elif data_type == "normals" or data_type in SIMPLE_SHADING_MODES or data_type == str(RenderBufferKind.RGB_HDR):
+            elif (
+                data_type == "normals"
+                or data_type in SIMPLE_SHADING_MODES
+                or data_type == str(RenderBufferKind.RGB_HDR)
+            ):
                 trim_channels = 3
 
             if trim_channels is not None:


### PR DESCRIPTION
# Description

This PR bundles four fixes for issues found:

  1. 6684416: **RTX renderer: fix crash on not-yet-warmed-up annotator buffers.** `IsaacRtxRenderer.render()` unconditionally trimmed the tiled buffer to 2/3 channels for `motion_vectors`/`normals`/`SIMPLE_SHADING_MODES`/`RGB_HDR`. Immediately after an annotator is attached (e.g. at env creation, before the RTX renderer has pumped a frame), Replicator can momentarily return a buffer whose channel dimension is 0. Warp's array slicing rejects trimming an already-empty dimension (unlike NumPy, which allows it), raising `RuntimeError: Invalid indexing in slice: 0:0:1`. Guard the trim and skip writing that data type for the frame instead of crashing.
  2. 6683697: **`robust_eval.py`/`play.py`: pass `enable_cameras=True` explicitly.** `release/3.0.0` removed the `--enable_cameras` CLI flag and the `ENABLE_CAMERAS` env-var fallback from `AppLauncher` in favor of `launch_simulation()`'s scene-scan auto-detection, but these two robomimic scripts still use the legacy `AppLauncher(args_cli)` pattern and were never migrated. Without cameras enabled, and with the old explicit "pass --enable_cameras" guard in `IsaacRtxRenderer.__init__` also removed in this release, the failure now surfaces as an opaque `ValueError: Invalid object in Py_Graph in getWrappedGraphFromNode` deep inside OmniGraph/SyntheticData. Pass `enable_cameras=True` explicitly, matching the pattern already used in `generate_dataset.py`.
  3. 6683610: **Docs: add `uv run` examples for the HDF5/MP4 conversion and merge tools.** The Augmented Imitation Learning doc recommends `uv` as the primary workflow throughout (dataset generation, training, eval all show a "uv (Recommended)" tab), but the `hdf5_to_mp4.py`, `mp4_to_hdf5.py`, and `merge_hdf5_datasets.py` examples only showed a bare `python ...` invocation with no indication of which environment/extras to use. Added matching `uv (Recommended)` / `isaaclab.sh` tab-sets (`--extra mimic`, since these tools only need `h5py`/`opencv`/`numpy`, no Isaac Sim import). 
  4. 6702683: **RTX renderer: fail fast on oversized tiled camera buffers.** `IsaacRtxRenderer.render()` flattens every environment's camera tile into one Warp array per data type. Warp requires every array dimension to fit in a signed 32-bit int, so a large enough `num_envs * resolution` combination overflows that limit and crashes deep inside `render()`'s `.flatten()` call with `ValueError: Array shapes must not exceed the maximum representable value of a signed 32-bit integer, got 2621440000 in dimension 0` and no indication of what to change. Compute the worst-case tiled buffer size upfront in `create_render_data()` and raise a clear error naming the offending env count/grid/resolution and suggesting to reduce `--num_envs` or camera resolution. This does not lift the underlying Warp/RTX limit — it only replaces the opaque failure with an actionable one.
  
## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
    
## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
