### PR TITLE
Add TorchRL environment wrapper for isaaclab_rl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -454,7 +454,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_rl"
-        extra-pip-packages: "leapp"
+        extra-pip-packages: "leapp torchrl"
         container-name: isaac-lab-rl-test
 
   test-isaaclab-mimic:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ Guidelines for modifications:
 
 ## Contributors
 
+* Achintya Paningapalli
 * Advait Jayant
 * Agon Serifi
 * Alessandro Assirelli

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,6 +262,7 @@ autodoc_mock_imports = [
     "psutil",
     "tqdm",
     "tensordict",
+    "torchrl",
     "trimesh",
     "toml",
     "pink",

--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -14,8 +14,8 @@
         const taskRows = [
             ["Isaac-Ant-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/ant.jpg", true],
             ["Isaac-Ant", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/ant.jpg", true],
-            ["Isaac-Cartpole-Direct", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
-            ["Isaac-Cartpole", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
+            ["Isaac-Cartpole-Direct", "rl_games,rsl_rl,skrl,sb3,torchrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
+            ["Isaac-Cartpole", "rl_games,rsl_rl,skrl,sb3,torchrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
             ["Isaac-Cartpole-Camera-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "tasks/classic/cartpole.jpg"],
             ["Isaac-Cartpole-Camera", "rl_games,rsl_rl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,resnet18,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl,theia_tiny", {"rl_games_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rl_games_feature_cfg_entry_point": ["resnet18", "theia_tiny"], "rsl_rl_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rsl_rl_feature_cfg_entry_point": ["resnet18", "theia_tiny"]}, "tasks/classic/cartpole.jpg"],
             ["Isaac-Fourbar-Pole-Swingup", "rsl_rl", "newton_kamino", "", "", {}, "tasks/classic/fourbar_pole.jpg"],
@@ -195,7 +195,9 @@
         task: "Isaac-Cartpole",
         benchmarkWorkload: "runtime",
     };
-    const rlLibraryExtras = {rl_games: "rl-games", sb3: "sb3", skrl: "skrl", rlinf: "rlinf"};
+    const rlLibraryExtras = {rl_games: "rl-games", sb3: "sb3", skrl: "skrl", rlinf: "rlinf", torchrl: "torchrl"};
+    // Libraries with a train backend but no play backend in isaaclab_rl.entrypoints.dispatch.
+    const trainOnlyRlLibraries = new Set(["torchrl"]);
     let benchmarkRows = [];
 
     const categoryFor = (task) => {
@@ -284,14 +286,22 @@
 
     const updateModeControls = () => {
         const supportsRl = selectedTask().rl.length > 0;
+        const supportsPlay = supportsRl && !trainOnlyRlLibraries.has(fields.rl.value);
+        if (supportsRl && !supportsPlay) {
+            state.mode = "train";
+        }
         for (const modeButton of modeButtons) {
-            modeButton.disabled = !supportsRl;
+            const isPlayButton = modeButton.dataset.commandMode === "play";
+            modeButton.disabled = !supportsRl || (isPlayButton && !supportsPlay);
+            modeButton.title = isPlayButton && supportsRl && !supportsPlay
+                ? `${fields.rl.value} supports training only`
+                : "";
             const isActive = supportsRl && modeButton.dataset.commandMode === state.mode;
             modeButton.classList.toggle("is-active", isActive);
             modeButton.setAttribute("aria-pressed", String(isActive));
         }
         nonRlNote.hidden = supportsRl;
-        const supportsPretrainedCheckpoint = supportsRl && state.scope === "core";
+        const supportsPretrainedCheckpoint = supportsPlay && state.scope === "core";
         fields.checkpoint.disabled = !supportsPretrainedCheckpoint;
         if (!supportsPretrainedCheckpoint) {
             fields.checkpoint.checked = false;
@@ -670,6 +680,9 @@
     });
     for (const field of [fields.rl, fields.physics, fields.renderer, fields.presets, fields.checkpoint]) {
         field.addEventListener("change", () => {
+            if (field === fields.rl) {
+                updateModeControls();
+            }
             commandOutput.textContent = currentCommand();
             updatePreview();
         });

--- a/docs/source/api/lab_rl/isaaclab_rl.rst
+++ b/docs/source/api/lab_rl/isaaclab_rl.rst
@@ -66,3 +66,11 @@ Stable-Baselines3 Wrapper
 .. automodule:: isaaclab_rl.sb3
    :members:
    :show-inheritance:
+
+TorchRL Wrapper
+---------------
+
+.. automodule:: isaaclab_rl.torchrl
+   :members:
+   :imported-members:
+   :show-inheritance:

--- a/docs/source/concepts/reinforcement_learning.rst
+++ b/docs/source/concepts/reinforcement_learning.rst
@@ -80,6 +80,11 @@ features your experiment needs, not on a single throughput result.
      - RL fine-tuning of Vision-Language-Action models
      - Distributed GR00T and OpenVLA post-training with Ray and FSDP
      - Specialized setup
+   * - **TorchRL**
+     - Building custom algorithms from PyTorch-native RL components
+     - PPO reference runner on a ``torchrl.envs.EnvBase`` wrapper that keeps observation groups and
+       terminal observations
+     - ``--extra torchrl``
 
 Install optional dependencies by selecting the corresponding ``uv`` extra when running a command:
 
@@ -88,6 +93,7 @@ Install optional dependencies by selecting the corresponding ``uv`` extra when r
    uv run --extra skrl isaaclab train --rl_library skrl --task Isaac-Cartpole
    uv run --extra rl-games isaaclab train --rl_library rl_games --task Isaac-Cartpole
    uv run --extra sb3 isaaclab train --rl_library sb3 --task Isaac-Cartpole
+   uv run --extra torchrl isaaclab train --rl_library torchrl --task Isaac-Cartpole
 
 
 Typical training workflow

--- a/docs/source/concepts/reinforcement_learning.rst
+++ b/docs/source/concepts/reinforcement_learning.rst
@@ -83,7 +83,7 @@ features your experiment needs, not on a single throughput result.
    * - **TorchRL**
      - Building custom algorithms from PyTorch-native RL components
      - PPO reference runner on a ``torchrl.envs.EnvBase`` wrapper that keeps observation groups and
-       terminal observations
+       terminal observations; training only (no ``play`` backend yet)
      - ``--extra torchrl``
 
 Install optional dependencies by selecting the corresponding ``uv`` extra when running a command:

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -640,7 +640,7 @@ have dedicated commands below.
      - Both OV backends: OV PhysX and OV RTX.
    * - ``ovphysx`` / ``ovrtx``
      - OV PhysX only / OV RTX only.
-   * - ``rl-games`` / ``sb3`` / ``skrl`` / ``rsl-rl`` / ``rlinf``
+   * - ``rl-games`` / ``sb3`` / ``skrl`` / ``rsl-rl`` / ``rlinf`` / ``torchrl``
      - The corresponding RL framework.
    * - ``rerun`` / ``viser``
      - The corresponding visualizer.

--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -228,7 +228,7 @@ backends. Pass a comma-separated list or repeat ``--extra``. No extras conflict,
 any combination resolves into one environment. The ``--extra all`` shortcut installs the
 curated ``ov``, ``rl-games``, ``sb3``, ``skrl``, ``rsl-rl``, ``rerun``, and ``viser`` extras.
 It does not include Isaac Sim or the specialized ``rlinf``, ``mimic``, ``teleop``,
-``tetrahedralization``, ``video``, and ``leapp`` extras; request them by name:
+``tetrahedralization``, ``video``, ``leapp``, and ``torchrl`` extras; request them by name:
 
 .. code-block:: bash
 
@@ -659,7 +659,7 @@ have dedicated commands below.
      - Developer test and documentation tooling.
 
 Use ``all`` for the curated list above. Isaac Sim, standalone importers, specialized extras
-(``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, ``leapp``), and the
+(``rlinf``, ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, ``leapp``, ``torchrl``), and the
 developer ``test`` tooling remain opt-in.
 
 .. _installation-importers-extra:

--- a/docs/source/setup/quickstart.rst
+++ b/docs/source/setup/quickstart.rst
@@ -61,8 +61,8 @@ Training outputs, including checkpoints, are saved under ``logs/``. Add
    ``physics=ovphysx`` selects it for the task. You can combine extras as needed. The ``--extra all``
    shortcut installs the curated ``ov``, ``rl-games``, ``sb3``, ``skrl``, ``rsl-rl``, ``rerun``,
    and ``viser`` extras. Isaac Sim, standalone importers, and specialized extras such as ``rlinf``,
-   ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, and ``leapp`` are not included; add
-   them explicitly. See
+   ``mimic``, ``teleop``, ``tetrahedralization``, ``video``, ``leapp``, and ``torchrl`` are not
+   included; add them explicitly. See
    :ref:`installation-optional-extras` for the complete list.
 
 Choose an RL library
@@ -92,6 +92,9 @@ and is a good starting point for GPU-based training.
    * - ``rlinf``
      - VLA model fine-tuning
      - ``uv run --extra rlinf isaaclab train --rl_library rlinf ...``
+   * - ``torchrl``
+     - Custom algorithms from PyTorch-native RL components (training only)
+     - ``uv run --extra torchrl isaaclab train --rl_library torchrl ...``
 
 RL libraries differ in their supported algorithms, tasks, and workflows. See
 :ref:`choose-an-rl-library` for a detailed comparison.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,8 @@ rl-games = [
 
 rsl-rl = ["rsl-rl-lib==5.4.1", "onnxscript>=0.5"]
 
+torchrl = ["torchrl>=0.13"]
+
 viser = ["viser>=1.0.16"]
 
 rerun = [

--- a/source/isaaclab/changelog.d/torchrl-wrapper.rst
+++ b/source/isaaclab/changelog.d/torchrl-wrapper.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab.envs.multi_agent_to_single_agent` to expose the terminal observations that
+  :class:`~isaaclab.envs.DirectMARLEnv` captures per agent (``extras[agent]["final_obs"]``, see
+  :attr:`~isaaclab.envs.DirectMARLEnvCfg.compute_final_obs`) as the concatenated single-agent
+  ``extras["final_obs"]`` entry, so single-agent RL wrappers bootstrap time-outs of converted multi-agent tasks
+  correctly. The converted environment now also exposes :attr:`extras` like :class:`~isaaclab.envs.DirectRLEnv`.

--- a/source/isaaclab/isaaclab/envs/utils/marl.py
+++ b/source/isaaclab/isaaclab/envs/utils/marl.py
@@ -81,8 +81,9 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
             )
             self.action_space = gym.vector.utils.batch_space(self.single_action_space, self.num_envs)
 
-            # latest converted observations, refreshed by reset() and step()
+            # latest converted observations and extras, refreshed by reset() and step()
             self._obs_buf: VecEnvObs = {}
+            self._extras: dict = {}
 
         @property
         def episode_length_buf(self) -> torch.Tensor:
@@ -99,6 +100,15 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
             """Latest observations from the wrapped multi-agent environment."""
             return self._obs_buf
 
+        @property
+        def extras(self) -> dict:
+            """Latest extras from the wrapped multi-agent environment, keyed by agent.
+
+            Includes the single-agent ``"final_obs"`` entry when terminal observations were captured
+            (see :meth:`_convert_final_obs`).
+            """
+            return self._extras
+
         def _convert_observations(self, obs: dict[AgentID, ObsType]) -> VecEnvObs:
             """Convert multi-agent observations to the single-agent policy observation."""
             # FIXME: This implementation assumes the spaces are fundamental ones. Fix it to support composite spaces
@@ -110,10 +120,27 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
                 )
             }
 
+        def _convert_final_obs(self, extras: dict) -> dict:
+            """Expose the terminal observations captured by the multi-agent environment to single-agent wrappers.
+
+            :class:`DirectMARLEnv` stores them per agent under ``extras[agent]["final_obs"]`` (see
+            :attr:`DirectMARLEnvCfg.compute_final_obs`), whereas single-agent wrappers read the observation
+            dictionary under ``extras["final_obs"]``. The environment state is not captured before a reset, so no
+            terminal observation is exposed in the state-as-observation mode.
+            """
+            if self._state_as_observation or not all(
+                "final_obs" in extras.get(agent, {}) for agent in self.env.possible_agents
+            ):
+                return extras
+            final_obs = {agent: extras[agent]["final_obs"] for agent in self.env.possible_agents}
+            # shallow copy so the per-agent extras of the wrapped environment stay untouched
+            return {**extras, "final_obs": self._convert_observations(final_obs)}
+
         def reset(self, seed: int | None = None, options: dict[str, Any] | None = None) -> tuple[VecEnvObs, dict]:
             obs, extras = self.env.reset(seed, options)
             self._obs_buf = self._convert_observations(obs)
-            return self._obs_buf, extras
+            self._extras = extras
+            return self._obs_buf, self._extras
 
         def step(self, action: torch.Tensor) -> VecEnvStepReturn:
             # split single-agent actions to build the multi-agent ones
@@ -129,13 +156,14 @@ def multi_agent_to_single_agent(env: DirectMARLEnv, state_as_observation: bool =
             obs, rewards, terminated, time_outs, extras = self.env.step(_actions)
 
             self._obs_buf = self._convert_observations(obs)
+            self._extras = self._convert_final_obs(extras)
 
             # process environment outputs to return single-agent data
             rewards = sum(rewards.values())
             terminated = math.prod(terminated.values()).to(dtype=torch.bool)
             time_outs = math.prod(time_outs.values()).to(dtype=torch.bool)
 
-            return self._obs_buf, rewards, terminated, time_outs, extras
+            return self._obs_buf, rewards, terminated, time_outs, self._extras
 
         def render(self, recompute: bool = False) -> np.ndarray | None:
             return self.env.render(recompute)

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -95,6 +95,7 @@ def test_all_extra_aggregates_curated_ov_rl_and_visualizer_extras():
 
     assert set(optional) - reachable - {"all"} == {
         "rlinf",
+        "torchrl",
         "isaacsim",
         "importers",
         "mimic",

--- a/source/isaaclab/test/envs/test_marl_utils.py
+++ b/source/isaaclab/test/envs/test_marl_utils.py
@@ -23,9 +23,10 @@ class _FakeMultiAgentEnv:
     }
     render_mode = None
 
-    def __init__(self):
+    def __init__(self, compute_final_obs=False):
         self.unwrapped = self
-        self.cfg = SimpleNamespace(state_space=2)
+        self.cfg = SimpleNamespace(state_space=2, compute_final_obs=compute_final_obs)
+        self.extras = {agent: {} for agent in self.possible_agents}
         self.state_space = gym.spaces.Box(low=-1.0, high=1.0, shape=(2,))
         self.sim = object()
         self.scene = SimpleNamespace(num_envs=2)
@@ -36,14 +37,18 @@ class _FakeMultiAgentEnv:
         }
 
     def reset(self, seed=None, options=None):
-        return self.obs_dict, {}
+        return self.obs_dict, self.extras
 
     def step(self, actions):
         # shift the observations so a step is distinguishable from a reset
         self.obs_dict = {agent: obs + 10.0 for agent, obs in self.obs_dict.items()}
+        if self.cfg.compute_final_obs:
+            # per-agent terminal observations, distinguishable from the returned (post-reset) observations
+            for agent, obs in self.obs_dict.items():
+                self.extras[agent]["final_obs"] = obs + 100.0
         rewards = {agent: torch.zeros(2) for agent in self.possible_agents}
         dones = {agent: torch.zeros(2, dtype=torch.bool) for agent in self.possible_agents}
-        return self.obs_dict, rewards, dones, dones, {}
+        return self.obs_dict, rewards, dones, dones, self.extras
 
     def state(self):
         return torch.tensor([[7.0, 8.0], [9.0, 10.0]])
@@ -107,3 +112,26 @@ def test_multi_agent_to_single_agent_state_observation_tracks_steps():
 
     step_obs = env.step(torch.zeros(2, 2))[0]
     torch.testing.assert_close(env.obs_buf["policy"], step_obs["policy"])
+
+
+def test_multi_agent_to_single_agent_concatenates_final_obs():
+    """Per-agent terminal observations should surface as the single-agent ``extras["final_obs"]`` entry."""
+    source_env = _FakeMultiAgentEnv(compute_final_obs=True)
+    env = multi_agent_to_single_agent(source_env)
+
+    extras = env.step(torch.zeros(2, 2))[4]
+
+    expected = torch.tensor([[111.0, 112.0, 115.0], [113.0, 114.0, 116.0]])
+    torch.testing.assert_close(extras["final_obs"]["policy"], expected)
+    torch.testing.assert_close(env.extras["final_obs"]["policy"], expected)
+    # the per-agent extras of the wrapped environment are left untouched
+    assert "final_obs" not in source_env.extras
+
+
+def test_multi_agent_to_single_agent_omits_final_obs_when_unavailable():
+    """No ``final_obs`` entry without captured terminal observations or in the state-as-observation mode."""
+    env = multi_agent_to_single_agent(_FakeMultiAgentEnv())
+    assert "final_obs" not in env.step(torch.zeros(2, 2))[4]
+
+    env = multi_agent_to_single_agent(_FakeMultiAgentEnv(compute_final_obs=True), state_as_observation=True)
+    assert "final_obs" not in env.step(torch.zeros(2, 2))[4]

--- a/source/isaaclab_rl/changelog.d/torchrl-wrapper.minor.rst
+++ b/source/isaaclab_rl/changelog.d/torchrl-wrapper.minor.rst
@@ -9,3 +9,6 @@ Added
   observations, since Isaac Lab already reset those environments inside ``step()``, and the terminal
   observation (``extras["final_obs"]``, when ``cfg.compute_final_obs`` is enabled) is reported for done
   transitions so that time-limit bootstrapping is correct.
+* Added :func:`~isaaclab_rl.torchrl.train_ppo` with :class:`~isaaclab_rl.torchrl.TorchRlPpoCfg`, a PPO example
+  built from TorchRL's collector, GAE, and clipped PPO loss, and the ``torchrl`` backend of the unified ``train``
+  entrypoint (``--rl_library torchrl``).

--- a/source/isaaclab_rl/changelog.d/torchrl-wrapper.minor.rst
+++ b/source/isaaclab_rl/changelog.d/torchrl-wrapper.minor.rst
@@ -1,0 +1,11 @@
+Added
+^^^^^
+
+* Added :class:`~isaaclab_rl.torchrl.IsaacLabTorchRLWrapper` to wrap Isaac Lab environments for the
+  `TorchRL <https://github.com/pytorch/rl>`_ library. The wrapper implements :class:`~torchrl.envs.EnvBase`
+  directly, preserving per-group observation structure (e.g. ``"policy"``/``"critic"``) as a
+  :class:`~torchrl.data.Composite` spec and exposing ``done``/``terminated``/``truncated`` as separate spec
+  keys. Reset requests that TorchRL issues after a step with done environments are served from the current
+  observations, since Isaac Lab already reset those environments inside ``step()``, and the terminal
+  observation (``extras["final_obs"]``, when ``cfg.compute_final_obs`` is enabled) is reported for done
+  transitions so that time-limit bootstrapping is correct.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/api.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/api.py
@@ -12,7 +12,8 @@ from typing import Literal
 
 from .dispatch import run_play_cli, run_random_agent_cli, run_train_cli, run_zero_agent_cli
 
-BackendName = Literal["rl_games", "rlinf", "rsl_rl", "sb3", "skrl"]
+BackendName = Literal["rl_games", "rlinf", "rsl_rl", "sb3", "skrl", "torchrl"]
+"""Backends of the unified entrypoints. ``torchrl`` provides training only."""
 
 MULTI_GPU_BACKENDS: tuple[BackendName, ...] = ("rl_games", "rsl_rl", "skrl")
 """Backends the multi-GPU launcher can drive."""

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_torchrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_torchrl.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""TorchRL training logic for the unified reinforcement learning entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import logging
+import os
+import random
+import time
+from datetime import datetime
+
+from isaaclab.app import add_launcher_args
+
+from isaaclab_rl.entrypoints.common import (
+    add_common_train_args,
+    apply_env_overrides,
+    apply_video_recording,
+    configure_io_descriptors,
+    create_isaaclab_env,
+    dump_train_configs,
+    enable_cameras_for_video,
+    pre_launch_video_config,
+    set_hydra_args,
+    show_run_summary,
+    startup_screen,
+    wrap_training_capture,
+    write_run_manifest,
+)
+
+import isaaclab_tasks  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+with contextlib.suppress(ImportError):
+    import isaaclab_tasks_experimental  # noqa: F401
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse TorchRL training arguments."""
+    from isaaclab_tasks.utils import setup_preset_cli
+
+    parser = argparse.ArgumentParser(description="Train an RL agent with TorchRL.")
+    add_common_train_args(
+        parser,
+        agent_default="torchrl_cfg_entry_point",
+        agent_help="Name of the RL agent configuration entry point.",
+        include_distributed=False,
+    )
+    add_launcher_args(parser)
+    args_cli, hydra_args = setup_preset_cli(parser, argv, agent_library="torchrl")
+    enable_cameras_for_video(args_cli)
+    set_hydra_args(hydra_args)
+    return args_cli
+
+
+def run(argv: list[str]) -> None:
+    """Train a PPO agent with TorchRL."""
+    from isaaclab.app import launch_simulation
+    from isaaclab.envs import DirectMARLEnvCfg
+    from isaaclab.utils.seed import configure_seed
+
+    from isaaclab_tasks.utils import resolve_task_config
+
+    args_cli = _parse_args(argv)
+    with startup_screen(args_cli, num_stages=2) as screen:
+        env_cfg, agent_cfg = resolve_task_config(args_cli.task, args_cli.agent)
+        pre_launch_video_config(env_cfg, args_cli=args_cli)
+        show_run_summary(screen, args_cli, env_cfg, library="torchrl", action="train")
+        screen.stage("Launching simulation")
+        with launch_simulation(env_cfg, args_cli):
+            # imported after the task config is resolved so preset errors surface even without torchrl installed
+            from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper, train_ppo
+
+            apply_env_overrides(args_cli, env_cfg)
+            if args_cli.seed is not None:
+                agent_cfg.seed = args_cli.seed if args_cli.seed != -1 else random.randint(0, 10000)
+            if args_cli.max_iterations is not None:
+                agent_cfg.max_iterations = args_cli.max_iterations
+            agent_cfg.device = env_cfg.sim.device
+            env_cfg.seed = agent_cfg.seed
+            # terminal observations let the value estimator bootstrap correctly on time-outs
+            env_cfg.compute_final_obs = True
+
+            run_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + (
+                f"_{agent_cfg.run_name}" if agent_cfg.run_name else ""
+            )
+            log_dir = os.path.abspath(os.path.join("logs", "torchrl", agent_cfg.experiment_name, run_name))
+            print(f"[INFO] Logging experiment in directory: {log_dir}")
+            write_run_manifest(log_dir, library="torchrl", task=args_cli.task, metadata={"agent": args_cli.agent})
+            dump_train_configs(log_dir, env_cfg, agent_cfg)
+            configure_io_descriptors(env_cfg, args_cli, logger)
+            env_cfg.log_dir = log_dir
+            apply_video_recording(env_cfg, log_dir, args_cli)
+
+            screen.stage("Creating environment")
+            env = create_isaaclab_env(
+                args_cli.task,
+                env_cfg,
+                args_cli,
+                convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
+            )
+            env = IsaacLabTorchRLWrapper(
+                wrap_training_capture(env, log_dir, args_cli), clip_actions=agent_cfg.clip_actions
+            )
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
+            screen.close()
+
+            start_time = time.time()
+            with contextlib.suppress(KeyboardInterrupt):
+                train_ppo(env, agent_cfg, log_dir)
+            print(f"Training time: {round(time.time() - start_time, 2)} seconds")
+            env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_torchrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_torchrl.py
@@ -113,7 +113,9 @@ def run(argv: list[str]) -> None:
             screen.close()
 
             start_time = time.time()
-            with contextlib.suppress(KeyboardInterrupt):
+            try:
                 train_ppo(env, agent_cfg, log_dir)
+            except KeyboardInterrupt:
+                print("[TorchRL] Training interrupted.")
             print(f"Training time: {round(time.time() - start_time, 2)} seconds")
             env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/dispatch.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/dispatch.py
@@ -25,6 +25,7 @@ _BACKEND_MODULES = {
         "rsl_rl": "isaaclab_rl.entrypoints.backends.train_rsl_rl",
         "sb3": "isaaclab_rl.entrypoints.backends.train_sb3",
         "skrl": "isaaclab_rl.entrypoints.backends.train_skrl",
+        "torchrl": "isaaclab_rl.entrypoints.backends.train_torchrl",
     },
     "play": {
         "rl_games": "isaaclab_rl.entrypoints.backends.play_rl_games",

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.py
@@ -5,13 +5,14 @@
 
 """Wrappers and utilities to configure an environment for the TorchRL library.
 
-The following example shows how to wrap an environment for TorchRL:
+The following example shows how to wrap an environment for TorchRL and train it with the bundled PPO example:
 
 .. code-block:: python
 
-    from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper
+    from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper, train_ppo
 
     env = IsaacLabTorchRLWrapper(env)
+    actor = train_ppo(env, agent_cfg, log_dir)
 
 """
 

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Wrappers and utilities to configure an environment for the TorchRL library.
+
+The following example shows how to wrap an environment for TorchRL:
+
+.. code-block:: python
+
+    from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper
+
+    env = IsaacLabTorchRLWrapper(env)
+
+"""
+
+from isaaclab.utils.module import lazy_export
+
+lazy_export()

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.pyi
@@ -5,6 +5,12 @@
 
 __all__ = [
     "IsaacLabTorchRLWrapper",
+    "TorchRlPpoCfg",
+    "make_actor",
+    "make_critic",
+    "train_ppo",
 ]
 
+from .ppo import make_actor, make_critic, train_ppo
+from .ppo_cfg import TorchRlPpoCfg
 from .vecenv_wrapper import IsaacLabTorchRLWrapper

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/__init__.pyi
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "IsaacLabTorchRLWrapper",
+]
+
+from .vecenv_wrapper import IsaacLabTorchRLWrapper

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/ppo.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/ppo.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""PPO for Isaac Lab environments built from TorchRL's collector, GAE, and clipped PPO loss."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from tensordict.nn import NormalParamExtractor, TensorDictModule
+from torch import nn
+from torch.utils.tensorboard import SummaryWriter
+from torchrl.collectors import Collector
+from torchrl.data import Composite
+from torchrl.envs import ExplorationType
+from torchrl.modules import MLP, IndependentNormal, ProbabilisticActor, ValueOperator
+from torchrl.objectives import ClipPPOLoss, ValueEstimators
+
+from .ppo_cfg import TorchRlPpoCfg
+from .vecenv_wrapper import IsaacLabTorchRLWrapper
+
+
+def make_actor(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg) -> ProbabilisticActor:
+    """Gaussian MLP policy over the ``"policy"`` observation group."""
+    net = nn.Sequential(
+        _mlp(env, "policy", 2 * env.action_spec.shape[-1], cfg.actor_hidden_dims, cfg.activation),
+        NormalParamExtractor(scale_mapping=f"biased_softplus_{cfg.init_noise_std}"),
+    )
+    return ProbabilisticActor(
+        TensorDictModule(net, in_keys=["policy"], out_keys=["loc", "scale"]),
+        in_keys=["loc", "scale"],
+        out_keys=["action"],
+        distribution_class=IndependentNormal,
+        return_log_prob=True,
+        log_prob_key="sample_log_prob",
+        default_interaction_type=ExplorationType.RANDOM,
+    )
+
+
+def make_critic(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg) -> ValueOperator:
+    """MLP value function over the flat ``"critic"`` observation group when the task defines one, else ``"policy"``."""
+    critic_spec = env.observation_spec.get("critic", None)
+    key = "critic" if critic_spec is not None and not isinstance(critic_spec, Composite) else "policy"
+    return ValueOperator(_mlp(env, key, 1, cfg.critic_hidden_dims, cfg.activation), in_keys=[key])
+
+
+def train_ppo(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg, log_dir: str) -> ProbabilisticActor:
+    """Trains a PPO agent for ``cfg.max_iterations`` iterations and returns the actor.
+
+    Actor checkpoints (``model_<iteration>.pt``, loadable with :meth:`torch.nn.Module.load_state_dict` on
+    :func:`make_actor`) and TensorBoard scalars, including the episode statistics Isaac Lab reports under
+    ``extras["log"]``, are written to ``log_dir``.
+    """
+    torch.manual_seed(cfg.seed)
+    actor = make_actor(env, cfg).to(cfg.device)
+    critic = make_critic(env, cfg).to(cfg.device)
+    loss = ClipPPOLoss(
+        actor,
+        critic,
+        clip_epsilon=cfg.clip_param,
+        entropy_bonus=cfg.entropy_coef > 0,
+        entropy_coeff=cfg.entropy_coef,
+        critic_coeff=cfg.value_loss_coef,
+    )
+    loss.set_keys(sample_log_prob="sample_log_prob")
+    loss.make_value_estimator(ValueEstimators.GAE, gamma=cfg.gamma, lmbda=cfg.lam)
+    optimizer = torch.optim.Adam(loss.parameters(), lr=cfg.learning_rate)
+    frames_per_batch = env.batch_size[0] * cfg.num_steps_per_env
+    collector = Collector(
+        env,
+        actor,
+        frames_per_batch=frames_per_batch,
+        total_frames=frames_per_batch * cfg.max_iterations,
+        device=cfg.device,
+        auto_register_policy_transforms=False,
+    )
+    writer = SummaryWriter(log_dir)
+
+    for iteration, batch in enumerate(collector, start=1):
+        with torch.no_grad():
+            loss.value_estimator(batch)
+        samples = batch.reshape(-1)
+        for _ in range(cfg.num_learning_epochs):
+            for indices in torch.randperm(samples.shape[0], device=samples.device).chunk(cfg.num_mini_batches):
+                terms = loss(samples[indices])
+                optimizer.zero_grad()
+                sum(value for key, value in terms.items() if key.startswith("loss_")).backward()
+                nn.utils.clip_grad_norm_(loss.parameters(), cfg.max_grad_norm)
+                optimizer.step()
+
+        stats = {f"Loss/{key}": value.item() for key, value in terms.items() if key.startswith("loss_")}
+        stats["Train/mean_step_reward"] = batch["next", "reward"].mean().item()
+        stats.update({key: float(value) for key, value in env.unwrapped.extras.get("log", {}).items()})
+        for key, value in stats.items():
+            writer.add_scalar(key, value, iteration)
+        print(f"[TorchRL] iteration {iteration}/{cfg.max_iterations}: reward {stats['Train/mean_step_reward']:.4f}")
+        if iteration % cfg.save_interval == 0 or iteration == cfg.max_iterations:
+            torch.save(actor.state_dict(), os.path.join(log_dir, f"model_{iteration}.pt"))
+
+    collector.shutdown()
+    writer.close()
+    return actor
+
+
+def _mlp(env: IsaacLabTorchRLWrapper, key: str, out_features: int, hidden_dims: list[int], activation: str) -> MLP:
+    in_features = env.observation_spec[key].shape[len(env.batch_size) :].numel()
+    return MLP(in_features, out_features, num_cells=hidden_dims, activation_class=getattr(nn, activation))

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/ppo.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/ppo.py
@@ -14,7 +14,7 @@ from tensordict.nn import NormalParamExtractor, TensorDictModule
 from torch import nn
 from torch.utils.tensorboard import SummaryWriter
 from torchrl.collectors import Collector
-from torchrl.data import Composite
+from torchrl.data import Bounded, Composite, Unbounded
 from torchrl.envs import ExplorationType
 from torchrl.modules import MLP, IndependentNormal, ProbabilisticActor, ValueOperator
 from torchrl.objectives import ClipPPOLoss, ValueEstimators
@@ -24,9 +24,24 @@ from .vecenv_wrapper import IsaacLabTorchRLWrapper
 
 
 def make_actor(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg) -> ProbabilisticActor:
-    """Gaussian MLP policy over the ``"policy"`` observation group."""
+    """Gaussian MLP policy over the ``"policy"`` observation group.
+
+    Raises:
+        NotImplementedError: When the action spec is not a flat continuous vector or the ``"policy"``
+            observation group is not a flat tensor.
+    """
+    action_spec = env.action_spec
+    if (
+        not isinstance(action_spec, (Bounded, Unbounded))
+        or not action_spec.dtype.is_floating_point
+        or len(action_spec.shape) != len(env.batch_size) + 1
+    ):
+        raise NotImplementedError(
+            f"{type(action_spec).__name__} action spec of shape {tuple(action_spec.shape)} is not supported: the PPO"
+            " example expects a flat continuous action vector (one-dimensional gymnasium.spaces.Box)."
+        )
     net = nn.Sequential(
-        _mlp(env, "policy", 2 * env.action_spec.shape[-1], cfg.actor_hidden_dims, cfg.activation),
+        _mlp(env, "policy", 2 * action_spec.shape[-1], cfg.actor_hidden_dims, cfg.activation),
         NormalParamExtractor(scale_mapping=f"biased_softplus_{cfg.init_noise_std}"),
     )
     return ProbabilisticActor(
@@ -41,9 +56,12 @@ def make_actor(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg) -> Probabilistic
 
 
 def make_critic(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg) -> ValueOperator:
-    """MLP value function over the flat ``"critic"`` observation group when the task defines one, else ``"policy"``."""
-    critic_spec = env.observation_spec.get("critic", None)
-    key = "critic" if critic_spec is not None and not isinstance(critic_spec, Composite) else "policy"
+    """MLP value function over the ``"critic"`` observation group when the task defines one, else ``"policy"``.
+
+    Raises:
+        NotImplementedError: When the selected observation group is not a flat tensor.
+    """
+    key = "critic" if env.observation_spec.get("critic", None) is not None else "policy"
     return ValueOperator(_mlp(env, key, 1, cfg.critic_hidden_dims, cfg.activation), in_keys=[key])
 
 
@@ -79,32 +97,46 @@ def train_ppo(env: IsaacLabTorchRLWrapper, cfg: TorchRlPpoCfg, log_dir: str) -> 
     )
     writer = SummaryWriter(log_dir)
 
-    for iteration, batch in enumerate(collector, start=1):
-        with torch.no_grad():
-            loss.value_estimator(batch)
-        samples = batch.reshape(-1)
-        for _ in range(cfg.num_learning_epochs):
-            for indices in torch.randperm(samples.shape[0], device=samples.device).chunk(cfg.num_mini_batches):
-                terms = loss(samples[indices])
-                optimizer.zero_grad()
-                sum(value for key, value in terms.items() if key.startswith("loss_")).backward()
-                nn.utils.clip_grad_norm_(loss.parameters(), cfg.max_grad_norm)
-                optimizer.step()
+    try:
+        for iteration, batch in enumerate(collector, start=1):
+            with torch.no_grad():
+                loss.value_estimator(batch)
+            samples = batch.reshape(-1)
+            for _ in range(cfg.num_learning_epochs):
+                for indices in torch.randperm(samples.shape[0], device=samples.device).chunk(cfg.num_mini_batches):
+                    terms = loss(samples[indices])
+                    optimizer.zero_grad()
+                    sum(value for key, value in terms.items() if key.startswith("loss_")).backward()
+                    nn.utils.clip_grad_norm_(loss.parameters(), cfg.max_grad_norm)
+                    optimizer.step()
 
-        stats = {f"Loss/{key}": value.item() for key, value in terms.items() if key.startswith("loss_")}
-        stats["Train/mean_step_reward"] = batch["next", "reward"].mean().item()
-        stats.update({key: float(value) for key, value in env.unwrapped.extras.get("log", {}).items()})
-        for key, value in stats.items():
-            writer.add_scalar(key, value, iteration)
-        print(f"[TorchRL] iteration {iteration}/{cfg.max_iterations}: reward {stats['Train/mean_step_reward']:.4f}")
-        if iteration % cfg.save_interval == 0 or iteration == cfg.max_iterations:
-            torch.save(actor.state_dict(), os.path.join(log_dir, f"model_{iteration}.pt"))
-
-    collector.shutdown()
-    writer.close()
+            stats = {f"Loss/{key}": value.item() for key, value in terms.items() if key.startswith("loss_")}
+            stats["Train/mean_step_reward"] = batch["next", "reward"].mean().item()
+            stats.update({key: float(value) for key, value in env.unwrapped.extras.get("log", {}).items()})
+            for key, value in stats.items():
+                writer.add_scalar(key, value, iteration)
+            print(f"[TorchRL] iteration {iteration}/{cfg.max_iterations}: reward {stats['Train/mean_step_reward']:.4f}")
+            if iteration % cfg.save_interval == 0 or iteration == cfg.max_iterations:
+                torch.save(actor.state_dict(), os.path.join(log_dir, f"model_{iteration}.pt"))
+    finally:
+        # release the collector and flush the logs also when training is interrupted
+        collector.shutdown()
+        writer.close()
     return actor
 
 
 def _mlp(env: IsaacLabTorchRLWrapper, key: str, out_features: int, hidden_dims: list[int], activation: str) -> MLP:
-    in_features = env.observation_spec[key].shape[len(env.batch_size) :].numel()
+    """MLP reading the flat observation group ``key``.
+
+    Raises:
+        NotImplementedError: When the observation group is a dictionary of terms or not a flat tensor.
+    """
+    spec = env.observation_spec[key]
+    if isinstance(spec, Composite) or len(spec.shape) != len(env.batch_size) + 1:
+        shape = f"terms {sorted(spec.keys())}" if isinstance(spec, Composite) else f"shape {tuple(spec.shape)}"
+        raise NotImplementedError(
+            f'The "{key}" observation group ({shape}) is not supported: the PPO example expects a flat tensor per'
+            " observation group (e.g. concatenate_terms=True in manager-based tasks)."
+        )
+    in_features = spec.shape[-1]
     return MLP(in_features, out_features, num_cells=hidden_dims, activation_class=getattr(nn, activation))

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/ppo_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/ppo_cfg.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+
+from isaaclab.utils.configclass import configclass
+
+
+@configclass
+class TorchRlPpoCfg:
+    """Configuration of :func:`~isaaclab_rl.torchrl.train_ppo`."""
+
+    seed: int = 42
+    device: str = "cuda:0"
+    num_steps_per_env: int = MISSING
+    """Environment steps collected from every environment per iteration."""
+    max_iterations: int = MISSING
+    save_interval: int = MISSING
+    """Iterations between checkpoints."""
+    experiment_name: str = MISSING
+    """Name of the experiment folder under ``logs/torchrl``."""
+    run_name: str = ""
+    """Optional suffix of the timestamped run folder."""
+    clip_actions: float | None = None
+    """Clipping range applied to actions before they reach the environment; ``None`` disables it."""
+
+    actor_hidden_dims: list[int] = MISSING
+    critic_hidden_dims: list[int] = MISSING
+    """The critic reads the ``"critic"`` observation group when the task defines one, else ``"policy"``."""
+    activation: str = "ELU"
+    """Name of a :mod:`torch.nn` activation class."""
+    init_noise_std: float = 1.0
+    """Initial standard deviation of the Gaussian policy."""
+
+    num_learning_epochs: int = MISSING
+    num_mini_batches: int = MISSING
+    learning_rate: float = MISSING
+    gamma: float = MISSING
+    lam: float = MISSING
+    clip_param: float = 0.2
+    entropy_coef: float = 0.0
+    value_loss_coef: float = 1.0
+    max_grad_norm: float = 1.0

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/ppo_cfg.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/ppo_cfg.py
@@ -30,7 +30,10 @@ class TorchRlPpoCfg:
 
     actor_hidden_dims: list[int] = MISSING
     critic_hidden_dims: list[int] = MISSING
-    """The critic reads the ``"critic"`` observation group when the task defines one, else ``"policy"``."""
+    """The critic reads the ``"critic"`` observation group when the task defines one, else ``"policy"``.
+
+    Both groups must be flat tensors; dictionary observation groups are not supported by the PPO example.
+    """
     activation: str = "ELU"
     """Name of a :mod:`torch.nn` activation class."""
     init_noise_std: float = 1.0

--- a/source/isaaclab_rl/isaaclab_rl/torchrl/vecenv_wrapper.py
+++ b/source/isaaclab_rl/isaaclab_rl/torchrl/vecenv_wrapper.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import gymnasium as gym
+import torch
+from tensordict import TensorDict
+from tensordict.utils import expand_as_right
+from torchrl.data import Bounded, Categorical, Composite, MultiCategorical, TensorSpec, Unbounded
+from torchrl.envs import EnvBase
+
+if TYPE_CHECKING:
+    from isaaclab.envs import DirectRLEnv, ManagerBasedRLEnv
+
+    with contextlib.suppress(ImportError):
+        from isaaclab_experimental.envs import DirectRLEnvWarp, ManagerBasedRLEnvWarp
+
+
+class IsaacLabTorchRLWrapper(EnvBase):
+    """Wraps around Isaac Lab environment for the TorchRL library.
+
+    The wrapper implements :class:`~torchrl.envs.EnvBase` directly on the batched Isaac Lab environment
+    instead of going through :class:`torchrl.envs.libs.gym.GymWrapper`, so it also accepts the Warp-based
+    environments (which are not ``gymnasium`` subclasses) and keeps the tensordicts on the simulation device
+    by default. Observation groups (e.g. ``"policy"``, ``"critic"``) become one :class:`~torchrl.data.Composite`
+    each, and ``done``, ``terminated``, and ``truncated`` are separate spec keys.
+
+    Isaac Lab resets finished environments inside :meth:`step` and returns the first observation of their new
+    episodes. The ``"next"`` observation of a done transition is therefore taken from ``extras["final_obs"]``
+    when the environment captures it (``cfg.compute_final_obs=True``), which keeps value bootstrapping on
+    time-outs correct; otherwise it is NaN-filled following TorchRL's auto-reset convention. The ``"_reset"``
+    requests TorchRL issues after a step with done environments (including the case where all of them
+    finished) return the current observations without resetting again; only :meth:`reset` calls without a
+    ``"_reset"`` mask reset the simulation.
+
+    Episode statistics (``extras["log"]``) are per-batch scalars and are not part of the tensordicts; they
+    remain available under ``env.unwrapped.extras["log"]``.
+
+    .. caution::
+        This class must be the last wrapper in the wrapper chain, since it does not follow the
+        :class:`gymnasium.Wrapper` interface.
+    """
+
+    def __init__(
+        self,
+        env: ManagerBasedRLEnv | DirectRLEnv,
+        device: str | None = None,
+        clip_actions: float | None = None,
+    ):
+        """Initializes the wrapper.
+
+        Args:
+            env: The environment to wrap around.
+            device: The device the returned tensordicts should live on. If ``None``, the
+                wrapper stays on :attr:`env`'s device and performs no device conversion.
+            clip_actions: The clipping value for actions. If ``None``, then no clipping is
+                done. Only supported for :class:`gymnasium.spaces.Box` action spaces.
+
+        Raises:
+            ValueError: When the environment is not an instance of :class:`ManagerBasedRLEnv`
+                or :class:`DirectRLEnv`.
+        """
+        # NOTE: import here (not at module level) to avoid loading heavy env classes before Isaac Sim is initialized.
+        from isaaclab.envs import DirectRLEnv, ManagerBasedRLEnv
+
+        try:
+            from isaaclab_experimental.envs import DirectRLEnvWarp, ManagerBasedRLEnvWarp
+        except ImportError:
+            DirectRLEnvWarp = None
+            ManagerBasedRLEnvWarp = None
+
+        allowed_types = (ManagerBasedRLEnv, DirectRLEnv)
+        if DirectRLEnvWarp is not None:
+            allowed_types += (DirectRLEnvWarp,)
+        if ManagerBasedRLEnvWarp is not None:
+            allowed_types += (ManagerBasedRLEnvWarp,)
+
+        if not isinstance(env.unwrapped, allowed_types):
+            raise ValueError(
+                "The environment must be inherited from ManagerBasedRLEnv / DirectRLEnv / DirectRLEnvWarp /"
+                f" ManagerBasedRLEnvWarp. Environment type: {type(env)}"
+            )
+
+        self.env = env
+        self._clip_actions = clip_actions
+        num_envs = self.unwrapped.num_envs
+
+        super().__init__(
+            device=device if device is not None else self.unwrapped.device,
+            batch_size=torch.Size([num_envs]),
+        )
+
+        self.observation_spec = self._make_observation_spec(self.unwrapped.single_observation_space)
+        self.action_spec = self._make_action_spec(self.unwrapped.single_action_space, clip_actions)
+        self.reward_spec = Unbounded(shape=(*self.batch_size, 1), device=self.device)
+        self.done_spec = Composite(
+            {
+                key: Categorical(2, dtype=torch.bool, shape=(*self.batch_size, 1), device=self.device)
+                for key in ("done", "terminated", "truncated")
+            },
+            shape=self.batch_size,
+        )
+        # the wrapped environment is already running
+        self.is_closed = False
+
+    def __str__(self):
+        """Returns the wrapper name and the :attr:`env` representation string."""
+        return f"<{type(self).__name__}{self.env}>"
+
+    def __repr__(self):
+        """Returns the string representation of the wrapper."""
+        return str(self)
+
+    """
+    Properties
+    """
+
+    @property
+    def unwrapped(self) -> ManagerBasedRLEnv | DirectRLEnv | DirectRLEnvWarp | ManagerBasedRLEnvWarp:
+        """Returns the base environment of the wrapper.
+
+        This will be the bare :class:`gymnasium.Env` environment, underneath all layers of wrappers.
+        """
+        return self.env.unwrapped
+
+    """
+    Operations - EnvBase
+    """
+
+    def _step(self, tensordict: TensorDict) -> TensorDict:
+        """Steps the environment with the ``"action"`` entry of ``tensordict``.
+
+        Returns:
+            The observation groups, ``reward``, ``terminated``, ``truncated`` and ``done`` of the transition.
+        """
+        actions = tensordict.get("action")
+        if self._clip_actions is not None:
+            actions = torch.clamp(actions, -self._clip_actions, self._clip_actions)
+
+        obs_dict, rew, terminated, truncated, extras = self.env.step(actions)
+
+        # Isaac Lab reuses these buffers across steps; TorchRL keeps every step's tensordict alive until stacked.
+        rew = rew.reshape(*self.batch_size, 1).clone()
+        terminated = terminated.reshape(*self.batch_size, 1).clone()
+        truncated = truncated.reshape(*self.batch_size, 1).clone()
+        if getattr(self.unwrapped.cfg, "is_finite_horizon", False):
+            # finite-horizon tasks treat the time limit as terminal (same convention as the RSL-RL wrapper)
+            terminated |= truncated
+            truncated.zero_()
+        done = terminated | truncated
+
+        obs = TensorDict(obs_dict, batch_size=self.batch_size, device=self.device)
+        out = self._terminal_observations(obs, extras, done)
+        out["reward"] = rew
+        out["terminated"] = terminated
+        out["truncated"] = truncated
+        out["done"] = done
+        return out
+
+    def _reset(self, tensordict: TensorDict | None = None, **kwargs) -> TensorDict:
+        """Resets the environment and returns the initial observations.
+
+        A ``"_reset"`` mask in ``tensordict`` does not reset anything: TorchRL issues it after a step with done
+        environments, which Isaac Lab already reset inside :meth:`step`, so the current observations are returned.
+        """
+        if tensordict is not None and tensordict.get("_reset", None) is not None:
+            obs_dict = self.unwrapped.obs_buf
+        else:
+            reset_kwargs = {key: kwargs[key] for key in ("seed", "options") if key in kwargs}
+            obs_dict, _ = self.env.reset(**reset_kwargs)
+        return TensorDict(obs_dict, batch_size=self.batch_size, device=self.device)
+
+    def _set_seed(self, seed: int | None) -> None:
+        """Seeds the environment. ``None`` leaves the random number generators untouched."""
+        if seed is not None:
+            self.unwrapped.seed(seed)
+
+    def close(self, *, raise_if_closed: bool = True) -> None:  # noqa: D102
+        if not self.is_closed:
+            self.env.close()
+        self.is_closed = True
+
+    """
+    Helper functions
+    """
+
+    def _terminal_observations(self, obs: TensorDict, extras: dict, done: torch.Tensor) -> TensorDict:
+        """Replaces the post-reset observations of done environments with ``extras["final_obs"]`` when available.
+
+        Without terminal observations, done rows are NaN-filled (zero-filled for non-floating-point observations)
+        following TorchRL's auto-reset convention.
+        """
+        done = done.reshape(self.batch_size)
+        if "final_obs" in extras:
+            final_obs = TensorDict(extras["final_obs"], batch_size=self.batch_size, device=self.device)
+            return obs.where(~done, final_obs)
+
+        def _invalidate(value: torch.Tensor) -> torch.Tensor:
+            fill = torch.full_like(value, torch.nan) if value.is_floating_point() else torch.zeros_like(value)
+            return torch.where(expand_as_right(done, value), fill, value)
+
+        return obs.apply(_invalidate)
+
+    def _make_observation_spec(self, obs_space: gym.spaces.Dict) -> Composite:
+        """Builds a :class:`~torchrl.data.Composite` mirroring Isaac Lab's observation groups."""
+        return Composite(
+            {group: self._gym_space_to_spec(space) for group, space in obs_space.spaces.items()},
+            shape=self.batch_size,
+        )
+
+    def _gym_space_to_spec(self, space: gym.Space) -> TensorSpec | Composite:
+        """Converts a per-environment gymnasium space into a batch-prefixed TorchRL spec.
+
+        Raises:
+            NotImplementedError: When the space is not a :class:`gymnasium.spaces.Box` or a
+                :class:`gymnasium.spaces.Dict` of supported spaces.
+        """
+        if isinstance(space, gym.spaces.Dict):
+            return Composite(
+                {key: self._gym_space_to_spec(subspace) for key, subspace in space.spaces.items()},
+                shape=self.batch_size,
+            )
+        if isinstance(space, gym.spaces.Box):
+            shape = (*self.batch_size, *space.shape)
+            low = torch.as_tensor(space.low)
+            high = torch.as_tensor(space.high)
+            if bool(torch.isfinite(low).all()) and bool(torch.isfinite(high).all()):
+                return Bounded(
+                    low=low.expand(shape), high=high.expand(shape), shape=shape, dtype=low.dtype, device=self.device
+                )
+            return Unbounded(shape=shape, dtype=low.dtype, device=self.device)
+        raise NotImplementedError(f"Space type {type(space)} is not supported by {type(self).__name__}.")
+
+    def _make_action_spec(self, action_space: gym.Space, clip_actions: float | None) -> TensorSpec:
+        """Builds the action spec, narrowed to ``[-clip_actions, clip_actions]`` when clipping is enabled.
+
+        Raises:
+            ValueError: When ``clip_actions`` is set for a non-:class:`gymnasium.spaces.Box` action space.
+            NotImplementedError: When the action space type is not supported.
+        """
+        if isinstance(action_space, gym.spaces.Box):
+            if clip_actions is not None:
+                shape = (*self.batch_size, *action_space.shape)
+                return Bounded(low=-clip_actions, high=clip_actions, shape=shape, device=self.device)
+            return self._gym_space_to_spec(action_space)
+        if clip_actions is not None:
+            raise ValueError(f"Action clipping is only supported for Box action spaces, got {type(action_space)}.")
+        if isinstance(action_space, gym.spaces.Discrete):
+            return Categorical(int(action_space.n), shape=(*self.batch_size, 1), dtype=torch.int64, device=self.device)
+        if isinstance(action_space, gym.spaces.MultiDiscrete):
+            nvec = action_space.nvec.tolist()
+            return MultiCategorical(nvec, shape=(*self.batch_size, len(nvec)), dtype=torch.int64, device=self.device)
+        raise NotImplementedError(f"Action space type {type(action_space)} is not supported by {type(self).__name__}.")

--- a/source/isaaclab_rl/test/test_torchrl_wrapper.py
+++ b/source/isaaclab_rl/test/test_torchrl_wrapper.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch the simulator
+app_launcher = AppLauncher(headless=True, enable_cameras=True)
+simulation_app = app_launcher.app
+
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import pytest
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.app.settings_manager import get_settings_manager
+from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
+
+pytest.importorskip("torchrl")
+
+from torchrl.envs.utils import check_env_specs  # noqa: E402
+
+from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper  # noqa: E402
+
+import isaaclab_tasks  # noqa: F401, E402
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def registered_tasks():
+    registered_tasks = list()
+    for task_spec in gym.registry.values():
+        if "Isaac" in task_spec.id:
+            cfg_entry_point = gym.spec(task_spec.id).kwargs.get("rsl_rl_cfg_entry_point")
+            if cfg_entry_point is not None:
+                registered_tasks.append(task_spec.id)
+    registered_tasks.sort()
+    registered_tasks = registered_tasks[:5]
+
+    # this flag is necessary to prevent a bug where the simulation gets stuck randomly when running the
+    # test on many environments.
+    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+
+    print(">>> All registered environments:", registered_tasks)
+    return registered_tasks
+
+
+def _make_env(task_name: str, num_envs: int, device: str, **cfg_overrides) -> IsaacLabTorchRLWrapper:
+    sim_utils.create_new_stage()
+    get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
+    env_cfg = parse_env_cfg(task_name, device=device, num_envs=num_envs)
+    for key, value in cfg_overrides.items():
+        setattr(env_cfg, key, value)
+    env = gym.make(task_name, cfg=env_cfg)
+    if isinstance(env.unwrapped, DirectMARLEnv):
+        env = multi_agent_to_single_agent(env)
+    return IsaacLabTorchRLWrapper(env)
+
+
+def test_random_actions(registered_tasks):
+    """Roll out random actions through TorchRL's own step/reset machinery and check the signals."""
+    num_envs = 64
+    device = "cuda"
+    for task_name in registered_tasks:
+        print(f">>> Running test for environment: {task_name}")
+        try:
+            # terminal observations are needed for the "next" observation of done rows to be finite
+            env = _make_env(task_name, num_envs, device, compute_final_obs=True)
+        except Exception as e:
+            pytest.fail(f"Failed to set-up the environment for task {task_name}. Error: {e}")
+
+        check_env_specs(env)
+
+        with torch.inference_mode():
+            rollout = env.rollout(100, break_when_any_done=False)
+
+        assert rollout.batch_size == torch.Size([num_envs, 100])
+        assert not rollout.isnan().any(), f"NaN found in rollout for task {task_name}"
+        assert torch.equal(rollout["next", "done"], rollout["next", "terminated"] | rollout["next", "truncated"])
+
+        print(f">>> Closing environment: {task_name}")
+        env.close()
+
+
+def test_finite_horizon_reports_time_outs_as_terminal(registered_tasks):
+    """Finite-horizon tasks must not surface time-outs, so value estimators do not bootstrap past them."""
+    num_envs = 64
+    device = "cuda"
+    for task_name in registered_tasks:
+        print(f">>> Running test for environment: {task_name}")
+        env = _make_env(task_name, num_envs, device, is_finite_horizon=True)
+
+        with torch.inference_mode():
+            rollout = env.rollout(10, break_when_any_done=False)
+
+        assert not rollout["next", "truncated"].any(), "Time-out signal found in finite horizon environment."
+
+        print(f">>> Closing environment: {task_name}")
+        env.close()

--- a/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
+++ b/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
@@ -21,17 +21,10 @@ pytest.importorskip("torchrl")
 
 from tensordict import TensorDict  # noqa: E402
 from torchrl.data import Bounded, Categorical, Composite, MultiCategorical, Unbounded  # noqa: E402
-from torchrl.envs import StepCounter, TransformedEnv  # noqa: E402
+from torchrl.envs import ExplorationType, StepCounter, TransformedEnv, set_exploration_type  # noqa: E402
 from torchrl.envs.utils import check_env_specs  # noqa: E402
 
-try:
-    import isaaclab.envs as _isaaclab_envs
-except ImportError:
-    # Isaac Sim is not available: provide the module the wrapper imports for its type check.
-    _isaaclab_envs = types.ModuleType("isaaclab.envs")
-    sys.modules["isaaclab.envs"] = _isaaclab_envs
-
-from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper  # noqa: E402
+from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper, TorchRlPpoCfg, make_actor, train_ppo  # noqa: E402
 
 NUM_ENVS = 4
 CLOCK_SCALE = 100.0
@@ -40,6 +33,21 @@ CLOCK_SCALE = 100.0
 
 class _FakeEnvBase:
     """Stand-in for an Isaac Lab environment base class (registered on ``isaaclab.envs`` per test)."""
+
+
+def _install_fake_env_classes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Points the env base classes the wrapper checks against at :class:`_FakeEnvBase` for one test.
+
+    The classes are written straight into the module dictionary so that Isaac Lab's lazy module loader does
+    not import the real environment stack; when Isaac Lab is not installed a stub module stands in for it.
+    """
+    try:
+        import isaaclab.envs as module
+    except ImportError:
+        module = types.ModuleType("isaaclab.envs")
+        monkeypatch.setitem(sys.modules, "isaaclab.envs", module)
+    for name in ("DirectRLEnv", "ManagerBasedRLEnv"):
+        monkeypatch.setitem(module.__dict__, name, _FakeEnvBase)
 
 
 class _FakeUnwrapped(_FakeEnvBase):
@@ -131,9 +139,7 @@ class _FakeEnv:
 @pytest.fixture
 def make_wrapper(monkeypatch):
     """Returns a factory building a real :class:`IsaacLabTorchRLWrapper` around a fake environment."""
-    for name in ("DirectRLEnv", "ManagerBasedRLEnv"):
-        if not hasattr(_isaaclab_envs, name) or name == "DirectRLEnv":
-            monkeypatch.setattr(_isaaclab_envs, name, _FakeEnvBase, raising=False)
+    _install_fake_env_classes(monkeypatch)
 
     def _make(device=None, clip_actions=None, **fake_kwargs):
         fake = _FakeUnwrapped(**fake_kwargs)
@@ -358,3 +364,39 @@ def test_tensordict_lives_on_requested_device(make_wrapper):
     assert isinstance(td, TensorDict)
     assert td.device == torch.device("cpu")
     assert td["next", "policy"].device == torch.device("cpu")
+
+
+"""
+PPO example
+"""
+
+
+def test_train_ppo_learns_checkpoints_and_reloads(make_wrapper, tmp_path):
+    wrapper, _ = make_wrapper(truncate_at={3: [0, 1]})
+    cfg = TorchRlPpoCfg(
+        seed=0,
+        device="cpu",
+        num_steps_per_env=4,
+        max_iterations=2,
+        save_interval=1,
+        experiment_name="fake",
+        actor_hidden_dims=[8],
+        critic_hidden_dims=[8],
+        num_learning_epochs=2,
+        num_mini_batches=2,
+        learning_rate=1e-3,
+        gamma=0.99,
+        lam=0.95,
+        entropy_coef=0.01,
+    )
+
+    actor = train_ppo(wrapper, cfg, str(tmp_path))
+
+    assert sorted(path.name for path in tmp_path.glob("model_*.pt")) == ["model_1.pt", "model_2.pt"]
+    assert all(torch.isfinite(parameter).all() for parameter in actor.parameters())
+    # the checkpoint holds the actor weights and reloads into a freshly built actor
+    reloaded = make_actor(wrapper, cfg)
+    reloaded.load_state_dict(torch.load(tmp_path / "model_2.pt"))
+    td = wrapper.reset()
+    with torch.no_grad(), set_exploration_type(ExplorationType.DETERMINISTIC):
+        assert torch.equal(actor(td.clone())["action"], reloaded(td.clone())["action"])

--- a/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
+++ b/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
@@ -1,0 +1,360 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Kit-free checks for :class:`IsaacLabTorchRLWrapper`'s spec conversion and step/reset contract.
+
+The wrapper is built for real around a fake environment that mimics the parts of the Isaac Lab contract it
+depends on (same-step auto-reset, in-place reuse of the reward/termination buffers, scalar episode logs, terminal
+observations under ``extras["final_obs"]``) and is driven through TorchRL's public ``EnvBase`` API.
+"""
+
+import sys
+import types
+
+import gymnasium as gym
+import pytest
+import torch
+
+pytest.importorskip("torchrl")
+
+from tensordict import TensorDict  # noqa: E402
+from torchrl.data import Bounded, Categorical, Composite, MultiCategorical, Unbounded  # noqa: E402
+from torchrl.envs import StepCounter, TransformedEnv  # noqa: E402
+from torchrl.envs.utils import check_env_specs  # noqa: E402
+
+try:
+    import isaaclab.envs as _isaaclab_envs
+except ImportError:
+    # Isaac Sim is not available: provide the module the wrapper imports for its type check.
+    _isaaclab_envs = types.ModuleType("isaaclab.envs")
+    sys.modules["isaaclab.envs"] = _isaaclab_envs
+
+from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper  # noqa: E402
+
+NUM_ENVS = 4
+CLOCK_SCALE = 100.0
+"""Observations encode the per-environment step clock divided by this, keeping them inside the policy bounds."""
+
+
+class _FakeEnvBase:
+    """Stand-in for an Isaac Lab environment base class (registered on ``isaaclab.envs`` per test)."""
+
+
+class _FakeUnwrapped(_FakeEnvBase):
+    """Fake Isaac Lab environment.
+
+    Each environment keeps a step clock that is encoded in the observations, reset to zero when the environment
+    resets, and used to schedule time-outs. Rewards and done flags live in persistent buffers mutated in place.
+    """
+
+    def __init__(self, action_space=None, truncate_at=None, compute_final_obs=True, is_finite_horizon=False):
+        self.num_envs = NUM_ENVS
+        self.device = "cpu"
+        self.cfg = types.SimpleNamespace(compute_final_obs=compute_final_obs, is_finite_horizon=is_finite_horizon)
+        self.single_observation_space = gym.spaces.Dict(
+            {
+                "policy": gym.spaces.Box(low=-1.0, high=1.0, shape=(8,), dtype="float32"),
+                "critic": gym.spaces.Dict(
+                    {"privileged": gym.spaces.Box(low=-float("inf"), high=float("inf"), shape=(12,), dtype="float32")}
+                ),
+            }
+        )
+        self.single_action_space = action_space or gym.spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype="float32")
+        self.truncate_at = truncate_at or {}
+        self.extras = {}
+        self.reward_buf = torch.zeros(NUM_ENVS)
+        self.reset_terminated = torch.zeros(NUM_ENVS, dtype=torch.bool)
+        self.reset_time_outs = torch.zeros(NUM_ENVS, dtype=torch.bool)
+        self.clock = torch.zeros(NUM_ENVS)
+        self.obs_buf = self._compute_obs()
+        self.step_count = 0
+        self.reset_calls = []
+        self.last_actions = None
+        self.last_seed = None
+        self.closed = False
+
+    def _compute_obs(self):
+        policy = (self.clock / CLOCK_SCALE).unsqueeze(-1).expand(NUM_ENVS, 8).clone()
+        privileged = self.clock.unsqueeze(-1).expand(NUM_ENVS, 12).clone()
+        return {"policy": policy, "critic": {"privileged": privileged}}
+
+    def seed(self, seed=-1):
+        self.last_seed = seed
+        return seed
+
+    def reset(self, seed=None, options=None):
+        self.reset_calls.append((seed, options))
+        self.clock[:] = 0.0
+        self.extras["log"] = {"Episode_Reward/track": torch.tensor(0.5)}
+        self.obs_buf = self._compute_obs()
+        return self.obs_buf, self.extras
+
+    def step(self, actions):
+        self.last_actions = actions
+        self.step_count += 1
+        self.clock += 1.0
+        self.reward_buf[:] = float(self.step_count)
+        self.reset_terminated[:] = False
+        self.reset_time_outs[:] = False
+        self.reset_time_outs[self.truncate_at.get(self.step_count, [])] = True
+        done_ids = self.reset_time_outs.nonzero(as_tuple=True)[0]
+        if len(done_ids) > 0:
+            if self.cfg.compute_final_obs:
+                self.extras["final_obs"] = self._compute_obs()
+            self.clock[done_ids] = 0.0
+            self.extras["log"] = {"Episode_Reward/track": torch.tensor(0.5)}
+        self.obs_buf = self._compute_obs()
+        return self.obs_buf, self.reward_buf, self.reset_terminated, self.reset_time_outs, self.extras
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeEnv:
+    """Outermost gymnasium-style wrapper around :class:`_FakeUnwrapped`."""
+
+    def __init__(self, unwrapped):
+        self.unwrapped = unwrapped
+
+    def step(self, actions):
+        return self.unwrapped.step(actions)
+
+    def reset(self, *, seed=None, options=None):
+        return self.unwrapped.reset(seed=seed, options=options)
+
+    def close(self):
+        self.unwrapped.close()
+
+
+@pytest.fixture
+def make_wrapper(monkeypatch):
+    """Returns a factory building a real :class:`IsaacLabTorchRLWrapper` around a fake environment."""
+    for name in ("DirectRLEnv", "ManagerBasedRLEnv"):
+        if not hasattr(_isaaclab_envs, name) or name == "DirectRLEnv":
+            monkeypatch.setattr(_isaaclab_envs, name, _FakeEnvBase, raising=False)
+
+    def _make(device=None, clip_actions=None, **fake_kwargs):
+        fake = _FakeUnwrapped(**fake_kwargs)
+        return IsaacLabTorchRLWrapper(_FakeEnv(fake), device=device, clip_actions=clip_actions), fake
+
+    return _make
+
+
+def _clock(td, *key):
+    """Decodes the step clock from the policy observations stored under ``key``."""
+    return (td[key if len(key) > 1 else key[0]][..., 0] * CLOCK_SCALE).tolist()
+
+
+"""
+Construction and spec conversion
+"""
+
+
+def test_rejects_non_isaaclab_env(make_wrapper):
+    with pytest.raises(ValueError, match="must be inherited"):
+        IsaacLabTorchRLWrapper(_FakeEnv(types.SimpleNamespace()))
+
+
+def test_specs_mirror_isaaclab_spaces(make_wrapper):
+    wrapper, _ = make_wrapper()
+
+    assert isinstance(wrapper.observation_spec["policy"], Bounded)
+    assert wrapper.observation_spec["policy"].shape == torch.Size([NUM_ENVS, 8])
+    assert isinstance(wrapper.observation_spec["critic"], Composite)
+    assert isinstance(wrapper.observation_spec["critic", "privileged"], Unbounded)
+    assert wrapper.observation_spec["critic", "privileged"].shape == torch.Size([NUM_ENVS, 12])
+    assert wrapper.reward_spec.shape == torch.Size([NUM_ENVS, 1])
+    assert set(wrapper.done_keys) == {"done", "terminated", "truncated"}
+    check_env_specs(wrapper)
+
+
+@pytest.mark.parametrize(
+    ("action_space", "clip_actions", "spec_type", "shape"),
+    [
+        (gym.spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype="float32"), None, Bounded, (6,)),
+        (gym.spaces.Box(low=-1.0, high=1.0, shape=(2, 3), dtype="float32"), None, Bounded, (2, 3)),
+        (gym.spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype="float32"), 2.0, Bounded, (6,)),
+        (gym.spaces.Discrete(3), None, Categorical, (1,)),
+        (gym.spaces.MultiDiscrete([3, 2]), None, MultiCategorical, (2,)),
+    ],
+    ids=["box", "box-2d", "box-clipped", "discrete", "multi-discrete"],
+)
+def test_action_spec_conversion(make_wrapper, action_space, clip_actions, spec_type, shape):
+    wrapper, _ = make_wrapper(action_space=action_space, clip_actions=clip_actions)
+
+    assert isinstance(wrapper.action_spec, spec_type)
+    assert wrapper.action_spec.shape == torch.Size([NUM_ENVS, *shape])
+    if clip_actions is not None:
+        assert float(wrapper.action_spec.space.low.flatten()[0]) == -clip_actions
+        assert float(wrapper.action_spec.space.high.flatten()[0]) == clip_actions
+    if spec_type is not Bounded:
+        assert wrapper.action_spec.dtype == torch.int64
+
+
+@pytest.mark.parametrize(
+    ("action_space", "clip_actions", "error"),
+    [
+        (gym.spaces.Tuple((gym.spaces.Discrete(2), gym.spaces.Discrete(2))), None, NotImplementedError),
+        (gym.spaces.Discrete(3), 1.0, ValueError),
+    ],
+    ids=["unsupported-space", "clip-on-discrete"],
+)
+def test_unsupported_action_configurations_raise(make_wrapper, action_space, clip_actions, error):
+    with pytest.raises(error):
+        make_wrapper(action_space=action_space, clip_actions=clip_actions)
+
+
+"""
+Step / reset contract
+"""
+
+
+def test_step_clips_actions_before_passing_to_env(make_wrapper):
+    wrapper, fake = make_wrapper(clip_actions=1.0)
+    td = wrapper.reset()
+    td["action"] = torch.full((NUM_ENVS, 6), 5.0)
+
+    wrapper.step(td)
+
+    assert bool((fake.last_actions.abs() <= 1.0).all())
+
+
+@pytest.mark.parametrize(
+    ("is_finite_horizon", "expected_terminated", "expected_truncated"),
+    [(False, False, True), (True, True, False)],
+    ids=["infinite-horizon", "finite-horizon"],
+)
+def test_step_reports_time_outs(make_wrapper, is_finite_horizon, expected_terminated, expected_truncated):
+    """Time-outs surface as ``truncated``, except in finite-horizon tasks where they are terminal."""
+    wrapper, _ = make_wrapper(truncate_at={1: [0]}, is_finite_horizon=is_finite_horizon)
+    td = wrapper.reset()
+    td["action"] = torch.zeros(NUM_ENVS, 6)
+
+    td = wrapper.step(td)
+
+    for key in ("reward", "terminated", "truncated", "done"):
+        assert td["next", key].shape == torch.Size([NUM_ENVS, 1])
+    assert bool(td["next", "terminated"][0, 0]) is expected_terminated
+    assert bool(td["next", "truncated"][0, 0]) is expected_truncated
+    assert bool(td["next", "done"][0, 0]) is True
+    assert not bool(td["next", "done"][1:].any())
+
+
+def test_rollout_transitions_at_time_out(make_wrapper):
+    """Per-step buffer copies, terminal observation on the done row, and post-reset continuation."""
+    wrapper, fake = make_wrapper(truncate_at={2: [0]})
+
+    rollout = wrapper.rollout(4, break_when_any_done=False)
+
+    assert rollout["next", "reward"][0, :, 0].tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert rollout["next", "truncated"][0, :, 0].tolist() == [False, True, False, False]
+    assert rollout["next", "done"][0, :, 0].tolist() == [False, True, False, False]
+    # env 0 timed out at step 2 with clock 2 and restarted from clock 0; env 1 ran through
+    assert _clock(rollout[0], "next", "policy") == [1.0, 2.0, 1.0, 2.0]
+    assert (rollout["next", "critic", "privileged"][0, 1] == 2.0).all()
+    assert _clock(rollout[0], "policy") == [0.0, 1.0, 0.0, 1.0]
+    assert _clock(rollout[1], "policy") == [0.0, 1.0, 2.0, 3.0]
+    assert len(fake.reset_calls) == 1
+
+
+def test_transformed_env_resets_transforms_on_done(make_wrapper):
+    wrapper, fake = make_wrapper(truncate_at={2: [0]})
+    env = TransformedEnv(wrapper, StepCounter())
+
+    rollout = env.rollout(4, break_when_any_done=False)
+
+    assert len(fake.reset_calls) == 1
+    assert _clock(rollout[0], "next", "policy") == [1.0, 2.0, 1.0, 2.0]
+    assert rollout["step_count"][0, :, 0].tolist() == [0, 1, 0, 1]
+    assert rollout["step_count"][1, :, 0].tolist() == [0, 1, 2, 3]
+
+
+def test_next_obs_at_time_out_is_nan_without_final_obs(make_wrapper):
+    wrapper, _ = make_wrapper(truncate_at={2: [0]}, compute_final_obs=False)
+
+    rollout = wrapper.rollout(4, break_when_any_done=False)
+
+    assert bool(rollout["next", "policy"][0, 1].isnan().all())
+    assert not bool(rollout["next", "policy"][0, [0, 2, 3]].isnan().any())
+    assert not bool(rollout["next", "policy"][1:].isnan().any())
+
+
+def test_reset_returns_initial_state_and_forwards_kwargs(make_wrapper):
+    wrapper, fake = make_wrapper()
+
+    td = wrapper.reset(seed=7, options={"key": "value"})
+
+    assert fake.reset_calls == [(7, {"key": "value"})]
+    for key in ("done", "terminated", "truncated"):
+        assert not bool(td[key].any())
+    assert td["policy"].shape == torch.Size([NUM_ENVS, 8])
+    assert td["critic", "privileged"].shape == torch.Size([NUM_ENVS, 12])
+
+
+def test_partial_reset_returns_current_observations_without_resetting(make_wrapper):
+    wrapper, fake = make_wrapper()
+    td = wrapper.rollout(3, break_when_any_done=False)[:, -1].exclude("next")
+    td["_reset"] = torch.tensor([False, True, False, False]).unsqueeze(-1)
+
+    td = wrapper.reset(td)
+
+    # the masked env receives its current observation (clock 3); the others keep the last rollout step's (clock 2)
+    assert len(fake.reset_calls) == 1
+    assert _clock(td, "policy") == [2.0, 3.0, 2.0, 2.0]
+    assert not bool(td["done"].any())
+
+
+def test_reset_after_all_envs_done_does_not_reset_env(make_wrapper):
+    wrapper, fake = make_wrapper(truncate_at={2: list(range(NUM_ENVS))})
+
+    rollout = wrapper.rollout(4, break_when_any_done=False)
+
+    # Isaac Lab already reset every environment inside step(); a second reset would re-randomize the new
+    # episodes and overwrite the episode statistics just logged under extras["log"]
+    assert len(fake.reset_calls) == 1
+    assert _clock(rollout, "policy") == [[0.0, 1.0, 0.0, 1.0]] * NUM_ENVS
+
+
+def test_seed_and_unwrapped_delegate_to_base_env(make_wrapper):
+    wrapper, fake = make_wrapper()
+
+    wrapper.set_seed(42)
+    wrapper.set_seed(None)
+
+    assert fake.last_seed == 42
+    assert wrapper.unwrapped is fake
+
+
+@pytest.mark.parametrize("transformed", [False, True], ids=["plain", "transformed"])
+def test_close_delegates_to_wrapped_env(make_wrapper, transformed):
+    wrapper, fake = make_wrapper()
+    env = TransformedEnv(wrapper, StepCounter()) if transformed else wrapper
+    env.rollout(2)
+
+    env.close()
+
+    assert fake.closed
+    assert wrapper.is_closed is True
+
+
+def test_episode_log_is_not_part_of_the_tensordict(make_wrapper):
+    wrapper, fake = make_wrapper(truncate_at={1: [0]})
+
+    td = wrapper.rollout(2, break_when_any_done=False)
+
+    assert "info" not in td.keys()
+    assert "Episode_Reward/track" in fake.extras["log"]
+
+
+def test_tensordict_lives_on_requested_device(make_wrapper):
+    wrapper, _ = make_wrapper(device="cpu")
+    td = wrapper.reset()
+    td["action"] = torch.zeros(NUM_ENVS, 6)
+
+    td = wrapper.step(td)
+
+    assert isinstance(td, TensorDict)
+    assert td.device == torch.device("cpu")
+    assert td["next", "policy"].device == torch.device("cpu")

--- a/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
+++ b/source/isaaclab_rl/test/test_torchrl_wrapper_specs.py
@@ -24,7 +24,7 @@ from torchrl.data import Bounded, Categorical, Composite, MultiCategorical, Unbo
 from torchrl.envs import ExplorationType, StepCounter, TransformedEnv, set_exploration_type  # noqa: E402
 from torchrl.envs.utils import check_env_specs  # noqa: E402
 
-from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper, TorchRlPpoCfg, make_actor, train_ppo  # noqa: E402
+from isaaclab_rl.torchrl import IsaacLabTorchRLWrapper, TorchRlPpoCfg, make_actor, make_critic, train_ppo  # noqa: E402
 
 NUM_ENVS = 4
 CLOCK_SCALE = 100.0
@@ -55,18 +55,21 @@ class _FakeUnwrapped(_FakeEnvBase):
 
     Each environment keeps a step clock that is encoded in the observations, reset to zero when the environment
     resets, and used to schedule time-outs. Rewards and done flags live in persistent buffers mutated in place.
+    The ``"critic"`` group is a dictionary of terms unless ``flat_critic`` is set.
     """
 
-    def __init__(self, action_space=None, truncate_at=None, compute_final_obs=True, is_finite_horizon=False):
+    def __init__(
+        self, action_space=None, truncate_at=None, compute_final_obs=True, is_finite_horizon=False, flat_critic=False
+    ):
         self.num_envs = NUM_ENVS
         self.device = "cpu"
         self.cfg = types.SimpleNamespace(compute_final_obs=compute_final_obs, is_finite_horizon=is_finite_horizon)
+        self._flat_critic = flat_critic
+        critic_space = gym.spaces.Box(low=-float("inf"), high=float("inf"), shape=(12,), dtype="float32")
         self.single_observation_space = gym.spaces.Dict(
             {
                 "policy": gym.spaces.Box(low=-1.0, high=1.0, shape=(8,), dtype="float32"),
-                "critic": gym.spaces.Dict(
-                    {"privileged": gym.spaces.Box(low=-float("inf"), high=float("inf"), shape=(12,), dtype="float32")}
-                ),
+                "critic": critic_space if flat_critic else gym.spaces.Dict({"privileged": critic_space}),
             }
         )
         self.single_action_space = action_space or gym.spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype="float32")
@@ -86,7 +89,7 @@ class _FakeUnwrapped(_FakeEnvBase):
     def _compute_obs(self):
         policy = (self.clock / CLOCK_SCALE).unsqueeze(-1).expand(NUM_ENVS, 8).clone()
         privileged = self.clock.unsqueeze(-1).expand(NUM_ENVS, 12).clone()
-        return {"policy": policy, "critic": {"privileged": privileged}}
+        return {"policy": policy, "critic": privileged if self._flat_critic else {"privileged": privileged}}
 
     def seed(self, seed=-1):
         self.last_seed = seed
@@ -371,9 +374,9 @@ PPO example
 """
 
 
-def test_train_ppo_learns_checkpoints_and_reloads(make_wrapper, tmp_path):
-    wrapper, _ = make_wrapper(truncate_at={3: [0, 1]})
-    cfg = TorchRlPpoCfg(
+def _ppo_cfg() -> TorchRlPpoCfg:
+    """Small PPO configuration for the fake environment."""
+    return TorchRlPpoCfg(
         seed=0,
         device="cpu",
         num_steps_per_env=4,
@@ -389,6 +392,41 @@ def test_train_ppo_learns_checkpoints_and_reloads(make_wrapper, tmp_path):
         lam=0.95,
         entropy_coef=0.01,
     )
+
+
+def test_make_critic_reads_flat_critic_group(make_wrapper):
+    wrapper, _ = make_wrapper(flat_critic=True)
+
+    assert make_critic(wrapper, _ppo_cfg()).in_keys == ["critic"]
+
+
+@pytest.mark.parametrize(
+    "action_space",
+    [
+        gym.spaces.Discrete(3),
+        gym.spaces.MultiDiscrete([3, 2]),
+        gym.spaces.Box(low=-1.0, high=1.0, shape=(2, 3), dtype="float32"),
+    ],
+    ids=["discrete", "multi-discrete", "box-2d"],
+)
+def test_make_actor_rejects_non_flat_continuous_actions(make_wrapper, action_space):
+    wrapper, _ = make_wrapper(action_space=action_space, flat_critic=True)
+
+    with pytest.raises(NotImplementedError, match="action"):
+        make_actor(wrapper, _ppo_cfg())
+
+
+def test_make_critic_rejects_dictionary_observation_group(make_wrapper):
+    """A ``"critic"`` group made of several terms is rejected instead of silently falling back to ``"policy"``."""
+    wrapper, _ = make_wrapper()
+
+    with pytest.raises(NotImplementedError, match='"critic" observation group'):
+        make_critic(wrapper, _ppo_cfg())
+
+
+def test_train_ppo_learns_checkpoints_and_reloads(make_wrapper, tmp_path):
+    wrapper, _ = make_wrapper(truncate_at={3: [0, 1]}, flat_critic=True)
+    cfg = _ppo_cfg()
 
     actor = train_ppo(wrapper, cfg, str(tmp_path))
 

--- a/source/isaaclab_tasks/changelog.d/torchrl-wrapper.rst
+++ b/source/isaaclab_tasks/changelog.d/torchrl-wrapper.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added TorchRL PPO agent configurations (``torchrl_cfg_entry_point``) for the ``Isaac-Cartpole`` and
+  ``Isaac-Cartpole-Direct`` tasks.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
@@ -37,6 +37,7 @@ gym.register(
         "env_cfg_entry_point": f"{__name__}.cartpole_direct_env_cfg:CartpoleEnvCfg",
         "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_direct_ppo_cfg.yaml",
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleDirectPPORunnerCfg",
+        "torchrl_cfg_entry_point": f"{agents.__name__}.torchrl_ppo_cfg:CartpoleDirectPPOCfg",
         "default_agent": "rsl_rl",
         "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_ppo_cfg.yaml",
         "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
@@ -68,10 +69,9 @@ gym.register(
         "env_cfg_entry_point": f"{__name__}.cartpole_manager_env_cfg:CartpoleEnvCfg",
         "rl_games_cfg_entry_point": f"{agents.__name__}:rl_games_manager_ppo_cfg.yaml",
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpolePPORunnerCfg",
+        "torchrl_cfg_entry_point": f"{agents.__name__}.torchrl_ppo_cfg:CartpolePPOCfg",
         "default_agent": "rsl_rl",
-        "rsl_rl_with_symmetry_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:CartpolePPORunnerWithSymmetryCfg"
-        ),
+        "rsl_rl_with_symmetry_cfg_entry_point": (f"{agents.__name__}.rsl_rl_ppo_cfg:CartpolePPORunnerWithSymmetryCfg"),
         "skrl_cfg_entry_point": f"{agents.__name__}:skrl_manager_ppo_cfg.yaml",
         "sb3_cfg_entry_point": f"{agents.__name__}:sb3_ppo_cfg.yaml",
     },
@@ -87,9 +87,7 @@ gym.register(
         "rl_games_feature_cfg_entry_point": f"{agents.__name__}:rl_games_manager_feature_ppo_cfg.yaml",
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraPPORunnerCfg",
         "default_agent": "rsl_rl",
-        "rsl_rl_feature_cfg_entry_point": (
-            f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraFeaturePPORunnerCfg"
-        ),
+        "rsl_rl_feature_cfg_entry_point": (f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraFeaturePPORunnerCfg"),
         "agent_preset_compatibility": {
             "rl_games_cfg_entry_point": _RAW_CAMERA_PRESETS,
             "rl_games_feature_cfg_entry_point": ("resnet18", "theia_tiny"),

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/agents/torchrl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/agents/torchrl_ppo_cfg.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_rl.torchrl import TorchRlPpoCfg
+
+
+@configclass
+class CartpolePPOCfg(TorchRlPpoCfg):
+    num_steps_per_env = 16
+    max_iterations = 150
+    save_interval = 50
+    experiment_name = "cartpole"
+    actor_hidden_dims = [32, 32]
+    critic_hidden_dims = [32, 32]
+    num_learning_epochs = 5
+    num_mini_batches = 4
+    learning_rate = 1.0e-3
+    gamma = 0.99
+    lam = 0.95
+    entropy_coef = 0.005
+
+
+@configclass
+class CartpoleDirectPPOCfg(CartpolePPOCfg):
+    experiment_name = "cartpole_direct"

--- a/tools/environ_docs.py
+++ b/tools/environ_docs.py
@@ -49,7 +49,7 @@ _BACKEND_MIRROR_NAMES = frozenset(
 )
 
 # RL libraries listed in a stable order across generated docs.
-_RL_LIBRARY_ORDER = ("rl_games", "rsl_rl", "skrl", "sb3", "rlinf")
+_RL_LIBRARY_ORDER = ("rl_games", "rsl_rl", "skrl", "sb3", "rlinf", "torchrl")
 
 # Gym IDs excluded from the training list. The ``-Eval`` suffix marks dedicated
 # evaluation variants (e.g. ``IsaacContrib-Assemble-Trocar-G129-Dex3-Eval``, an alias

--- a/uv.lock
+++ b/uv.lock
@@ -1532,6 +1532,20 @@ wheels = [
 ]
 
 [[package]]
+name = "hoptorch"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyvers" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "platform_machine != 'x86_64' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/e4/6b4a08168cd3c9dd804df68131e1dcd7ea9507ad78d548f63d3979a34e5c/hoptorch-0.1.4.tar.gz", hash = "sha256:958e22455460342f195c63f989543da6fcc66337b2f8fca1980454209d36d450", size = 15745, upload-time = "2026-06-05T10:02:12.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/43/c038f118b0ce03385de7dcabfa64281e3387681f64668b1ee44f6b555cac/hoptorch-0.1.4-py3-none-any.whl", hash = "sha256:fc0b49e5a8b2370db8b47185fedaf91b3c6cf7f6e726079bb02aca6dbf8bb04f", size = 12527, upload-time = "2026-06-05T10:02:11.673Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1980,6 +1994,9 @@ test = [
 tetrahedralization = [
     { name = "pytetwild", extra = ["all"] },
 ]
+torchrl = [
+    { name = "torchrl" },
+]
 video = [
     { name = "moviepy" },
 ]
@@ -2111,6 +2128,7 @@ requires-dist = [
     { name = "torchaudio", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchaudio", marker = "sys_platform == 'win32'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchrl", marker = "extra == 'torchrl'", specifier = ">=0.13" },
     { name = "torchvision", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')", specifier = ">=0.26.0" },
     { name = "torchvision", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=0.26.0", index = "https://download.pytorch.org/whl/cu130" },
     { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=0.26.0", index = "https://download.pytorch.org/whl/cu128" },
@@ -2124,7 +2142,7 @@ requires-dist = [
     { name = "viser", marker = "extra == 'viser'", specifier = ">=1.0.16" },
     { name = "warp-lang", specifier = "==1.16.0" },
 ]
-provides-extras = ["tetrahedralization", "video", "importers", "test", "sb3", "skrl", "rl-games", "rsl-rl", "viser", "rerun", "isaacsim", "ov", "ovphysx", "ovrtx", "mimic", "teleop", "rlinf", "leapp", "all"]
+provides-extras = ["tetrahedralization", "video", "importers", "test", "sb3", "skrl", "rl-games", "rsl-rl", "torchrl", "viser", "rerun", "isaacsim", "ov", "ovphysx", "ovrtx", "mimic", "teleop", "rlinf", "leapp", "all"]
 
 [[package]]
 name = "isaaclab-experimental"
@@ -5700,6 +5718,26 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchaudio-2.11.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7171f810887e7cd1a4763974d5a1f2e1466692404315bb70705e0f49fb3a28e0", upload-time = "2026-03-23T15:50:26Z" },
+]
+
+[[package]]
+name = "torchrl"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "hoptorch" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyvers" },
+    { name = "tensordict" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "platform_machine != 'x86_64' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/75/af20f583756f03c1d387dcbc0941cd91ebbf8c46a1ad5c62cef279a8fc63/torchrl-0.13.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0f2f43d60f29f6329ecbcd70702491941660e2381f3e527858b2d9ae2c8e87d0", size = 2523860, upload-time = "2026-07-14T17:50:55.559Z" },
+    { url = "https://files.pythonhosted.org/packages/37/40/704bbc51863d5aad82604f3f62e87fd33ba8dbfe1e95e8a5c3ed862e0a82/torchrl-0.13.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2af6826ee7739172ace06df68382f6cb6a4e5ebec7c74ca9894b4da039a0bad7", size = 2538579, upload-time = "2026-07-14T17:50:57.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/75/a3b61ac47fd8379080458daf655c5c8db9229a8634e2465c5e61ba6de884/torchrl-0.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:6261c94bb790dfc53623f43262f8005f1856bcb71aa5607ea8488dda5dd8aae5", size = 2512425, upload-time = "2026-07-14T17:50:59.33Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Adds `isaaclab_rl.torchrl.IsaacLabTorchRLWrapper`, a `torchrl.envs.EnvBase` implementation over Isaac Lab's batched environments, together with a `torchrl` extra, API docs, and tests.

Validated on an A100-40GB (Isaac Sim 6.0, torchrl 0.13.3, 64 envs per task):

| Check | Result |
| --- | --- |
| `test_torchrl_wrapper_specs.py` (kit-free) | passed |
| `test_torchrl_wrapper.py` (first 5 registered tasks) | 2 passed |
| Same checks over Ant, Ant-Direct, Cartpole, Cartpole-Direct, Cartpole-Camera, Cartpole-Camera-Direct, Humanoid-Direct, Velocity-Flat-AnymalD, Reorient-Cube-Shadow-OpenAI-FF-Direct | 9/9 OK, no NaNs, terminal observation reported on every done row |
| Cartpole, 200 steps, vs `torchrl.envs.libs.isaac_lab.IsaacLabWrapper` | 12.5k env-steps/s with terminal observations on done rows; upstream 9.6k (`native_autoreset=True`) / 10.4k (`False`) with NaN next-observations on done rows |


## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
