### PR TITLE
[Docker] Call the isaaclab console script directly in the images

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -149,11 +149,6 @@ COPY ../source/ ${ISAACLAB_PATH}/source/
 RUN find ${ISAACLAB_PATH} -type f -name "*.sh" -exec sed -i 's/\r$//' {} + \
  && chmod 755 ${ISAACLAB_PATH}/isaaclab.sh
 
-# Install apt dependencies for extensions that declare them in their extension.toml,
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source && \
-    apt-get -y autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # robomimic and moviepy declare imageio-ffmpeg for optional video helpers. Its bundled
 # FFmpeg binary stays out of the distributed image; users who enable video recording install
 # MoviePy and its video backend explicitly.
@@ -164,25 +159,32 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     find ${VIRTUAL_ENV} \! -user isaaclab \
       -exec chown isaaclab:isaaclab {} + -exec chmod a+rwX {} +
 
+# Resolve ``isaaclab``/``python`` from the environment. Kept below the install layers, which it
+# would otherwise invalidate.
+ENV PATH="${VENV_PATH_ARG}/bin:${PATH}"
+
+# Install apt dependencies for extensions that declare them in their extension.toml.
+RUN isaaclab -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source && \
+    apt-get -y autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Isaac Sim's prebundled packages sit on PYTHONPATH ahead of the venv for launch paths that
 # never import isaaclab (``runheadless.sh``, ``isaac-sim.streaming.sh``), so its torch would
 # shadow the venv's and load a libtorch_cuda.so needing an NCCL symbol the bundled NCCL does
 # not export (nvbugs 6343978). Repoint them at the venv; the pip install path did this itself.
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p -c \
+RUN isaaclab -p -c \
       "from isaaclab.cli.commands.install import _repoint_prebundle_packages; _repoint_prebundle_packages()"
 
 # uv venv/uv sync above needed Kit's interpreter as the venv base; from here on ``uv pip``
 # should target the venv, including the interactive ``pip`` alias below.
 ENV UV_PYTHON=${VENV_PATH_ARG}/bin/python
 
-# aliasing isaaclab.sh and python for convenience
+# aliasing python for convenience; ``isaaclab`` and ``tensorboard`` come from PATH
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias python='${ISAACLAB_PATH}/isaaclab.sh -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias python3='${ISAACLAB_PATH}/isaaclab.sh -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
+    echo "alias python='isaaclab -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
+    echo "alias python3='isaaclab -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "alias pip='uv pip'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "alias pip3='uv pip'" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias tensorboard='${VIRTUAL_ENV}/bin/tensorboard'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "export TZ=$(date +%Z)" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "shopt -s histappend" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "PROMPT_COMMAND='history -a'" >> ${DOCKER_USER_HOME}/.bashrc
@@ -227,7 +229,7 @@ RUN set -o pipefail \
  && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
            DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
            DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
- && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
+ && dirs="$(isaaclab -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
  && mkdir -p ${dirs} \
  && chown -R isaaclab:isaaclab ${dirs}
 

--- a/docker/Dockerfile.curobo
+++ b/docker/Dockerfile.curobo
@@ -189,11 +189,6 @@ COPY ../source/ ${ISAACLAB_PATH}/source/
 # Fix the line endings of the scripts the COPY above just wrote.
 RUN find ${ISAACLAB_PATH}/source -type f -name "*.sh" -exec sed -i 's/\r$//' {} +
 
-# Install apt dependencies for extensions that declare them in their extension.toml,
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source && \
-    apt-get -y autoremove && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # The workspace members install editable now that their sources are present; ``find`` fixes
 # only what this layer wrote, so overlayfs does not copy up the venv again.
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -203,11 +198,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     find ${VIRTUAL_ENV} \! -user isaaclab \
       -exec chown isaaclab:isaaclab {} + -exec chmod a+rwX {} +
 
+# Resolve ``isaaclab``/``python`` from the environment. Kept below the install layers, which it
+# would otherwise invalidate.
+ENV PATH="${VENV_PATH_ARG}/bin:${PATH}"
+
+# Install apt dependencies for extensions that declare them in their extension.toml.
+RUN isaaclab -p ${ISAACLAB_PATH}/tools/install_deps.py apt ${ISAACLAB_PATH}/source && \
+    apt-get -y autoremove && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Isaac Sim's prebundled packages sit on PYTHONPATH ahead of the venv for launch paths that
 # never import isaaclab (``runheadless.sh``, ``isaac-sim.streaming.sh``), so its torch would
 # shadow the venv's and load a libtorch_cuda.so needing an NCCL symbol the bundled NCCL does
 # not export (nvbugs 6343978). Repoint them at the venv; the pip install path did this itself.
-RUN ${ISAACLAB_PATH}/isaaclab.sh -p -c \
+RUN isaaclab -p -c \
       "from isaaclab.cli.commands.install import _repoint_prebundle_packages; _repoint_prebundle_packages()"
 
 # uv venv/uv sync above needed Kit's interpreter as the venv base; from here on ``uv pip``
@@ -224,14 +228,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
  && find ${VIRTUAL_ENV} \! -user isaaclab \
       -exec chown isaaclab:isaaclab {} + -exec chmod a+rwX {} +
 
-# aliasing isaaclab.sh and python for convenience
+# aliasing python for convenience; ``isaaclab`` and ``tensorboard`` come from PATH
 RUN echo "export ISAACLAB_PATH=${ISAACLAB_PATH}" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias isaaclab=${ISAACLAB_PATH}/isaaclab.sh" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias python='${ISAACLAB_PATH}/isaaclab.sh -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias python3='${ISAACLAB_PATH}/isaaclab.sh -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
+    echo "alias python='isaaclab -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
+    echo "alias python3='isaaclab -p'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "alias pip='uv pip'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "alias pip3='uv pip'" >> ${DOCKER_USER_HOME}/.bashrc && \
-    echo "alias tensorboard='${VIRTUAL_ENV}/bin/tensorboard'" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "export TZ=$(date +%Z)" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "shopt -s histappend" >> ${DOCKER_USER_HOME}/.bashrc && \
     echo "PROMPT_COMMAND='history -a'" >> ${DOCKER_USER_HOME}/.bashrc
@@ -273,7 +275,7 @@ RUN set -o pipefail \
  && export DOCKER_ISAACSIM_ROOT_PATH="${ISAACSIM_ROOT_PATH}" \
            DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
            DOCKER_USER_HOME="${DOCKER_USER_HOME}" \
- && dirs="$(${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
+ && dirs="$(isaaclab -p ${ISAACLAB_PATH}/docker/utils/volume_mounts.py | grep '^/')" \
  && mkdir -p ${dirs} \
  && chown -R isaaclab:isaaclab ${dirs}
 

--- a/docker/Dockerfile.ros2
+++ b/docker/Dockerfile.ros2
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     ros-dev-tools && \
     # Install rosdeps for extensions that declare a ros_ws in
     # their extension.toml
-    ${ISAACLAB_PATH}/isaaclab.sh -p ${ISAACLAB_PATH}/tools/install_deps.py rosdep ${ISAACLAB_PATH}/source && \
+    isaaclab -p ${ISAACLAB_PATH}/tools/install_deps.py rosdep ${ISAACLAB_PATH}/source && \
     apt -y autoremove && apt clean autoclean && \
     rm -rf /var/lib/apt/lists/* && \
     # Add sourcing of setup.bash to .bashrc


### PR DESCRIPTION
## Summary

The Docker images call `isaaclab.sh -p` for every Python invocation. Putting the environment
on `PATH` makes the `isaaclab` console script directly callable, so the call sites read
`isaaclab -p` — shorter than the launcher path, with no wrapper.

# Description

Follow-up to a review comment asking what it would take to remove `isaaclab.sh -p` from the
images:

https://github.com/isaac-sim/IsaacLab/pull/7405 — [Docker] Install the Docker images from uv.lock (merged)

- **`ENV PATH="${VENV_PATH_ARG}/bin:${PATH}"`** — placed below the install layers, which it
  would otherwise invalidate. Nothing is shadowed: `python3`, `pip3` and `isaaclab` are not on
  `PATH` in the current images at all.
- **`uv run` was the alternative** and needs `--frozen --no-sync --project` to behave the same:
  without them it re-resolves the project on every call and warns when invoked outside it.
  Measured 124 ms against 110 ms per call, for a longer line.
- **`install_deps.py apt` moves below the workspace install.** It ran before it, where the
  console script cannot import its own package. Nothing between the two steps needs apt
  first — the third-party packages are already installed and the workspace members are
  pure-Python editables.
- **Two aliases removed** — `isaaclab` shadowed the console script once it is on `PATH`, and
  `tensorboard` was an explicit path into the environment.

`isaaclab.sh` still ships and is unchanged; this only changes how the images reach it.

## Type of change

- New feature (non-breaking change which adds functionality) — the images gain `isaaclab` on
  `PATH`; no public API changes

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] No documentation change is required — the documented `isaaclab.sh` entrypoint still ships and is unchanged
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — built base and cuRobo and verified `isaaclab -p` imports `isaacsim`, the prebundle repoint still runs, and no prebundled package is left dangling
- [x] A changelog fragment is not required because no source package changed — the diff is `docker/` only
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
