### PR TITLE
[Backport release/3.0.0] Serve the sim-to-sim transfer videos from S3 instead of LFS-backed mp4

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,8 +57,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        lfs: true
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
@@ -91,8 +89,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      with:
-        lfs: true
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v6

--- a/docs/source/_static/how-to/sim2sim_allegro_transfer.mp4
+++ b/docs/source/_static/how-to/sim2sim_allegro_transfer.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72fb443c6ab18f0acc6774aa013d9a3bea57cf77db9064308aebcb89b0784f39
-size 769345

--- a/docs/source/_static/how-to/sim2sim_anymal_d_transfer.mp4
+++ b/docs/source/_static/how-to/sim2sim_anymal_d_transfer.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a386e8aeb569296e125124bf353188a5c42cd8d7244da5581299a6b75c78f340
-size 3226579

--- a/docs/source/how-to/transfer_policies_between_physx_and_newton.rst
+++ b/docs/source/how-to/transfer_policies_between_physx_and_newton.rst
@@ -300,7 +300,7 @@ They do not represent full PP/PN/NN/NP validation. The backends are shown side b
 .. raw:: html
 
    <video controls preload="metadata" style="width:100%; max-width:960px; margin-bottom:1.5em;">
-     <source src="../../_static/sim2sim_anymal_d_transfer.mp4" type="video/mp4">
+     <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_anymal_d_transfer_10s_trimmed.mp4" type="video/mp4">
    </video>
 
 **Allegro hand cube reorientation** (``Isaac-Reorient-Cube-Allegro``, PhysX-to-Newton direction only)
@@ -308,7 +308,7 @@ They do not represent full PP/PN/NN/NP validation. The backends are shown side b
 .. raw:: html
 
    <video controls preload="metadata" style="width:100%; max-width:960px; margin-bottom:1.5em;">
-     <source src="../../_static/sim2sim_allegro_transfer.mp4" type="video/mp4">
+     <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/sim2sim_allegro_transfer_trimmed.mp4" type="video/mp4">
    </video>
 
 .. tip::


### PR DESCRIPTION
# Description

Backports #7338 to `release/3.0.0`.

The sim-to-sim transfer demonstration videos are served from the Isaac Sim download server instead of the Git LFS-backed copies in this repository. This also removes the two LFS pointer files and the now-unnecessary `lfs: true` checkout options from the documentation workflow.

Original PR: #7338

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

Not applicable: this PR already targets `release/3.0.0`.

## Validation

- Confirmed the backport patch has the same stable patch ID as the sole commit in #7338.
- Confirmed both remote URLs return HTTP 200 with `Content-Type: video/mp4`.
- Confirmed the generated HTML contains both remote video sources.
- Passed the changed-file YAML, whitespace, codespell, and reStructuredText pre-commit hooks.
- The full prescribed `uv` environment cannot resolve on this macOS host because the repository lockfile supports Linux and Windows; the reduced docs build reached completion, with only unrelated missing optional backend-package warnings.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the relevant `pre-commit` checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] No source package was touched, so no package changelog fragment is required
- [x] The original contributor is already listed in `CONTRIBUTORS.md`
