### PR TITLE
[RL] Fix lazy import in isaaclab_rl subpackage

### DIFF
--- a/source/isaaclab_rl/changelog.d/lazy-rl-entrypoint-imports.rst
+++ b/source/isaaclab_rl/changelog.d/lazy-rl-entrypoint-imports.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed single-GPU reinforcement learning entrypoints eagerly importing the multi-GPU Torch Elastic launcher.

--- a/source/isaaclab_rl/isaaclab_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.py
@@ -22,35 +22,12 @@ The package also provides the unified training and playback entrypoints used by 
 """
 
 import importlib.metadata
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from .entrypoints import PlaybackRequest, SimpleAgentRequest, TrainingRequest
+from isaaclab.utils.module import lazy_export
 
 try:
     __version__ = importlib.metadata.version("isaaclab_rl")
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
-__all__ = [
-    "PlaybackRequest",
-    "SimpleAgentRequest",
-    "TrainingRequest",
-    "play",
-    "random_agent",
-    "run_play_cli",
-    "run_random_agent_cli",
-    "run_train_cli",
-    "run_train_multigpu_cli",
-    "run_zero_agent_cli",
-    "train",
-    "zero_agent",
-]
 
-
-def __getattr__(name: str):
-    """Lazily expose unified reinforcement learning entrypoint APIs."""
-    if name in __all__:
-        from . import entrypoints
-
-        return getattr(entrypoints, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+lazy_export()

--- a/source/isaaclab_rl/isaaclab_rl/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.pyi
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "PlaybackRequest",
+    "SimpleAgentRequest",
+    "TrainingRequest",
+    "play",
+    "random_agent",
+    "run_play_cli",
+    "run_random_agent_cli",
+    "run_train_cli",
+    "run_train_multigpu_cli",
+    "run_zero_agent_cli",
+    "train",
+    "zero_agent",
+]
+
+from .entrypoints import (
+    PlaybackRequest,
+    SimpleAgentRequest,
+    TrainingRequest,
+    play,
+    random_agent,
+    run_play_cli,
+    run_random_agent_cli,
+    run_train_cli,
+    run_train_multigpu_cli,
+    run_zero_agent_cli,
+    train,
+    zero_agent,
+)
+
+__version__: str

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.py
@@ -23,22 +23,6 @@ Example:
     train(TrainingRequest(backend="rsl_rl", task="Isaac-Cartpole", max_iterations=100))
 """
 
-from .api import BackendName, PlaybackRequest, SimpleAgentRequest, TrainingRequest, play, random_agent, train, zero_agent
-from .dispatch import run_play_cli, run_random_agent_cli, run_train_cli, run_zero_agent_cli
-from .multigpu import run_train_multigpu_cli
+from isaaclab.utils.module import lazy_export
 
-__all__ = [
-    "BackendName",
-    "PlaybackRequest",
-    "SimpleAgentRequest",
-    "TrainingRequest",
-    "play",
-    "random_agent",
-    "run_play_cli",
-    "run_random_agent_cli",
-    "run_train_cli",
-    "run_train_multigpu_cli",
-    "run_zero_agent_cli",
-    "train",
-    "zero_agent",
-]
+lazy_export()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.pyi
@@ -1,0 +1,24 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "BackendName",
+    "PlaybackRequest",
+    "SimpleAgentRequest",
+    "TrainingRequest",
+    "play",
+    "random_agent",
+    "run_play_cli",
+    "run_random_agent_cli",
+    "run_train_cli",
+    "run_train_multigpu_cli",
+    "run_zero_agent_cli",
+    "train",
+    "zero_agent",
+]
+
+from .api import BackendName, PlaybackRequest, SimpleAgentRequest, TrainingRequest, play, random_agent, train, zero_agent
+from .dispatch import run_play_cli, run_random_agent_cli, run_train_cli, run_zero_agent_cli
+from .multigpu import run_train_multigpu_cli

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import runpy
+import subprocess
 import sys
 import types
 from types import SimpleNamespace
@@ -21,6 +22,45 @@ import torch
 from isaaclab_rl.entrypoints import PlaybackRequest, TrainingRequest, api, dispatch
 from isaaclab_rl.entrypoints import simple_agents as _simple_agents
 from isaaclab_rl.entrypoints.simple_agents import _create_zero_action_policy
+
+
+@pytest.mark.parametrize(
+    ("statement", "unexpected_modules"),
+    [
+        ("import isaaclab_rl", ["isaaclab_rl.entrypoints", "torch"]),
+        ("import isaaclab_rl.entrypoints", ["isaaclab_rl.entrypoints.multigpu", "torch"]),
+        ("import isaaclab_rl.entrypoints.backends", ["torch"]),
+        ("import isaaclab_rl.rl_games", ["isaaclab_rl.rl_games.rl_games", "rl_games", "torch"]),
+        ("import isaaclab_rl.rl_games.pbt", ["isaaclab_rl.rl_games.pbt.pbt", "rl_games", "torch"]),
+        ("import isaaclab_rl.rsl_rl", ["isaaclab_rl.rsl_rl.vecenv_wrapper", "rsl_rl", "torch"]),
+        ("import isaaclab_rl.utils", ["torch"]),
+        (
+            "from isaaclab_rl import run_play_cli",
+            ["isaaclab_rl.entrypoints.multigpu", "torch"],
+        ),
+        (
+            "from isaaclab_rl.entrypoints import run_play_cli",
+            ["isaaclab_rl.entrypoints.multigpu", "torch"],
+        ),
+    ],
+)
+def test_public_namespaces_do_not_import_unrelated_frameworks(statement: str, unexpected_modules: list[str]) -> None:
+    """Importing public namespaces must not eagerly load unrelated RL frameworks."""
+    unexpected_modules_literal = repr(unexpected_modules)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"{statement}; import sys; "
+            f"unexpected = [name for name in {unexpected_modules_literal} if name in sys.modules]; "
+            "assert not unexpected, f'Unexpected eager imports: {unexpected}'",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_zero_agent_infers_finite_manager_actions() -> None:


### PR DESCRIPTION
# Description

Make the isaaclab_rl root package and unified entrypoints use the standard stub-driven lazy export mechanism. This prevents single-GPU play imports from loading the multi-GPU Torch Elastic launcher during Torch initialization, which caused a circular-import failure on Windows with Torch 2.11.

The change also adds static export stubs for both public namespaces and subprocess regression coverage for every isaaclab_rl package initializer, ensuring namespace imports do not eagerly load Torch or unrelated RL frameworks.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] Backport this pull request to the active release branch after it merges into develop

## Testing

- 54 focused entrypoint, installed-workflow, and multi-GPU command tests passed
- Full Isaac Lab formatting and lint checks passed
- isaaclab_rl changelog validation passed

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with uv run isaaclab -f
- [x] Documentation changes are not required for this internal import fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in CONTRIBUTORS.md