### PR TITLE
[Workflow] Fix zero agent and random agent to launch newton visualizer by default

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-zero-agent-newton-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/fix-zero-agent-newton-visualizer.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed the zero agent to use the Newton GL visualizer by default. Pass ``--viz kit`` to keep using the Kit
+  visualizer.

--- a/source/isaaclab_rl/changelog.d/fix-zero-agent-newton-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/fix-zero-agent-newton-visualizer.rst
@@ -1,5 +1,5 @@
 Changed
 ^^^^^^^
 
-* Changed the zero agent to use the Newton GL visualizer by default. Pass ``--viz kit`` to keep using the Kit
-  visualizer.
+* Changed the zero and random agents to use the Newton GL visualizer by default. Pass ``--viz kit`` to keep using
+  the Kit visualizer.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -245,8 +245,8 @@ def _parse_args(argv: list[str] | None, policy: PolicyName) -> argparse.Namespac
     )
     # append AppLauncher cli args
     add_launcher_args(parser)
-    # simple agents should open Kit visualizer by default
-    parser.set_defaults(visualizer=["kit"])
+    # Keep the zero agent on the kitless default path while preserving the random-agent behavior.
+    parser.set_defaults(visualizer=["newton_gl"] if policy == "zero" else ["kit"])
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     sys.argv = [sys.argv[0]] + hydra_args
     return args_cli

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -245,8 +245,8 @@ def _parse_args(argv: list[str] | None, policy: PolicyName) -> argparse.Namespac
     )
     # append AppLauncher cli args
     add_launcher_args(parser)
-    # Keep the zero agent on the kitless default path while preserving the random-agent behavior.
-    parser.set_defaults(visualizer=["newton_gl"] if policy == "zero" else ["kit"])
+    # Keep checkpoint-free agents on the kitless default path.
+    parser.set_defaults(visualizer=["newton_gl"])
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     sys.argv = [sys.argv[0]] + hydra_args
     return args_cli

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -184,18 +184,17 @@ def test_zero_agent_supports_direct_multi_agent_action_spaces() -> None:
     assert torch.equal(actions["object"], torch.zeros(3, 1, dtype=torch.int64))
 
 
-@pytest.mark.parametrize(("policy", "expected_visualizer"), [("zero", ["newton_gl"]), ("random", ["kit"])])
-def test_simple_agent_default_visualizer_depends_on_policy(
+@pytest.mark.parametrize("policy", ["zero", "random"])
+def test_simple_agents_default_to_newton_visualizer(
     policy: _simple_agents.PolicyName,
-    expected_visualizer: list[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The zero agent defaults to Newton visualization without changing the random agent."""
+    """Checkpoint-free agents default to Newton visualization."""
     monkeypatch.setattr(sys, "argv", ["pytest"])
 
     args = _simple_agents._parse_args([], policy)
 
-    assert args.visualizer == expected_visualizer
+    assert args.visualizer == ["newton_gl"]
 
 
 def test_zero_agent_rejects_invalid_config_before_launch(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -184,6 +184,20 @@ def test_zero_agent_supports_direct_multi_agent_action_spaces() -> None:
     assert torch.equal(actions["object"], torch.zeros(3, 1, dtype=torch.int64))
 
 
+@pytest.mark.parametrize(("policy", "expected_visualizer"), [("zero", ["newton_gl"]), ("random", ["kit"])])
+def test_simple_agent_default_visualizer_depends_on_policy(
+    policy: _simple_agents.PolicyName,
+    expected_visualizer: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The zero agent defaults to Newton visualization without changing the random agent."""
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+
+    args = _simple_agents._parse_args([], policy)
+
+    assert args.visualizer == expected_visualizer
+
+
 def test_zero_agent_rejects_invalid_config_before_launch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Unsupported task presets fail cleanly before a simulator backend is initialized."""
 


### PR DESCRIPTION
# Description

The zero and random agents forced the Kit visualizer by default, which launched the Isaac Sim runtime even when a task resolved to Newton physics. This change defaults both checkpoint-free agents to the canonical Newton GL visualizer while preserving explicit --viz overrides.

A regression test covers both agent defaults. An isaaclab_rl changelog fragment documents how to retain the Kit visualizer explicitly.

Fixes # N/A

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into develop

## Screenshots

N/A — workflow default change.

## Validation

- uv run --frozen python -m pytest source/isaaclab_rl/test/test_entrypoints.py -q (20 passed, 2 skipped)
- uv run --frozen python tools/changelog/cli.py check develop
- uv run --frozen isaaclab -f
- uv run --frozen isaaclab zero_agent --task Isaac-Cartpole-Direct --num_envs 1 --max_steps 32 physics=newton_mjwarp
- uv run --frozen isaaclab random_agent --task Isaac-Cartpole-Direct --num_envs 1 --max_steps 32 physics=newton_mjwarp

Both smoke tests initialized NewtonVisualizer and completed without launching Isaac Sim/Kit. In the headless validation shell, the Newton viewer used EGL because DISPLAY was unset.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation through the changelog fragment
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for every touched package
- [x] My name already exists in CONTRIBUTORS.md