### PR TITLE
[Fix] Allow virtual environments built on Isaac Sim's own Python

### DIFF
--- a/isaaclab.sh
+++ b/isaaclab.sh
@@ -21,12 +21,29 @@ for arg in "$@"; do
     fi
 done
 
+# A virtual environment reuses the interpreter it was created from, so one created on the
+# package's own Python runs that exact binary and loads Kit's extensions unchanged. Only
+# environments that supply their own interpreter, such as conda, are rejected. Anything
+# unreadable counts as foreign so the check fails closed.
+venv_on_bundled_python=false
+if [ -n "$VIRTUAL_ENV" ] && [ -z "$CONDA_PREFIX" ] && [ -f "$VIRTUAL_ENV/pyvenv.cfg" ]; then
+    venv_home=$(sed -n 's/^[[:space:]]*home[[:space:]]*=[[:space:]]*//p' "$VIRTUAL_ENV/pyvenv.cfg" | head -1)
+    sim_root=$(readlink -f "$ISAACLAB_PATH/_isaac_sim" 2>/dev/null)
+    venv_home=$(readlink -f "$venv_home" 2>/dev/null)
+    if [ -n "$sim_root" ] && [ -n "$venv_home" ]; then
+        case "$venv_home" in
+            "$sim_root" | "$sim_root"/*) venv_on_bundled_python=true ;;
+        esac
+    fi
+fi
+
 downloaded_isaac_sim=false
 if [ -d "$ISAACLAB_PATH/_isaac_sim" ] && [ ! -f "$ISAACLAB_PATH/_isaac_sim/.isaaclab_source_build" ]; then
     downloaded_isaac_sim=true
-    if [ "$isaacsim_source_requested" = false ] && { [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ]; }; then
+    if [ "$isaacsim_source_requested" = false ] && [ "$venv_on_bundled_python" = false ] \
+        && { [ -n "$VIRTUAL_ENV" ] || [ -n "$CONDA_PREFIX" ]; }; then
         echo "[ERROR] Downloaded Isaac Sim packages cannot be combined with a Python virtual environment." >&2
-        echo "[ERROR] Use the bundled Python after deactivating the virtual environment, or run '--isaacsim_source PATH' to link a live source build." >&2
+        echo "[ERROR] Use the bundled Python after deactivating the virtual environment, create the environment on that Python ('uv venv --python \$ISAACLAB_PATH/_isaac_sim/kit/python/bin/python3'), or run '--isaacsim_source PATH' to link a live source build." >&2
         exit 1
     fi
 fi

--- a/source/isaaclab/changelog.d/fix-venv-on-isaac-sim-python.rst
+++ b/source/isaaclab/changelog.d/fix-venv-on-isaac-sim-python.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed ``isaaclab.sh`` and the ``isaaclab`` CLI rejecting a virtual environment that was created on
+  a downloaded Isaac Sim package's own Python. Such an environment reuses that interpreter, so Kit's
+  extension modules load exactly as they do under the bundled Python; only environments supplying
+  their own interpreter, such as conda, are still refused. Create one with
+  ``uv venv --python _isaac_sim/kit/python/bin/python3``.

--- a/source/isaaclab/isaaclab/cli/utils.py
+++ b/source/isaaclab/isaaclab/cli/utils.py
@@ -60,6 +60,70 @@ def is_isaac_sim_source_build(isaac_sim_path: Path = DEFAULT_ISAAC_SIM_PATH) -> 
     return (isaac_sim_path / ISAAC_SIM_SOURCE_BUILD_MARKER).is_file()
 
 
+def _pyvenv_home(venv_path: Path) -> Path | None:
+    """Return the interpreter directory a virtual environment was created from.
+
+    Args:
+        venv_path: Virtual environment root.
+
+    Returns:
+        The ``home`` directory recorded in ``pyvenv.cfg``, or ``None`` when it cannot be read.
+    """
+    config = venv_path / "pyvenv.cfg"
+    if not config.is_file():
+        return None
+    for line in config.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "home":
+            return Path(value.strip())
+    return None
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Check whether a path resolves inside a directory."""
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    return resolved == root or root in resolved.parents
+
+
+def runs_isaac_sim_python(
+    isaac_sim_path: Path = DEFAULT_ISAAC_SIM_PATH, python_exe: str | None = None, venv_path: str | None = None
+) -> bool:
+    """Check whether the interpreter about to run Isaac Sim is the package's own Python.
+
+    A virtual environment adds a ``site-packages`` directory but reuses the interpreter it was
+    created from, so one created on the Isaac Sim package's Python runs that exact binary and loads
+    Kit's extension modules unchanged. Environments that supply their own interpreter and native
+    libraries, such as conda, do not qualify: a conda environment has no ``pyvenv.cfg``, and a
+    virtual environment layered on one records that interpreter instead.
+
+    Args:
+        isaac_sim_path: Isaac Sim installation directory.
+        python_exe: Interpreter that will be launched, if known.
+        venv_path: Virtual environment root, usually ``VIRTUAL_ENV``.
+
+    Returns:
+        Whether the interpreter resolves inside ``isaac_sim_path``. Anything unproven is ``False``
+        so the caller keeps rejecting environments it cannot verify.
+    """
+    try:
+        root = isaac_sim_path.resolve()
+    except OSError:
+        return False
+
+    # ``uv venv`` symlinks ``bin/python`` at its base interpreter; resolving it is the direct answer.
+    if python_exe and _is_within(Path(python_exe), root):
+        return True
+    # Fall back to the recorded base for environments whose interpreter is a copy, not a symlink.
+    if venv_path:
+        home = _pyvenv_home(Path(venv_path))
+        if home is not None and _is_within(home, root):
+            return True
+    return False
+
+
 def _colorize(text: str, color: str, stream: IO[str]) -> str:
     """Colorize bit of text, if the stream supports colors or colors aren't disabled.
 
@@ -636,11 +700,13 @@ def run_python_command(
         and python_launcher.is_file()
         and not is_isaac_sim_source_build(local_sim)
         and using_virtual_environment
+        and not runs_isaac_sim_python(local_sim, python_exe, command_env.get("VIRTUAL_ENV"))
     ):
         print_error("Downloaded Isaac Sim packages cannot be combined with a Python virtual environment.")
         print_error(
-            "Use the bundled Python through isaaclab.sh/isaaclab.bat, or remove '_isaac_sim' and install "
-            "Isaac Sim from pip in the virtual environment."
+            "Use the bundled Python through isaaclab.sh/isaaclab.bat, create the virtual environment on "
+            f"that Python ('uv venv --python {local_sim / 'kit' / 'python' / 'bin' / 'python3'}'), or "
+            "remove '_isaac_sim' and install Isaac Sim from pip in the virtual environment."
         )
         raise SystemExit(1)
     isaac_env_active = (

--- a/source/isaaclab/test/cli/test_env_commands.py
+++ b/source/isaaclab/test/cli/test_env_commands.py
@@ -102,6 +102,49 @@ def test_launcher_uses_bundled_python_with_inactive_default_environment(tmp_path
 
 
 @pytest.mark.skipif(envs.is_windows(), reason="Linux launcher behavior")
+def test_launcher_accepts_virtual_environment_on_bundled_python(tmp_path):
+    """A virtual environment created on the package's own Python runs that interpreter, so it is allowed."""
+    launcher = tmp_path / "isaaclab.sh"
+    shutil.copy2(envs.ISAACLAB_ROOT / "isaaclab.sh", launcher)
+    bundled_python = tmp_path / "_isaac_sim" / "python.sh"
+    bundled_python.parent.mkdir()
+    bundled_python.write_text("#!/usr/bin/env bash\necho bundled-python\n")
+    bundled_python.chmod(0o755)
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(bundled_python)
+    # ``home`` points into the Isaac Sim tree, exactly as ``uv venv --python`` on it would record.
+    (venv / "pyvenv.cfg").write_text(f"home = {bundled_python.parent}\n")
+
+    environment = os.environ.copy()
+    environment["VIRTUAL_ENV"] = str(venv)
+    environment.pop("CONDA_PREFIX", None)
+    result = subprocess.run(["bash", str(launcher), "-h"], capture_output=True, text=True, check=False, env=environment)
+
+    assert result.returncode == 0, result.stderr
+    assert "cannot be combined" not in result.stderr
+
+
+@pytest.mark.skipif(envs.is_windows(), reason="Linux launcher behavior")
+def test_launcher_rejects_virtual_environment_on_foreign_python(tmp_path):
+    """A virtual environment built on another interpreter stays rejected."""
+    launcher = tmp_path / "isaaclab.sh"
+    shutil.copy2(envs.ISAACLAB_ROOT / "isaaclab.sh", launcher)
+    (tmp_path / "_isaac_sim").mkdir()
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+
+    environment = os.environ.copy()
+    environment["VIRTUAL_ENV"] = str(venv)
+    environment.pop("CONDA_PREFIX", None)
+    result = subprocess.run(["bash", str(launcher), "-h"], capture_output=True, text=True, check=False, env=environment)
+
+    assert result.returncode == 1
+    assert "Downloaded Isaac Sim packages cannot be combined" in result.stderr
+
+
+@pytest.mark.skipif(envs.is_windows(), reason="Linux launcher behavior")
 def test_launcher_allows_relinking_unmarked_source_build(tmp_path):
     """The source-build command must bypass downloaded-package environment rejection."""
     launcher = tmp_path / "isaaclab.sh"

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -86,6 +86,49 @@ def test_run_python_command_uses_live_isaac_sim_with_active_python(tmp_path):
     assert run.call_args.kwargs["env"]["PYTHONEXE"] == active_python
 
 
+def test_run_python_command_accepts_virtual_environment_on_bundled_python(tmp_path):
+    """A virtual environment created on a downloaded package's Python runs that interpreter."""
+    local_sim = tmp_path / "_isaac_sim"
+    local_sim.mkdir()
+    (local_sim / "python.sh").touch()
+    bundled_python = local_sim / "kit" / "python" / "bin" / "python3"
+    bundled_python.parent.mkdir(parents=True)
+    bundled_python.touch()
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(bundled_python)
+    (venv / "pyvenv.cfg").write_text(f"home = {bundled_python.parent}\n")
+
+    with (
+        mock.patch("isaaclab.cli.utils.DEFAULT_ISAAC_SIM_PATH", local_sim),
+        mock.patch("isaaclab.cli.utils.extract_python_exe", return_value=str(venv / "bin" / "python")),
+        mock.patch("isaaclab.cli.utils.run_command") as run,
+        mock.patch.dict(os.environ, {"VIRTUAL_ENV": str(venv)}, clear=True),
+    ):
+        run_python_command("script.py", [])
+
+    assert run.call_args is not None
+
+
+def test_run_python_command_rejects_virtual_environment_on_foreign_python(tmp_path):
+    """A virtual environment built on another interpreter stays rejected."""
+    local_sim = tmp_path / "_isaac_sim"
+    local_sim.mkdir()
+    (local_sim / "python.sh").touch()
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\n")
+
+    with (
+        mock.patch("isaaclab.cli.utils.DEFAULT_ISAAC_SIM_PATH", local_sim),
+        mock.patch("isaaclab.cli.utils.extract_python_exe", return_value=str(venv / "bin" / "python")),
+        mock.patch("isaaclab.cli.utils.run_command"),
+        mock.patch.dict(os.environ, {"VIRTUAL_ENV": str(venv)}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        run_python_command("script.py", [])
+
+
 def test_run_python_command_does_not_wrap_an_active_isaac_sim_environment(tmp_path):
     """The legacy wrapper path must not source the same Isaac Sim environment twice."""
     local_sim = tmp_path / "_isaac_sim"


### PR DESCRIPTION
# Description

#7466 stopped downloaded Isaac Sim packages from running with conda, `uv`, or `venv` environments.
The restriction is right for the breakages it targets, but it tests whether *any* virtual environment
is active, while the property that actually matters is *which interpreter runs Kit's extension modules*.

A virtual environment does not introduce an interpreter. It adds a `site-packages` directory and
reuses the interpreter it was created from, so one created on the package's own Python runs that exact
binary. The failures the restriction exists for come from environments that ship their own interpreter
and native libraries — the conda workarounds already in the tree are the evidence: preloading torch's
`libgomp` and conda's `libstdc++` for `CXXABI_1.3.15` in `commands/envs.py`, and `_sanitized_conda_env()`
guarding against conda's "SRE mismatch" from a mismatched Python. None of those apply to a virtual
environment built on Isaac Sim's own interpreter.

This PR compares the interpreter against the Isaac Sim directory instead of testing for an active
environment, in both `isaaclab.sh` and the CLI. The check resolves the interpreter that will be
launched, falling back to `pyvenv.cfg`'s `home` when `bin/python` is a copy rather than a symlink.
Anything it cannot resolve stays rejected, so conda environments, foreign-interpreter virtual
environments, and environments with no readable `pyvenv.cfg` behave exactly as they do today.

`isaaclab.bat` keeps the broader check. Narrowing it needs junction resolution and case-insensitive
prefix matching that I cannot exercise on this platform, so I would rather leave it to someone who can
test it than ship untested path handling in a launcher.

This unblocks `uv venv --python _isaac_sim/kit/python/bin/python3`, and the container images, which are
exactly this shape: Kit's tree plus a virtual environment created on its interpreter.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run --frozen python -m pytest source/isaaclab/test/cli/test_install.py source/isaaclab/test/cli/test_env_commands.py` — 32 passed, 1 skipped
- Full `source/isaaclab/test/cli/` — 272 passed, 1 skipped
- Both new accepting tests fail without the change and pass with it; the paired rejecting tests pass either way
- Every test added by #7466 still passes, including the launcher rejection that relies on a `VIRTUAL_ENV` with no `pyvenv.cfg`
- Built `Dockerfile.base`, `Dockerfile.curobo` and `Dockerfile.kitless` against this branch; `isaaclab.sh -p`, `isaaclab -p` and `import isaaclab` all resolve to the image's virtual environment
- `uv run isaaclab -f` — passed

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
