### PR TITLE
Deduplicate ovphysx contact-sensor bodies from mid-path wildcards

### DIFF
--- a/source/isaaclab_ov/changelog.d/ovphysx-contact-sensor-dedup.rst
+++ b/source/isaaclab_ov/changelog.d/ovphysx-contact-sensor-dedup.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_ov.sensors.contact_sensor.ContactSensor` registering the same leaf
+  body once per matching ancestor when the sensor ``prim_path`` used a mid-path wildcard (for
+  example ``Robot/.*/left_ankle_roll_link``), which inflated the sensor and filter counts and
+  tripped the physics-cloned init guard. The bodies resolved from the prim path are now
+  deduplicated by prim path before they are consumed.

--- a/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/contact_sensor.py
+++ b/source/isaaclab_ov/isaaclab_ov/sensors/contact_sensor/contact_sensor.py
@@ -205,6 +205,21 @@ class ContactSensor(BaseContactSensor):
 
         resolve_kwargs = {"raise_if_no_matches": False, "traverse_instance_prims": False}
         body_matches = resolve_matching_prims_from_source(parent_expr, has_contact_report, **resolve_kwargs)
+
+        # A mid-path wildcard prim path (Robot/.*/left_ankle_roll_link) makes
+        # resolve_matching_prims_from_source return the same leaf body once per matching
+        # ancestor, so without a dedup the body is registered many times and the sensor
+        # and filter counts are inflated. Deduplicate by prim path, keeping first order.
+        seen_paths: set[str] = set()
+        unique_matches: list[tuple[object, str]] = []
+        for prim, expr in body_matches:
+            path_string = prim.GetPath().pathString
+            if path_string in seen_paths:
+                continue
+            seen_paths.add(path_string)
+            unique_matches.append((prim, expr))
+        body_matches = unique_matches
+
         body_names = [prim.GetPath().pathString.rsplit("/", 1)[-1] for prim, _ in body_matches]
         if not body_names:
             raise RuntimeError(

--- a/source/isaaclab_ov/test/sensors/test_contact_sensor.py
+++ b/source/isaaclab_ov/test/sensors/test_contact_sensor.py
@@ -609,6 +609,62 @@ def test_nested_rigid_body_hierarchy(device, num_envs):
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("num_envs", [1, 3])
+def test_mid_path_wildcard_dedup(device, num_envs):
+    """Checks that a mid-path wildcard prim path resolves each leaf body exactly once.
+
+    Regression test for body discovery: a mid-path wildcard prim path
+    (``Robot/.*/left_knee``) makes ``resolve_matching_prims_from_source`` return the same
+    leaf body once per matching ancestor (``pelvis`` and ``pelvis/left_hip`` both carry it as
+    a descendant). Without a dedup by prim path the single ``left_knee`` body is registered
+    multiple times, which inflates ``num_sensors`` and trips the physics-cloned init guard.
+
+    The source chain is authored under ``env_0`` and replicated through the OVPhysX clone
+    path so the check also covers the multi-environment binding.
+    """
+    with _ovphysx_sim_context(device=device, dt=_SIM_DT, add_lighting=False) as sim:
+        stage = get_current_stage()
+        env_positions, _ = cloner.grid_transforms(num_envs, spacing=3.0, device=device)
+        env_0 = UsdGeom.Xform.Define(stage, "/World/envs/env_0")
+        env_0.AddTranslateOp().Set(Gf.Vec3d(*env_positions[0].tolist()))
+        _author_nested_chain("/World/envs/env_0/Robot")
+
+        src, dest = "/World/envs/env_0", "/World/envs/env_{}"
+        clone_plan = cloner.clone_plan_from_env_0(src, dest, num_envs, device, env_positions)
+        assert clone_plan.env_ids is not None
+        ovphysx_replicate(
+            stage,
+            clone_plan.sources,
+            clone_plan.destinations,
+            clone_plan.env_ids,
+            clone_plan.clone_mask,
+            positions=clone_plan.positions,
+        )
+        sim.set_clone_plan(clone_plan)
+
+        contact_sensor = ContactSensor(
+            ContactSensorCfg(
+                prim_path="{ENV_REGEX_NS}/Robot/.*/left_knee",
+                track_pose=False,
+                debug_vis=False,
+                update_period=0.0,
+            )
+        )
+        sim.reset()
+
+        # the mid-path wildcard matches two ancestors but the leaf must be registered once
+        assert contact_sensor.num_sensors == 1
+        assert contact_sensor.body_names == ["left_knee"]
+
+        # step to fill the sensor buffers; kinematic bodies generate no contact forces
+        for _ in range(2):
+            sim.step()
+            contact_sensor.update(_SIM_DT, force_recompute=True)
+        net_forces = contact_sensor.data.net_forces_w.torch
+        assert net_forces.shape == (num_envs, 1, 3)
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 def test_sensor_print(device):
     """Test sensor print is working correctly."""
     with _ovphysx_sim_context(device=device, dt=_SIM_DT, add_lighting=False) as sim:


### PR DESCRIPTION
# Description

The `isaaclab_ov` `ContactSensor` discovers bodies with `resolve_matching_prims_from_source`, which matches every ancestor in phase one and then collects the leaf as a descendant of each match in phase two. With a mid-path wildcard prim path (for example `Robot/.*/left_ankle_roll_link`) the same leaf body is returned **once per matching ancestor**, with no dedup by prim identity. That inflates the sensor and filter counts and makes the physics-cloned init guard `sensor_count % num_sensors` fire, breaking any reward reading a self-collision force off the sensor. The classic `isaaclab.sensors.contact_sensor` does not resolve discovery this way and is unaffected.

The fix deduplicates the resolved matches by prim path before they are consumed — the minimal change that keeps the natural mid-path wildcard prim path working on both the Newton and the ovphysx backends. A regression test authors a nested link chain (`pelvis/left_hip/left_knee`) and resolves the single `left_knee` leaf through a `Robot/.*/left_knee` wildcard, asserting the body is registered exactly once (it fails without the fix with `RuntimeError: Failed to initialize contact binding` and passes with it).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — this is a body-count bug, not a visual change. The evidence is behavioral (regression test).

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
