### PR TITLE
[Changelog] Make the fragment check merge-aware in pre-commit

### DIFF
--- a/tools/changelog/cli.py
+++ b/tools/changelog/cli.py
@@ -743,14 +743,19 @@ class PRDiff:
 
         remote_base = f"origin/{base_ref}"
         if include_worktree:
-            merge_base = subprocess.run(
-                ["git", "merge-base", remote_base, "HEAD"],
-                capture_output=True,
-                text=True,
-                check=True,
-                cwd=REPO_ROOT,
-            ).stdout.strip()
-            diff_target = merge_base
+
+            def _git(*args: str) -> str | None:
+                """Trimmed stdout of a git query, or None when it reports failure (rc != 0)."""
+                result = subprocess.run(["git", *args], capture_output=True, text=True, cwd=REPO_ROOT)
+                return result.stdout.strip() if result.returncode == 0 else None
+
+            diff_target = _git("merge-base", remote_base, "HEAD")
+            # a pending merge puts the other side's commits in the worktree before HEAD has them;
+            # measure from the newer base so that history is not read as this branch's changes
+            if _git("rev-parse", "-q", "--verify", "MERGE_HEAD") is not None:
+                merged_base = _git("merge-base", remote_base, "MERGE_HEAD")
+                if merged_base and _git("merge-base", "--is-ancestor", diff_target, merged_base) is not None:
+                    diff_target = merged_base
         else:
             diff_target = f"{remote_base}...HEAD"
 

--- a/tools/changelog/test/test_git_diff.py
+++ b/tools/changelog/test/test_git_diff.py
@@ -54,3 +54,42 @@ def test_from_git_include_worktree_collects_tracked_local_changes(tmp_path, monk
             "source/example/staged.py",
         },
     )
+
+
+def test_from_git_include_worktree_ignores_history_merged_in_from_the_base(tmp_path, monkeypatch):
+    """A pending merge of the base branch must not report the base's own commits as branch changes.
+
+    The scheduled changelog-compile commit deletes fragments on the base branch; while ``git merge
+    develop`` is waiting for its commit, those deletions sit in the worktree but not in ``HEAD``.
+    """
+    _git(tmp_path, "init", "-b", "develop")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test User")
+
+    package_dir = tmp_path / "source" / "example"
+    (package_dir / "changelog.d").mkdir(parents=True)
+    (package_dir / "base.py").write_text("base\n", encoding="utf-8")
+    (package_dir / "changelog.d" / "compiled.rst").write_text("Fixed\n^^^^^\n\n* Fixed a thing.\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example")
+    _git(tmp_path, "commit", "-m", "Add base")
+    _git(tmp_path, "switch", "-c", "feature")
+    (package_dir / "feature.py").write_text("feature\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/feature.py")
+    _git(tmp_path, "commit", "-m", "Add feature")
+
+    # the base moves on: a compile commit removes the fragment and other work lands
+    _git(tmp_path, "switch", "develop")
+    _git(tmp_path, "rm", "-q", "source/example/changelog.d/compiled.rst")
+    (package_dir / "upstream.py").write_text("upstream\n", encoding="utf-8")
+    _git(tmp_path, "add", "source/example/upstream.py")
+    _git(tmp_path, "commit", "-m", "Compile changelog fragments")
+    _git(tmp_path, "update-ref", "refs/remotes/origin/develop", "HEAD")
+
+    _git(tmp_path, "switch", "feature")
+    _git(tmp_path, "merge", "--no-commit", "--no-ff", "develop")
+
+    monkeypatch.setattr(cli, "REPO_ROOT", tmp_path)
+    assert cli.PRDiff.from_git("develop", include_worktree=True) == cli.PRDiff(
+        changed={"source/example/feature.py"},
+        added={"source/example/feature.py"},
+    )


### PR DESCRIPTION
## Summary

Merging develop into a branch no longer fails the local `check changelog fragments` hook whenever develop has compiled fragments since the fork point. The hook now measures a pending merge from the base branch's tip instead of the old fork point.

# Description

`tools/changelog/cli.py`, `PRDiff.from_git(include_worktree=True)`, diffed the worktree against `merge-base(origin/<base>, HEAD)`. During `git merge develop` HEAD is still the pre-merge tip, so develop's commits since the fork point are in the worktree but not in HEAD and read as branch changes; the scheduled compile commits delete fragments, which trips the immutability rule and marks the compiled packages as missing a fragment (observed on #7161: 7 false immutability hits, 7 false missing packages, none genuine). When `MERGE_HEAD` exists, the diff base is now the newer of the two merge-bases. The three-dot diff CI uses is unchanged.

Fixes # (none)

## Type of change

- Bug fix

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Test plan

- [x] `python -m pytest tools/changelog/test/` 92 passed; the new test fails on develop and passes here
- [x] pre-commit on the changed files

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (none needed: tooling only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] A package changelog fragment is not required because no source package changed
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
