### PR TITLE
Render Newton RTX markers in the viewer and headless capture

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/newton-rtx-video-capture.rst
+++ b/source/isaaclab_visualizers/changelog.d/newton-rtx-video-capture.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the Newton RTX visualizer dropping visualization markers, so both the interactive
+  ``--viz newton_rtx`` viewer and videos captured through it now draw the goal poses, command
+  arrows, and other debug markers the GL viewer already showed, sanitizing the marker group
+  ids into valid USD prim paths the RTX stage accepts.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualization_markers.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -42,15 +43,47 @@ class _NewtonMarkerSpec:
     preloaded_mesh: Any | None = field(default=None, hash=False, compare=False)
 
 
-def render_newton_visualization_markers(viewer: ViewerBase, visible_env_ids: list[int] | None, num_envs: int) -> None:
-    """Render all active Newton visualization marker groups into a Newton-family viewer."""
+def render_newton_visualization_markers(
+    viewer: ViewerBase,
+    visible_env_ids: list[int] | None,
+    num_envs: int,
+    sanitize_group_ids: bool = False,
+) -> None:
+    """Render all active Newton visualization marker groups into a Newton-family viewer.
+
+    Args:
+        viewer: The Newton-family viewer the marker groups are logged into.
+        visible_env_ids: The env ids to draw markers for, or None for all envs.
+        num_envs: The number of environments the marker state is batched over.
+        sanitize_group_ids: Rewrite each marker group id into a valid USD prim path
+            before rendering. The RTX viewer overlays markers on a USD stage that
+            rejects the ``::`` and other characters the registry key carries, so it
+            needs sanitized ids while the GL viewer renders the raw ids directly.
+    """
     sim = sim_utils.SimulationContext.instance()
     if sim is None:
         return
 
     for marker in sim.vis_marker_registry.get_groups().values():
-        if isinstance(marker, NewtonVisualizationMarkers):
+        if not isinstance(marker, NewtonVisualizationMarkers):
+            continue
+        if not sanitize_group_ids:
             marker.render(viewer, visible_env_ids=visible_env_ids, num_envs=num_envs)
+            continue
+        # The registry is keyed on the original group id and remove_group() removes
+        # it by that key, so render under a sanitized id and restore the original.
+        original_group_id = marker.group_id
+        marker.group_id = _sanitize_newton_marker_group_id(original_group_id)
+        try:
+            marker.render(viewer, visible_env_ids=visible_env_ids, num_envs=num_envs)
+        finally:
+            marker.group_id = original_group_id
+
+
+def _sanitize_newton_marker_group_id(group_id: str) -> str:
+    """Rewrite a marker group id into a USD-safe prim path for the RTX viewer."""
+    sanitized = re.sub(r"[^A-Za-z0-9_/]+", "_", group_id)
+    return sanitized if sanitized.startswith("/") else f"/{sanitized}"
 
 
 class NewtonVisualizationMarkers:

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1182,11 +1182,15 @@ class NewtonVisualizer(BaseVisualizer):
                             self._viewer.log_contacts(contacts, self._state)
                         else:
                             self._log_scene_contact_sensor_arrows(num_envs)
-                        if self.cfg.enable_markers and not isinstance(self._viewer, NewtonViewerRTX):
-                            # ViewerRTX uses a USD stage whose prim paths are not set up
-                            # for the debug mesh overlays that markers require; skip for RTX.
+                        if self.cfg.enable_markers:
+                            # ViewerRTX overlays markers on a USD stage that rejects the
+                            # registry group ids verbatim, so sanitize them into valid prim
+                            # paths for RTX while the GL viewer renders the raw ids.
                             render_newton_visualization_markers(
-                                self._viewer, self._resolved_visible_env_ids, num_envs=num_envs
+                                self._viewer,
+                                self._resolved_visible_env_ids,
+                                num_envs=num_envs,
+                                sanitize_group_ids=isinstance(self._viewer, NewtonViewerRTX),
                             )
                         self._log_streaming_image()
                         self._render_live_plots()
@@ -2221,6 +2225,17 @@ class NewtonRTXVisualizer(NewtonVisualizer):
             self._viewer.begin_frame(self._sim_time)
             try:
                 self._viewer.log_state(self._state)
+                # The interactive path logs markers every frame; a headless capture that
+                # skips them records the scene without its goal poses and command arrows.
+                if self.cfg.enable_markers:
+                    from isaaclab_newton.physics import NewtonManager
+
+                    render_newton_visualization_markers(
+                        self._viewer,
+                        self._resolved_visible_env_ids,
+                        num_envs=NewtonManager.get_num_envs(),
+                        sanitize_group_ids=True,
+                    )
             finally:
                 self._viewer.end_frame()
         return self._viewer.get_frame()

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -168,6 +168,106 @@ def test_newton_marker_registry_lifecycle(monkeypatch: pytest.MonkeyPatch):
     assert registry.groups == {}
 
 
+def test_sanitize_newton_marker_group_id_rewrites_invalid_chars_into_usd_path():
+    """The registry ``prim_path::id`` key is rewritten into a USD-safe prim path."""
+    # The ``::`` the registry key carries is what the RTX USD stage rejects.
+    assert newton_markers._sanitize_newton_marker_group_id("/Visuals/test::140") == "/Visuals/test_140"
+    # A key without a leading slash is anchored to one so it is a valid prim path.
+    assert newton_markers._sanitize_newton_marker_group_id("Visuals/test::140") == "/Visuals/test_140"
+    # A run of invalid characters collapses into a single underscore.
+    assert newton_markers._sanitize_newton_marker_group_id("/a b::c") == "/a_b_c"
+
+
+def test_render_newton_visualization_markers_sanitizes_group_id_and_restores(monkeypatch: pytest.MonkeyPatch):
+    """RTX rendering logs the marker under a sanitized id and restores the registry key."""
+
+    class _Registry:
+        def __init__(self) -> None:
+            self.groups: dict[str, object] = {}
+
+        def set_group(self, group_id: str, marker) -> None:
+            self.groups[group_id] = marker
+
+        def remove_group(self, group_id: str) -> None:
+            self.groups.pop(group_id)
+
+    class _FakeContext:
+        def __init__(self, registry: _Registry) -> None:
+            self.vis_marker_registry = registry
+
+    class _FakeSimulationContext:
+        current: object | None = None
+
+        @classmethod
+        def instance(cls):
+            return cls.current
+
+    registry = _Registry()
+    registry.get_groups = lambda: registry.groups
+    monkeypatch.setattr(newton_markers.sim_utils, "SimulationContext", _FakeSimulationContext)
+    _FakeSimulationContext.current = _FakeContext(registry)
+
+    marker = newton_markers.NewtonVisualizationMarkers(
+        newton_markers.VisualizationMarkersCfg(prim_path="/Visuals/test", markers={}), visible=False
+    )
+    original_group_id = marker.group_id
+    assert "::" in original_group_id  # the raw registry key the RTX stage rejects
+
+    rendered_group_ids: list[str] = []
+    marker.render = lambda *args, **kwargs: rendered_group_ids.append(marker.group_id)
+
+    render_newton_visualization_markers = newton_markers.render_newton_visualization_markers
+    render_newton_visualization_markers(viewer=Mock(), visible_env_ids=None, num_envs=1, sanitize_group_ids=True)
+
+    # rendered under the sanitized id, and the original registry key is restored afterwards
+    assert rendered_group_ids == [newton_markers._sanitize_newton_marker_group_id(original_group_id)]
+    assert "::" not in rendered_group_ids[0]
+    assert marker.group_id == original_group_id
+
+
+def test_render_newton_visualization_markers_keeps_raw_group_id_without_sanitizing(monkeypatch: pytest.MonkeyPatch):
+    """The GL path is unchanged: markers render under the raw registry key."""
+
+    class _Registry:
+        def __init__(self) -> None:
+            self.groups: dict[str, object] = {}
+
+        def set_group(self, group_id: str, marker) -> None:
+            self.groups[group_id] = marker
+
+        def remove_group(self, group_id: str) -> None:
+            self.groups.pop(group_id)
+
+    class _FakeContext:
+        def __init__(self, registry: _Registry) -> None:
+            self.vis_marker_registry = registry
+
+    class _FakeSimulationContext:
+        current: object | None = None
+
+        @classmethod
+        def instance(cls):
+            return cls.current
+
+    registry = _Registry()
+    registry.get_groups = lambda: registry.groups
+    monkeypatch.setattr(newton_markers.sim_utils, "SimulationContext", _FakeSimulationContext)
+    _FakeSimulationContext.current = _FakeContext(registry)
+
+    marker = newton_markers.NewtonVisualizationMarkers(
+        newton_markers.VisualizationMarkersCfg(prim_path="/Visuals/test", markers={}), visible=False
+    )
+    original_group_id = marker.group_id
+
+    rendered_group_ids: list[str] = []
+    marker.render = lambda *args, **kwargs: rendered_group_ids.append(marker.group_id)
+
+    newton_markers.render_newton_visualization_markers(viewer=Mock(), visible_env_ids=None, num_envs=1)
+
+    assert rendered_group_ids == [original_group_id]
+    assert marker.group_id == original_group_id
+
+
 def test_newton_visualizer_cfg_exposes_world_spacing():
     cfg = NewtonGLVisualizerCfg(world_spacing=(2.0, 2.0, 0.0))
 


### PR DESCRIPTION
# Description

This PR adds experimental visualization-marker support to the Newton RTX visualizer. Newton RTX overlays markers on a USD stage that rejects the `::` and other characters carried by marker registry group ids (the registry key has the form `prim_path::id`). Without RTX-specific handling, both the interactive `newton_rtx` viewer and headless captures omit goal poses, command arrows and the other debug markers drawn by the GL viewer.

The change sanitizes each marker group id into a valid USD prim path before logging it into the RTX viewer, renders markers during the RTX live step, and adds the same marker pass to the RTX `render_rgb_array` headless capture. The sanitization is scoped to the RTX path through a new `sanitize_group_ids` argument on `render_newton_visualization_markers`, restoring the original registry key after each render, so the GL viewer keeps rendering the raw ids and its behavior is unchanged.

Newton RTX remains experimental. This implementation intentionally provides a small compatibility layer for the existing Newton marker backend and can be streamlined together with the broader Newton RTX marker path in a future release.

This is the RTX counterpart of the GL-only fix in [#7011](https://github.com/isaac-sim/IsaacLab/pull/7011), kept as a separate PR so it can be reviewed on its own.

Tested with the unit tests, which need no simulator:

```bash
uv run --extra test python -m pytest \
  source/isaaclab_visualizers/test/test_newton_adapter.py
```

`70 passed`. The three added tests cover group-id sanitization, the RTX render sanitizing the id and restoring the original registry key, and the GL path still rendering the raw id.

## Type of change

- New feature (non-breaking change which adds functionality)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not attached: the markers are the same goal poses and command arrows the GL viewer already draws, now also visible in the RTX viewer and its captures. I can add before/after RTX captures if useful.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` -- CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
