### PR TITLE
[Odin] Fix semantic_segmentation camera observations reaching the policy as integers

### DIFF
--- a/source/isaaclab/changelog.d/fix-semantic-segmentation-dtype.rst
+++ b/source/isaaclab/changelog.d/fix-semantic-segmentation-dtype.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :func:`isaaclab.utils.images.normalize_camera_image` returning non-colorized
+  ``"semantic_segmentation"`` unchanged. Such output is an ``int32`` label map on every renderer,
+  and feeding it to a convolution raised ``Input type (int) and bias type (float) should be the
+  same``. It is now cast to ``float32``; label ids carry no scale, so they are not rescaled.
+  Colorized (``uint8`` RGBA) segmentation keeps its existing ``(x / 255) - mean`` normalization.

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -52,6 +52,8 @@ def normalize_camera_image(
 
     Dispatch (in order of check):
 
+    - non-colorized ``"semantic_segmentation"`` (any non-``uint8`` dtype, ``int32`` label ids in
+      practice): cast to ``float32``. Label ids carry no scale, so no further normalization.
     - :func:`is_rgb_like` or colorized ``"semantic_segmentation"`` (``uint8``) and contiguous
       4D: routes to the
       fused Warp kernel via :func:`~isaaclab.utils.warp.ops.normalize_image_uint8`. ``out`` and
@@ -79,10 +81,15 @@ def normalize_camera_image(
 
     Returns:
         The normalized tensor. For RGB-like and colorized semantic-segmentation input this is a
-        fresh (or pre-allocated) float32 tensor; for depth-like input it is ``images`` itself
-        (mutated in place); for normals-like input it is a new tensor; for anything else,
-        ``images`` unchanged.
+        fresh (or pre-allocated) float32 tensor; for non-colorized semantic segmentation it is a
+        float32 view or copy of ``images``; for depth-like input it is ``images`` itself (mutated
+        in place); for normals-like input it is a new tensor; for anything else, ``images``
+        unchanged.
     """
+    if data_type == "semantic_segmentation" and images.dtype != torch.uint8:
+        # Non-colorized segmentation is an integer label map (``int32`` for every renderer). Label
+        # ids have no meaningful scale, so only cast to float32 so downstream convolutions accept it.
+        return images.float()
     if is_rgb_like(data_type) or (data_type == "semantic_segmentation" and images.dtype == torch.uint8):
         if images.dtype == torch.uint8 and images.ndim == 4 and images.is_contiguous():
             return normalize_image_uint8(images, channel_dim=channel_dim, out=out)

--- a/source/isaaclab/isaaclab/utils/images.py
+++ b/source/isaaclab/isaaclab/utils/images.py
@@ -81,14 +81,14 @@ def normalize_camera_image(
 
     Returns:
         The normalized tensor. For RGB-like and colorized semantic-segmentation input this is a
-        fresh (or pre-allocated) float32 tensor; for non-colorized semantic segmentation it is a
-        float32 view or copy of ``images``; for depth-like input it is ``images`` itself (mutated
-        in place); for normals-like input it is a new tensor; for anything else, ``images``
+        fresh (or pre-allocated) float32 tensor; for non-colorized semantic segmentation it is
+        ``images`` cast to float32; for depth-like input it is ``images`` itself (mutated in
+        place); for normals-like input it is a new tensor; for anything else, ``images``
         unchanged.
     """
     if data_type == "semantic_segmentation" and images.dtype != torch.uint8:
-        # Non-colorized segmentation is an integer label map (``int32`` for every renderer). Label
-        # ids have no meaningful scale, so only cast to float32 so downstream convolutions accept it.
+        # Non-colorized segmentation is an integer label map (``int32`` for every renderer).
+        # Label ids carry no scale, so cast for the downstream convolutions without rescaling.
         return images.float()
     if is_rgb_like(data_type) or (data_type == "semantic_segmentation" and images.dtype == torch.uint8):
         if images.dtype == torch.uint8 and images.ndim == 4 and images.is_contiguous():

--- a/source/isaaclab/test/utils/test_images.py
+++ b/source/isaaclab/test/utils/test_images.py
@@ -146,8 +146,8 @@ class TestNormalizeCameraImageRGBLike:
         torch.testing.assert_close(out, expected)
 
 
-class TestNormalizeCameraImageColorizedSegmentation:
-    """Colorized segmentation dispatch."""
+class TestNormalizeCameraImageSegmentation:
+    """Segmentation dispatch, keyed on the tensor dtype rather than on the ``colorize`` flag."""
 
     def test_colorized_semantic_segmentation_is_normalized(self, device):
         """RGBA uint8 semantic segmentation produces a float32 normalized image."""
@@ -161,6 +161,21 @@ class TestNormalizeCameraImageColorizedSegmentation:
         expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
         torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
         assert out.dtype == torch.float32
+
+    def test_non_colorized_semantic_segmentation_is_cast_to_float(self, device):
+        """int32 label-id segmentation is cast to float32 with the ids left untouched.
+
+        Non-colorized segmentation is ``int32`` for every renderer, and feeding it to a
+        convolution raises ``Input type (int) and bias type (float) should be the same``.
+        """
+        from isaaclab.utils.images import normalize_camera_image
+
+        torch.manual_seed(0)
+        src = torch.randint(0, 4, (2, 8, 8, 1), dtype=torch.int32, device=device)
+        out = normalize_camera_image(src, "semantic_segmentation")
+
+        assert out.dtype == torch.float32
+        torch.testing.assert_close(out, src.to(torch.float32))
 
 
 class TestNormalizeCameraImageDepth:
@@ -192,7 +207,7 @@ class TestNormalizeCameraImageNormals:
 class TestNormalizeCameraImagePassthrough:
     """Unknown data_types return the input unchanged."""
 
-    @pytest.mark.parametrize("data_type", ["semantic_segmentation", "instance_segmentation", "motion_vectors"])
+    @pytest.mark.parametrize("data_type", ["instance_segmentation", "motion_vectors"])
     def test_unknown_type_passthrough(self, device, data_type):
         from isaaclab.utils.images import normalize_camera_image
 

--- a/source/isaaclab_tasks/changelog.d/fix-cartpole-semantic-segmentation-dtype.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-cartpole-semantic-segmentation-dtype.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed the Cartpole camera tasks crashing at the first training step with
+  ``RuntimeError: Input type (unsigned char) and bias type (float) should be the same`` when the
+  ``semantic_segmentation`` preset was selected. Both the manager-based observation term and the
+  direct environment normalized only RGB-like and depth output, so segmentation reached the feature
+  extractor as an integer tensor. Segmentation is now routed through
+  :func:`isaaclab.utils.images.normalize_camera_image`, which keys on the tensor dtype and therefore
+  handles both colorized (``uint8`` RGBA) and non-colorized (``int32`` label ids) output.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import torch
+
 import isaaclab.sim as sim_utils
 from isaaclab import cloner
 from isaaclab.assets import Articulation
@@ -78,15 +80,17 @@ class CartpoleCameraEnv(CartpoleEnv):
         camera_data = self._tiled_camera.data.output[data_type]
 
         rgb_like = is_rgb_like(data_type)
+        segmentation = data_type == "semantic_segmentation"
         # Defer normalize past the ring buffer when stacking RGB-like data so the ring holds
         # uint8 (4x cheaper per-step copies). Math is identical -- K frames live in disjoint
-        # channel slices of (B, K*C, H, W).
-        defer_normalize = self._stack is not None and rgb_like
+        # channel slices of (B, K*C, H, W). Colorized segmentation is uint8 RGBA and qualifies;
+        # non-colorized segmentation is an int32 label map and does not.
+        defer_normalize = self._stack is not None and (rgb_like or (segmentation and camera_data.dtype == torch.uint8))
 
         if data_type == "albedo":
             # albedo carries an extra alpha channel that the policy does not use
             camera_data = camera_data[..., :3]
-        if rgb_like and not defer_normalize:
+        if (rgb_like or segmentation) and not defer_normalize:
             camera_data = normalize_camera_image(camera_data, data_type)
         elif data_type == "depth":
             camera_data[camera_data == float("inf")] = 0

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/mdp/observations.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/mdp/observations.py
@@ -46,10 +46,13 @@ class CameraImageStack(ManagerTermBase):
         camera_data = camera.data.output[data_type]
 
         rgb_like = is_rgb_like(data_type)
-        defer_normalize = self._stack is not None and rgb_like
+        segmentation = data_type == "semantic_segmentation"
+        # Colorized segmentation is uint8 RGBA, so it can ride the same deferred-normalize path as
+        # the RGB-like types; non-colorized segmentation is an int32 label map that cannot.
+        defer_normalize = self._stack is not None and (rgb_like or (segmentation and camera_data.dtype == torch.uint8))
         if data_type == "albedo":
             camera_data = camera_data[..., :3]
-        if rgb_like and not defer_normalize:
+        if (rgb_like or segmentation) and not defer_normalize:
             camera_data = normalize_camera_image(camera_data, data_type)
         elif data_type == "depth":
             camera_data[camera_data == float("inf")] = 0

--- a/source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py
+++ b/source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sim-free tests for the Cartpole camera observation term.
+
+The term must hand the policy a float32 tensor for every camera data type. Segmentation is the
+interesting case: it is ``uint8`` RGBA when colorized and ``int32`` label ids when not, and the
+feature extractor's first convolution rejects both integer dtypes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from isaaclab.managers import ObservationTermCfg, SceneEntityCfg
+
+from isaaclab_tasks.core.cartpole.mdp.observations import CameraImageStack
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(params=["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"])
+def device(request):
+    return request.param
+
+
+def _make_env(camera_output: dict[str, torch.Tensor], frame_stack: int, device: str) -> SimpleNamespace:
+    """Build the minimal environment stub the observation term reads from."""
+    camera = SimpleNamespace(data=SimpleNamespace(output=camera_output))
+    return SimpleNamespace(
+        cfg=SimpleNamespace(frame_stack=frame_stack),
+        num_envs=next(iter(camera_output.values())).shape[0],
+        device=device,
+        scene=SimpleNamespace(sensors={"tiled_camera": camera}),
+    )
+
+
+@pytest.mark.parametrize("frame_stack", [1, 2])
+@pytest.mark.parametrize(
+    "dtype,num_channels",
+    [(torch.uint8, 4), (torch.int32, 1)],
+    ids=["colorized_uint8_rgba", "non_colorized_int32_labels"],
+)
+def test_semantic_segmentation_observation_is_float32(device, frame_stack, dtype, num_channels):
+    """Segmentation observations are float32 regardless of the renderer's ``colorize`` setting."""
+    torch.manual_seed(0)
+    images = torch.randint(0, 5, (2, 8, 8, num_channels), dtype=dtype, device=device)
+    env = _make_env({"semantic_segmentation": images}, frame_stack, device)
+    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
+
+    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+
+    assert observation.dtype == torch.float32
+    assert observation.shape == (2, frame_stack * num_channels, 8, 8)
+
+
+def test_colorized_segmentation_matches_rgb_normalization(device):
+    """Colorized segmentation gets the same ``(x / 255) - per-image mean`` treatment as RGB."""
+    torch.manual_seed(0)
+    images = torch.randint(0, 255, (2, 8, 8, 4), dtype=torch.uint8, device=device)
+    env = _make_env({"semantic_segmentation": images}, frame_stack=1, device=device)
+    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
+
+    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+
+    expected = images.float() / 255.0
+    expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
+    torch.testing.assert_close(observation, expected.permute(0, 3, 1, 2), atol=1e-5, rtol=1e-5)
+
+
+def test_non_colorized_segmentation_preserves_label_ids(device):
+    """Label ids carry no scale, so the int32 map is only cast, never rescaled."""
+    images = torch.arange(2 * 8 * 8, dtype=torch.int32, device=device).reshape(2, 8, 8, 1) % 5
+    env = _make_env({"semantic_segmentation": images}, frame_stack=1, device=device)
+    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
+
+    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+
+    torch.testing.assert_close(observation, images.to(torch.float32).permute(0, 3, 1, 2))

--- a/source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py
+++ b/source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py
@@ -5,9 +5,9 @@
 
 """Sim-free tests for the Cartpole camera observation term.
 
-The term must hand the policy a float32 tensor for every camera data type. Segmentation is the
-interesting case: it is ``uint8`` RGBA when colorized and ``int32`` label ids when not, and the
-feature extractor's first convolution rejects both integer dtypes.
+Segmentation output is ``uint8`` RGBA when colorized and ``int32`` label ids when not. Either
+integer dtype crashes the feature extractor's first convolution, so the term must return float32
+for both. ``frame_stack`` is parametrized because the stacking path defers normalization.
 """
 
 from __future__ import annotations
@@ -29,56 +29,44 @@ def device(request):
     return request.param
 
 
-def _make_env(camera_output: dict[str, torch.Tensor], frame_stack: int, device: str) -> SimpleNamespace:
-    """Build the minimal environment stub the observation term reads from."""
-    camera = SimpleNamespace(data=SimpleNamespace(output=camera_output))
-    return SimpleNamespace(
+def _observe(images: torch.Tensor, frame_stack: int, device: str) -> torch.Tensor:
+    """Run the observation term over ``images`` using a minimal environment stub."""
+    camera = SimpleNamespace(data=SimpleNamespace(output={"semantic_segmentation": images}))
+    env = SimpleNamespace(
         cfg=SimpleNamespace(frame_stack=frame_stack),
-        num_envs=next(iter(camera_output.values())).shape[0],
+        num_envs=images.shape[0],
         device=device,
         scene=SimpleNamespace(sensors={"tiled_camera": camera}),
     )
+    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
+    return term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+
+
+def _to_expected_layout(images: torch.Tensor, frame_stack: int) -> torch.Tensor:
+    """Convert BHWC to the channel-first layout, repeated as the ring buffer fills on first append."""
+    return images.permute(0, 3, 1, 2).repeat(1, frame_stack, 1, 1)
 
 
 @pytest.mark.parametrize("frame_stack", [1, 2])
-@pytest.mark.parametrize(
-    "dtype,num_channels",
-    [(torch.uint8, 4), (torch.int32, 1)],
-    ids=["colorized_uint8_rgba", "non_colorized_int32_labels"],
-)
-def test_semantic_segmentation_observation_is_float32(device, frame_stack, dtype, num_channels):
-    """Segmentation observations are float32 regardless of the renderer's ``colorize`` setting."""
-    torch.manual_seed(0)
-    images = torch.randint(0, 5, (2, 8, 8, num_channels), dtype=dtype, device=device)
-    env = _make_env({"semantic_segmentation": images}, frame_stack, device)
-    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
-
-    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
-
-    assert observation.dtype == torch.float32
-    assert observation.shape == (2, frame_stack * num_channels, 8, 8)
-
-
-def test_colorized_segmentation_matches_rgb_normalization(device):
-    """Colorized segmentation gets the same ``(x / 255) - per-image mean`` treatment as RGB."""
+def test_colorized_segmentation_is_normalized_like_rgb(device, frame_stack):
+    """Colorized uint8 RGBA segmentation gets the same ``(x / 255) - per-image mean`` as RGB."""
     torch.manual_seed(0)
     images = torch.randint(0, 255, (2, 8, 8, 4), dtype=torch.uint8, device=device)
-    env = _make_env({"semantic_segmentation": images}, frame_stack=1, device=device)
-    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
 
-    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+    observation = _observe(images, frame_stack, device)
 
     expected = images.float() / 255.0
     expected = expected - torch.mean(expected, dim=(1, 2), keepdim=True)
-    torch.testing.assert_close(observation, expected.permute(0, 3, 1, 2), atol=1e-5, rtol=1e-5)
+    assert observation.dtype == torch.float32
+    torch.testing.assert_close(observation, _to_expected_layout(expected, frame_stack), atol=1e-5, rtol=1e-5)
 
 
-def test_non_colorized_segmentation_preserves_label_ids(device):
-    """Label ids carry no scale, so the int32 map is only cast, never rescaled."""
+@pytest.mark.parametrize("frame_stack", [1, 2])
+def test_non_colorized_segmentation_is_cast_to_float(device, frame_stack):
+    """Non-colorized int32 label ids are cast to float32 and, carrying no scale, left unrescaled."""
     images = torch.arange(2 * 8 * 8, dtype=torch.int32, device=device).reshape(2, 8, 8, 1) % 5
-    env = _make_env({"semantic_segmentation": images}, frame_stack=1, device=device)
-    term = CameraImageStack(ObservationTermCfg(func=CameraImageStack), env)
 
-    observation = term(env, SceneEntityCfg("tiled_camera"), "semantic_segmentation")
+    observation = _observe(images, frame_stack, device)
 
-    torch.testing.assert_close(observation, images.to(torch.float32).permute(0, 3, 1, 2))
+    assert observation.dtype == torch.float32
+    torch.testing.assert_close(observation, _to_expected_layout(images.float(), frame_stack))


### PR DESCRIPTION
## Description

Every `semantic_segmentation` camera row in benchmark dispatch `20260901-153531` (image built from `origin/release/3.0.0` at `f88dbc59c82`, `rsl_rl`, all core tasks) failed at the first training step — **60 failed rows** total, with:

```
RuntimeError: Input type (unsigned char) and bias type (float) should be the same
```

The failure is renderer-independent: `isaacsim_rtx` 18 rows, `ovrtx` 18, `newton_renderer` 24. The segmentation output reaches the feature extractor's first convolution still as an integer tensor.

### Root cause

Both Cartpole camera observation paths normalize only RGB-like and `depth` data types, so `semantic_segmentation` falls through unconverted:

- `source/isaaclab_tasks/isaaclab_tasks/core/cartpole/mdp/observations.py` (`CameraImageStack.__call__`)
- `source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env.py` (`CartpoleCameraEnv._get_observations`)

Both files are byte-identical between `release/3.0.0` and `develop`, so the bug is present on `develop` as-is.

### Why the fix belongs in the observation term

The renderer is producing exactly what its published contract says it should — `NewtonWarpRenderer.supported_output_types` deliberately emits RGBA `uint8` when colorized and a single `int32` id channel when not, *"matching the Isaac RTX / OVRTX contract so backend-independent consumers see the same dtype"*. Segmentation label ids are integers; making a renderer emit floats would break every consumer that reads ids (visualization, semantic id lookup, dataset export).

Nor does it belong in the feature extractor: the extractor's contract is "float32 image in", and the observation pipeline already owns dtype/layout normalization for every other camera data type via `normalize_camera_image`. Making the CNN defensively cast would paper over the same gap for every future task and duplicate logic that already exists.

So the fix goes where the gap is: the observation term, routed through the shared helper.

### The int32-vs-uint8 subtlety

Segmentation has **two** dtypes depending on `colorize_semantic_segmentation`:

- `colorize=True` (the `CameraCfg` default, and what the failing sweep used): RGBA `uint8`, 4 channels
- `colorize=False`: a single `int32` label-id channel

`normalize_camera_image` already handled the colorized `uint8` case correctly — it was simply never called for this data type. The non-colorized `int32` case was **not** handled: it fell through every branch and was returned unchanged, so a fix that only wired up the existing call would still break `colorize=False`.

The `int32` half is not demonstrated by the sweep (see the caveat below), but it is not opportunistic scope creep: the caller now dispatches on the data type alone, so the helper is the single place that decides what segmentation means, and leaving it to silently return `int32` unchanged would ship a fix that reads as complete while still crashing under `colorize=False`.

Handled by keying on the tensor dtype rather than on the `colorize` flag or a hardcoded uint8 assumption:

- In `normalize_camera_image`, non-`uint8` segmentation is cast to `float32`. Label ids carry no meaningful scale, so they are cast and **not** rescaled — applying `(x / 255) - mean` to label ids would be inventing semantics.
- In both Cartpole callers, the uint8 deferred-normalize fast path (which keeps the frame-stack ring buffer in `uint8` for cheaper per-step copies) is gated on `camera_data.dtype == torch.uint8`, so colorized segmentation rides it and `int32` label maps are normalized before entering the ring.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Test evidence

Construction-only reproduction, no simulator needed. The bug fires when the extractor first sees an observation, so exercising the observation term directly on stub camera output is sufficient and much faster.

Extended `source/isaaclab/test/utils/test_images.py` with the `int32` case next to the existing colorized case, and dropped `semantic_segmentation` from the "unknown type passthrough" parametrization — that class asserts `out is src` under the heading "Unknown data_types return the input unchanged", and segmentation is no longer unknown. It would still pass by the accident that `.float()` on a float32 tensor returns self, so leaving it would have left the suite documenting the opposite of the new behaviour.

Added `source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py` for the observation term itself; no sim-free test of it existed (the `test_rendering_cartpole*.py` neighbours need a renderer and golden images, and the `*_camera_presets.py` files only resolve configs). Two tests, each parametrized over `frame_stack` `[1, 2]` so both the immediate and the deferred-normalize branch are covered, and each asserting exact values rather than just dtype.

Both dtypes are covered: colorized `uint8` RGBA and non-colorized `int32`.

**Without the fix** (the three source files reverted to `origin/develop`, tests kept):

```
$ uv run --frozen --extra dev python -m pytest source/isaaclab/test/utils/test_images.py \
      source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py -q
FAILED test_images.py::TestNormalizeCameraImageSegmentation::test_non_colorized_semantic_segmentation_is_cast_to_float[cpu]
FAILED test_images.py::TestNormalizeCameraImageSegmentation::test_non_colorized_semantic_segmentation_is_cast_to_float[cuda:0]
FAILED test_cartpole_camera_observations.py::test_colorized_segmentation_is_normalized_like_rgb[cpu-1]
FAILED test_cartpole_camera_observations.py::test_colorized_segmentation_is_normalized_like_rgb[cpu-2]
FAILED test_cartpole_camera_observations.py::test_colorized_segmentation_is_normalized_like_rgb[cuda:0-1]
FAILED test_cartpole_camera_observations.py::test_colorized_segmentation_is_normalized_like_rgb[cuda:0-2]
FAILED test_cartpole_camera_observations.py::test_non_colorized_segmentation_is_cast_to_float[cpu-1]
FAILED test_cartpole_camera_observations.py::test_non_colorized_segmentation_is_cast_to_float[cpu-2]
FAILED test_cartpole_camera_observations.py::test_non_colorized_segmentation_is_cast_to_float[cuda:0-1]
FAILED test_cartpole_camera_observations.py::test_non_colorized_segmentation_is_cast_to_float[cuda:0-2]
10 failed, 62 passed in 8.56s
```

Note that the pre-existing colorized-`uint8` helper test passes on `develop`: `normalize_camera_image` always handled that case correctly, and the crash came from the Cartpole callers never invoking it.

**With the fix:**

```
$ uv run --frozen --extra dev python -m pytest source/isaaclab/test/utils/test_images.py \
      source/isaaclab_tasks/test/core/test_cartpole_camera_observations.py -q
72 passed in 3.53s
```

`uv run --frozen isaaclab -f` passes clean.

### Caveats a reviewer should know

- The sweep exercised the **colorized `uint8` path**: `CameraCfg.colorize_semantic_segmentation` defaults to `True` and the Cartpole config declares `observation_space=[4, 96, 96]` (4 channels = RGBA). The `int32` path is reachable only with `colorize=False`; it was genuinely broken (the helper returned it unchanged) but the 60 rows do not prove it.
- The **direct-environment edit is not covered by a test**. `CartpoleCameraEnv._get_observations` calls `super()._get_observations()`, which needs a constructed environment, so it cannot be exercised sim-free. The edit is line-for-line identical to the manager-term edit, which is tested.

## Relationship to #7440

#7440 touches `isaaclab/utils/images.py` and the shared `isaaclab/envs/mdp/observations.py::image` term, but **neither Cartpole file**, so it does not fix this. Its `images.py` work is a fused normalize+layout-conversion perf change that adds an `output_channel_dim` parameter; it leaves the segmentation dispatch condition semantically unchanged and does not add `int32` handling. This PR adds an early-return branch above that condition and leaves #7440's line untouched, so the two should merge cleanly in either order.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (docstrings for `normalize_camera_image`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file (changelog fragments; `extension.toml` is generated)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`