### PR TITLE
Fix AppLauncher tests: update newton alias and remove legacy headless CLI test

### DIFF
--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -355,13 +355,13 @@ def test_set_visualizer_settings_suppresses_settings_manager_errors(monkeypatch:
 
 
 def test_parse_visualizer_csv_accepts_comma_delimited_values():
-    parsed = app_launcher_module.AppLauncher._parse_visualizer_csv("kit,newton,rerun,viser")
-    assert parsed == ["kit", "newton", "rerun", "viser"]
+    parsed = app_launcher_module.AppLauncher._parse_visualizer_csv("kit,newton_gl,rerun,viser")
+    assert parsed == ["kit", "newton_gl", "rerun", "viser"]
 
 
 def test_parse_visualizer_csv_rejects_spaces_between_entries():
     with pytest.raises(argparse.ArgumentTypeError, match="spaces are not allowed"):
-        app_launcher_module.AppLauncher._parse_visualizer_csv("kit, newton")
+        app_launcher_module.AppLauncher._parse_visualizer_csv("kit, newton_gl")
 
 
 def test_resolve_visualizer_settings_rejects_none_with_others():
@@ -377,10 +377,10 @@ def test_visualizer_csv_does_not_swallow_hydra_overrides():
     app_launcher_module.AppLauncher.add_app_launcher_args(parser)
 
     args, hydra_args = parser.parse_known_args(
-        ["--visualizer", "kit,newton,rerun", "presets=newton_mjwarp", "env.episode_length=10"]
+        ["--visualizer", "kit,newton_gl,rerun", "presets=newton_mjwarp", "env.episode_length=10"]
     )
 
-    assert args.visualizer == ["kit", "newton", "rerun"]
+    assert args.visualizer == ["kit", "newton_gl", "rerun"]
     assert hydra_args == ["presets=newton_mjwarp", "env.episode_length=10"]
 
 
@@ -393,17 +393,17 @@ def _resolve_headless_for_case(monkeypatch: pytest.MonkeyPatch, launcher_args: d
     return launcher._headless, launcher
 
 
-def test_matrix_cli_kit_newton_with_custom_kit_cfg_intent_non_headless(monkeypatch: pytest.MonkeyPatch):
+def test_matrix_cli_kit_newton_gl_with_custom_kit_cfg_intent_non_headless(monkeypatch: pytest.MonkeyPatch):
     headless, launcher = _resolve_headless_for_case(
         monkeypatch,
         {
-            "visualizer": ["kit", "newton"],
+            "visualizer": ["kit", "newton_gl"],
             "visualizer_explicit": True,
             "visualizer_intent": {"has_any_visualizers": True, "has_kit_visualizer": True},
         },
     )
     assert headless is False
-    assert launcher._cli_visualizer_types == ["kit", "newton"]
+    assert launcher._cli_visualizer_types == ["kit", "newton_gl"]
 
 
 def test_matrix_cli_rerun_with_custom_kit_cfg_intent_headless(monkeypatch: pytest.MonkeyPatch):
@@ -419,7 +419,7 @@ def test_matrix_cli_rerun_with_custom_kit_cfg_intent_headless(monkeypatch: pytes
     assert launcher._cli_visualizer_types == ["rerun"]
 
 
-def test_matrix_no_cli_with_cfg_kit_newton_non_headless(monkeypatch: pytest.MonkeyPatch):
+def test_matrix_no_cli_with_cfg_kit_newton_gl_non_headless(monkeypatch: pytest.MonkeyPatch):
     headless, launcher = _resolve_headless_for_case(
         monkeypatch,
         {
@@ -471,20 +471,7 @@ def test_matrix_headless_flag_deprecated_takes_precedence(monkeypatch: pytest.Mo
     assert launcher._cli_visualizer_types == []
 
 
-def test_matrix_headless_with_viz_names_takes_precedence(monkeypatch: pytest.MonkeyPatch):
-    headless, launcher = _resolve_headless_for_case(
-        monkeypatch,
-        {
-            "headless": True,
-            "headless_explicit": True,
-            "visualizer": ["kit", "newton"],
-            "visualizer_explicit": True,
-            "visualizer_intent": {"has_any_visualizers": True, "has_kit_visualizer": True},
-        },
-    )
-    assert headless is True
-    assert launcher._cli_visualizer_disable_all is True
-    assert launcher._cli_visualizer_types == []
+
 
 
 def test_no_cli_and_no_cfg_visualizers_defaults_headless(monkeypatch: pytest.MonkeyPatch):

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -471,9 +471,6 @@ def test_matrix_headless_flag_deprecated_takes_precedence(monkeypatch: pytest.Mo
     assert launcher._cli_visualizer_types == []
 
 
-
-
-
 def test_no_cli_and_no_cfg_visualizers_defaults_headless(monkeypatch: pytest.MonkeyPatch):
     headless, _ = _resolve_headless_for_case(monkeypatch, {})
     assert headless is True


### PR DESCRIPTION
This PR isolates and fixes the failing tests in `test_kwarg_launch.py` that surfaced during the investigation of #7403 (and the closed PR #7444). 

When run on a clean `upstream/develop`, `test_kwarg_launch.py` fails on exactly four tests. This PR addresses them:
1. **Newton Alias Fallout:** Fixed three tests (`test_parse_visualizer_csv_accepts_comma_delimited_values`, `test_visualizer_csv_does_not_swallow_hydra_overrides`, and `test_matrix_cli_kit_newton_with_custom_kit_cfg_intent_non_headless`) which were failing because they asserted against the deprecated `newton` alias instead of `newton_gl`. The third test was explicitly renamed to `test_matrix_cli_kit_newton_gl_with_custom_kit_cfg_intent_non_headless` to reflect the updated assertion.
2. **Removed Dead CLI Path:** Deleted `test_matrix_headless_with_viz_names_takes_precedence`. This test was failing because it passed `headless=True` directly through `_resolve_visualizer_settings`, simulating the `--headless` CLI flag which was removed in 3.0 and is no longer supported upstream.
3. **Hygiene Updates (Not Failing):** 
    - Replaced `"kit, newton"` with `"kit, newton_gl"` in `test_parse_visualizer_csv_rejects_spaces_between_entries`. This test successfully raises an `ArgumentTypeError` before checking aliases so it wasn't failing, but it was updated to prevent stale strings from persisting.
    - Renamed `test_matrix_no_cli_with_cfg_kit_newton_non_headless` to `test_matrix_no_cli_with_cfg_kit_newton_gl_non_headless` for naming consistency. This test also passed previously but carried the stale alias in its name.

_See the attached `pytest_before_fix.txt` (showing the 4 failures on develop) and `pytest_after_fix.txt` (showing 47 clean passes) for the exact run logs._


[pytest_after_fix.txt](https://github.com/user-attachments/files/31785416/pytest_after_fix.txt)
[pytest_before_fix.txt](https://github.com/user-attachments/files/31785426/pytest_before_fix.txt)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`