### PR TITLE
Move external wrench frame selection into WrenchComposer

### DIFF
--- a/source/isaaclab/changelog.d/wrench-submission-plan.minor.rst
+++ b/source/isaaclab/changelog.d/wrench-submission-plan.minor.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.resolve_submission`, which returns the
+  cheapest representation of the buffered external wrench a consumer can accept, along with the
+  :class:`~isaaclab.utils.wrench_composer.WrenchComposer.Frame` enum describing it. Consumers that can
+  apply a world-frame wrench at the center of mass opt in with the new ``supports_world_at_com``
+  constructor argument. Wrenches that are already local-frame, or already global-frame at the center of
+  mass, are now submitted without composing them through the body poses.

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
+from enum import IntEnum, IntFlag, auto
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -30,7 +31,29 @@ if TYPE_CHECKING:
 
 
 class WrenchComposer:
-    def __init__(self, asset: BaseArticulation | BaseRigidObject | BaseRigidObjectCollection) -> None:
+    class Frame(IntEnum):
+        """Representation of a submitted external wrench."""
+
+        BODY = 0
+        """Body frame, force applied at the body's center of mass."""
+
+        WORLD_AT_COM = 1
+        """World frame, force applied at the body's center of mass."""
+
+    class _Content(IntFlag):
+        """Which input buffer families currently hold contributions."""
+
+        NONE = 0
+        LOCAL = auto()
+        GLOBAL_AT_COM = auto()
+        GLOBAL_POSITIONED = auto()
+
+    def __init__(
+        self,
+        asset: BaseArticulation | BaseRigidObject | BaseRigidObjectCollection,
+        *,
+        supports_world_at_com: bool = False,
+    ) -> None:
         """Wrench composer with dual-buffer architecture.
 
         This class composes forces and torques applied to rigid bodies. Forces and torques can be
@@ -55,6 +78,9 @@ class WrenchComposer:
 
         Args:
             asset: Asset to use.
+            supports_world_at_com: Whether the consumer can apply a world-frame wrench at the body's
+                center of mass. When False, :meth:`resolve_submission` always returns a body-frame
+                wrench. Defaults to False.
         """
         self.num_envs = asset.num_instances
         # Avoid isinstance to prevent circular import issues; check by attribute presence instead.
@@ -66,6 +92,8 @@ class WrenchComposer:
         self._asset = asset
         self._active = False
         self._dirty = False
+        self._supports_world_at_com = supports_world_at_com
+        self._content = self._Content.NONE
         if hasattr(self._asset.data, "body_com_pos_w"):
             self._get_com_pos_fn = lambda a=self._asset: a.data.body_com_pos_w.warp
         else:
@@ -265,6 +293,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._content |= self._classify(forces, torques, positions, is_global)
 
         wp.launch(
             add_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -328,6 +357,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._content |= self._classify(forces, torques, positions, is_global)
 
         wp.launch(
             set_forces_to_dual_buffers_index_kernel(env_ids, body_ids),
@@ -388,6 +418,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._content |= self._classify(forces, torques, positions, is_global)
 
         wp.launch(
             add_forces_to_dual_buffers_mask,
@@ -453,6 +484,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._content |= self._classify(forces, torques, positions, is_global)
 
         wp.launch(
             set_forces_to_dual_buffers_mask,
@@ -493,6 +525,7 @@ class WrenchComposer:
 
         self._active = True
         self._dirty = True
+        self._content |= other._content
 
         wp.launch(
             add_raw_wrench_buffers,
@@ -542,6 +575,30 @@ class WrenchComposer:
         )
         self._dirty = False
 
+    def resolve_submission(self) -> tuple[wp.array, wp.array, Frame]:
+        """Return the cheapest representation of the buffered wrench this consumer can accept.
+
+        Composition into the body frame reads the body poses, which on some backends forces a
+        kinematics update. That work is unnecessary when the buffered wrench is already in a frame
+        the consumer accepts: an all-local wrench is its own body-frame composition, and an
+        all-global-at-CoM wrench is directly submittable by a consumer that accepts a world frame.
+
+        The eligibility state is conservative after a partial :meth:`reset`: it may keep composing
+        even when the selected reset removed every contribution that made composition necessary. A
+        full :meth:`reset` restores it. This never changes the resulting wrench, only the cost.
+
+        Returns:
+            Force [N], torque [N·m], and the frame both are expressed in. Shapes are
+            ``(num_envs, num_bodies)`` with dtype ``wp.vec3f``. The arrays are owned by the composer
+            and stay valid until the next mutating call.
+        """
+        if self._content == self._Content.LOCAL:
+            return self._local_force_b, self._local_torque_b, self.Frame.BODY
+        if self._supports_world_at_com and self._content == self._Content.GLOBAL_AT_COM:
+            return self._global_force_at_com_w, self._global_torque_w, self.Frame.WORLD_AT_COM
+        self._ensure_composed()
+        return self._out_force_b, self._out_torque_b, self.Frame.BODY
+
     def reset(
         self,
         env_ids: wp.array | torch.Tensor | Sequence[int] | slice | None = None,
@@ -571,6 +628,7 @@ class WrenchComposer:
             self._out_torque_b.zero_()
             self._active = False
             self._dirty = False
+            self._content = self._Content.NONE
         elif env_mask is not None:
             wp.launch(
                 reset_wrench_composer_mask,
@@ -716,6 +774,30 @@ class WrenchComposer:
         raise TypeError(
             f"body_ids must be None, slice(None), a sequence, torch.Tensor, or wp.array, got {type(body_ids).__name__}"
         )
+
+    @staticmethod
+    def _classify(
+        forces: wp.array | torch.Tensor | None,
+        torques: wp.array | torch.Tensor | None,
+        positions: wp.array | torch.Tensor | None,
+        is_global: bool,
+    ) -> WrenchComposer._Content:
+        """Which input buffer families a contribution writes into.
+
+        Mirrors the routing in the ``add_forces_to_dual_buffers_*`` kernels: a local contribution
+        always lands in the local buffers, including a positioned force whose moment folds into
+        ``local_torque_b``. A global positioned force additionally stores a moment about the world
+        origin, which only the CoM correction in composition can resolve.
+        """
+        content = WrenchComposer._Content
+        if not is_global:
+            return content.LOCAL
+        result = content.NONE
+        if forces is not None:
+            result |= content.GLOBAL_POSITIONED if positions is not None else content.GLOBAL_AT_COM
+        if torques is not None:
+            result |= content.GLOBAL_AT_COM
+        return result
 
     def _ensure_composed(self):
         """Compose input buffers into output buffers if dirty."""

--- a/source/isaaclab/isaaclab/utils/wrench_composer.py
+++ b/source/isaaclab/isaaclab/utils/wrench_composer.py
@@ -596,7 +596,8 @@ class WrenchComposer:
             return self._local_force_b, self._local_torque_b, self.Frame.BODY
         if self._supports_world_at_com and self._content == self._Content.GLOBAL_AT_COM:
             return self._global_force_at_com_w, self._global_torque_w, self.Frame.WORLD_AT_COM
-        self._ensure_composed()
+        # The fallback depends on the live body pose, even when the input buffers are unchanged.
+        self.compose_to_body_frame()
         return self._out_force_b, self._out_torque_b, self.Frame.BODY
 
     def reset(

--- a/source/isaaclab/test/assets/_articulation_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_articulation_iface_test_utils.py
@@ -124,8 +124,8 @@ def create_physx_articulation(
     data.spatial_tendon_names = spatial_tendon_names
 
     # Create wrench composers (pass articulation which has num_instances, num_bodies, device properties)
-    mock_inst_wrench = WrenchComposer(articulation)
-    mock_perm_wrench = WrenchComposer(articulation)
+    mock_inst_wrench = WrenchComposer(articulation, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(articulation, supports_world_at_com=True)
     object.__setattr__(articulation, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(articulation, "_permanent_wrench_composer", mock_perm_wrench)
 

--- a/source/isaaclab/test/assets/_articulation_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_articulation_iface_test_utils.py
@@ -279,8 +279,8 @@ def create_ovphysx_articulation(
     articulation._create_buffers()
 
     # Wrench composers
-    mock_inst_wrench = WrenchComposer(articulation)
-    mock_perm_wrench = WrenchComposer(articulation)
+    mock_inst_wrench = WrenchComposer(articulation, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(articulation, supports_world_at_com=True)
     object.__setattr__(articulation, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(articulation, "_permanent_wrench_composer", mock_perm_wrench)
     # Prevent __del__ / _clear_callbacks from raising

--- a/source/isaaclab/test/assets/_rigid_object_collection_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_rigid_object_collection_iface_test_utils.py
@@ -101,8 +101,8 @@ def create_physx_rigid_object_collection(
     data.body_names = [f"object_{i}" for i in range(num_bodies)]
 
     # Create wrench composers
-    mock_inst_wrench = WrenchComposer(collection)
-    mock_perm_wrench = WrenchComposer(collection)
+    mock_inst_wrench = WrenchComposer(collection, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(collection, supports_world_at_com=True)
     object.__setattr__(collection, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(collection, "_permanent_wrench_composer", mock_perm_wrench)
 
@@ -260,8 +260,8 @@ def create_ovphysx_rigid_object_collection(
     collection._create_buffers()
 
     # Use production wrench composers for interface coverage.
-    mock_inst_wrench = WrenchComposer(collection)
-    mock_perm_wrench = WrenchComposer(collection)
+    mock_inst_wrench = WrenchComposer(collection, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(collection, supports_world_at_com=True)
     object.__setattr__(collection, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(collection, "_permanent_wrench_composer", mock_perm_wrench)
 

--- a/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
@@ -86,8 +86,8 @@ def create_physx_rigid_object(
     data.body_names = body_names
 
     # Create wrench composers
-    mock_inst_wrench = WrenchComposer(rigid_object)
-    mock_perm_wrench = WrenchComposer(rigid_object)
+    mock_inst_wrench = WrenchComposer(rigid_object, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(rigid_object, supports_world_at_com=True)
     object.__setattr__(rigid_object, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(rigid_object, "_permanent_wrench_composer", mock_perm_wrench)
 
@@ -247,8 +247,8 @@ def create_ovphysx_rigid_object(
     obj._create_buffers()
 
     # Use production wrench composers for interface coverage.
-    mock_inst_wrench = WrenchComposer(obj)
-    mock_perm_wrench = WrenchComposer(obj)
+    mock_inst_wrench = WrenchComposer(obj, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(obj, supports_world_at_com=True)
     object.__setattr__(obj, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(obj, "_permanent_wrench_composer", mock_perm_wrench)
 

--- a/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
+++ b/source/isaaclab/test/assets/_rigid_object_iface_test_utils.py
@@ -104,10 +104,6 @@ def create_physx_rigid_object(
     # Cached .view(wp.float32) wrappers
     object.__setattr__(rigid_object, "_root_link_pose_w_f32", None)
     object.__setattr__(rigid_object, "_root_com_vel_w_f32", None)
-    object.__setattr__(rigid_object, "_inst_wrench_force_f32", None)
-    object.__setattr__(rigid_object, "_inst_wrench_torque_f32", None)
-    object.__setattr__(rigid_object, "_perm_wrench_force_f32", None)
-    object.__setattr__(rigid_object, "_perm_wrench_torque_f32", None)
 
     # Pre-allocated pinned CPU buffers for PhysX TensorAPI writes
     N, B = num_instances, 1  # rigid object has 1 body

--- a/source/isaaclab/test/assets/test_articulation_iface.py
+++ b/source/isaaclab/test/assets/test_articulation_iface.py
@@ -2835,3 +2835,27 @@ class TestPhysXArticulationSubmissionFrame:
         assert call["is_global"] is False
         actual = wp.to_torch(call["force_data"]).reshape(num_instances, num_bodies, 3)
         torch.testing.assert_close(actual, forces)
+
+
+@pytest.mark.skipif("newton" not in BACKENDS, reason="Newton backend unavailable")
+class TestNewtonArticulationSubmissionFrame:
+    """Newton always consumes a body-frame wrench, and skips composition for local content."""
+
+    @_default_devices
+    def test_local_frame_skips_composition(self, device):
+        num_instances, num_bodies = 2, 3
+        art, _ = get_articulation(
+            "newton", num_instances=num_instances, num_joints=2, num_bodies=num_bodies, device=device
+        )
+        composer = art.permanent_wrench_composer
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        forces[:, 1, 0] = torch.tensor([1.0, 2.0], device=device)
+        composer.set_forces_and_torques_index(forces=forces, is_global=False)
+
+        calls = []
+        composer._get_com_pos_fn = lambda: calls.append("com")
+        composer._get_link_quat_fn = lambda: calls.append("quat")
+
+        art.write_data_to_sim()
+
+        assert calls == [], "Newton read body poses for an all-local wrench"

--- a/source/isaaclab/test/assets/test_articulation_iface.py
+++ b/source/isaaclab/test/assets/test_articulation_iface.py
@@ -22,6 +22,8 @@ import torch
 import warp as wp
 from _articulation_iface_test_utils import BACKENDS, get_articulation
 
+from isaaclab.utils.wrench_composer import WrenchComposer
+
 pytestmark = pytest.mark.integration
 
 
@@ -2859,3 +2861,80 @@ class TestNewtonArticulationSubmissionFrame:
         art.write_data_to_sim()
 
         assert calls == [], "Newton read body poses for an all-local wrench"
+
+
+@pytest.mark.skipif("ovphysx" not in BACKENDS, reason="OvPhysX backend unavailable")
+class TestOvPhysxArticulationSubmissionFrame:
+    """OvPhysX packs the same world-frame wrench whether or not it takes the rotation path.
+
+    ``_body_wrench_to_world_ordered`` keeps the wrench indexed in public body order while reading
+    poses -- and writing the packed output -- in backend body order. A nonidentity ``body_ordering``
+    is required so that a user/backend body-id mix-up in that kernel would show up as a wrench
+    applied to the wrong body instead of passing silently.
+    """
+
+    @_default_devices
+    def test_global_at_com_matches_composed_path_under_body_ordering(self, device):
+        from isaaclab_ov import tensor_types as TT
+
+        num_instances, num_joints, num_bodies = 2, 1, 3
+        # Nonidentity ordering: exercises the user_body_id / backend_body_id split.
+        body_ordering = ("body_2", "body_1", "body_0")
+
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        torques = torch.zeros((num_instances, num_bodies, 3), device=device)
+        for body in range(num_bodies):
+            forces[:, body, 0] = torch.tensor([10.0 * env + body + 1.0 for env in range(num_instances)], device=device)
+            # Torque on a different axis than the force so an axis mix-up cannot hide.
+            torques[:, body, 2] = torch.tensor([10.0 * env + body + 0.5 for env in range(num_instances)], device=device)
+
+        # Reference: force the rotation path by denying world-frame support.
+        ref, ref_bindings = get_articulation(
+            "ovphysx",
+            num_instances=num_instances,
+            num_joints=num_joints,
+            num_bodies=num_bodies,
+            device=device,
+            body_ordering=body_ordering,
+        )
+        object.__setattr__(ref, "_permanent_wrench_composer", WrenchComposer(ref, supports_world_at_com=False))
+        ref.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+        ref._wrench_buf.zero_()
+        ref.write_data_to_sim()
+        # Only the force/torque slice ([:6]) is compared: the packed [6:9] link position comes
+        # from the mock's randomized pose, which is independent per constructed object and is
+        # identical on both paths by construction, so it adds no coverage here.
+        expected = ref_bindings.bindings[TT.LINK_WRENCH]._data.copy()[..., :6]
+
+        obj, obj_bindings = get_articulation(
+            "ovphysx",
+            num_instances=num_instances,
+            num_joints=num_joints,
+            num_bodies=num_bodies,
+            device=device,
+            body_ordering=body_ordering,
+        )
+        composer = obj.permanent_wrench_composer
+        assert composer._supports_world_at_com is True
+        composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+        calls = []
+        composer._get_com_pos_fn = lambda: calls.append("com")
+        composer._get_link_quat_fn = lambda: calls.append("quat")
+        obj._wrench_buf.zero_()
+        obj.write_data_to_sim()
+
+        assert calls == [], "OvPhysX read body poses for a global-at-CoM wrench"
+        actual = obj_bindings.bindings[TT.LINK_WRENCH]._data.copy()[..., :6]
+        np.testing.assert_allclose(actual, expected, atol=1e-5, rtol=1e-5)
+
+        # Confirm the ordering subtlety is actually exercised: the configured body_ordering is
+        # nonidentity, and the packed backend-order wrench lands on the permuted body slots, not
+        # the public-order ones.
+        user_to_backend = np.asarray(obj.body_ordering.user_to_backend_indices, dtype=np.int64)
+        assert not np.array_equal(user_to_backend, np.arange(num_bodies))
+        expected_backend_force = np.zeros((num_instances, num_bodies, 3), dtype=np.float32)
+        expected_backend_torque = np.zeros((num_instances, num_bodies, 3), dtype=np.float32)
+        expected_backend_force[:, user_to_backend] = forces.cpu().numpy()
+        expected_backend_torque[:, user_to_backend] = torques.cpu().numpy()
+        np.testing.assert_allclose(actual[..., :3], expected_backend_force, atol=1e-5, rtol=1e-5)
+        np.testing.assert_allclose(actual[..., 3:6], expected_backend_torque, atol=1e-5, rtol=1e-5)

--- a/source/isaaclab/test/assets/test_articulation_iface.py
+++ b/source/isaaclab/test/assets/test_articulation_iface.py
@@ -14,6 +14,7 @@ The setup is a bit convoluted so that we can run these tests without requiring I
 """
 
 import warnings
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -2788,3 +2789,49 @@ class TestArticulationWritersTendonToSim:
         art.write_spatial_tendon_properties_to_sim_mask(
             spatial_tendon_mask=_make_item_mask(num_spatial_tendons, [0], device)
         )
+
+
+@pytest.mark.skipif("physx" not in BACKENDS, reason="PhysX backend unavailable")
+class TestPhysXArticulationSubmissionFrame:
+    """PhysX submits an eligible global-at-CoM wrench in the world frame, without composing."""
+
+    @_default_devices
+    def test_global_at_com_submits_world_frame(self, device):
+        num_instances, num_bodies = 2, 3
+        art, root_view = get_articulation(
+            "physx", num_instances=num_instances, num_joints=2, num_bodies=num_bodies, device=device
+        )
+        root_view.get_link_transforms = MagicMock(side_effect=AssertionError("unexpected body-pose read"))
+        root_view.apply_forces_and_torques_at_position = MagicMock()
+
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        forces[:, 1, 2] = torch.tensor([3.0, 7.0], device=device)
+        art.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, is_global=True)
+
+        art.write_data_to_sim()
+
+        call = root_view.apply_forces_and_torques_at_position.call_args.kwargs
+        assert call["is_global"] is True
+        assert call["position_data"] is None
+        actual = wp.to_torch(call["force_data"]).reshape(num_instances, num_bodies, 3)
+        torch.testing.assert_close(actual, forces)
+
+    @_default_devices
+    def test_local_frame_submits_body_frame(self, device):
+        num_instances, num_bodies = 2, 3
+        art, root_view = get_articulation(
+            "physx", num_instances=num_instances, num_joints=2, num_bodies=num_bodies, device=device
+        )
+        root_view.get_link_transforms = MagicMock(side_effect=AssertionError("unexpected body-pose read"))
+        root_view.apply_forces_and_torques_at_position = MagicMock()
+
+        forces = torch.zeros((num_instances, num_bodies, 3), device=device)
+        forces[:, 1, 0] = torch.tensor([1.0, 2.0], device=device)
+        art.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, is_global=False)
+
+        art.write_data_to_sim()
+
+        call = root_view.apply_forces_and_torques_at_position.call_args.kwargs
+        assert call["is_global"] is False
+        actual = wp.to_torch(call["force_data"]).reshape(num_instances, num_bodies, 3)
+        torch.testing.assert_close(actual, forces)

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -19,6 +19,8 @@ import torch
 import warp as wp
 from _rigid_object_iface_test_utils import BACKENDS, get_rigid_object
 
+from isaaclab.utils.wrench_composer import WrenchComposer
+
 pytestmark = pytest.mark.integration
 
 
@@ -1131,3 +1133,42 @@ class TestRigidObjectDataAliases:
         assert d.body_vel_w.shape == d.body_com_vel_w.shape
         assert d.body_lin_vel_w.shape == d.body_com_lin_vel_w.shape
         assert d.body_ang_vel_w.shape == d.body_com_ang_vel_w.shape
+
+
+@pytest.mark.skipif("ovphysx" not in BACKENDS, reason="OvPhysX backend unavailable")
+class TestOvPhysxRigidObjectSubmissionFrame:
+    """OvPhysX packs the same world-frame wrench whether or not it takes the rotation path."""
+
+    @_default_devices
+    def test_global_at_com_matches_composed_path(self, device):
+        num_instances = 2
+        forces = torch.zeros((num_instances, 1, 3), device=device)
+        forces[:, 0, 0] = torch.tensor([1.0, 2.0], device=device)
+        torques = torch.zeros_like(forces)
+        torques[:, 0, 2] = torch.tensor([0.5, 1.5], device=device)
+
+        # Reference: force the rotation path by denying world-frame support. Seed before each
+        # mock construction so `ref` and `obj` get identical random link poses -- the packed
+        # position ([6:9]) is required on both paths and must match too, so both mocks need
+        # the same underlying pose data for the comparison below to be meaningful.
+        np.random.seed(0)
+        ref, _ = get_rigid_object("ovphysx", num_instances=num_instances, device=device)
+        ref._permanent_wrench_composer = WrenchComposer(ref, supports_world_at_com=False)
+        ref.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+        ref._wrench_buf.zero_()
+        ref.write_data_to_sim()
+        expected = wp.to_torch(ref._wrench_buf).clone().reshape(num_instances, -1)
+
+        np.random.seed(0)
+        obj, _ = get_rigid_object("ovphysx", num_instances=num_instances, device=device)
+        composer = obj.permanent_wrench_composer
+        composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+        calls = []
+        composer._get_com_pos_fn = lambda: calls.append("com")
+        composer._get_link_quat_fn = lambda: calls.append("quat")
+        obj._wrench_buf.zero_()
+        obj.write_data_to_sim()
+
+        assert calls == [], "OvPhysX read body poses for a global-at-CoM wrench"
+        actual = wp.to_torch(obj._wrench_buf).reshape(num_instances, -1)
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -1147,19 +1147,17 @@ class TestOvPhysxRigidObjectSubmissionFrame:
         torques = torch.zeros_like(forces)
         torques[:, 0, 2] = torch.tensor([0.5, 1.5], device=device)
 
-        # Reference: force the rotation path by denying world-frame support. Seed before each
-        # mock construction so `ref` and `obj` get identical random link poses -- the packed
-        # position ([6:9]) is required on both paths and must match too, so both mocks need
-        # the same underlying pose data for the comparison below to be meaningful.
-        np.random.seed(0)
+        # Reference: force the rotation path by denying world-frame support.
         ref, _ = get_rigid_object("ovphysx", num_instances=num_instances, device=device)
         ref._permanent_wrench_composer = WrenchComposer(ref, supports_world_at_com=False)
         ref.permanent_wrench_composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
         ref._wrench_buf.zero_()
         ref.write_data_to_sim()
-        expected = wp.to_torch(ref._wrench_buf).clone().reshape(num_instances, -1)
+        # Only the force/torque slice ([:6]) is compared: the packed [6:9] link position comes
+        # from the mock's randomized pose, which is independent per constructed object and is
+        # identical on both paths by construction, so it adds no coverage here.
+        expected = wp.to_torch(ref._wrench_buf).clone().reshape(num_instances, -1)[:, :6]
 
-        np.random.seed(0)
         obj, _ = get_rigid_object("ovphysx", num_instances=num_instances, device=device)
         composer = obj.permanent_wrench_composer
         composer.set_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
@@ -1170,5 +1168,5 @@ class TestOvPhysxRigidObjectSubmissionFrame:
         obj.write_data_to_sim()
 
         assert calls == [], "OvPhysX read body poses for a global-at-CoM wrench"
-        actual = wp.to_torch(obj._wrench_buf).reshape(num_instances, -1)
+        actual = wp.to_torch(obj._wrench_buf).reshape(num_instances, -1)[:, :6]
         torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -1208,8 +1208,11 @@ class TestRigidObjectSubmissionEquivalence:
 
         forces = torch.zeros((num_instances, 1, 3), device=device)
         forces[:, 0, 0] = torch.tensor([1.0, 2.0], device=device)
+        # Torque on a different axis than the force so an axis mix-up in the rotation cannot hide.
+        torques = torch.zeros((num_instances, 1, 3), device=device)
+        torques[:, 0, 2] = torch.tensor([0.5, 1.5], device=device)
         positions = torch.full((num_instances, 1, 3), 0.1, device=device) if with_positions else None
-        composer.set_forces_and_torques_index(forces=forces, positions=positions, is_global=is_global)
+        composer.set_forces_and_torques_index(forces=forces, torques=torques, positions=positions, is_global=is_global)
 
         force, torque, frame = composer.resolve_submission()
         composer.compose_to_body_frame()

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -1170,3 +1170,82 @@ class TestOvPhysxRigidObjectSubmissionFrame:
         assert calls == [], "OvPhysX read body poses for a global-at-CoM wrench"
         actual = wp.to_torch(obj._wrench_buf).reshape(num_instances, -1)[:, :6]
         torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Tests: resolve_submission cross-backend equivalence
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def _rotate_inv_kernel(
+    link_quat_w: wp.array2d(dtype=wp.quatf),
+    world_force: wp.array2d(dtype=wp.vec3f),
+    world_torque: wp.array2d(dtype=wp.vec3f),
+    out_force_b: wp.array2d(dtype=wp.vec3f),
+    out_torque_b: wp.array2d(dtype=wp.vec3f),
+):
+    """Rotate world-frame force/torque into the body frame, mirroring ``compose_wrench_to_body_frame``."""
+    tid_env, tid_body = wp.tid()
+    out_force_b[tid_env, tid_body] = wp.quat_rotate_inv(link_quat_w[tid_env, tid_body], world_force[tid_env, tid_body])
+    out_torque_b[tid_env, tid_body] = wp.quat_rotate_inv(
+        link_quat_w[tid_env, tid_body], world_torque[tid_env, tid_body]
+    )
+
+
+class TestRigidObjectSubmissionEquivalence:
+    """Whatever frame ``resolve_submission`` picks, the returned wrench matches the fully composed one."""
+
+    @_production_backends
+    @pytest.mark.parametrize(
+        ("is_global", "with_positions"), [(False, False), (False, True), (True, False), (True, True)]
+    )
+    def test_submission_matches_composed_wrench(self, backend, is_global, with_positions):
+        device = "cpu"
+        num_instances = 2
+        obj, _ = get_rigid_object(backend, num_instances=num_instances, device=device)
+        composer = obj.permanent_wrench_composer
+
+        forces = torch.zeros((num_instances, 1, 3), device=device)
+        forces[:, 0, 0] = torch.tensor([1.0, 2.0], device=device)
+        positions = torch.full((num_instances, 1, 3), 0.1, device=device) if with_positions else None
+        composer.set_forces_and_torques_index(forces=forces, positions=positions, is_global=is_global)
+
+        force, torque, frame = composer.resolve_submission()
+        composer.compose_to_body_frame()
+
+        # Expected frame per the resolve_submission contract:
+        # - a local wrench is already body-frame.
+        # - a global positioned force always needs the CoM correction, so it composes to body-frame.
+        # - a global unpositioned (at-CoM) wrench stays world-frame only on consumers that accept it.
+        if not is_global or with_positions:
+            expected_frame = WrenchComposer.Frame.BODY
+        elif composer._supports_world_at_com:
+            expected_frame = WrenchComposer.Frame.WORLD_AT_COM
+        else:
+            expected_frame = WrenchComposer.Frame.BODY
+        assert frame is expected_frame
+
+        if frame is WrenchComposer.Frame.BODY:
+            torch.testing.assert_close(wp.to_torch(force), wp.to_torch(composer.out_force_b.warp))
+            torch.testing.assert_close(wp.to_torch(torque), wp.to_torch(composer.out_torque_b.warp))
+        else:
+            # Mirror `compose_wrench_to_body_frame` exactly: rotate the same world-frame arrays with
+            # the same `link_quat_w` buffer the production composer uses, then compare against the
+            # fully-composed body-frame output. This avoids re-deriving the rotation with a torch
+            # helper whose quaternion component order may not match `body_link_quat_w`.
+            link_quat_w = obj.data.body_link_quat_w.warp
+            rotated_force = wp.zeros_like(composer.out_force_b.warp)
+            rotated_torque = wp.zeros_like(composer.out_torque_b.warp)
+            wp.launch(
+                _rotate_inv_kernel,
+                dim=(num_instances, obj.num_bodies),
+                inputs=[link_quat_w, force, torque, rotated_force, rotated_torque],
+                device=device,
+            )
+            torch.testing.assert_close(
+                wp.to_torch(rotated_force), wp.to_torch(composer.out_force_b.warp), atol=1e-5, rtol=1e-5
+            )
+            torch.testing.assert_close(
+                wp.to_torch(rotated_torque), wp.to_torch(composer.out_torque_b.warp), atol=1e-5, rtol=1e-5
+            )

--- a/source/isaaclab/test/assets/test_rigid_object_iface.py
+++ b/source/isaaclab/test/assets/test_rigid_object_iface.py
@@ -1217,6 +1217,11 @@ class TestRigidObjectSubmissionEquivalence:
         force, torque, frame = composer.resolve_submission()
         composer.compose_to_body_frame()
 
+        # The invariant under test: Newton must never accept a world frame. Derive the expectation
+        # from the backend name rather than from `composer._supports_world_at_com` itself, so that
+        # flipping Newton's constructed value would not keep this test tautologically green.
+        assert composer._supports_world_at_com is (backend != "newton")
+
         # Expected frame per the resolve_submission contract:
         # - a local wrench is already body-frame.
         # - a global positioned force always needs the CoM correction, so it composes to body-frame.

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -1849,12 +1849,23 @@ def test_resolve_submission_mixed_content_composes(device: str):
     """Mixed local and global content is pose-dependent and must compose."""
     asset = create_mock_asset(2, 1, device)
     composer = WrenchComposer(asset, supports_world_at_com=True)
-    composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=True)
-    composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=False)
+    composer.add_forces_and_torques_index(
+        forces=torch.full((2, 1, 3), 2.0, device=device),
+        torques=torch.full((2, 1, 3), 3.0, device=device),
+        is_global=True,
+    )
+    composer.add_forces_and_torques_index(
+        forces=torch.full((2, 1, 3), 5.0, device=device),
+        torques=torch.full((2, 1, 3), 7.0, device=device),
+        is_global=False,
+    )
 
-    _, _, frame = composer.resolve_submission()
+    force, torque, frame = composer.resolve_submission()
 
     assert frame is WrenchComposer.Frame.BODY
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(force.numpy(), composer.out_force_b.warp.numpy(), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), composer.out_torque_b.warp.numpy(), atol=1e-6)
 
 
 @pytest.mark.parametrize("device", test_devices())
@@ -1863,14 +1874,17 @@ def test_resolve_submission_positioned_global_force_composes(device: str):
     asset = create_mock_asset(2, 1, device)
     composer = WrenchComposer(asset, supports_world_at_com=True)
     composer.add_forces_and_torques_index(
-        forces=torch.ones(2, 1, 3, device=device),
-        positions=torch.ones(2, 1, 3, device=device),
+        forces=torch.full((2, 1, 3), 4.0, device=device),
+        positions=torch.full((2, 1, 3), 6.0, device=device),
         is_global=True,
     )
 
-    _, _, frame = composer.resolve_submission()
+    force, torque, frame = composer.resolve_submission()
 
     assert frame is WrenchComposer.Frame.BODY
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(force.numpy(), composer.out_force_b.warp.numpy(), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), composer.out_torque_b.warp.numpy(), atol=1e-6)
 
 
 @pytest.mark.parametrize("device", test_devices())

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -1775,3 +1775,139 @@ def test_deprecated_set_forces_and_torques_clears_previous(device: str):
     assert np.allclose(composer.out_force_b.warp.numpy(), forces_b_np, atol=1e-4, rtol=1e-5), (
         "Deprecated set_forces_and_torques did not replace previous values"
     )
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_local_only_returns_local_buffers(device: str):
+    """All-local content submits the local buffers directly, in the body frame."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset)
+    forces = torch.ones(2, 1, 3, device=device)
+    torques = torch.full((2, 1, 3), 2.0, device=device)
+    composer.add_forces_and_torques_index(forces=forces, torques=torques, is_global=False)
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(force.numpy(), composer.out_force_b.warp.numpy(), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), composer.out_torque_b.warp.numpy(), atol=1e-6)
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_local_positioned_force_keeps_fast_path(device: str):
+    """A positioned local force folds into local_torque_b, so it stays on the body fast path."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset)
+    composer.add_forces_and_torques_index(
+        forces=torch.ones(2, 1, 3, device=device),
+        positions=torch.ones(2, 1, 3, device=device),
+        is_global=False,
+    )
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(force.numpy(), composer.out_force_b.warp.numpy(), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), composer.out_torque_b.warp.numpy(), atol=1e-6)
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_global_at_com_returns_world_buffers(device: str):
+    """All-global-at-CoM content submits the world buffers when the consumer accepts them."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset, supports_world_at_com=True)
+    forces = torch.ones(2, 1, 3, device=device)
+    torques = torch.full((2, 1, 3), 3.0, device=device)
+    composer.add_forces_and_torques_index(forces=forces, torques=torques, is_global=True)
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.WORLD_AT_COM
+    np.testing.assert_allclose(force.numpy(), forces.cpu().numpy().reshape(2, 1, 3), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), torques.cpu().numpy().reshape(2, 1, 3), atol=1e-6)
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_without_world_support_composes(device: str):
+    """A consumer that cannot take a world frame always gets the composed body-frame output."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset, supports_world_at_com=False)
+    composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=True)
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+    composer.compose_to_body_frame()
+    np.testing.assert_allclose(force.numpy(), composer.out_force_b.warp.numpy(), atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), composer.out_torque_b.warp.numpy(), atol=1e-6)
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_mixed_content_composes(device: str):
+    """Mixed local and global content is pose-dependent and must compose."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset, supports_world_at_com=True)
+    composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=True)
+    composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=False)
+
+    _, _, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_positioned_global_force_composes(device: str):
+    """A positioned global force needs the CoM correction, so it must compose."""
+    asset = create_mock_asset(2, 1, device)
+    composer = WrenchComposer(asset, supports_world_at_com=True)
+    composer.add_forces_and_torques_index(
+        forces=torch.ones(2, 1, 3, device=device),
+        positions=torch.ones(2, 1, 3, device=device),
+        is_global=True,
+    )
+
+    _, _, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_fast_paths_read_no_body_pose(device: str):
+    """Neither fast path may touch body poses; that read is the cost this change removes."""
+    asset = create_mock_asset(2, 1, device)
+
+    for supports, is_global in ((False, False), (True, True)):
+        composer = WrenchComposer(asset, supports_world_at_com=supports)
+        composer.add_forces_and_torques_index(forces=torch.ones(2, 1, 3, device=device), is_global=is_global)
+        calls = []
+        composer._get_com_pos_fn = lambda: calls.append("com")
+        composer._get_link_quat_fn = lambda: calls.append("quat")
+
+        composer.resolve_submission()
+
+        assert calls == [], f"pose read on fast path (supports={supports}, is_global={is_global})"
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_content_propagates_and_resets(device: str):
+    """Content accumulates, propagates through merges, is sticky on partial reset, clears on full."""
+    asset = create_mock_asset(2, 1, device)
+    forces = torch.ones(2, 1, 3, device=device)
+
+    composer = WrenchComposer(asset, supports_world_at_com=True)
+    composer.add_forces_and_torques_index(forces=forces, is_global=True)
+    assert composer.resolve_submission()[2] is WrenchComposer.Frame.WORLD_AT_COM
+
+    local_source = WrenchComposer(asset)
+    local_source.add_forces_and_torques_index(forces=forces, is_global=False)
+    composer.add_raw_buffers_from(local_source)
+    assert composer.resolve_submission()[2] is WrenchComposer.Frame.BODY
+
+    composer.reset(env_ids=[0])
+    assert composer.resolve_submission()[2] is WrenchComposer.Frame.BODY
+
+    composer.reset()
+    composer.add_forces_and_torques_index(forces=forces, is_global=True)
+    assert composer.resolve_submission()[2] is WrenchComposer.Frame.WORLD_AT_COM

--- a/source/isaaclab/test/utils/test_wrench_composer.py
+++ b/source/isaaclab/test/utils/test_wrench_composer.py
@@ -1888,6 +1888,33 @@ def test_resolve_submission_positioned_global_force_composes(device: str):
 
 
 @pytest.mark.parametrize("device", test_devices())
+def test_resolve_submission_recomposes_pose_dependent_wrench(device: str):
+    """A body-frame submission is recomposed when the body pose changes."""
+    asset = create_mock_asset(1, 1, device)
+    composer = WrenchComposer(asset, supports_world_at_com=True)
+    composer.add_forces_and_torques_index(
+        forces=torch.tensor([[[1.0, 0.0, 0.0]]], device=device),
+        positions=torch.tensor([[[0.0, 1.0, 0.0]]], device=device),
+        is_global=True,
+    )
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+    np.testing.assert_allclose(force.numpy(), [[[1.0, 0.0, 0.0]]], atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), [[[0.0, 0.0, -1.0]]], atol=1e-6)
+
+    quat_180_z = torch.tensor([[[0.0, 0.0, 1.0, 0.0]]], device=device)
+    asset.data.body_link_quat_w = ProxyArray(wp.from_torch(quat_180_z, dtype=wp.quatf))
+
+    force, torque, frame = composer.resolve_submission()
+
+    assert frame is WrenchComposer.Frame.BODY
+    np.testing.assert_allclose(force.numpy(), [[[-1.0, 0.0, 0.0]]], atol=1e-6)
+    np.testing.assert_allclose(torque.numpy(), [[[0.0, 0.0, -1.0]]], atol=1e-6)
+
+
+@pytest.mark.parametrize("device", test_devices())
 def test_resolve_submission_fast_paths_read_no_body_pose(device: str):
     """Neither fast path may touch body poses; that read is the cost this change removes."""
     asset = create_mock_asset(2, 1, device)

--- a/source/isaaclab_newton/changelog.d/wrench-submission-plan.rst
+++ b/source/isaaclab_newton/changelog.d/wrench-submission-plan.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed the external-wrench writers to submit through
+  :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.resolve_submission`, so an all-local-frame
+  wrench no longer reads the body transforms before being written to the solver.

--- a/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/articulation/articulation.py
@@ -393,7 +393,7 @@ class Articulation(BaseArticulation):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            force_b, torque_b, _ = composer.resolve_submission()
             # Kept separate from the joint-target gather below: this scatter runs
             # over bodies while the target gather runs over joints (mismatched
             # item axes), and it must precede the actuator compute/submit below,
@@ -405,8 +405,8 @@ class Articulation(BaseArticulation):
                     dim=(self.num_instances, self.num_bodies),
                     device=self.device,
                     inputs=[
-                        composer.out_force_b.warp,
-                        composer.out_torque_b.warp,
+                        force_b,
+                        torque_b,
                         self._data.body_link_pose_w.warp,
                         self._body_user_to_backend_map(),
                         self._data._sim_bind_body_external_wrench,
@@ -420,8 +420,8 @@ class Articulation(BaseArticulation):
                     dim=(self.num_instances, self.num_bodies),
                     device=self.device,
                     inputs=[
-                        composer.out_force_b,
-                        composer.out_torque_b,
+                        force_b,
+                        torque_b,
                         self._data.body_link_pose_w.warp,
                         self._data._sim_bind_body_external_wrench,
                         self._ALL_ENV_MASK,

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object/rigid_object.py
@@ -148,14 +148,14 @@ class RigidObject(BaseRigidObject):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            force_b, torque_b, _ = composer.resolve_submission()
             wp.launch(
                 shared_kernels.update_wrench_array_with_force_and_torque,
                 dim=(self.num_instances, self.num_bodies),
                 device=self.device,
                 inputs=[
-                    composer.out_force_b,
-                    composer.out_torque_b,
+                    force_b,
+                    torque_b,
                     self._data.body_link_pose_w.warp,
                     self._data._sim_bind_body_external_wrench,
                     self._ALL_ENV_MASK,

--- a/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_newton/isaaclab_newton/assets/rigid_object_collection/rigid_object_collection.py
@@ -197,14 +197,14 @@ class RigidObjectCollection(BaseRigidObjectCollection):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            force_b, torque_b, _ = composer.resolve_submission()
             wp.launch(
                 shared_kernels.update_wrench_array_with_force_and_torque,
                 dim=(self.num_instances, self.num_bodies),
                 device=self.device,
                 inputs=[
-                    composer.out_force_b,
-                    composer.out_torque_b,
+                    force_b,
+                    torque_b,
                     self._data.body_link_pose_w.warp,
                     self._wrench_buffer,
                     self._ALL_ENV_MASK,

--- a/source/isaaclab_ov/changelog.d/wrench-submission-plan.rst
+++ b/source/isaaclab_ov/changelog.d/wrench-submission-plan.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed the external-wrench writers to submit through
+  :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.resolve_submission`. A wrench that is already
+  global-frame at the center of mass is now packed without rotating it into the body frame and back,
+  and an all-local-frame wrench no longer reads the body transforms before packing.

--- a/source/isaaclab_ov/isaaclab_ov/assets/articulation/articulation.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/articulation/articulation.py
@@ -242,11 +242,11 @@ class Articulation(BaseArticulation):
             if inst.active:
                 if perm.active:
                     inst.add_raw_buffers_from(perm)
-                force_b = inst.out_force_b.warp
-                torque_b = inst.out_torque_b.warp
+                composer = inst
             else:
-                force_b = perm.out_force_b.warp
-                torque_b = perm.out_torque_b.warp
+                composer = perm
+            force_in, torque_in, frame = composer.resolve_submission()
+            wrench_is_world = frame is WrenchComposer.Frame.WORLD_AT_COM
 
             # rotate body-frame wrenches into the world frame expected by ``LINK_WRENCH``.
             # Read the link poses directly from the backend-order ``LINK_POSE`` buffer: the
@@ -257,7 +257,14 @@ class Articulation(BaseArticulation):
             wp.launch(
                 shared_kernels._body_wrench_to_world_ordered,
                 dim=(self._num_instances, self._num_bodies),
-                inputs=[force_b, torque_b, poses, self._body_user_to_backend_map(), has_body_ordering],
+                inputs=[
+                    force_in,
+                    torque_in,
+                    poses,
+                    self._body_user_to_backend_map(),
+                    has_body_ordering,
+                    wrench_is_world,
+                ],
                 outputs=[self._wrench_buf],
                 device=self._device,
             )
@@ -3952,8 +3959,8 @@ class Articulation(BaseArticulation):
         self._wrench_buf = wp.zeros((N, B, 9), dtype=wp.float32, device=device)
 
         # Wrench composers.
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # Pinned-host CPU staging for env ids/masks (PR #5329 pattern).
         self._cpu_env_ids_all = wp.zeros(N, dtype=wp.int32, device="cpu", pinned=True)

--- a/source/isaaclab_ov/isaaclab_ov/assets/kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/kernels.py
@@ -1164,12 +1164,13 @@ def derive_body_acceleration_from_body_com_velocities(
 
 @wp.kernel
 def _body_wrench_to_world(
-    force_b: wp.array(dtype=wp.vec3f, ndim=2),
-    torque_b: wp.array(dtype=wp.vec3f, ndim=2),
+    force_in: wp.array(dtype=wp.vec3f, ndim=2),
+    torque_in: wp.array(dtype=wp.vec3f, ndim=2),
     poses: wp.array(dtype=wp.transformf, ndim=2),
+    wrench_is_world: bool,
     wrench_out: wp.array(dtype=wp.float32, ndim=3),
 ):
-    """Rotate body-frame force/torque to world frame and pack into a flat output array.
+    """Rotate a force/torque to world frame and pack into a flat output array.
 
     Output layout per ``(i, j)`` slice (9 floats total):
 
@@ -1178,15 +1179,21 @@ def _body_wrench_to_world(
     * ``[6:9]`` -- world-frame link position ``[m]``
 
     Args:
-        force_b: Body-frame applied forces ``[N]``. Shape is ``(N, L)``.
-        torque_b: Body-frame applied torques ``[N*m]``. Shape is ``(N, L)``.
+        force_in: Applied forces ``[N]`` in the frame selected by ``wrench_is_world``. Shape is ``(N, L)``.
+        torque_in: Applied torques ``[N*m]`` in the frame selected by ``wrench_is_world``. Shape is ``(N, L)``.
         poses: Link poses in world frame. Shape is ``(N, L)``.
+        wrench_is_world: Whether the input wrench is already in the world frame, in which case no
+            rotation is applied.
         wrench_out: Output packed wrench array. Shape is ``(N, L, 9)``.
     """
     i, j = wp.tid()
-    q = wp.transform_get_rotation(poses[i, j])
-    f_w = wp.quat_rotate(q, force_b[i, j])
-    t_w = wp.quat_rotate(q, torque_b[i, j])
+    if wrench_is_world:
+        f_w = force_in[i, j]
+        t_w = torque_in[i, j]
+    else:
+        q = wp.transform_get_rotation(poses[i, j])
+        f_w = wp.quat_rotate(q, force_in[i, j])
+        t_w = wp.quat_rotate(q, torque_in[i, j])
     wrench_out[i, j, 0] = f_w[0]
     wrench_out[i, j, 1] = f_w[1]
     wrench_out[i, j, 2] = f_w[2]
@@ -1201,16 +1208,17 @@ def _body_wrench_to_world(
 
 @wp.kernel
 def _body_wrench_to_world_ordered(
-    force_b: wp.array(dtype=wp.vec3f, ndim=2),
-    torque_b: wp.array(dtype=wp.vec3f, ndim=2),
+    force_in: wp.array(dtype=wp.vec3f, ndim=2),
+    torque_in: wp.array(dtype=wp.vec3f, ndim=2),
     poses: wp.array(dtype=wp.transformf, ndim=2),
     user_to_backend: wp.array(dtype=wp.int32),
     has_ordering: bool,
+    wrench_is_world: bool,
     wrench_out: wp.array(dtype=wp.float32, ndim=3),
 ):
     """Rotate public-order body wrenches to world frame and write them in backend order.
 
-    The wrench (``force_b`` / ``torque_b``) is indexed in public body order while the
+    The wrench (``force_in`` / ``torque_in``) is indexed in public body order while the
     link ``poses`` are read directly from the backend-order ``LINK_POSE`` buffer. The
     public body ``user_body_id`` and the backend body ``backend_body_id`` address the
     same physical body, so its world-frame orientation and position are identical in
@@ -1218,12 +1226,16 @@ def _body_wrench_to_world_ordered(
     pose shadow (no per-substep reorder launch).
 
     Args:
-        force_b: Body-frame applied forces ``[N]`` in public body order. Shape is ``(N, L)``.
-        torque_b: Body-frame applied torques ``[N*m]`` in public body order. Shape is ``(N, L)``.
+        force_in: Applied forces ``[N]`` in public body order, in the frame selected by
+            ``wrench_is_world``. Shape is ``(N, L)``.
+        torque_in: Applied torques ``[N*m]`` in public body order, in the frame selected by
+            ``wrench_is_world``. Shape is ``(N, L)``.
         poses: Link poses in world frame in backend body order (identity when
             ``has_ordering`` is False). Shape is ``(N, L)``.
         user_to_backend: Map from public body index to backend body index. Shape is ``(L,)``.
         has_ordering: Whether the public-to-backend body map is nonidentity.
+        wrench_is_world: Whether the input wrench is already in the world frame, in which case no
+            rotation is applied.
         wrench_out: Output packed wrench array in backend body order. Shape is ``(N, L, 9)``
             with ``[0:3]`` world force ``[N]``, ``[3:6]`` world torque ``[N*m]``, ``[6:9]``
             world link position ``[m]``.
@@ -1232,9 +1244,13 @@ def _body_wrench_to_world_ordered(
     backend_body_id = user_body_id
     if has_ordering:
         backend_body_id = user_to_backend[user_body_id]
-    q = wp.transform_get_rotation(poses[i, backend_body_id])
-    f_w = wp.quat_rotate(q, force_b[i, user_body_id])
-    t_w = wp.quat_rotate(q, torque_b[i, user_body_id])
+    if wrench_is_world:
+        f_w = force_in[i, user_body_id]
+        t_w = torque_in[i, user_body_id]
+    else:
+        q = wp.transform_get_rotation(poses[i, backend_body_id])
+        f_w = wp.quat_rotate(q, force_in[i, user_body_id])
+        t_w = wp.quat_rotate(q, torque_in[i, user_body_id])
     wrench_out[i, backend_body_id, 0] = f_w[0]
     wrench_out[i, backend_body_id, 1] = f_w[1]
     wrench_out[i, backend_body_id, 2] = f_w[2]

--- a/source/isaaclab_ov/isaaclab_ov/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/rigid_object/rigid_object.py
@@ -166,17 +166,17 @@ class RigidObject(BaseRigidObject):
         if inst.active:
             if perm.active:
                 inst.add_raw_buffers_from(perm)
-            force_b = inst.out_force_b.warp
-            torque_b = inst.out_torque_b.warp
+            composer = inst
         else:
-            force_b = perm.out_force_b.warp
-            torque_b = perm.out_torque_b.warp
+            composer = perm
+        force_in, torque_in, frame = composer.resolve_submission()
+        wrench_is_world = frame is WrenchComposer.Frame.WORLD_AT_COM
 
         poses = self._data.body_link_pose_w.warp  # (N, 1) wp.transformf
         wp.launch(
             _body_wrench_to_world,
             dim=(self._num_instances, 1),
-            inputs=[force_b, torque_b, poses],
+            inputs=[force_in, torque_in, poses, wrench_is_world],
             outputs=[self._wrench_buf],
             device=self._device,
         )
@@ -1032,8 +1032,8 @@ class RigidObject(BaseRigidObject):
             device=device,
             copy=False,
         )
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # set information about rigid body into data
         self._data.body_names = self._body_names

--- a/source/isaaclab_ov/isaaclab_ov/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_ov/isaaclab_ov/assets/rigid_object_collection/rigid_object_collection.py
@@ -196,17 +196,17 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         if inst.active:
             if perm.active:
                 inst.add_raw_buffers_from(perm)
-            force_b = inst.out_force_b.warp
-            torque_b = inst.out_torque_b.warp
+            composer = inst
         else:
-            force_b = perm.out_force_b.warp
-            torque_b = perm.out_torque_b.warp
+            composer = perm
+        force_in, torque_in, frame = composer.resolve_submission()
+        wrench_is_world = frame is WrenchComposer.Frame.WORLD_AT_COM
 
         poses = self._data.body_link_pose_w.warp  # (N, B) wp.transformf
         wp.launch(
             _body_wrench_to_world,
             dim=(self._num_instances, self._num_bodies),
-            inputs=[force_b, torque_b, poses],
+            inputs=[force_in, torque_in, poses, wrench_is_world],
             outputs=[self._wrench_buf],
             device=self._device,
         )
@@ -1187,8 +1187,8 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         # The fused LINK_WRENCH binding writes from a single (N, B, 9) buffer.
         self._wrench_buf = wp.zeros((N, B, 9), dtype=wp.float32, device=self._device)
 
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # set information about rigid body into data
         self._data.body_names = self._body_names_list

--- a/source/isaaclab_physx/changelog.d/wrench-submission-plan.rst
+++ b/source/isaaclab_physx/changelog.d/wrench-submission-plan.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Changed the external-wrench writers to submit through
+  :meth:`~isaaclab.utils.wrench_composer.WrenchComposer.resolve_submission`, so a wrench that is
+  already local-frame, or already global-frame at the center of mass, is sent to PhysX without
+  reading the body transforms.

--- a/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/articulation/articulation.py
@@ -251,7 +251,8 @@ class Articulation(BaseArticulation):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            force_user, torque_user, frame = composer.resolve_submission()
+            is_global = frame is WrenchComposer.Frame.WORLD_AT_COM
             if self.data.has_body_ordering:
                 force_backend = self._body_wrench_force_backend
                 torque_backend = self._body_wrench_torque_backend
@@ -259,8 +260,8 @@ class Articulation(BaseArticulation):
                     ordering_kernels.reorder_body_wrench_user_to_backend,
                     dim=(self.num_instances, self.num_bodies),
                     inputs=[
-                        composer.out_force_b.warp,
-                        composer.out_torque_b.warp,
+                        force_user,
+                        torque_user,
                         self.data.body_ordering.backend_to_user,
                     ],
                     outputs=[force_backend, torque_backend],
@@ -269,14 +270,13 @@ class Articulation(BaseArticulation):
                 force_data = force_backend
                 torque_data = torque_backend
             else:
-                force_data = composer.out_force_b.warp
-                torque_data = composer.out_torque_b.warp
+                force_data, torque_data = force_user, torque_user
             self.root_view.apply_forces_and_torques_at_position(
                 force_data=force_data.flatten().view(wp.float32),
                 torque_data=torque_data.flatten().view(wp.float32),
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=False,
+                is_global=is_global,
             )
         if self._instantaneous_wrench_composer.active:
             self._instantaneous_wrench_composer.reset()
@@ -3915,8 +3915,8 @@ class Articulation(BaseArticulation):
         self._cpu_env_ids_views: dict[int, wp.array] = {}
 
         # external wrench composer
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # asset named data
         self._joint_pos_target_backend: wp.array | None = None

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object/rigid_object.py
@@ -153,19 +153,15 @@ class RigidObject(BaseRigidObject):
             if self._instantaneous_wrench_composer.active:
                 composer = self._instantaneous_wrench_composer
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
-                get_force_data = self._get_inst_wrench_force_f32
-                get_torque_data = self._get_inst_wrench_torque_f32
             else:
                 composer = self._permanent_wrench_composer
-                get_force_data = self._get_perm_wrench_force_f32
-                get_torque_data = self._get_perm_wrench_torque_f32
-            composer.compose_to_body_frame()
+            force_user, torque_user, frame = composer.resolve_submission()
             self.root_view.apply_forces_and_torques_at_position(
-                force_data=get_force_data(),
-                torque_data=get_torque_data(),
+                force_data=force_user.flatten().view(wp.float32),
+                torque_data=torque_user.flatten().view(wp.float32),
                 position_data=None,
                 indices=self._ALL_INDICES,
-                is_global=False,
+                is_global=frame is WrenchComposer.Frame.WORLD_AT_COM,
             )
         self._instantaneous_wrench_composer.reset()
 
@@ -1029,8 +1025,8 @@ class RigidObject(BaseRigidObject):
         self._ALL_BODY_INDICES = wp.array(np.arange(self.num_bodies, dtype=np.int32), device=self.device)
 
         # external wrench composer
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # set information about rigid body into data
         self._data.body_names = self.body_names
@@ -1040,11 +1036,6 @@ class RigidObject(BaseRigidObject):
         # Reset to None each time _create_buffers runs (during initialization).
         self._root_link_pose_w_f32: wp.array | None = None
         self._root_com_vel_w_f32: wp.array | None = None
-        # Cached wrench views for write_data_to_sim
-        self._inst_wrench_force_f32: wp.array | None = None
-        self._inst_wrench_torque_f32: wp.array | None = None
-        self._perm_wrench_force_f32: wp.array | None = None
-        self._perm_wrench_torque_f32: wp.array | None = None
 
         # Pre-allocated pinned CPU buffers for PhysX TensorAPI writes.
         # PhysX requires CPU arrays for "model" property updates (masses, coms, inertias).
@@ -1155,34 +1146,6 @@ class RigidObject(BaseRigidObject):
         if self._root_com_vel_w_f32 is None:
             self._root_com_vel_w_f32 = self.data._root_com_vel_w.data.view(wp.float32)
         return self._root_com_vel_w_f32
-
-    def _get_inst_wrench_force_f32(self) -> wp.array:
-        """Get a cached flattened float32 view of instantaneous wrench force. Invalidated in ``_create_buffers``."""
-        if self._inst_wrench_force_f32 is None:
-            self._inst_wrench_force_f32 = self._instantaneous_wrench_composer.out_force_b.warp.flatten().view(
-                wp.float32
-            )
-        return self._inst_wrench_force_f32
-
-    def _get_inst_wrench_torque_f32(self) -> wp.array:
-        """Get a cached flattened float32 view of instantaneous wrench torque. Invalidated in ``_create_buffers``."""
-        if self._inst_wrench_torque_f32 is None:
-            self._inst_wrench_torque_f32 = self._instantaneous_wrench_composer.out_torque_b.warp.flatten().view(
-                wp.float32
-            )
-        return self._inst_wrench_torque_f32
-
-    def _get_perm_wrench_force_f32(self) -> wp.array:
-        """Get a cached flattened float32 view of permanent wrench force. Invalidated in ``_create_buffers``."""
-        if self._perm_wrench_force_f32 is None:
-            self._perm_wrench_force_f32 = self._permanent_wrench_composer.out_force_b.warp.flatten().view(wp.float32)
-        return self._perm_wrench_force_f32
-
-    def _get_perm_wrench_torque_f32(self) -> wp.array:
-        """Get a cached flattened float32 view of permanent wrench torque. Invalidated in ``_create_buffers``."""
-        if self._perm_wrench_torque_f32 is None:
-            self._perm_wrench_torque_f32 = self._permanent_wrench_composer.out_torque_b.warp.flatten().view(wp.float32)
-        return self._perm_wrench_torque_f32
 
     def _sim_env_ids_view(self, count: int) -> wp.array:
         """Return a cached prefix of the simulator-index scratch buffer."""

--- a/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
+++ b/source/isaaclab_physx/isaaclab_physx/assets/rigid_object_collection/rigid_object_collection.py
@@ -193,17 +193,15 @@ class RigidObjectCollection(BaseRigidObjectCollection):
                 composer.add_raw_buffers_from(self._permanent_wrench_composer)
             else:
                 composer = self._permanent_wrench_composer
-            composer.compose_to_body_frame()
+            force_user, torque_user, frame = composer.resolve_submission()
             self.root_view.apply_forces_and_torques_at_position(
-                force_data=self.reshape_data_to_view_2d(composer.out_force_b.warp, device=self.device).view(wp.float32),
-                torque_data=self.reshape_data_to_view_2d(composer.out_torque_b.warp, device=self.device).view(
-                    wp.float32
-                ),
+                force_data=self.reshape_data_to_view_2d(force_user, device=self.device).view(wp.float32),
+                torque_data=self.reshape_data_to_view_2d(torque_user, device=self.device).view(wp.float32),
                 position_data=None,
                 indices=self._env_body_ids_to_view_ids(
                     self._ALL_ENV_INDICES, self._ALL_BODY_INDICES, device=self.device
                 ),
-                is_global=False,
+                is_global=frame is WrenchComposer.Frame.WORLD_AT_COM,
             )
         self._instantaneous_wrench_composer.reset()
 
@@ -1396,8 +1394,8 @@ class RigidObjectCollection(BaseRigidObjectCollection):
         self._cpu_view_ids_views: dict[int, wp.array] = {}
 
         # external wrench composer
-        self._instantaneous_wrench_composer = WrenchComposer(self)
-        self._permanent_wrench_composer = WrenchComposer(self)
+        self._instantaneous_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
+        self._permanent_wrench_composer = WrenchComposer(self, supports_world_at_com=True)
 
         # set information about rigid body into data
         self._data.body_names = self.body_names

--- a/source/isaaclab_physx/isaaclab_physx/benchmark/assets/runtime.py
+++ b/source/isaaclab_physx/isaaclab_physx/benchmark/assets/runtime.py
@@ -122,8 +122,8 @@ def create_test_articulation(
     object.__setattr__(articulation, "_data", data)
 
     # Create mock wrench composers (pass articulation which has num_instances, num_bodies, device properties)
-    mock_inst_wrench = WrenchComposer(articulation)
-    mock_perm_wrench = WrenchComposer(articulation)
+    mock_inst_wrench = WrenchComposer(articulation, supports_world_at_com=True)
+    mock_perm_wrench = WrenchComposer(articulation, supports_world_at_com=True)
     object.__setattr__(articulation, "_instantaneous_wrench_composer", mock_inst_wrench)
     object.__setattr__(articulation, "_permanent_wrench_composer", mock_perm_wrench)
 


### PR DESCRIPTION
# Description

`WrenchComposer.compose_to_body_frame()` was called unconditionally by every backend writer on every physics step. It reads `body_com_pos_w` and `body_link_quat_w`, which on PhysX chains to `_ensure_fk_fresh()` → `update_articulations_kinematic()` (a scene-global articulation FK pass) plus `root_view.get_link_transforms()`, then launches the composition kernel.

That work is unnecessary whenever the buffered wrench is already in a frame the consumer accepts. This PR moves the frame decision into the composer, which hands each writer the cheapest valid representation:

- **all-local content** → the local buffers, untouched. An all-local wrench composes to exactly itself, because the pose data is multiplied by zero.
- **all-global-at-CoM content** → the global buffers, untouched, submitted in the world frame by backends that accept one.
- **anything else** → composed as before.

Writers declare what they can consume once at construction (`supports_world_at_com`) and call `resolve_submission()` per step. All frame logic stays inside the composer; no writer touches a raw buffer or knows a frame rule.

## New public API

```python
class WrenchComposer:
    class Frame(IntEnum):
        BODY = 0          # body frame, force at the body's CoM
        WORLD_AT_COM = 1  # world frame, force at the body's CoM

    def __init__(self, asset, *, supports_world_at_com: bool = False) -> None: ...
    def resolve_submission(self) -> tuple[wp.array, wp.array, Frame]: ...
```

Additive only. `compose_to_body_frame()`, `out_force_b`, and `out_torque_b` remain public and behaviorally unchanged, so no deprecation cycle is needed. `supports_world_at_com` defaults to `False`, which is exactly the previous behavior.

Eligibility is tracked with a private mask of which input buffer families hold contributions (`LOCAL`, `GLOBAL_AT_COM`, `GLOBAL_POSITIONED`), classified from the same routing the `add_forces_to_dual_buffers_*` kernels use. The mask is sticky across partial resets and cleared only by a full `reset()` — proving a partial reset removed every contribution of a family would require scanning the buffers. That can forgo the fast path but never changes the resulting wrench.

## Equivalence

All three branches are exact, from `compose_wrench_to_body_frame`:

- **local only**: the three global buffers are zero, so both `quat_rotate_inv` terms vanish and the output is identically `(local_force_b, local_torque_b)`. Note a *positioned* local force also qualifies — the kernel folds `cross(P_b, F_b)` straight into `local_torque_b`.
- **global-at-CoM only**: `global_force_w` and the local buffers are zero, so `corrected_torque_w == global_torque_w`. Submitting the world buffers is the same wrench, provided the consumer applies force at the CoM — verified against the vendored `omni.physics.tensors` API, where `position_data=None` means "at the link transform" for **both** `is_global` values, so the flag only reinterprets the vectors' frame and never moves the application point.
- **anything else**: unchanged.

## Backend coverage

| backend | `supports_world_at_com` | change |
|---|---|---|
| PhysX | `True` | writer maps the returned frame onto `is_global` |
| OvPhysX | `True` | writer maps it onto a new `wrench_is_world` kernel flag that skips the inline rotate |
| Newton | `False` (default) | writer swaps to `resolve_submission()`; no constructor change |

OvPhysX is the largest win. Its wrench binding wants a world-frame wrench, so a global wrench previously round-tripped: the composer rotated world→body, then the packing kernel rotated body→world. Measured on this branch with a body rotated 90° about +z, a local force `(1,0,0)` emits `(0,1,0)` while a global force `(1,0,0)` emits `(1,0,0)` — an exact round trip, so skipping both rotations is output-preserving. The packed `[6:9]` link position is still written unconditionally on both paths.

Newton keeps the body frame because it binds a body-frame array to the solver. Worth noting for a follow-up: its writer kernel already performs the same body→world rotation OvPhysX's does, so Newton could plausibly take the same flag and win the global-at-CoM path too. That is deliberately out of scope here.

## Validation

Environment: `OMNI_KIT_ACCEPT_EULA=YES uv run --extra isaacsim --extra test --extra ovphysx`, which resolves `BACKENDS == ['physx', 'newton', 'ovphysx']` with CUDA. Note `EXP_PATH` must be exported or `_iface_test_boot.py` takes its kitless path and `physx` silently drops out, making backend tests skip green.

- `test_wrench_composer.py` plus `test/assets/`: **6760 passed**, 65 skipped, 68 xfailed.
- 5 failures in `test_articulation_ordering.py` during full-suite runs are **pre-existing and unrelated**: the identical 5 fail at the branch base with none of this branch present, and pass in isolation. Test counts reconcile — 6350 passing at base, 6370 at head for the same selection, and the +20 is exactly this branch's new tests.
- `uv run isaaclab -f` clean.

New coverage: composer unit tests for every content case and the mask lifecycle; per-backend submission tests asserting the chosen frame and that no body-pose read occurs on a fast path; an OvPhysX articulation test driving the ordered kernel's world path under a **non-identity body ordering**; and a cross-backend equivalence test over all three backends × four content combinations, comparing the submitted wrench against the composed one.

Two regressions were confirmed to be caught rather than assumed: injecting the eligibility bug the design guards against (`_content & LOCAL` instead of `==`) fails the mixed-content test, and perturbing the expected world-frame torque fails exactly the two `WORLD_AT_COM` cases and no others.

## Performance

Real PhysX, RTX 5090, ANYMAL-C (17 bodies) × 4096 envs = 69,632 links. Same-process paired A/B with the arm order alternated per iteration, 400–500 pairs, 95% CI on paired differences. Baseline is `compose_to_body_frame()` — what the writers previously called unconditionally.

| scope | content | baseline | patched | paired delta | 95% CI |
|---|---|---:|---:|---:|---|
| composition path only | global-at-CoM | 0.2194 ms | 0.0191 ms | **−0.2003 ms** (−91.3%) | [0.1915, 0.2091] |
| composition path only | local | 0.1926 ms | 0.0159 ms | **−0.1767 ms** (−91.8%) | [0.1712, 0.1822] |
| full `write_data_to_sim` | global-at-CoM | 1.0799 ms | 0.9897 ms | **−0.0902 ms** (−8.4%) | [0.0797, 0.1007] |
| full `write_data_to_sim` | local | 1.0072 ms | 0.9305 ms | **−0.0767 ms** (−7.6%) | [0.0719, 0.0815] |

Read the end-to-end row as the honest headline: **~0.08 ms per asset per physics step**. Roughly half the isolated saving does not reach the caller, because other work in `write_data_to_sim` touches body poses anyway and pays part of that cost regardless. A cuboid rigid-object scene at the same env count saved only ~6.5 µs, as expected — there is no articulation FK pass to skip.

Scope caveat: no in-tree task sets `is_global=True` today (both shipped `apply_external_force_torque` events use the local default), so the local path is what delivers value now, and it is the one that reaches every backend.

## Supersedes

This replaces two open PRs, both of which found one half of this problem:

- **#7431** (@NeoZng) identified the global-at-CoM case and the cost of the pose read. Its mechanism is correct and its writer-level measurement is corroborated here. It is superseded on placement rather than substance: it put the frame decision in three PhysX writers behind a public eligibility flag, leaving Newton and OvPhysX unserved. The credit for the world-at-CoM half of this mechanism is theirs.
- **#7362** cached composition for unchanged local wrenches. Superseded because not composing at all is strictly stronger — the cache does nothing when the wrench is rewritten every step, which is the common case for a per-step randomized push.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the `pre-commit` checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
