### PR TITLE
Align lift experiment names and split shared camera experiment

### DIFF
--- a/source/isaaclab_tasks/changelog.d/rename-franka-soft-to-lift-soft.major.rst
+++ b/source/isaaclab_tasks/changelog.d/rename-franka-soft-to-lift-soft.major.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Changed the non-camera soft-beam ``rsl_rl`` experiment name from ``franka_soft`` to
+  ``lift_soft``, matching the ``lift_cloth`` and ``lift_cable`` naming of the sibling tasks. This
+  also moves the logs of the contributed ``IsaacContrib-Lift-Soft-Franka-Custom-Coupling`` task,
+  which reuses the same runner config. Existing checkpoints remain loadable: update log and
+  checkpoint paths that refer to ``logs/rsl_rl/franka_soft``, or pass
+  ``--experiment_name franka_soft``.

--- a/source/isaaclab_tasks/changelog.d/split-camera-lift-experiments.major.rst
+++ b/source/isaaclab_tasks/changelog.d/split-camera-lift-experiments.major.rst
@@ -1,0 +1,16 @@
+Changed
+^^^^^^^
+
+* **Breaking:** Split the camera ``rsl_rl`` experiment name ``franka_deformable_camera``, which
+  ``Isaac-Lift-Soft-Franka-Camera`` and ``Isaac-Lift-Cloth-Franka-Camera`` previously shared, into
+  ``lift_soft_camera`` and ``lift_cloth_camera``. Because both tasks have identical observation and
+  action shapes, a run of one task could silently load the other's checkpoint when replaying without
+  an explicit ``--checkpoint``. Move runs out of ``logs/rsl_rl/franka_deformable_camera`` into the
+  new per-task directories, using the ``task`` field of each run's ``run_manifest.json`` to tell them
+  apart.
+
+Added
+^^^^^
+
+* Added :class:`~isaaclab_tasks.core.lift.config.franka_soft.agents.rsl_rl_ppo_cfg.FrankaClothCameraPPORunnerCfg`
+  so ``Isaac-Lift-Cloth-Franka-Camera`` logs to its own experiment directory.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
@@ -73,7 +73,7 @@ gym.register(
     disable_env_checker=True,
     kwargs={
         "env_cfg_entry_point": f"{__name__}.franka_cloth_env_cfg:FrankaClothCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformableCameraPPORunnerCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaClothCameraPPORunnerCfg",
         "default_agent": "rsl_rl",
     },
 )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
@@ -67,7 +67,7 @@ class FrankaDeformableCameraPPORunnerCfg(RslRlOnPolicyRunnerCfg):
     num_steps_per_env = 24
     max_iterations = 5000
     save_interval = 50
-    experiment_name = "franka_deformable_camera"
+    experiment_name = "lift_soft_camera"
     obs_groups = {
         "actor": ["policy", "proprio", "base_image"],
         "critic": ["policy", "proprio", "perception"],
@@ -90,6 +90,11 @@ class FrankaDeformableCameraPPORunnerCfg(RslRlOnPolicyRunnerCfg):
         activation="elu",
     )
     algorithm = ALGO_CFG.replace(num_mini_batches=8)
+
+
+@configclass
+class FrankaClothCameraPPORunnerCfg(FrankaDeformableCameraPPORunnerCfg):
+    experiment_name = "lift_cloth_camera"
 
 
 @configclass

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
@@ -33,7 +33,7 @@ class FrankaDeformablePPORunnerCfg(RslRlOnPolicyRunnerCfg):
     num_steps_per_env = 24
     max_iterations = 3000
     save_interval = 50
-    experiment_name = "franka_soft"
+    experiment_name = "lift_soft"
     obs_groups = {
         "actor": ["policy"],
         "critic": ["policy"],


### PR DESCRIPTION
# Description

The lift task family had inconsistent `rsl_rl` experiment names. The cloth and cable tasks already used the `lift_*` scheme (`lift_cloth`, `lift_cable`, `lift_cable_camera`), while the soft-beam task used `franka_soft` and the camera variant used `franka_deformable_camera`. This PR brings both in line with their siblings.

The second commit fixes a real bug found while making the rename. `franka_deformable_camera` was shared by `Isaac-Lift-Soft-Franka-Camera` and `Isaac-Lift-Cloth-Franka-Camera`, so both tasks wrote runs into the same directory. Because the two tasks have identical observation and action shapes (both instantiate the same `FrankaCameraObservationsCfg` and the same 128x128 `FRANKA_CAMERA_CFG`, and `DeformableSampledPointsInRobotRootFrame` always emits 20 points regardless of mesh resolution), a checkpoint from one task loads into the other with no shape mismatch. Replaying without an explicit `--checkpoint` falls through to `get_checkpoint_path(log_root_path, agent_cfg.load_run, ...)` with `load_run` defaulting to `.*`, which globs the directory with no task filter, so it could silently evaluate a policy trained on the other task. Selecting `--checkpoint latest` or `best` was already safe because `resolve_checkpoint_selector` filters on the `task` field of `run_manifest.json`; only the legacy bare-glob fallback was exposed.

Resulting experiment directories, all distinct:

| Task | Experiment |
| --- | --- |
| `Isaac-Lift-Soft-Franka` | `lift_soft` |
| `Isaac-Lift-Cloth-Franka` | `lift_cloth` |
| `Isaac-Lift-Cable-Franka` | `lift_cable` |
| `Isaac-Lift-Soft-Franka-Camera` | `lift_soft_camera` |
| `Isaac-Lift-Cloth-Franka-Camera` | `lift_cloth_camera` |
| `Isaac-Lift-Cable-Franka-Camera` | `lift_cable_camera` |

Checkpoint weights are unaffected; only the log directory changes. Existing runs can be moved into the new directories, and the `task` field in each run's `run_manifest.json` distinguishes soft from cloth runs that previously shared `franka_deformable_camera`. Passing `--experiment_name franka_soft` also restores the old path.

Runner config class names are deliberately unchanged, since they are referenced by the registered `rsl_rl_cfg_entry_point` strings and renaming them would break that public API without a deprecation path. The only new class is `FrankaClothCameraPPORunnerCfg`, which gives the cloth camera task its own experiment directory.

## Type of change

- Breaking change (existing functionality will not work without user modification)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

Notes on the two unchecked or qualified items: no documentation references these log directories, so no docs changes were required. No test was added because the repository has no existing coverage asserting experiment names, and a test pinning the strings would restate the config rather than exercise behavior. Verified manually that all six lift tasks resolve to distinct experiment directories through the gym registry.
