### PR TITLE
Fix stale gravity in OvPhysxManager.get_gravity and in IMU/PVA sensors

### DIFF
--- a/source/isaaclab_ov/changelog.d/fix-ovphysx-get-gravity-stale.rst
+++ b/source/isaaclab_ov/changelog.d/fix-ovphysx-get-gravity-stale.rst
@@ -5,3 +5,7 @@ Fixed
   gravity after :meth:`~isaaclab_ov.physics.OvPhysxManager.set_gravity` changed the running scene.
   The manager now tracks the applied gravity vector, while ``SimulationCfg.gravity`` stays the
   nominal value that randomization terms resample from.
+* Fixed :class:`~isaaclab_ov.sensors.Imu` and :class:`~isaaclab_ov.sensors.Pva` reporting gravity
+  captured at sensor initialization. Both sensors now re-read the scene gravity on every update, so
+  runtime randomization through :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity`
+  is reflected in the accelerometer bias and the projected gravity direction.

--- a/source/isaaclab_ov/changelog.d/fix-ovphysx-get-gravity-stale.rst
+++ b/source/isaaclab_ov/changelog.d/fix-ovphysx-get-gravity-stale.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_ov.physics.OvPhysxManager.get_gravity` returning the construction-time
+  gravity after :meth:`~isaaclab_ov.physics.OvPhysxManager.set_gravity` changed the running scene.
+  The manager now tracks the applied gravity vector, while ``SimulationCfg.gravity`` stays the
+  nominal value that randomization terms resample from.

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -417,6 +417,10 @@ class OvPhysxManager(PhysicsManager):
     _pending_clones: ClassVar[list[tuple[str, list[str], list[CloneTransform]]]] = []
     _atexit_registered: ClassVar[bool] = False
     _scene_data_backend: ClassVar[OvPhysxSceneDataBackend | None] = None
+    # Gravity currently applied to the running scene [m/s^2]. Seeded from ``SimulationCfg.gravity``
+    # in :meth:`initialize` and refreshed by :meth:`set_gravity`. ``cfg.gravity`` stays the nominal
+    # value that randomization terms resample from, so live updates must not be written back to it.
+    _gravity: ClassVar[tuple[float, float, float] | None] = None
 
     @classmethod
     def get_dt(cls) -> float:
@@ -522,6 +526,7 @@ class OvPhysxManager(PhysicsManager):
         """
         super().initialize(sim_context)
         cls._ensure_physx_schemas_registered()
+        cls._gravity = tuple(sim_context.cfg.gravity)
         cls._warmup_done = False
         cls._requires_full_stage = False
         cls._stage_usda = None
@@ -688,17 +693,20 @@ class OvPhysxManager(PhysicsManager):
 
     @classmethod
     def get_gravity(cls) -> tuple[float, float, float]:
-        """Return the world-frame gravity vector [m/s^2] from the active simulation cfg.
+        """Return the world-frame gravity vector [m/s^2] currently applied to the scene.
 
         Mirrors PhysX's ``SimulationView.get_gravity()`` so backend-agnostic sensor code
-        can read gravity through one classmethod.
+        can read gravity through one classmethod. The value tracks :meth:`set_gravity`,
+        falling back to the simulation cfg until the first live update.
 
         Raises:
             RuntimeError: If no simulation is active. Call :meth:`initialize` first.
         """
         if cls._sim is None or not hasattr(cls._sim, "cfg"):
             raise RuntimeError("OvPhysxManager has not been initialized yet.")
-        return cls._sim.cfg.gravity
+        if cls._gravity is None:
+            return tuple(cls._sim.cfg.gravity)
+        return cls._gravity
 
     @classmethod
     def set_gravity(cls, gravity: tuple[float, float, float]) -> None:
@@ -744,6 +752,10 @@ class OvPhysxManager(PhysicsManager):
             ).wait()
             cls._ovstage.advance_write_floor(ordinal=ordinal).wait()
             cls._physx.update_from_ovstage(ordinal, ordinal)
+
+        # Only publish once the ordinal has been applied, so a failed write leaves
+        # :meth:`get_gravity` reporting the gravity the scene is still running with.
+        cls._gravity = (float(gravity_array[0]), float(gravity_array[1]), float(gravity_array[2]))
 
     @classmethod
     def get_scene_data_backend(cls) -> SceneDataBackend:

--- a/source/isaaclab_ov/isaaclab_ov/sensors/imu/imu.py
+++ b/source/isaaclab_ov/isaaclab_ov/sensors/imu/imu.py
@@ -149,10 +149,11 @@ class Imu(BaseImu):
                 " ancestor is unique per env."
             )
 
-        gravity = SimulationManager.get_gravity()
-        gravity_bias = torch.tensor((-gravity[0], -gravity[1], -gravity[2]), device=self._device)
-        gravity_bias_torch = gravity_bias.repeat(self._num_bodies, 1)
-        self._gravity_bias_w = wp.from_torch(gravity_bias_torch.contiguous(), dtype=wp.vec3f)
+        # Real IMUs always measure gravity, so the accelerometer is biased by -g. The scene value
+        # can change at runtime, so it is refreshed on every update instead of snapshotted here.
+        self._gravity_w: tuple[float, float, float] | None = None
+        self._gravity_bias_w = wp.empty(self._num_bodies, dtype=wp.vec3f, device=self._device)
+        self._refresh_gravity_bias()
 
         self._initialize_buffers_impl()
 
@@ -180,9 +181,25 @@ class Imu(BaseImu):
         self._vel_binding = None
         self._com_binding = None
 
+    def _refresh_gravity_bias(self):
+        """Refresh the cached gravity buffer when the scene gravity changed.
+
+        Scene gravity is runtime-mutable (see
+        :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity`), so the buffer is
+        re-filled in place rather than reallocated: consumers (and any recorded launch) hold
+        the array pointer, and a fresh allocation would freeze the sensor on the old value.
+        """
+        gravity = SimulationManager.get_gravity()
+        gravity = (float(gravity[0]), float(gravity[1]), float(gravity[2]))
+        if gravity == self._gravity_w:
+            return
+        self._gravity_w = gravity
+        self._gravity_bias_w.fill_(wp.vec3f(-gravity[0], -gravity[1], -gravity[2]))
+
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
         """Fills the buffers of the sensor data."""
         env_mask = self._resolve_indices_and_mask(None, env_mask)
+        self._refresh_gravity_bias()
 
         # ``read_into`` fills the structured-dtype destination in place through a cached
         # float32 reinterpret of the binding's flat shape (no extra copy).

--- a/source/isaaclab_ov/isaaclab_ov/sensors/pva/pva.py
+++ b/source/isaaclab_ov/isaaclab_ov/sensors/pva/pva.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -156,11 +157,10 @@ class Pva(BasePva):
             )
 
         # PVA reports projected gravity as the unit direction vector (not the bias the IMU uses).
-        gravity = SimulationManager.get_gravity()
-        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self._device)
-        gravity_dir = math_utils.normalize(gravity_dir.unsqueeze(0)).squeeze(0)
-        gravity_dir_repeated = gravity_dir.repeat(self._num_bodies, 1)
-        self._gravity_vec_w = wp.from_torch(gravity_dir_repeated.contiguous(), dtype=wp.vec3f)
+        # The scene value can change at runtime, so it is refreshed on every update.
+        self._gravity_w: tuple[float, float, float] | None = None
+        self._gravity_vec_w = wp.empty(self._num_bodies, dtype=wp.vec3f, device=self._device)
+        self._refresh_gravity_vec()
 
         self._initialize_buffers_impl()
 
@@ -185,9 +185,28 @@ class Pva(BasePva):
         # across the reset; ``_initialize_impl`` rebuilds a fresh view on the next play.
         self._root_view = None
 
+    def _refresh_gravity_vec(self):
+        """Refresh the cached gravity buffer when the scene gravity changed.
+
+        Scene gravity is runtime-mutable (see
+        :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity`), so the buffer is
+        re-filled in place rather than reallocated: consumers (and any recorded launch) hold
+        the array pointer, and a fresh allocation would freeze the sensor on the old value.
+        """
+        gravity = SimulationManager.get_gravity()
+        gravity = (float(gravity[0]), float(gravity[1]), float(gravity[2]))
+        if gravity == self._gravity_w:
+            return
+        self._gravity_w = gravity
+        # Mirrors ``math_utils.normalize``: the norm is clamped to eps, so zero scene gravity
+        # yields a zero direction instead of NaNs.
+        scale = 1.0 / max(math.sqrt(gravity[0] ** 2 + gravity[1] ** 2 + gravity[2] ** 2), 1.0e-9)
+        self._gravity_vec_w.fill_(wp.vec3f(gravity[0] * scale, gravity[1] * scale, gravity[2] * scale))
+
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
         """Fills the buffers of the sensor data."""
         env_mask = self._resolve_indices_and_mask(None, env_mask)
+        self._refresh_gravity_vec()
 
         # ``OvPhysxView.read_into`` fills the structured-dtype buffer in place via a
         # cached float32 reinterpret; no manual float32 alias is needed.

--- a/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
@@ -56,6 +56,7 @@ def manager_module(monkeypatch):
         "_atexit_registered": False,
         "_scene_data_backend": None,
         "_physx_schemas_registered": False,
+        "_gravity": None,
     }
     for name, value in test_state.items():
         monkeypatch.setattr(manager, name, value)
@@ -305,15 +306,20 @@ def test_set_gravity_writes_and_releases_ovstage_control_resources(monkeypatch, 
     monkeypatch.setitem(sys.modules, "ovstage", fake_ovstage)
     monkeypatch.setattr(manager, "_ovstage", FakeStage())
     monkeypatch.setattr(manager, "_physx", FakePhysX())
-    monkeypatch.setattr(manager, "_sim", SimpleNamespace(cfg=SimpleNamespace(physics_prim_path="/World/physicsScene")))
+    monkeypatch.setattr(
+        manager,
+        "_sim",
+        SimpleNamespace(cfg=SimpleNamespace(physics_prim_path="/World/physicsScene", gravity=(0.0, 0.0, -9.81))),
+    )
+    monkeypatch.setattr(manager, "_gravity", (0.0, 0.0, -9.81))
 
     if failure is None:
-        manager.set_gravity((0.0, 0.0, -9.81))
+        manager.set_gravity((0.0, 0.0, -3.72))
         expected_calls = [
             ("paths", ["/World/physicsScene"]),
             ("query", "physics-scene-paths"),
             ("write", "physics-scene-query", "physics:gravityDirection", 2, [[0.0, 0.0, -1.0]], False),
-            ("write", "physics-scene-query", "physics:gravityMagnitude", 2, [pytest.approx(9.81)], False),
+            ("write", "physics-scene-query", "physics:gravityMagnitude", 2, [pytest.approx(3.72)], False),
             ("seal", 2),
             ("update", 2, 2),
             ("release_query", "physics-scene-query"),
@@ -322,7 +328,7 @@ def test_set_gravity_writes_and_releases_ovstage_control_resources(monkeypatch, 
         ]
     else:
         with pytest.raises(RuntimeError, match=f"{failure} failed"):
-            manager.set_gravity((0.0, 0.0, -9.81))
+            manager.set_gravity((0.0, 0.0, -3.72))
         expected_calls = [
             ("paths", ["/World/physicsScene"]),
             ("query", "physics-scene-paths"),
@@ -342,6 +348,12 @@ def test_set_gravity_writes_and_releases_ovstage_control_resources(monkeypatch, 
         )
 
     assert calls == expected_calls
+    # ``get_gravity`` must report what the scene is actually running with: the new vector
+    # once the ordinal was applied, and the previous one when the update failed.
+    expected_gravity = (0.0, 0.0, -3.72) if failure is None else (0.0, 0.0, -9.81)
+    assert manager.get_gravity() == pytest.approx(expected_gravity)
+    # ``cfg.gravity`` stays the nominal base that randomization terms resample from.
+    assert manager._sim.cfg.gravity == (0.0, 0.0, -9.81)
 
 
 def _retained_binding_script() -> str:

--- a/source/isaaclab_physx/changelog.d/fix-sensor-gravity-tracking.rst
+++ b/source/isaaclab_physx/changelog.d/fix-sensor-gravity-tracking.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_physx.sensors.Imu` and :class:`~isaaclab_physx.sensors.Pva` reporting
+  gravity captured at sensor initialization. Both sensors now re-read the scene gravity on every
+  update, so runtime randomization through
+  :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity` is reflected in the
+  accelerometer bias and the projected gravity direction.

--- a/source/isaaclab_physx/isaaclab_physx/sensors/imu/imu.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/imu/imu.py
@@ -132,11 +132,11 @@ class Imu(BaseImu):
         self._rigid_parent_expr, fixed_pos_b, fixed_quat_b = self._resolve_rigid_body_ancestor_expr()
         self._view = self._physics_sim_view.create_rigid_body_view(path_expr_to_glob(self._rigid_parent_expr))
 
-        # Query world gravity and compute accelerometer bias (real IMUs always measure gravity)
-        gravity = self._physics_sim_view.get_gravity()
-        gravity_bias = torch.tensor((-gravity[0], -gravity[1], -gravity[2]), device=self._device)
-        gravity_bias_torch = gravity_bias.repeat(self._view.count, 1)
-        self._gravity_bias_w = wp.from_torch(gravity_bias_torch.contiguous(), dtype=wp.vec3f)
+        # Real IMUs always measure gravity, so the accelerometer is biased by -g. The scene value
+        # can change at runtime, so it is refreshed on every update instead of snapshotted here.
+        self._gravity_w: tuple[float, float, float] | None = None
+        self._gravity_bias_w = wp.empty(self._view.count, dtype=wp.vec3f, device=self._device)
+        self._refresh_gravity_bias()
 
         self._initialize_buffers_impl()
 
@@ -156,9 +156,25 @@ class Imu(BaseImu):
 
         self._use_recorded_launch = wp.get_device(self._device).is_cuda
 
+    def _refresh_gravity_bias(self):
+        """Refresh the cached gravity buffer when the scene gravity changed.
+
+        Scene gravity is runtime-mutable (see
+        :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity`), so the buffer is
+        re-filled in place rather than reallocated: the recorded launch that consumes it holds
+        the array pointer, and a fresh allocation would freeze the sensor on the old value.
+        """
+        gravity = self._physics_sim_view.get_gravity()
+        gravity = (float(gravity[0]), float(gravity[1]), float(gravity[2]))
+        if gravity == self._gravity_w:
+            return
+        self._gravity_w = gravity
+        self._gravity_bias_w.fill_(wp.vec3f(-gravity[0], -gravity[1], -gravity[2]))
+
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
         """Fills the buffers of the sensor data."""
         env_mask = self._resolve_indices_and_mask(None, env_mask)
+        self._refresh_gravity_bias()
 
         # Refresh the PhysX buffers every update, but create their typed Warp views only once:
         # the getters lazily allocate their output buffers and refresh the same memory in place

--- a/source/isaaclab_physx/isaaclab_physx/sensors/pva/pva.py
+++ b/source/isaaclab_physx/isaaclab_physx/sensors/pva/pva.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -158,12 +159,11 @@ class Pva(BasePva):
         # Create the rigid body view on the ancestor
         self._view = self._physics_sim_view.create_rigid_body_view(path_expr_to_glob(self._rigid_parent_expr))
 
-        # Get world gravity
-        gravity = self._physics_sim_view.get_gravity()
-        gravity_dir = torch.tensor((gravity[0], gravity[1], gravity[2]), device=self.device)
-        gravity_dir = math_utils.normalize(gravity_dir.unsqueeze(0)).squeeze(0)
-        gravity_dir_repeated = gravity_dir.repeat(self.num_instances, 1)
-        self.GRAVITY_VEC_W = ProxyArray(wp.from_torch(gravity_dir_repeated.contiguous(), dtype=wp.vec3f))
+        # Unit world-gravity direction. The scene value can change at runtime, so it is
+        # refreshed on every update instead of snapshotted here.
+        self._gravity_w: tuple[float, float, float] | None = None
+        self.GRAVITY_VEC_W = ProxyArray(wp.empty(self.num_instances, dtype=wp.vec3f, device=self.device))
+        self._refresh_gravity_vec()
 
         # Create internal buffers
         self._initialize_buffers_impl()
@@ -187,9 +187,28 @@ class Pva(BasePva):
 
         self._use_recorded_launch = wp.get_device(self._device).is_cuda
 
+    def _refresh_gravity_vec(self):
+        """Refresh the cached gravity buffer when the scene gravity changed.
+
+        Scene gravity is runtime-mutable (see
+        :func:`~isaaclab.envs.mdp.events.randomize_physics_scene_gravity`), so the buffer is
+        re-filled in place rather than reallocated: consumers (and any recorded launch) hold
+        the array pointer, and a fresh allocation would freeze the sensor on the old value.
+        """
+        gravity = self._physics_sim_view.get_gravity()
+        gravity = (float(gravity[0]), float(gravity[1]), float(gravity[2]))
+        if gravity == self._gravity_w:
+            return
+        self._gravity_w = gravity
+        # Mirrors ``math_utils.normalize``: the norm is clamped to eps, so zero scene gravity
+        # yields a zero direction instead of NaNs.
+        scale = 1.0 / max(math.sqrt(gravity[0] ** 2 + gravity[1] ** 2 + gravity[2] ** 2), 1.0e-9)
+        self.GRAVITY_VEC_W.warp.fill_(wp.vec3f(gravity[0] * scale, gravity[1] * scale, gravity[2] * scale))
+
     def _update_buffers_impl(self, env_mask: wp.array | None = None):
         """Fills the buffers of the sensor data."""
         env_mask = self._resolve_indices_and_mask(None, env_mask)
+        self._refresh_gravity_vec()
 
         # Refresh the PhysX buffers every update, but create their typed Warp views only once:
         # the getters lazily allocate their output buffers and refresh the same memory in place

--- a/source/isaaclab_physx/test/sensors/test_imu_pva_recorded_launch.py
+++ b/source/isaaclab_physx/test/sensors/test_imu_pva_recorded_launch.py
@@ -102,6 +102,7 @@ def _make_sensor(sensor_type: str, use_recorded_launch: bool = True):
     coms = wp.from_torch(coms_torch.contiguous()).view(wp.transformf)
     rigid_view = _FakeRigidView(transforms, velocities, coms)
 
+    gravity_sink = {"value": (0.0, 0.0, -9.81)}
     sensor_cls = Imu if sensor_type == "imu" else Pva
     sensor = sensor_cls.__new__(sensor_cls)
     sensor.cfg = SimpleNamespace(prim_path=f"/World/{sensor_type.upper()}")
@@ -125,6 +126,9 @@ def _make_sensor(sensor_type: str, use_recorded_launch: bool = True):
     sensor._initialize_handle = None
     sensor._invalidate_initialize_handle = None
     sensor._prim_deletion_handle = None
+    # ``_update_buffers_impl`` re-reads scene gravity so runtime randomization stays visible.
+    sensor._physics_sim_view = SimpleNamespace(get_gravity=lambda: gravity_sink["value"])
+    sensor._gravity_w = gravity_sink["value"]
 
     if sensor_type == "imu":
         sensor._data = ImuData()
@@ -137,13 +141,13 @@ def _make_sensor(sensor_type: str, use_recorded_launch: bool = True):
         sensor.GRAVITY_VEC_W = ProxyArray(wp.zeros(2, dtype=wp.vec3f, device=device))
 
     env_mask = wp.ones(2, dtype=wp.bool, device=device)
-    return sensor, rigid_view, velocities_torch, env_mask
+    return sensor, rigid_view, velocities_torch, env_mask, gravity_sink
 
 
 @pytest.mark.parametrize("sensor_type", ["imu", "pva"])
 def test_sensor_caches_physx_typed_views(sensor_type):
     """Repeated eager updates should reuse typed views over refreshed PhysX buffers."""
-    sensor, rigid_view, _, env_mask = _make_sensor(sensor_type, use_recorded_launch=False)
+    sensor, rigid_view, _, env_mask, _ = _make_sensor(sensor_type, use_recorded_launch=False)
 
     sensor._update_buffers_impl(env_mask)
     sensor._update_buffers_impl(env_mask)
@@ -158,7 +162,7 @@ def test_sensor_caches_physx_typed_views(sensor_type):
 @pytest.mark.parametrize("sensor_type", ["imu", "pva"])
 def test_sensor_records_and_replays_changed_runtime_inputs(sensor_type):
     """Replay should observe refreshed buffers, a new mask, and a changed sample interval."""
-    sensor, rigid_view, velocities_torch, env_mask = _make_sensor(sensor_type)
+    sensor, rigid_view, velocities_torch, env_mask, _ = _make_sensor(sensor_type)
 
     sensor._update_buffers_impl(env_mask)
     wp.synchronize_device(sensor.device)
@@ -189,7 +193,7 @@ def test_sensor_records_and_replays_changed_runtime_inputs(sensor_type):
 @pytest.mark.parametrize("sensor_type", ["imu", "pva"])
 def test_sensor_falls_back_when_recording_fails(monkeypatch, sensor_type):
     """A recording failure should disable recording and execute the update eagerly."""
-    sensor, _, _, env_mask = _make_sensor(sensor_type)
+    sensor, _, _, env_mask, _ = _make_sensor(sensor_type)
     sensor_module = imu_module if sensor_type == "imu" else pva_module
     original_launch = sensor_module.wp.launch
 
@@ -213,7 +217,7 @@ def test_sensor_falls_back_when_recording_fails(monkeypatch, sensor_type):
 @pytest.mark.parametrize("sensor_type", ["imu", "pva"])
 def test_sensor_invalidation_drops_cached_launch_state(monkeypatch, sensor_type):
     """Physics invalidation should release cached PhysX views and the recorded command."""
-    sensor, _, _, _ = _make_sensor(sensor_type)
+    sensor, _, _, _, _ = _make_sensor(sensor_type)
     sensor._raw_transforms = object()
     sensor._raw_velocities = object()
     sensor._raw_coms = object()
@@ -230,3 +234,45 @@ def test_sensor_invalidation_drops_cached_launch_state(monkeypatch, sensor_type)
     assert sensor._raw_coms is None
     assert sensor._update_cmd is None
     assert sensor._update_env_mask is None
+
+
+@pytest.mark.parametrize("sensor_type", ["imu", "pva"])
+def test_sensor_tracks_runtime_gravity_changes(sensor_type):
+    """Scene gravity randomized after initialization must reach the sensor's replayed launch."""
+    sensor, _, _, env_mask, gravity_sink = _make_sensor(sensor_type)
+    buffer = sensor._gravity_bias_w if sensor_type == "imu" else sensor.GRAVITY_VEC_W.warp
+    buffer.fill_(wp.vec3f(0.0, 0.0, -9.81) if sensor_type == "imu" else wp.vec3f(0.0, 0.0, -1.0))
+
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(sensor.device)
+    # The recorded launch holds this pointer, so the refresh must not reallocate the buffer.
+    buffer_ptr = buffer.ptr
+
+    gravity_sink["value"] = (0.0, 3.72, 0.0)
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(sensor.device)
+
+    # IMU reports the accelerometer bias (-g); PVA reports the unit gravity direction.
+    expected = (0.0, -3.72, 0.0) if sensor_type == "imu" else (0.0, 1.0, 0.0)
+    torch.testing.assert_close(
+        wp.to_torch(buffer),
+        torch.tensor(expected, device=sensor.device).repeat(2, 1),
+    )
+    assert buffer.ptr == buffer_ptr
+
+
+@pytest.mark.parametrize("sensor_type", ["imu", "pva"])
+def test_sensor_skips_gravity_refill_when_unchanged(sensor_type):
+    """An unchanged scene gravity must not overwrite the buffer on every update."""
+    sensor, _, _, env_mask, _ = _make_sensor(sensor_type)
+    buffer = sensor._gravity_bias_w if sensor_type == "imu" else sensor.GRAVITY_VEC_W.warp
+    sentinel = wp.vec3f(7.0, 7.0, 7.0)
+    buffer.fill_(sentinel)
+
+    sensor._update_buffers_impl(env_mask)
+    wp.synchronize_device(sensor.device)
+
+    torch.testing.assert_close(
+        wp.to_torch(buffer),
+        torch.tensor((7.0, 7.0, 7.0), device=sensor.device).repeat(2, 1),
+    )


### PR DESCRIPTION
# Description

Two related gravity defects, both surfaced by a QA report against the OVPhysX backend.

**1. `OvPhysxManager.get_gravity()` returned a stale value.** `set_gravity()` authors the new gravity into OvStage and applies the ordinal to the running simulation, but `get_gravity()` read `SimulationCfg.gravity`, which the setter never touched. Every call after a live update returned the construction-time value, silently and permanently:

```
get_gravity before set : (0.0, 0.0, -9.81)
set_gravity called with: (0.0, 0.0, -3.72)
get_gravity after  set : (0.0, 0.0, -9.81)
```

The fix tracks the applied gravity on the manager rather than writing back to `cfg.gravity`. Writing back would have been wrong: both `_call_physx` and `_call_ovphysx` in `randomize_physics_scene_gravity` resample from `env.sim.cfg.gravity` as the pristine base, so mutating it would make successive `"add"`/`"scale"` randomizations compound and skew the distribution.

**2. IMU and PVA snapshotted gravity at initialization.** Both sensors read gravity once in `_initialize_impl` and baked it into a static Warp buffer, so gravity randomized at runtime never reached the accelerometer bias or the projected gravity direction. This affected **both** PhysX and OVPhysX — it was not specific to defect 1, and fixing `get_gravity()` alone would not have changed sensor behavior.

Both sensors now refresh the buffer at the top of `_update_buffers_impl`, skipping the refill when the scene gravity is unchanged (a tuple compare, so steady-state cost is one `get_gravity()` call per sensor per update and no GPU work). The buffer is filled **in place** rather than reallocated: the PhysX sensors consume it through a recorded `wp.Launch` that captures the array pointer, and PVA additionally exposes it as the public `GRAVITY_VEC_W` proxy. PVA's normalization mirrors `math_utils.normalize`'s eps-clamp, so zero gravity yields a zero direction rather than NaNs.

Newton's `Pva` already passes the live `model.gravity` array into its kernel each update and needed no change.

## Known remaining gaps (not addressed here)

- `GRAVITY_VEC_W` is still snapshotted at construction in the **asset** data classes (`rigid_object_data.py`, `rigid_object_collection_data.py`, `articulation_data.py`) for both `isaaclab_physx` and `isaaclab_ov`. Newton already fixed its three by binding `ProxyArray(model.gravity[:world_count])` zero-copy. Extending that here needs an API decision first: Newton's `GRAVITY_VEC_W` carries the actual m/s² vector with consumers normalizing on read, whereas PhysX/OV carry a pre-normalized unit direction. Converging on Newton's convention would change a public attribute's units and touch consumers in `isaaclab_experimental` and `isaaclab_tasks_experimental`.
- Newton's `Imu` applies no gravity bias at all, unlike the PhysX and OVPhysX IMUs which bias the accelerometer by `-g`. This looks like a cross-backend behavioral gap rather than a staleness bug.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

None.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Testing

Regression coverage, each verified to fail without the corresponding fix and pass with it:

- `test_set_gravity_writes_and_releases_ovstage_control_resources` — extended to assert `get_gravity()` round-trips after a successful `set_gravity()`, still reports the previously applied value when the OvStage write fails, and that `cfg.gravity` is left untouched as the randomization base. Without the fix it fails with `assert (0.0, 0.0, -9.81) == approx((0.0, 0.0, -3.72))`, reproducing the reported symptom exactly.
- `test_sensor_tracks_runtime_gravity_changes` (new) — a mid-run gravity change must reach a *replayed* recorded launch, with the buffer pointer unchanged.
- `test_sensor_skips_gravity_refill_when_unchanged` (new) — an unchanged gravity must not clobber the buffer every update.

Suites run locally: PhysX IMU 11 passed, PhysX PVA 11 passed, OV IMU 12 passed / 14 skipped, OV PVA 13 passed / 15 skipped, `isaaclab_ov/test/physics/` 53 passed (includes the real-backend gravity test). `pre-commit run --all-files` clean.
