### PR TITLE
[Backport release/3.0.0] Bundle selected develop PRs

### DIFF
--- a/.github/actions/run-package-tests/cleanup_docker_storage.sh
+++ b/.github/actions/run-package-tests/cleanup_docker_storage.sh
@@ -58,6 +58,16 @@ remove_isaacsim_image_pin() {
     docker rm "${ISAACSIM_IMAGE_PIN_CONTAINER}" >/dev/null 2>&1 || true
 }
 
+run_volume_cleanup() {
+    # Anonymous volumes left behind by test containers are referenced by nothing
+    # once the container is gone, and no image or builder prune reclaims them, so
+    # they accumulate for the life of the runner. A stopped container still counts
+    # as a reference, so this runs after container pruning to also catch the
+    # volumes that prune releases.
+    echo "[${CLEANUP_CONTEXT}] Removing Docker volumes no container is using."
+    docker volume prune -f || true
+}
+
 run_conservative_cleanup() {
     echo "[${CLEANUP_CONTEXT}] Running conservative Docker cleanup."
     echo "[${CLEANUP_CONTEXT}] Removing Docker images older than ${DOCKER_CONSERVATIVE_PRUNE_UNTIL}."
@@ -93,6 +103,7 @@ main() {
         pin_isaacsim_image_if_present
         trap remove_isaacsim_image_pin EXIT
         run_conservative_cleanup
+        run_volume_cleanup
         print_docker_storage_usage
         if [ "${FAIL_IF_STILL_HIGH}" = "true" ]; then
             echo "::error::Could not determine Docker storage usage after cleanup. The self-hosted runner needs a measurable Docker storage path before tests can run." >&2
@@ -111,6 +122,8 @@ main() {
         echo "[${CLEANUP_CONTEXT}] Docker storage is at ${usage_percent}%, below the ${DOCKER_CLEANUP_THRESHOLD_PERCENT}% threshold."
         run_conservative_cleanup
     fi
+
+    run_volume_cleanup
 
     echo "[${CLEANUP_CONTEXT}] Docker storage after cleanup."
     print_docker_storage_usage

--- a/.github/actions/run-package-tests/test_cleanup_docker_storage.py
+++ b/.github/actions/run-package-tests/test_cleanup_docker_storage.py
@@ -136,6 +136,48 @@ def test_cleanup_keeps_conservative_image_pruning_below_threshold(tmp_path: Path
     assert "builder prune" not in docker_log
 
 
+def test_cleanup_prunes_unused_volumes_above_threshold(tmp_path: Path):
+    result = _run_cleanup(tmp_path, first_usage=91, final_usage=70)
+
+    assert result.returncode == 0, result.stderr
+    docker_log = (tmp_path / "bin" / "docker.log").read_text(encoding="utf-8")
+    assert "volume prune -f" in docker_log
+
+
+def test_cleanup_prunes_unused_volumes_below_threshold(tmp_path: Path):
+    result = _run_cleanup(tmp_path, first_usage=70, final_usage=70)
+
+    assert result.returncode == 0, result.stderr
+    docker_log = (tmp_path / "bin" / "docker.log").read_text(encoding="utf-8")
+    assert "volume prune -f" in docker_log
+
+
+def test_cleanup_prunes_unused_volumes_after_stopped_containers_are_removed(tmp_path: Path):
+    result = _run_cleanup(tmp_path, first_usage=91, final_usage=70)
+
+    assert result.returncode == 0, result.stderr
+    docker_calls = (tmp_path / "bin" / "docker.log").read_text(encoding="utf-8").splitlines()
+    assert docker_calls.index("container prune -f --filter until=24h") < docker_calls.index("volume prune -f")
+    volume_prune_position = result.stdout.index("Removing Docker volumes no container is using")
+    final_check_position = result.stdout.index("Docker storage after cleanup")
+    assert volume_prune_position < final_check_position
+
+
+def test_cleanup_prunes_unused_volumes_when_usage_cannot_be_measured(tmp_path: Path):
+    result = _run_cleanup(
+        tmp_path,
+        first_usage=91,
+        final_usage=89,
+        failed_path="/var/lib/docker",
+        docker_root_dir="",
+    )
+
+    assert result.returncode == 1
+    assert "Could not determine Docker storage usage after cleanup" in result.stderr
+    docker_log = (tmp_path / "bin" / "docker.log").read_text(encoding="utf-8")
+    assert "volume prune -f" in docker_log
+
+
 def test_cleanup_fails_early_when_aggressive_pruning_cannot_recover_space(tmp_path: Path):
     result = _run_cleanup(tmp_path, first_usage=91, final_usage=89)
 

--- a/docs/source/api/lab/isaaclab.envs.leapp_deployment_env.rst
+++ b/docs/source/api/lab/isaaclab.envs.leapp_deployment_env.rst
@@ -1,0 +1,10 @@
+LEAPP Deployment Environment
+==============================
+
+.. currentmodule:: isaaclab.envs.leapp_deployment_env
+
+Use :class:`LeappDeploymentEnv` to run a LEAPP-exported policy in an Isaac Lab scene. For command-line deployment instructions and prerequisites, see the
+:doc:`LEAPP deployment guide </source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp>`.
+
+.. autoclass:: LeappDeploymentEnv
+   :members:

--- a/docs/source/api/lab/isaaclab.envs.rst
+++ b/docs/source/api/lab/isaaclab.envs.rst
@@ -139,3 +139,8 @@ The following classes are part of the public :mod:`isaaclab.envs` API.
 
 .. autoclass:: VideoRecorderCfg
    :show-inheritance:
+
+.. toctree::
+   :hidden:
+
+   isaaclab.envs.leapp_deployment_env

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -1294,16 +1294,19 @@ XR Camera Feedback
 An ordered list of :class:`~isaaclab_teleop.XrCameraFeedCfg` objects selects existing task scene
 cameras. The manager publishes each new RGBA frame after rendering, while
 :class:`~isaaclab_teleop.XrCameraFeedLayoutCfg` places the panels manually or in horizontal,
-vertical, and grid layouts. ``IsaacContrib-PickPlace-GR1T2-Abs`` and
-``IsaacContrib-PickPlace-Locomanipulation-G1-Abs`` are the primary reference examples.
+vertical, and grid layouts. The following registered tasks enable PiP by default:
+
+* ``IsaacContrib-PickPlace-Locomanipulation-G1-Abs``
+* ``IsaacContrib-PickPlace-GR1T2-Abs``
+* ``IsaacContrib-NutPour-GR1T2-Pink-IK-Abs``
+* ``IsaacContrib-ExhaustPipe-GR1T2-Pink-IK-Abs``
 
 ``teleop_se3_agent.py`` and ``record_demos.py`` show every enabled feed when an IsaacTeleop-enabled
 environment runs with ``--xr``. PiP is absent unless the task explicitly selects an existing
-``CameraCfg`` through ``xr_camera_feeds``. In the reference examples, the selected
+``CameraCfg`` through ``xr_camera_feeds``. In the registered tasks above, the selected
 ``robot_pov_cam`` is also a policy image observation, so the normal demonstration recorder stores
-the same view shown to the operator. Both reference cameras are parented to a physical robot body
-link, so the recorded view follows robot motion. The NutPour and ExhaustPipe GR1T2 teleoperation
-tasks also present their existing recorded ``robot_pov_cam``:
+the same view shown to the operator. Each camera is parented to a physical robot body link, so the
+recorded view follows robot motion:
 
 .. figure:: ../_static/teleop/xr-camera-pip.jpg
    :width: 80%

--- a/docs/source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp.rst
@@ -1,0 +1,180 @@
+Deploy Exported Policies with LEAPP
+===================================
+
+Isaac Lab provides :class:`~envs.LeappDeploymentEnv` for running exported policies back in
+simulation without the training infrastructure. This is the Isaac Lab deployment path for
+LEAPP-exported policies and is useful for validating that the packaged policy still behaves
+correctly when driven through the deployment stack instead of the training stack.
+
+Run the deployment script with the task name and the exported LEAPP ``.yaml`` file. Use the
+same backend extra and backend selector that you used for training and export, and pass a
+``--viz`` option when you want a viewport:
+
+.. tab-set::
+   :sync-group: os
+
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. tab-set::
+
+         .. tab-item:: uv (Recommended)
+
+            .. code-block:: bash
+
+               # Newton backend (kitless)
+               uv run --extra leapp python \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz newton_gl physics=newton_mjwarp
+
+               # OV PhysX backend
+               uv run --extra ovphysx,leapp python \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz kit physics=ovphysx
+
+               # Isaac Sim PhysX backend
+               OMNI_KIT_ACCEPT_EULA=Y ACCEPT_EULA=Y uv run --extra isaacsim,leapp python \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz kit physics=isaacsim_physx
+
+         .. tab-item:: isaaclab.sh / isaaclab.bat
+
+            .. code-block:: bash
+
+               # Newton backend (kitless)
+               ./isaaclab.sh -p \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz newton_gl physics=newton_mjwarp
+
+               # OV PhysX backend
+               ./isaaclab.sh -p \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz kit physics=ovphysx
+
+               # Isaac Sim PhysX backend
+               OMNI_KIT_ACCEPT_EULA=Y ACCEPT_EULA=Y ./isaaclab.sh -p \
+                   scripts/reinforcement_learning/leapp/deploy.py \
+                   --task <TASK_NAME> \
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+                   --viz kit physics=isaacsim_physx
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. tab-set::
+
+         .. tab-item:: uv (Recommended)
+
+            .. code-block:: batch
+
+               :: Newton backend (kitless)
+               uv run --extra leapp python scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz newton_gl physics=newton_mjwarp
+
+               :: OV PhysX backend
+               uv run --extra ovphysx,leapp python scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz kit physics=ovphysx
+
+               :: Isaac Sim PhysX backend
+               set OMNI_KIT_ACCEPT_EULA=Y
+               set ACCEPT_EULA=Y
+               uv run --extra isaacsim,leapp python scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz kit physics=isaacsim_physx
+
+         .. tab-item:: isaaclab.sh / isaaclab.bat
+
+            .. code-block:: batch
+
+               :: Newton backend (kitless)
+               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz newton_gl physics=newton_mjwarp
+
+               :: OV PhysX backend
+               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz kit physics=ovphysx
+
+               :: Isaac Sim PhysX backend
+               set OMNI_KIT_ACCEPT_EULA=Y
+               set ACCEPT_EULA=Y
+               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
+                   --task <TASK_NAME> ^
+                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
+                   --viz kit physics=isaacsim_physx
+
+
+What the Deployment Environment Does
+------------------------------------
+
+The deployment environment loads the task scene and then bypasses the training-time
+observation, action, reward, termination, and curriculum managers. It reads the scene
+objects and commands identified by the ``isaaclab_connection`` metadata in the LEAPP YAML,
+uses them as inputs to the exported policy pipeline, and runs that pipeline through
+LEAPP's ``InferenceManager``. The resulting outputs are written back to the mapped scene
+entities.
+
+Match the Training and Export Configuration
+-------------------------------------------
+
+The deployment script rebuilds the task configuration from ``--task``. It cannot infer the
+training configuration from the checkpoint or LEAPP YAML, so you must provide the same
+configuration selections used for training and export. The task name, LEAPP YAML, and
+checkpoint must describe the same policy.
+
+Carry these settings through **training**, **export**, and **deployment**:
+
+* **Task and Hydra overrides:** use the same task name and every configuration override that
+  changes the scene, robot, sensors, command terms, observation/action term configuration,
+  reset behavior, or simulation timing (``sim.dt`` and ``decimation``).
+* **Physics and renderer presets:** pass the same backend selectors when you selected a
+  non-default backend. For example, a policy trained and exported with
+  ``physics=newton_mjwarp`` must also be deployed with ``physics=newton_mjwarp``; the same
+  applies to the untyped ``presets=<PRESET_NAME>`` form.
+* **Seed, when applicable:** use the same ``--seed`` when reproducible command sampling,
+  reset events, or other randomized task behavior matters to your validation.
+
+For example, append the preset after the deployment options:
+
+.. code-block:: bash
+
+   uv run --extra leapp python \
+       scripts/reinforcement_learning/leapp/deploy.py \
+       --task Isaac-Humanoid \
+       --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+       --viz newton_gl \
+       presets=newton_mjwarp
+
+Visualization Options
+^^^^^^^^^^^^^^^^^^^^^
+
+Visualization does not change the policy or its LEAPP inputs. Omit ``--viz`` for headless
+execution, use ``--viz kit`` for the Omniverse Kit viewport, or select ``newton_gl``,
+``newton_rtx`` (experimental), ``rerun``, or ``viser`` when those visualizers are installed.
+Use ``--viz none`` to explicitly disable all visualizers, and ``--max_visible_envs <COUNT>``
+to limit displayed environments. Choose a visualizer compatible with the selected physics and
+renderer backend.
+
+.. note::
+
+   For Direct workflow policies, see the
+   :doc:`Direct workflow export guide <exporting_direct_workflow_policies_with_leapp>`.
+   Direct workflow policies are not supported by ``LeappDeploymentEnv``.

--- a/docs/source/policy_deployment/05_leapp/exporting_direct_workflow_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_direct_workflow_policies_with_leapp.rst
@@ -1,19 +1,18 @@
-Exporting Direct Workflow Policies with LEAPP
-=============================================
+Export Direct-Workflow Policies with LEAPP
+==========================================
 
 .. currentmodule:: isaaclab
 
-This tutorial shows how to prepare a Direct workflow policy for export with
-LEAPP. If your policy is manager-based, use the
-:doc:`manager-based LEAPP export guide </source/policy_deployment/05_leapp/exporting_policies_with_leapp>`
-instead.
+This advanced tutorial shows how to prepare a Direct workflow policy for export
+with LEAPP. If your policy is manager-based, follow the
+:doc:`standard LEAPP deployment workflow <exporting_policies_with_leapp>` instead.
 
 For background on LEAPP concepts, supported node patterns, state feedback, and
 runtime validation, see the `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`__.
 
 
-Overview
-~~~~~~~~
+Quick Start
+~~~~~~~~~~~
 
 To export a Direct workflow policy with LEAPP, you add LEAPP annotations to the
 environment code. During export, LEAPP traces the annotated tensors and builds an
@@ -144,7 +143,7 @@ exported artifacts. If you omit it, the export is written next to the checkpoint
    ``scripts/reinforcement_learning/leapp/deploy.py``.
 
 For more information on the export arguments, see the
-:doc:`manager-based LEAPP export guide </source/policy_deployment/05_leapp/exporting_policies_with_leapp>`.
+:doc:`standard LEAPP deployment workflow <exporting_policies_with_leapp>`.
 
 
 .. dropdown:: Full example script
@@ -152,7 +151,7 @@ For more information on the export arguments, see the
 
    .. literalinclude:: ../../../../scripts/tutorials/06_deploy/anymal_c_env.py
       :language: python
-      :emphasize-lines: 20, 75-77, 92-107
+      :emphasize-lines: 21, 82-83, 98-113
       :linenos:
 
 
@@ -263,9 +262,10 @@ Semantic Annotations
 
 This example covers the minimum annotations needed to trace the pipeline. In
 more advanced export workflows, you may also want to attach semantic metadata
-so downstream runtimes know what each tensor represents.
+so downstream runtimes know what each tensor represents. Semantic Annotations
+is a prerequisite for being able to deploy to a downstream deployment library.
 
-For direct environments, semantic annotations are optional and should be
+For direct environments, semantic annotations are optional and need to be
 authored explicitly by the user. Unlike the manager-based export path, Isaac Lab
 does not infer tensor semantics automatically for direct environments, instead it
 is up to the user to provide this data. LEAPP provides this through

--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -1,9 +1,9 @@
-Exporting Policies with LEAPP
-=============================
+Deploy Policies with LEAPP
+==========================
 
 .. currentmodule:: isaaclab
 
-This guide covers how to export trained reinforcement learning policies from Isaac Lab using
+This guide covers how to export and deploy trained reinforcement learning policies from Isaac Lab using
 `LEAPP <https://nvidia-isaac.github.io/leapp/>`__ (Lightweight Export Annotations for Policy Pipelines).
 The main goal of the LEAPP export path is to package a policy together with the input and output
 semantics needed for deployment, so downstream users do not need to reimplement Isaac Lab
@@ -11,15 +11,43 @@ observation preprocessing, action postprocessing, or recurrent-state handling by
 
 The Isaac Lab LEAPP exporter traces the data flowing between the policy and the simulation,
 capturing the operations applied along the way. It also embeds semantic metadata for the exported
-policy inputs and outputs. In practice, this makes the exported policy a better fit for Isaac
-deployment libraries. Isaac Lab can already consume these exports through
-:class:`~envs.LeappDeploymentEnv`.
+policy inputs and outputs. Isaac Lab can consume these exports through :class:`~envs.LeappDeploymentEnv`.
+
+Supported Workflows
+-------------------
+
+**Manager-based RL environments:** The standard export and deployment workflow supports manager-based RL environments
+(``ManagerBasedRLEnv``) trained with ``rsl_rl``, ``rl_games``, ``skrl``, or
+``sb3``. It exports the policy from a manager-based environment and
+deploys it through :class:`~envs.LeappDeploymentEnv`.
+
+**Physics backend:** The manager-based exporter relies on the environment's manager interfaces and does
+not select a physics backend itself. This includes **Newton** for tasks that expose a Newton
+preset. The LEAPP integration test creates an RSL-RL ``Isaac-Humanoid`` checkpoint and exports it
+with **Isaac Sim PhysX** (``presets=isaacsim_physx``) and **Newton MJWarp**
+(``presets=newton_mjwarp``). When its optional runtime is installed, the same test also covers
+**OV PhysX** (``presets=ovphysx``).
+
+You do not need to specify a preset when using the task's default backend. To select a backend,
+append its ``presets=<PRESET_NAME>`` argument to both the training and export commands. Use the
+same preset for both commands so the export recreates the environment configuration used by the
+checkpoint.
+
+**Direct RL environments:** ``DirectRLEnv`` environments can be exported with the RSL-RL workflow
+after you add LEAPP annotations; see the advanced
+:doc:`Direct workflow export guide <exporting_direct_workflow_policies_with_leapp>`.
+They are not supported by :class:`~envs.LeappDeploymentEnv`.
+
+.. toctree::
+   :hidden:
+
+   exporting_direct_workflow_policies_with_leapp
+   deploying_exported_policies_with_leapp
 
 .. note::
 
-   This export path currently supports **manager-based RL environments** (``ManagerBasedRLEnv``)
-   trained with **RSL-RL**, **RL-Games**, **skrl**, or **Stable-Baselines3**. Other environments
-   are not yet supported.
+   For more information on LEAPP, please visit the
+   `LEAPP documentation <https://nvidia-isaac.github.io/leapp/>`__.
 
 
 Prerequisites
@@ -38,6 +66,27 @@ integration available; ``physics=...`` selects it for the task:
 
 See :ref:`uv-run-training` and :ref:`installation-optional-extras` for the full
 extras model used by training and play.
+
+
+Quick Start
+-----------
+
+Export a trained policy, then launch the exported policy in Isaac Lab:
+
+.. code-block:: bash
+
+   uv run --extra leapp python \
+       scripts/reinforcement_learning/leapp/<RL_LIBRARY>/export.py \
+       --task <TASK_NAME>
+
+   uv run --extra leapp python \
+       scripts/reinforcement_learning/leapp/deploy.py \
+       --task <TASK_NAME> \
+       --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
+       --viz kit
+
+Continue with the sections below to select a different RL library, configure the
+export, and validate the generated artifacts.
 
 
 Why Export with LEAPP
@@ -288,7 +337,7 @@ The export script performs the following steps:
    downstream runtimes, and optionally validates that the exported model reproduces the traced
    outputs.
 
-The patching is transparent to the policy — no changes to your training code or environment
+The patching is transparent to the policy; no changes to your training code or environment
 configuration are needed.
 
 .. warning::
@@ -298,76 +347,29 @@ configuration are needed.
 
    - **Dynamic control flow** is not supported when the condition depends on runtime tensor
      values, such as tensor-dependent ``if``, ``for``, or ``while`` logic.
-   - **Complex slicing** is not fully supported. Examples include dynamic masked indexing
-     using multiple traced tensors such as ``tensor[traced1, traced2]``. Slicing with constant values
-     or with a single traced tensor is supported such as ``tensor[mask]`` or ``tensor[1:5]``.
    - **Critical traced operations should avoid unsupported third-party libraries.** PyTorch
      operations are the best-supported path. NumPy conversions inside the traced node can be
      captured when they do not cross the graph boundary, but external library calls may not be
-     traceable. Warp operations are not supported by this export path.
+     traceable. Warp operations will be supported in the future by this export path.
 
 
 Verifying an Export
 -------------------
 
-After export, we recommend validating the result in three ways.
+Verify an export in the following order:
 
-1. **Use LEAPP's automatic verification on seen traced data.**
-2. **Inspect the generated graph visualization.**
-3. **Read the LEAPP log carefully, especially when the export fails or emits warnings.**
+1. **Run automatic validation.** Keep ``--validation_steps`` greater than zero so LEAPP
+   can replay the traced rollout and compare the exported artifact with the original policy.
+   This catches conversion errors, unsupported operations, output mismatches, and common
+   feedback-state issues.
 
-Automatic Verification on Seen Data
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2. **Inspect the generated graph.** Open the graph PNG to confirm the expected inputs,
+   outputs, and feedback edges are present. Keep graph generation enabled while developing
+   a new export path; use ``--disable_graph_visualization`` only when you do not need it.
 
-By default, Isaac Lab asks LEAPP to validate the exported model after compilation. LEAPP does
-this by replaying the data it already saw during the traced rollout and checking that the
-exported artifact reproduces the same outputs.
-
-This is a strong first-line check because it is good at catching export-time issues such as:
-
-- backend conversion problems
-- unsupported or incorrectly lowered operators
-- output shape or dtype mismatches
-- numerical discrepancies between the original policy and the exported artifact
-- recurrent or feedback-state handling mistakes that show up during replay
-
-This validation is controlled by ``--validation_steps``. Setting it to a positive value gives
-LEAPP rollout data to validate against. Setting it to ``0`` skips this automatic check, which
-is useful for debugging but not recommended for normal export workflows.
-
-Inspect the Graph Visualization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-LEAPP can generate a diagram of the exported pipeline as part of ``compile_graph()``. Even when
-automatic verification passes, it is still worth opening the diagram and doing a quick visual
-inspection.
-
-This is especially useful for catching structural issues such as:
-
-- missing inputs or outputs
-- unexpected extra nodes
-- incorrect feedback edges
-- naming mistakes that make deployment harder to reason about
-
-You can disable the diagram with ``--disable_graph_visualization``, but we recommend keeping it
-enabled while developing and validating a new export path.
-
-Inspect the LEAPP Log
-^^^^^^^^^^^^^^^^^^^^^
-
-If something breaks, the LEAPP-generated log is usually the best place to determine exactly what
-happened. Read it closely and pay attention to both hard errors and warnings.
-
-The log is useful for diagnosing issues such as:
-
-- export backend failures
-- warnings about graph construction or validation
-- missing metadata
-- unsupported model patterns
-- file generation problems
-
-In practice, this should be your first stop when the export does not complete or when the output
-artifacts do not look correct.
+3. **Review the LEAPP log.** When validation fails or the artifacts look unexpected, the
+   log is the best starting point for backend errors, missing metadata, and unsupported
+   model patterns.
 
 Use the default ``onnx-dynamo`` backend unless your
 downstream runtime or workflow requires another format. Backend support can vary by model, so if
@@ -375,18 +377,6 @@ one backend fails, try another backend that produces an acceptable artifact form
 
 For details on ONNX, JIT, and PT2 export formats, see the
 `LEAPP export guide <https://nvidia-isaac.github.io/leapp/guides/export.html>`__.
-
-
-Export Backends
-^^^^^^^^^^^^^^^
-
-The ``--export_method`` argument controls how the policy network is serialized:
-
-- **onnx-dynamo** (default) — Uses ``torch.onnx.dynamo_export``. Best compatibility with
-  modern PyTorch features.
-- **onnx-torchscript** — Uses the legacy ``torch.onnx.export`` path. May be needed for
-  certain model architectures.
-- **jit-script** / **jit-trace** — Produces TorchScript ``.pt`` files instead of ONNX.
 
 
 Recurrent Policies
@@ -399,137 +389,8 @@ hidden state values are saved in the ``.safetensors`` file. Other recurrent arch
 not currently supported by these exporters.
 
 
-Running the Exported Policy in Simulation
------------------------------------------
-
-Isaac Lab provides :class:`~envs.LeappDeploymentEnv` for running exported policies back in
-simulation without the training infrastructure. This is the Isaac Lab deployment path for
-LEAPP-exported policies and is useful for validating that the packaged policy still behaves
-correctly when driven through the deployment stack instead of the training stack.
-
-Run the deployment script with the task name and the exported LEAPP ``.yaml`` file.
-Use the same backend extra pattern as training and export.
-
-By default, Isaac Lab launches headless when no visualization option is selected. If you expect
-to see the policy running in a viewport, pass a visualization option such as ``--viz newton``
-or ``--viz kit``:
-
-.. tab-set::
-   :sync-group: os
-
-   .. tab-item:: :icon:`fa-brands fa-linux` Linux
-      :sync: linux
-
-      .. tab-set::
-
-         .. tab-item:: uv (Recommended)
-
-            .. code-block:: bash
-
-               # Newton backend (kitless)
-               uv run --extra leapp python \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz newton physics=newton_mjwarp
-
-               # OV PhysX backend
-               uv run --extra ovphysx,leapp python \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz kit physics=ovphysx
-
-               # Isaac Sim PhysX backend
-               OMNI_KIT_ACCEPT_EULA=Y ACCEPT_EULA=Y uv run --extra isaacsim,leapp python \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz kit physics=isaacsim_physx
-
-         .. tab-item:: isaaclab.sh / isaaclab.bat
-
-            .. code-block:: bash
-
-               # Newton backend (kitless)
-               ./isaaclab.sh -p \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz newton physics=newton_mjwarp
-
-               # OV PhysX backend
-               ./isaaclab.sh -p \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz kit physics=ovphysx
-
-               # Isaac Sim PhysX backend
-               OMNI_KIT_ACCEPT_EULA=Y ACCEPT_EULA=Y ./isaaclab.sh -p \
-                   scripts/reinforcement_learning/leapp/deploy.py \
-                   --task <TASK_NAME> \
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-                   --viz kit physics=isaacsim_physx
-
-   .. tab-item:: :icon:`fa-brands fa-windows` Windows
-      :sync: windows
-
-      .. tab-set::
-
-         .. tab-item:: uv (Recommended)
-
-            .. code-block:: batch
-
-               :: Newton backend (kitless)
-               uv run --extra leapp python scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz newton physics=newton_mjwarp
-
-               :: OV PhysX backend
-               uv run --extra ovphysx,leapp python scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz kit physics=ovphysx
-
-               :: Isaac Sim PhysX backend
-               set OMNI_KIT_ACCEPT_EULA=Y
-               set ACCEPT_EULA=Y
-               uv run --extra isaacsim,leapp python scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz kit physics=isaacsim_physx
-
-         .. tab-item:: isaaclab.sh / isaaclab.bat
-
-            .. code-block:: batch
-
-               :: Newton backend (kitless)
-               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz newton physics=newton_mjwarp
-
-               :: OV PhysX backend
-               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz kit physics=ovphysx
-
-               :: Isaac Sim PhysX backend
-               set OMNI_KIT_ACCEPT_EULA=Y
-               set ACCEPT_EULA=Y
-               isaaclab.bat -p scripts\reinforcement_learning\leapp\deploy.py ^
-                   --task <TASK_NAME> ^
-                   --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> ^
-                   --viz kit physics=isaacsim_physx
-
-For Direct workflow policies, see the
-:doc:`Direct workflow LEAPP export tutorial </source/tutorials/06_exporting/exporting_direct_workflow_policies_with_leapp>`.
-That guide shows how to add LEAPP annotations to a direct RL environment so it can be
-exported with ``scripts/reinforcement_learning/leapp/rsl_rl/export.py``. Direct
-workflow policies are not currently supported by ``scripts/reinforcement_learning/leapp/deploy.py``.
+To run an exported policy in Isaac Lab, see the
+:doc:`deployment guide <deploying_exported_policies_with_leapp>`.
 
 
 Further Reading

--- a/docs/source/setup/installation/asset_caching_details.inc
+++ b/docs/source/setup/installation/asset_caching_details.inc
@@ -120,8 +120,8 @@ Isaac Lab launchers and asset helpers apply the profile automatically. A standal
 
 .. note::
    The China service mirrors a subset of the global asset set, and that subset can change between releases.
-   Check the `Isaac 6.0 asset availability manifest
-   <https://assets.simready.cn/manifests/isaac/6.0/asset-availability.csv>`__ before choosing an asset. The manifest lists
+   Check the `Isaac 6.1 asset availability manifest
+   <https://assets.simready.cn/manifests/isaac/6.1/asset-availability.csv>`__ before choosing an asset. The manifest lists
    service path records relative to the versioned ``Isaac`` folder. A path with no row is not mirrored, and a listed
    path must have an ``available`` status to load from the service. Use an available asset or a local asset pack when
    needed.

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -108,14 +108,3 @@ tutorials show you how to use motion generators to control the robots at the tas
 
     05_controllers/run_diff_ik
     05_controllers/run_osc
-
-Exporting Policies
-------------------
-
-The following tutorial shows how to prepare a Direct workflow policy for export with LEAPP.
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    06_exporting/exporting_direct_workflow_policies_with_leapp

--- a/source/isaaclab/changelog.d/china-storage-profile-6-1.rst
+++ b/source/isaaclab/changelog.d/china-storage-profile-6-1.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Updated the China storage profile to the Isaac Sim 6.1 asset set. Check the 6.1 availability
+  manifest before using mirrored assets.

--- a/source/isaaclab/changelog.d/fix-usd-frame-view-float-scale.rst
+++ b/source/isaaclab/changelog.d/fix-usd-frame-view-float-scale.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.sim.views.UsdFrameView` rejecting legal ``float3``-typed
+  ``xformOp:scale`` values while initializing a Fabric frame view.

--- a/source/isaaclab/isaaclab/sim/views/usd_frame_view.py
+++ b/source/isaaclab/isaaclab/sim/views/usd_frame_view.py
@@ -347,7 +347,7 @@ class UsdFrameView(BaseFrameView):
         scales = Vt.Vec3dArray(len(indices_list))
         for idx, prim_idx in enumerate(indices_list):
             prim = self._prims[prim_idx]
-            scales[idx] = prim.GetAttribute("xformOp:scale").Get()
+            scales[idx] = Gf.Vec3d(prim.GetAttribute("xformOp:scale").Get())
 
         return ProxyArray(wp.array(np.array(scales, dtype=np.float32), dtype=wp.float32, device=self._device))
 

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -52,7 +52,7 @@ _KIT_ASSET_ROOT_SETTINGS = ("default", "cloud")
 
 _STORAGE_PROFILE_ENV_VAR = "ISAACSIM_STORAGE_PROFILE"
 # Update this value when the China mirror moves to a new Isaac Sim asset release.
-_ISAAC_SIM_ASSET_RELEASE = "6.0"
+_ISAAC_SIM_ASSET_RELEASE = "6.1"
 _CHINA_STORAGE_ENDPOINT = "simready-cn.s3.oss-cn-shanghai.aliyuncs.com"
 
 

--- a/source/isaaclab/test/sim/test_views_xform_prim.py
+++ b/source/isaaclab/test/sim/test_views_xform_prim.py
@@ -186,6 +186,36 @@ def test_prim_ordering_follows_creation_order(device):
 
 
 @pytest.mark.parametrize("device", test_devices())
+@pytest.mark.parametrize(
+    ("scale_precision", "scale_value"),
+    [
+        (UsdGeom.XformOp.PrecisionHalf, Gf.Vec3h(0.25, 0.5, 0.75)),
+        (UsdGeom.XformOp.PrecisionFloat, Gf.Vec3f(0.01, 0.02, 0.03)),
+        (UsdGeom.XformOp.PrecisionDouble, Gf.Vec3d(0.01, 0.02, 0.03)),
+    ],
+    ids=["half3", "float3", "double3"],
+)
+def test_local_scales_accept_all_usd_precisions(device, scale_precision, scale_value):
+    """Scale reads normalize every legal USD precision without changing the FP32 view contract."""
+    stage = sim_utils.get_current_stage()
+    prim = stage.DefinePrim("/World/ScaledPrim", "Xform")
+    xformable = UsdGeom.Xformable(prim)
+    xformable.AddTranslateOp().Set(Gf.Vec3d(0.0))
+    xformable.AddOrientOp(UsdGeom.XformOp.PrecisionFloat).Set(Gf.Quatf(1.0, Gf.Vec3f(0.0)))
+    xformable.AddScaleOp(scale_precision).Set(scale_value)
+
+    view = FrameView("/World/ScaledPrim", device=device)
+    assert isinstance(prim.GetAttribute("xformOp:scale").Get(), type(scale_value))
+
+    expected = torch.tensor([[float(value) for value in scale_value]], dtype=torch.float32, device=device)
+    scales = view.get_local_scales()
+    assert scales.shape == (1, 3)
+    assert scales.warp.dtype == wp.float32
+    assert scales.torch.dtype == torch.float32
+    torch.testing.assert_close(scales.torch, expected, atol=1e-6, rtol=0)
+
+
+@pytest.mark.parametrize("device", test_devices())
 def test_standardize_transform_op(device):
     """FrameView standardizes a prim with xformOp:transform to translate/orient/scale."""
     if device == "cuda" and not torch.cuda.is_available():

--- a/source/isaaclab_ov/changelog.d/jichuanh-ovphysx-derived-data-cache-dir.minor.rst
+++ b/source/isaaclab_ov/changelog.d/jichuanh-ovphysx-derived-data-cache-dir.minor.rst
@@ -1,0 +1,13 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab_ov.physics.OvPhysxCfg.cooked_collider_cache_dir` to select where OVPhysX
+  writes its cooked-collider cache. It defaults to a per-user directory under the system temporary
+  directory, so cooked colliders are reusable across runs from that directory. Set it to ``None`` to
+  use the runtime default.
+
+Fixed
+^^^^^
+
+* Fixed OvPhysX writing its cooked-collider cache into the directory holding the Python interpreter,
+  which logged ``omni.datastore`` errors when that directory was not writable.

--- a/source/isaaclab_ov/changelog.d/pv-ovrtx-warp-device-cache.rst
+++ b/source/isaaclab_ov/changelog.d/pv-ovrtx-warp-device-cache.rst
@@ -1,0 +1,13 @@
+Fixed
+^^^^^
+
+* Fixed the OVRTX renderer re-deriving its CUDA device per call site from the device string, which
+  split a bare ``"cuda"`` across GPUs on multi-GPU processes: render-product device ids parsed it
+  to device 0 while Warp resolved kernel launches and sync streams on its current CUDA device. The
+  renderer now resolves the Warp device once when the render spec arrives, normalizes its device
+  string from it, and derives the render-product device ids and every CUDA sync stream — attribute
+  writes on both the legacy and ovstage paths, and render-var reads — from the cached device.
+
+* Updated ``map_attribute_for_warp_writes`` to accept a resolved Warp device as well as its string
+  alias, preserving the release branch's mapped-write path while keeping its mapping and stream on
+  the same device.

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -16,7 +16,9 @@ import atexit
 import contextlib
 import logging
 import math
+import os
 import re
+import stat
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -39,12 +41,46 @@ from isaaclab_ov._clone import CloneTransform, clone_transforms_from_positions
 from isaaclab_ov._runtime import import_ovphysx
 from isaaclab_ov.stage import create_ovstage
 
+from .ovphysx_manager_cfg import DEFAULT_COOKED_COLLIDER_CACHE_DIR
+
 if TYPE_CHECKING:
     from isaaclab.sim.simulation_context import SimulationContext
 
     from .ovphysx_manager_cfg import OvPhysxCfg
 
 __all__ = ["OvPhysxManager", "OvPhysxSceneDataBackend"]
+
+
+def _prepare_default_cache_dir(cache_dir: str) -> str:
+    """Create the default cooked-collider cache directory and refuse one this user does not own.
+
+    The default sits in the shared temporary directory, so any local user can pre-create the path;
+    OVPhysX follows a symlink there and writes through it. A directory the caller configured is
+    their own choice and is passed through untouched.
+
+    Args:
+        cache_dir: Default cache directory to create or validate.
+
+    Returns:
+        The validated directory.
+
+    Raises:
+        RuntimeError: If the path exists as a symlink, a non-directory, or another user's directory.
+    """
+    try:
+        os.makedirs(cache_dir, mode=0o700)
+        return cache_dir
+    except FileExistsError:
+        pass
+    entry = os.lstat(cache_dir)
+    if stat.S_ISLNK(entry.st_mode):
+        raise RuntimeError(f"OVPhysX cache directory '{cache_dir}' is a symlink; refusing to write through it.")
+    if not stat.S_ISDIR(entry.st_mode):
+        raise RuntimeError(f"OVPhysX cache directory '{cache_dir}' exists and is not a directory.")
+    if hasattr(os, "getuid") and entry.st_uid != os.getuid():
+        raise RuntimeError(f"OVPhysX cache directory '{cache_dir}' is owned by another user; refusing to use it.")
+    return cache_dir
+
 
 logger = logging.getLogger(__name__)
 
@@ -973,7 +1009,12 @@ class OvPhysxManager(PhysicsManager):
         """
         ovphysx = import_ovphysx()
         ovphysx.bootstrap()
-        cls._physx = cls._create_physx_instance(ovphysx, ovphysx_device, gpu_index)
+        # The runtime is also constructed outside a configured simulation, where no cfg exists.
+        cfg = PhysicsManager._cfg
+        cache_dir = DEFAULT_COOKED_COLLIDER_CACHE_DIR if cfg is None else cfg.cooked_collider_cache_dir
+        if cache_dir == DEFAULT_COOKED_COLLIDER_CACHE_DIR:
+            cache_dir = _prepare_default_cache_dir(cache_dir)
+        cls._physx = cls._create_physx_instance(ovphysx, ovphysx_device, gpu_index, cache_dir)
         if not cls._atexit_registered:
             # Globally retained environments may otherwise keep TensorBinding DLPack
             # caches alive until Python module finalization. Normal atexit cleanup runs
@@ -1001,13 +1042,17 @@ class OvPhysxManager(PhysicsManager):
             logger.exception("Failed to close OVPhysX during process exit.")
 
     @staticmethod
-    def _create_physx_instance(ovphysx: Any, ovphysx_device: str, gpu_index: int) -> Any:
+    def _create_physx_instance(
+        ovphysx: Any, ovphysx_device: str, gpu_index: int, cooked_collider_cache_dir: str | None
+    ) -> Any:
         """Create a PhysX instance through the pinned OVPhysX runtime API.
 
         Args:
             ovphysx: Imported OVPhysX runtime module.
             ovphysx_device: Physics device, either ``"cpu"`` or ``"gpu"``.
             gpu_index: CUDA device ordinal selected for GPU physics.
+            cooked_collider_cache_dir: Directory for the cooked-collider cache, or ``None`` to let
+                OVPhysX resolve it.
 
         Returns:
             The configured ``ovphysx.PhysX`` instance.
@@ -1028,7 +1073,11 @@ class OvPhysxManager(PhysicsManager):
             )
         ovphysx.PhysX.set_cpu_mode(ovphysx_device == "cpu")
         physx_kwargs = {
-            "config": ovphysx.PhysXConfig(num_threads=8, carbonite_overrides=carbonite_overrides),
+            "config": ovphysx.PhysXConfig(
+                num_threads=8,
+                cooked_collider_cache_dir=cooked_collider_cache_dir,
+                carbonite_overrides=carbonite_overrides,
+            ),
         }
         if ovphysx_device == "gpu":
             physx_kwargs["active_cuda_gpus"] = str(gpu_index)

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager_cfg.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager_cfg.py
@@ -7,8 +7,17 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
+
 from isaaclab.physics import PhysicsCfg
 from isaaclab.utils.configclass import configclass
+
+# POSIX temp roots are shared between users; Windows already gives each user a private one.
+_CACHE_DIR_NAME = f"ovphysx_derived_data_cache_{os.getuid()}" if hasattr(os, "getuid") else "ovphysx_derived_data_cache"
+
+DEFAULT_COOKED_COLLIDER_CACHE_DIR: str = os.path.join(tempfile.gettempdir(), _CACHE_DIR_NAME)
+"""Fallback cache directory used when the runtime is constructed without an :class:`OvPhysxCfg`."""
 
 
 @configclass
@@ -21,6 +30,16 @@ class OvPhysxCfg(PhysicsCfg):
     """
 
     class_type = "{DIR}.ovphysx_manager:OvPhysxManager"
+
+    cooked_collider_cache_dir: str | None = DEFAULT_COOKED_COLLIDER_CACHE_DIR
+    """Directory for the OVPhysX cooked-collider cache, defaulting to a per-user directory under the
+    system temporary directory. Set to ``None`` to use the runtime default.
+
+    The datastore is created once per process, so the first OVPhysX construction fixes the location and a
+    later config does not relocate it. The runtime garbage collects the cache against a disk budget;
+    deleting the directory reclaims the space immediately, and a system temporary directory may also be
+    purged between boots.
+    """
 
     enable_enhanced_determinism: bool = False
     """Enable/disable improved determinism at the expense of performance. Defaults to False.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_mapping.py
@@ -44,7 +44,7 @@ def cuda_device_id(device: str) -> int:
 
 
 @contextmanager
-def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iterator[wp.array]:
+def map_attribute_for_warp_writes(binding: Any, device: wp.Device | str, dtype: Any) -> Iterator[wp.array]:
     """Map ``binding`` for CUDA writes and yield its buffer as a Warp array; commit after the fill.
 
     The caller fills the yielded array with Warp work enqueued on ``device``'s current stream (the
@@ -55,7 +55,7 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
 
     Args:
         binding: OVRTX attribute binding (from ``bind_attribute``) whose buffer is written.
-        device: Warp CUDA device the fill work runs on (e.g. ``"cuda:0"``).
+        device: Warp CUDA device, or its string alias, on which the fill work runs.
         dtype: Warp dtype the mapped tensor is viewed as (e.g. ``wp.mat44d``).
 
     Yields:
@@ -67,8 +67,9 @@ def map_attribute_for_warp_writes(binding: Any, device: str, dtype: Any) -> Iter
     # already imported by the time this runs.
     from ovrtx import Device  # noqa: PLC0415
 
-    attr_mapping = binding.map(device=Device.CUDA, device_id=cuda_device_id(device))
+    warp_device = wp.get_device(device)
+    attr_mapping = binding.map(device=Device.CUDA, device_id=warp_device.ordinal)
     try:
         yield wp.from_dlpack(attr_mapping.tensor, dtype=dtype)
     finally:
-        attr_mapping.unmap(stream=wp.get_stream(device).cuda_stream)
+        attr_mapping.unmap(stream=warp_device.stream.cuda_stream)

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -85,7 +85,7 @@ from .ovrtx_annotator_utils import (
     decode_stable_id_map,
     decode_stable_id_semantic_id_map,
 )
-from .ovrtx_mapping import cuda_device_id, map_attribute_for_warp_writes
+from .ovrtx_mapping import map_attribute_for_warp_writes
 from .ovrtx_renderer_cfg import OVRTXRendererCfg
 from .ovrtx_renderer_kernels import (
     compute_cable_points_world_kernel,
@@ -304,7 +304,10 @@ class OVRTXRenderer(BaseRenderer):
 
     def __init__(self, cfg: OVRTXRendererCfg):
         self.cfg = cfg
-        self._device = "cuda:0"
+        self._device = "cuda:0"  # default; overridden by create_render_data(spec)
+        # Resolved by create_render_data(spec); every render-product device id and CUDA sync stream
+        # derives from this one cached device so a bare "cuda" cannot be re-interpreted per call site.
+        self._warp_device: wp.Device | None = None
         self._render_product_paths = []
         self._object_newton_indices: wp.array | None = None
         self._object_scales: wp.array | None = None
@@ -442,7 +445,7 @@ class OVRTXRenderer(BaseRenderer):
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
             camera_rel_path=self._camera_rel_path,
             background_color=getattr(spec.cfg, "background_color", None),
-            device_id=cuda_device_id(self._device),
+            device_id=self._warp_device.ordinal,
             enable_shadows=self.cfg.enable_shadows,
         )
         self._render_product_paths.append(render_product_path)
@@ -682,7 +685,10 @@ class OVRTXRenderer(BaseRenderer):
         )
 
     def create_render_data(self, spec: CameraRenderSpec) -> OVRTXRenderData:
-        self._device = spec.device
+        # Resolve the device once through Warp: a bare "cuda" pins to Warp's current CUDA device
+        # here, and the normalized string keeps every downstream consumer on that same device.
+        self._warp_device = wp.get_device(spec.device)
+        self._device = str(self._warp_device)
         if not self._initialized_scene:
             self._initialize_from_spec(spec)
         return OVRTXRenderData(spec, self._device)
@@ -716,7 +722,9 @@ class OVRTXRenderer(BaseRenderer):
         body_q = getattr(newton_state, "body_q", None)
         if body_q is None:
             return
-        with map_attribute_for_warp_writes(self._object_xform_binding, self._device, wp.mat44d) as ovrtx_transforms:
+        with map_attribute_for_warp_writes(
+            self._object_xform_binding, self._warp_device, wp.mat44d
+        ) as ovrtx_transforms:
             wp.launch(
                 kernel=sync_newton_transforms_kernel,
                 dim=len(self._object_newton_indices),
@@ -745,7 +753,7 @@ class OVRTXRenderer(BaseRenderer):
         self._cable_points_binding.write(
             cast(Any, self._cable_point_slices),
             data_access=DataAccess.ASYNC,
-            cuda_stream=wp.get_stream(self._device).cuda_stream,
+            cuda_stream=self._warp_device.stream.cuda_stream,
         )
 
     def _write_particle_q_slices(self, binding: Any, particle_offsets: list[int], particle_counts: list[int]) -> None:
@@ -763,7 +771,7 @@ class OVRTXRenderer(BaseRenderer):
         binding.write(
             cast(Any, particle_slices),
             data_access=DataAccess.ASYNC,
-            cuda_stream=wp.get_stream(self._device).cuda_stream,
+            cuda_stream=self._warp_device.stream.cuda_stream,
         )
 
     def _update_camera_legacy(
@@ -786,7 +794,9 @@ class OVRTXRenderer(BaseRenderer):
             device=self._device,
         )
         if self._camera_xform_binding is not None:
-            with map_attribute_for_warp_writes(self._camera_xform_binding, self._device, wp.mat44d) as transforms_view:
+            with map_attribute_for_warp_writes(
+                self._camera_xform_binding, self._warp_device, wp.mat44d
+            ) as transforms_view:
                 wp.copy(transforms_view, camera_transforms)
 
     def read_output(self, render_data: OVRTXRenderData, camera_data: CameraData) -> None:
@@ -808,7 +818,7 @@ class OVRTXRenderer(BaseRenderer):
     @contextlib.contextmanager
     def _map_render_var_to_dlpack(self, render_var: Any) -> Iterator[wp.array]:
         gpu_side_sync = _gpu_side_render_var_sync_enabled()
-        sync_stream = wp.get_stream(self._device).cuda_stream if gpu_side_sync else 0
+        sync_stream = self._warp_device.stream.cuda_stream if gpu_side_sync else 0
         with render_var.map(device=Device.CUDA, sync_stream=sync_stream) as mapping:
             if not gpu_side_sync:
                 mapping.wait()
@@ -1194,7 +1204,7 @@ class OVRTXRenderer(BaseRenderer):
             data_types=data_types,
             minimal_mode=_resolve_rtx_minimal_mode(data_types),
             camera_rel_path=self._camera_rel_path,
-            device_id=cuda_device_id(self._device),
+            device_id=self._warp_device.ordinal,
             enable_shadows=self.cfg.enable_shadows,
         )
         self._render_product_paths.append(render_product_path)
@@ -1420,7 +1430,7 @@ class OVRTXRenderer(BaseRenderer):
             tensors=xform_tensor_from_warp(transforms),
             is_array=False,
             semantic=ovstage.AttributeSemantic.MATRIX,
-            cuda_stream=wp.get_stream(self._device).cuda_stream,
+            cuda_stream=self._warp_device.stream.cuda_stream,
         ).wait()
 
     def _update_geometries_ovstage(self) -> None:
@@ -1459,7 +1469,7 @@ class OVRTXRenderer(BaseRenderer):
             tensors=tensors,
             is_array=True,
             semantic=ovstage.AttributeSemantic.POINT,
-            cuda_stream=wp.get_stream(self._device).cuda_stream,
+            cuda_stream=self._warp_device.stream.cuda_stream,
         ).wait()
 
     def _write_cable_points_ovstage(self) -> None:
@@ -1471,7 +1481,7 @@ class OVRTXRenderer(BaseRenderer):
             tensors=self._cable_point_tensors,
             is_array=True,
             semantic=ovstage.AttributeSemantic.POINT,
-            cuda_stream=wp.get_stream(self._device).cuda_stream,
+            cuda_stream=self._warp_device.stream.cuda_stream,
         ).wait()
 
     def _update_camera_ovstage(
@@ -1494,7 +1504,7 @@ class OVRTXRenderer(BaseRenderer):
                 tensors=xform_tensor_from_warp(transforms),
                 is_array=False,
                 semantic=ovstage.AttributeSemantic.MATRIX,
-                cuda_stream=wp.get_stream(self._device).cuda_stream,
+                cuda_stream=self._warp_device.stream.cuda_stream,
             ).wait()
 
     def _render_ovstage(self, render_data: OVRTXRenderData) -> None:

--- a/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
@@ -19,8 +19,9 @@ pytest.importorskip("ovphysx.types", reason="ovphysx wheel not installed")
 
 
 class _FakePhysXConfig:
-    def __init__(self, num_threads=None, carbonite_overrides=None):
+    def __init__(self, num_threads=None, cooked_collider_cache_dir=None, carbonite_overrides=None):
         self.num_threads = num_threads
+        self.cooked_collider_cache_dir = cooked_collider_cache_dir
         self.carbonite_overrides = carbonite_overrides or {}
 
 
@@ -419,3 +420,77 @@ def test_retained_binding_preserves_uncaught_failure_exit_status():
     assert "NORMAL_ATEXIT" in output, output[-8000:]
     assert "OVPHYSX_STOP" in output, output[-8000:]
     _assert_no_atexit_errors(output)
+
+
+def test_construct_physx_passes_the_configured_cooked_collider_cache_dir(monkeypatch, manager_module, tmp_path):
+    """The configured cache directory reaches ``PhysXConfig``; without a config the default does."""
+    from isaaclab_ov.physics.ovphysx_manager_cfg import DEFAULT_COOKED_COLLIDER_CACHE_DIR, OvPhysxCfg
+
+    from isaaclab.physics import PhysicsManager
+
+    manager = manager_module.OvPhysxManager
+    monkeypatch.setattr(manager_module, "import_ovphysx", lambda: _fake_ovphysx_module(lambda: None))
+
+    configured = str(tmp_path / "configured_cache")
+    monkeypatch.setattr(PhysicsManager, "_cfg", OvPhysxCfg(cooked_collider_cache_dir=configured))
+    manager._construct_physx("cpu", 0)
+    assert manager._physx.config.cooked_collider_cache_dir == configured
+
+    monkeypatch.setattr(PhysicsManager, "_cfg", None)
+    manager._physx = None
+    manager._construct_physx("cpu", 0)
+    assert manager._physx.config.cooked_collider_cache_dir == DEFAULT_COOKED_COLLIDER_CACHE_DIR
+
+
+def test_construct_physx_forwards_an_unset_cooked_collider_cache_dir(monkeypatch, manager_module):
+    """``None`` reaches ``PhysXConfig`` unchanged so OVPhysX applies its own resolution."""
+    from isaaclab_ov.physics.ovphysx_manager_cfg import OvPhysxCfg
+
+    from isaaclab.physics import PhysicsManager
+
+    manager = manager_module.OvPhysxManager
+    monkeypatch.setattr(manager_module, "import_ovphysx", lambda: _fake_ovphysx_module(lambda: None))
+    monkeypatch.setattr(PhysicsManager, "_cfg", OvPhysxCfg(cooked_collider_cache_dir=None))
+
+    manager._construct_physx("cpu", 0)
+
+    assert manager._physx.config.cooked_collider_cache_dir is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX ownership and mode semantics")
+def test_default_cache_dir_is_created_owner_only(manager_module, tmp_path, monkeypatch):
+    """The default directory is created ``0o700`` so another user cannot pre-own or read it."""
+    import stat
+
+    target = tmp_path / "ovphysx_derived_data_cache_1000"
+    monkeypatch.setattr(manager_module, "DEFAULT_COOKED_COLLIDER_CACHE_DIR", str(target))
+
+    assert manager_module._prepare_default_cache_dir(str(target)) == str(target)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX ownership and mode semantics")
+def test_default_cache_dir_rejects_a_planted_symlink(manager_module, tmp_path, monkeypatch):
+    """A symlink planted at the predictable path is refused instead of written through."""
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    target = tmp_path / "ovphysx_derived_data_cache_1000"
+    target.symlink_to(victim)
+    monkeypatch.setattr(manager_module, "DEFAULT_COOKED_COLLIDER_CACHE_DIR", str(target))
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        manager_module._prepare_default_cache_dir(str(target))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX ownership and mode semantics")
+def test_default_cache_dir_rejects_a_directory_owned_by_another_user(manager_module, tmp_path, monkeypatch):
+    """A pre-existing directory this user does not own is refused."""
+    import os as _os
+
+    target = tmp_path / "ovphysx_derived_data_cache_1000"
+    target.mkdir(mode=0o700)
+    monkeypatch.setattr(manager_module, "DEFAULT_COOKED_COLLIDER_CACHE_DIR", str(target))
+    monkeypatch.setattr(_os, "getuid", lambda: _os.stat(target).st_uid + 1)
+
+    with pytest.raises(RuntimeError, match="owned"):
+        manager_module._prepare_default_cache_dir(str(target))

--- a/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
@@ -366,9 +366,11 @@ def test_manager_forced_rewarm_invalidates_bindings_before_loading(monkeypatch):
     ("device", "gpu_index", "expected_cpu_mode", "expected_active_cuda_gpus"),
     [("cpu", 0, True, None), ("gpu", 2, False, "2")],
 )
-def test_manager_supports_pinned_runtime_api(device, gpu_index, expected_cpu_mode, expected_active_cuda_gpus):
+def test_manager_supports_pinned_runtime_api(tmp_path, device, gpu_index, expected_cpu_mode, expected_active_cuda_gpus):
     """The pinned OVPhysX wheel keeps its constructor, step, and reset API."""
     from isaaclab_ov.physics import OvPhysxManager
+
+    cache_dir = str(tmp_path / "cooked_colliders")
 
     class PinnedPhysX:
         cpu_mode = None
@@ -391,18 +393,24 @@ def test_manager_supports_pinned_runtime_api(device, gpu_index, expected_cpu_mod
         def wait_op(self, operation):
             self.calls.append(("wait_op", operation))
 
-    runtime = SimpleNamespace(
-        PhysX=PinnedPhysX,
-        PhysXConfig=lambda **kwargs: SimpleNamespace(**kwargs),
-    )
+    # Strict signature: a keyword the real wheel would reject fails here.
+    def pinned_config(*, num_threads=None, cooked_collider_cache_dir=None, carbonite_overrides=None):
+        return SimpleNamespace(
+            num_threads=num_threads,
+            cooked_collider_cache_dir=cooked_collider_cache_dir,
+            carbonite_overrides=carbonite_overrides,
+        )
 
-    physx = OvPhysxManager._create_physx_instance(runtime, device, gpu_index)
+    runtime = SimpleNamespace(PhysX=PinnedPhysX, PhysXConfig=pinned_config)
+
+    physx = OvPhysxManager._create_physx_instance(runtime, device, gpu_index, cache_dir)
     OvPhysxManager._step_physx(physx, dt=0.02)
     OvPhysxManager._reset_physx_stage(physx)
 
     assert PinnedPhysX.cpu_mode is expected_cpu_mode
     assert physx.constructor["active_cuda_gpus"] == expected_active_cuda_gpus
     assert physx.constructor["config"].num_threads == 8
+    assert physx.constructor["config"].cooked_collider_cache_dir == cache_dir
     assert physx.calls == [("step_sync", 0.02), ("reset_stage",), ("wait_op", 23)]
 
 

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -32,11 +32,13 @@ pytestmark = [
 
 if not _MISSING_MODULES:
     from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
+    from isaaclab_ov.renderers import ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer, _write_file  # noqa: E402
 
     from pxr import Sdf, Usd, UsdGeom, UsdShade  # noqa: E402
 else:
     OVRTXRenderer = None
+    ovrtx_renderer_module = None
     OVRTXRendererCfg = None
     Sdf = None
     Usd = None
@@ -100,6 +102,8 @@ def _make_ovrtx_renderer_without_backend() -> OVRTXRenderer:
     )
     renderer._clone_plan = None
     renderer._device = "cuda:0"  # __init__'s default, replaced by create_render_data(spec)
+    # create_render_data resolves this from the spec; tests that bypass it get the default.
+    renderer._warp_device = SimpleNamespace(ordinal=0)
     renderer._camera_rel_path = "Camera"
     renderer._render_product_paths = []
     renderer._exported_usd_string = None
@@ -450,7 +454,7 @@ def test_initialize_from_spec_writes_combined_stage_dump(tmp_path: Path):
     assert renderer._exported_usd_string is None
 
 
-def test_create_render_data_pins_the_render_product_to_the_spec_device(tmp_path: Path):
+def test_create_render_data_pins_the_render_product_to_the_spec_device(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """The render product is pinned to the CUDA device whose Warp kernels read its render vars.
 
     Without this, OVRTX picks the device itself and hands back buffers on ``cuda:0`` while the tile
@@ -464,6 +468,13 @@ def test_create_render_data_pins_the_render_product_to_the_spec_device(tmp_path:
     renderer._renderer.bind_attribute = lambda **kwargs: object()
     renderer._renderer.write_attribute = lambda **kwargs: None
 
+    class _FakeWarpDevice:
+        ordinal = 1
+
+        def __str__(self) -> str:
+            return "cuda:1"
+
+    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_device", lambda device: _FakeWarpDevice())
     renderer.create_render_data(_make_camera_render_spec(num_envs=1, device="cuda:1"))
 
     combined_text = (tmp_path / _OVRTX_STAGE_FILE).read_text(encoding="utf-8")

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -270,7 +270,7 @@ def test_update_deformable_points_writes_world_particle_positions(monkeypatch: p
     class _FakeStream:
         cuda_stream = 42
 
-    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: _FakeStream())  # noqa: ARG005
+    renderer._warp_device = SimpleNamespace(stream=_FakeStream())
 
     renderer.update_geometries()
 
@@ -406,7 +406,7 @@ def test_update_particle_points_writes_world_particle_positions(monkeypatch: pyt
     class _FakeStream:
         cuda_stream = 42
 
-    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: _FakeStream())  # noqa: ARG005
+    renderer._warp_device = SimpleNamespace(stream=_FakeStream())
 
     renderer.update_geometries()
 
@@ -448,7 +448,7 @@ def test_update_geometries_writes_deformable_and_mpm_bindings(monkeypatch: pytes
     class _FakeStream:
         cuda_stream = 42
 
-    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: _FakeStream())  # noqa: ARG005
+    renderer._warp_device = SimpleNamespace(stream=_FakeStream())
 
     renderer.update_geometries()
 
@@ -532,7 +532,7 @@ def test_update_geometries_writes_one_slice_per_cable(monkeypatch: pytest.Monkey
             launch_kwargs["kernel"] = args[0]
 
     monkeypatch.setattr(ovrtx_renderer_module.wp, "launch", _capture_launch)
-    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: SimpleNamespace(cuda_stream=1234))
+    renderer._warp_device = SimpleNamespace(stream=SimpleNamespace(cuda_stream=1234))
 
     renderer.update_geometries()
 
@@ -572,6 +572,7 @@ def test_write_particle_q_slices_ovstage_passes_device_slices_zero_copy():
 
     renderer._stage = SimpleNamespace(write_attribute=_write)
     renderer._current_ordinal = 7
+    renderer._warp_device = wp.get_device("cuda:0")
 
     renderer._write_particle_q_slices_ovstage("points_query", particle_q, [1], [3])
 

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -456,11 +456,11 @@ def test_ovrtx_map_render_var_orders_the_read_against_render_completion(monkeypa
     sentinel = object()
     render_var = _RecordingRenderVar()
     monkeypatch.setattr(ovrtx_renderer_module, "_gpu_side_render_var_sync_enabled", lambda: gpu_side)
-    monkeypatch.setattr(ovrtx_renderer_module.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=99))
     monkeypatch.setattr(ovrtx_renderer_module.wp, "from_dlpack", lambda mapping: sentinel)
 
     renderer = _make_ovrtx_renderer_without_backend()
     renderer._device = "cuda:0"
+    renderer._warp_device = types.SimpleNamespace(stream=types.SimpleNamespace(cuda_stream=99))
     with renderer._map_render_var_to_dlpack(render_var) as array:
         assert array is sentinel
 
@@ -487,9 +487,11 @@ class _RecordingMappedBinding:
         return _Mapping()
 
 
-def _patch_warp_device(monkeypatch, *, ordinal: int, cuda_stream: int) -> None:
-    """Fake the current Warp stream; ``ordinal`` documents the device the test pretends to run on."""
-    monkeypatch.setattr(ovrtx_mapping.wp, "get_stream", lambda device: types.SimpleNamespace(cuda_stream=cuda_stream))
+def _patch_warp_device(monkeypatch, *, ordinal: int, cuda_stream: int) -> types.SimpleNamespace:
+    """Return a fake resolved Warp device with the requested ordinal and stream."""
+    device = types.SimpleNamespace(ordinal=ordinal, stream=types.SimpleNamespace(cuda_stream=cuda_stream))
+    monkeypatch.setattr(ovrtx_mapping.wp, "get_device", lambda requested: device)  # noqa: ARG005
+    return device
 
 
 @pytest.mark.parametrize(("device", "expected"), [("cuda:1", 1), ("cuda", 0)])
@@ -513,7 +515,7 @@ def test_map_attribute_for_warp_writes_commits_on_the_producer_stream(monkeypatc
     _patch_warp_device(monkeypatch, ordinal=1, cuda_stream=99)
     monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: sentinel)
 
-    with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda:1", wp.mat44d) as array:
+    with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda", wp.mat44d) as array:
         assert array is sentinel
 
     assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 1}]
@@ -527,11 +529,11 @@ def test_map_attribute_for_warp_writes_unmaps_when_the_fill_raises(monkeypatch):
     fire-and-forget without any CUDA sync.
     """
     binding = _RecordingMappedBinding()
-    _patch_warp_device(monkeypatch, ordinal=0, cuda_stream=7)
+    device = _patch_warp_device(monkeypatch, ordinal=0, cuda_stream=7)
     monkeypatch.setattr(ovrtx_mapping.wp, "from_dlpack", lambda tensor, dtype: object())
 
     with pytest.raises(ValueError, match="fill failed"):
-        with ovrtx_mapping.map_attribute_for_warp_writes(binding, "cuda:0", wp.mat44d):
+        with ovrtx_mapping.map_attribute_for_warp_writes(binding, device, wp.mat44d):
             raise ValueError("fill failed")
 
     assert binding.map_calls == [{"device": ovrtx_renderer_module.Device.CUDA, "device_id": 0}]

--- a/source/isaaclab_physx/changelog.d/fix-usd-frame-view-float-scale.skip
+++ b/source/isaaclab_physx/changelog.d/fix-usd-frame-view-float-scale.skip
@@ -1,0 +1,1 @@
+Test-only regression coverage; the user-facing fix is recorded in the ``isaaclab`` package.

--- a/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
+++ b/source/isaaclab_physx/test/sim/test_views_xform_prim_fabric.py
@@ -135,6 +135,36 @@ def view_factory(request):
 # ------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("device", test_devices())
+def test_float_scale_initializes_fabric(device):
+    """A legal float3 scale initializes Fabric without changing the FP32 view contract."""
+    _skip_if_unavailable(device)
+
+    stage = sim_utils.get_current_stage()
+    prim = stage.DefinePrim("/World/SiteGuide", "Sphere")
+    xformable = UsdGeom.Xformable(prim)
+    xformable.AddTranslateOp(UsdGeom.XformOp.PrecisionFloat).Set(Gf.Vec3f(0.1, -0.2, 0.3))
+    xformable.AddOrientOp(UsdGeom.XformOp.PrecisionFloat).Set(Gf.Quatf(1.0, Gf.Vec3f(0.0)))
+    xformable.AddScaleOp(UsdGeom.XformOp.PrecisionFloat).Set(Gf.Vec3f(0.01, 0.02, 0.03))
+
+    sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, device=device, use_fabric=True))
+    view = FrameView("/World/SiteGuide", device=device)
+    try:
+        assert isinstance(prim.GetAttribute("xformOp:scale").Get(), Gf.Vec3f)
+
+        world_positions, _ = view.get_world_poses()
+        expected_position = torch.tensor([[0.1, -0.2, 0.3]], dtype=torch.float32, device=device)
+        torch.testing.assert_close(world_positions.torch, expected_position, atol=1e-6, rtol=0)
+
+        expected_scale = torch.tensor([[0.01, 0.02, 0.03]], dtype=torch.float32, device=device)
+        scales = view.get_local_scales()
+        assert scales.warp.dtype == wp.float32
+        assert scales.torch.dtype == torch.float32
+        torch.testing.assert_close(scales.torch, expected_scale, atol=1e-6, rtol=0)
+    finally:
+        view.close()
+
+
 @wp.kernel
 def _fill_position(out: wp.array(dtype=wp.float32, ndim=2), x: float, y: float, z: float):
     i = wp.tid()

--- a/source/isaaclab_rl/changelog.d/fix-external-callback-order.rst
+++ b/source/isaaclab_rl/changelog.d/fix-external-callback-order.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed RSL-RL training resolving agent metadata before external task registration callbacks run.

--- a/source/isaaclab_rl/changelog.d/lazy-rl-entrypoint-imports.rst
+++ b/source/isaaclab_rl/changelog.d/lazy-rl-entrypoint-imports.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed single-GPU reinforcement learning entrypoints eagerly importing the multi-GPU Torch Elastic launcher.

--- a/source/isaaclab_rl/isaaclab_rl/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.py
@@ -22,35 +22,12 @@ The package also provides the unified training and playback entrypoints used by 
 """
 
 import importlib.metadata
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from .entrypoints import PlaybackRequest, SimpleAgentRequest, TrainingRequest
+from isaaclab.utils.module import lazy_export
 
 try:
     __version__ = importlib.metadata.version("isaaclab_rl")
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
-__all__ = [
-    "PlaybackRequest",
-    "SimpleAgentRequest",
-    "TrainingRequest",
-    "play",
-    "random_agent",
-    "run_play_cli",
-    "run_random_agent_cli",
-    "run_train_cli",
-    "run_train_multigpu_cli",
-    "run_zero_agent_cli",
-    "train",
-    "zero_agent",
-]
 
-
-def __getattr__(name: str):
-    """Lazily expose unified reinforcement learning entrypoint APIs."""
-    if name in __all__:
-        from . import entrypoints
-
-        return getattr(entrypoints, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+lazy_export()

--- a/source/isaaclab_rl/isaaclab_rl/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/__init__.pyi
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "PlaybackRequest",
+    "SimpleAgentRequest",
+    "TrainingRequest",
+    "play",
+    "random_agent",
+    "run_play_cli",
+    "run_random_agent_cli",
+    "run_train_cli",
+    "run_train_multigpu_cli",
+    "run_zero_agent_cli",
+    "train",
+    "zero_agent",
+]
+
+from .entrypoints import (
+    PlaybackRequest,
+    SimpleAgentRequest,
+    TrainingRequest,
+    play,
+    random_agent,
+    run_play_cli,
+    run_random_agent_cli,
+    run_train_cli,
+    run_train_multigpu_cli,
+    run_zero_agent_cli,
+    train,
+    zero_agent,
+)
+
+__version__: str

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.py
@@ -23,22 +23,6 @@ Example:
     train(TrainingRequest(backend="rsl_rl", task="Isaac-Cartpole", max_iterations=100))
 """
 
-from .api import BackendName, PlaybackRequest, SimpleAgentRequest, TrainingRequest, play, random_agent, train, zero_agent
-from .dispatch import run_play_cli, run_random_agent_cli, run_train_cli, run_zero_agent_cli
-from .multigpu import run_train_multigpu_cli
+from isaaclab.utils.module import lazy_export
 
-__all__ = [
-    "BackendName",
-    "PlaybackRequest",
-    "SimpleAgentRequest",
-    "TrainingRequest",
-    "play",
-    "random_agent",
-    "run_play_cli",
-    "run_random_agent_cli",
-    "run_train_cli",
-    "run_train_multigpu_cli",
-    "run_zero_agent_cli",
-    "train",
-    "zero_agent",
-]
+lazy_export()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.pyi
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/__init__.pyi
@@ -1,0 +1,24 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+__all__ = [
+    "BackendName",
+    "PlaybackRequest",
+    "SimpleAgentRequest",
+    "TrainingRequest",
+    "play",
+    "random_agent",
+    "run_play_cli",
+    "run_random_agent_cli",
+    "run_train_cli",
+    "run_train_multigpu_cli",
+    "run_zero_agent_cli",
+    "train",
+    "zero_agent",
+]
+
+from .api import BackendName, PlaybackRequest, SimpleAgentRequest, TrainingRequest, play, random_agent, train, zero_agent
+from .dispatch import run_play_cli, run_random_agent_cli, run_train_cli, run_zero_agent_cli
+from .multigpu import run_train_multigpu_cli

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -88,13 +88,18 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     cli_args.add_rsl_rl_args(parser)
     add_launcher_args(parser)
+
+    # Register external tasks before preset setup reads their Gym metadata.
+    registration_parser = argparse.ArgumentParser(add_help=False)
+    registration_parser.add_argument("--external_callback")
+    registration_args, _ = registration_parser.parse_known_args(argv)
+    remaining_args_env_registration = None
+    if registration_args.external_callback:
+        external_callback_function = string_to_callable(registration_args.external_callback, separator=".")
+        remaining_args_env_registration = external_callback_function()
+
     args_cli, remaining_args = setup_preset_cli(parser, argv, agent_library="rsl_rl")
     enable_cameras_for_video(args_cli)
-
-    remaining_args_env_registration = None
-    if args_cli.external_callback:
-        external_callback_function = string_to_callable(args_cli.external_callback, separator=".")
-        remaining_args_env_registration = external_callback_function()
 
     set_hydra_args(list_intersection(remaining_args, remaining_args_env_registration))
     return args_cli

--- a/source/isaaclab_rl/test/export/leapp_initialized_checkpoints.py
+++ b/source/isaaclab_rl/test/export/leapp_initialized_checkpoints.py
@@ -288,18 +288,15 @@ def task_checkpoint_dir(checkpoint_root: Path, backend_id: str, task_name: str) 
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """CLI entrypoint: create initialized checkpoints in one Kit process.
+    """CLI entrypoint: create initialized checkpoints with the task's runtime.
 
-    Accepts one or more ``--spec BACKEND TASK [PRESET]`` entries and writes each
-    checkpoint under ``checkpoint_root/BACKEND/TASK/``. When a per-spec preset is
-    omitted, ``--preset`` is used if provided; otherwise no Hydra preset token is
-    applied.
+    Accepts one ``--spec BACKEND TASK [PRESET]`` entry and writes the checkpoint
+    under ``checkpoint_root/BACKEND/TASK/``. When the spec preset is omitted,
+    ``--preset`` is used if provided; otherwise no Hydra preset token is applied.
 
     Usage:
         python leapp_initialized_checkpoints.py --checkpoint_root /tmp/ckpt \\
-            --preset newton_mjwarp \\
-            --spec rsl_rl Isaac-Cartpole \\
-            --spec rsl_rl IsaacContrib-Lift-Cube-Franka _
+            --spec rsl_rl Isaac-Cartpole newton_mjwarp
     """
     import argparse
     import os
@@ -314,80 +311,71 @@ def main(argv: Sequence[str] | None = None) -> None:
         action="append",
         metavar="BACKEND_TASK_PRESET",
         required=True,
-        help="Backend/task pair, optionally with a preset override: BACKEND TASK [PRESET]. "
-        "Use PRESET=_ to force no preset even when --preset is set. Repeat for multiple "
-        "checkpoints in one Kit process.",
+        help="One backend/task pair, optionally with a preset override: BACKEND TASK [PRESET].",
     )
     parser.add_argument("--checkpoint_root", required=True, type=Path)
     parser.add_argument(
         "--preset",
         default=None,
-        help="Default Hydra preset for specs that do not override it.",
+        help="Default Hydra preset when --spec does not include one.",
     )
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--algorithm", type=str, default="ppo", help="skrl algorithm name.")
     args = parser.parse_args(argv)
 
     backend_choices = ("rsl_rl", "rl_games", "skrl", "sb3")
-    specs: list[tuple[str, str, str | None]] = []
-    for raw_spec in args.spec:
-        if len(raw_spec) not in (2, 3):
-            raise SystemExit(f"Each --spec must be 'BACKEND TASK' or 'BACKEND TASK PRESET', got: {raw_spec}")
-        backend_id, task_name = raw_spec[0], raw_spec[1]
-        if backend_id not in backend_choices:
-            raise SystemExit(f"Unsupported backend '{backend_id}'. Choose from {backend_choices}.")
-        if len(raw_spec) == 3:
-            preset = None if raw_spec[2] in ("_", "") else raw_spec[2]
-        else:
-            preset = args.preset
-        specs.append((backend_id, task_name, preset))
+    if len(args.spec) != 1:
+        raise SystemExit("--spec may be provided exactly once")
+    raw_spec = args.spec[0]
+    if len(raw_spec) not in (2, 3):
+        raise SystemExit(f"--spec must be 'BACKEND TASK' or 'BACKEND TASK PRESET', got: {raw_spec}")
+    backend_id, task_name = raw_spec[0], raw_spec[1]
+    if backend_id not in backend_choices:
+        raise SystemExit(f"Unsupported backend '{backend_id}'. Choose from {backend_choices}.")
+    if len(raw_spec) == 3:
+        preset = None if raw_spec[2] in ("_", "") else raw_spec[2]
+    else:
+        preset = args.preset
 
-    from isaaclab.app import AppLauncher
-
-    # TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases
-    # can corrupt the heap while parsing the Newton Franka payload concurrently.
-    app_launcher = AppLauncher(headless=True, limit_cpu_threads=1)
-    simulation_app = app_launcher.app
-
+    from isaaclab.app import launch_simulation
     from isaaclab.app.settings_manager import get_settings_manager
 
     from isaaclab_tasks.utils.hydra import resolve_task_config
 
-    get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
-    get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
-
-    cli_args = SimpleNamespace(seed=args.seed, algorithm=args.algorithm)
-    failures: list[str] = []
+    # TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases
+    # can corrupt the heap while parsing the Newton Franka payload concurrently.
+    cli_args = SimpleNamespace(
+        seed=args.seed,
+        algorithm=args.algorithm,
+        headless=True,
+        limit_cpu_threads=1,
+    )
+    task_dir = task_checkpoint_dir(args.checkpoint_root, backend_id, task_name)
+    task_dir.mkdir(parents=True, exist_ok=True)
     original_argv = sys.argv
+    sys.argv = [sys.argv[0], f"presets={preset}"] if preset else [sys.argv[0]]
     try:
-        for backend_id, task_name, preset in specs:
-            task_dir = task_checkpoint_dir(args.checkpoint_root, backend_id, task_name)
-            task_dir.mkdir(parents=True, exist_ok=True)
-            sys.argv = [sys.argv[0], f"presets={preset}"] if preset else [sys.argv[0]]
-            try:
-                env_cfg, agent_cfg = resolve_task_config(task_name, _agent_cfg_entry_point(backend_id))
-                checkpoint_path = create_initialized_checkpoint(
-                    backend_id,
-                    task_name,
-                    cli_args,
-                    env_cfg,
-                    agent_cfg,
-                    task_dir,
-                )
-                resolved_path_file(task_dir).write_text(str(checkpoint_path))
-            except BaseException:
-                failures.append(f"{backend_id}/{task_name}")
-                traceback.print_exc(file=sys.stdout)
-                sys.stdout.flush()
-                sys.stderr.flush()
+        env_cfg, agent_cfg = resolve_task_config(task_name, _agent_cfg_entry_point(backend_id))
+        with launch_simulation(env_cfg, vars(cli_args)):
+            get_settings_manager().set_bool("/physics/cooking/ujitsoCollisionCooking", False)
+            get_settings_manager().set_bool("/isaaclab/render/rtx_sensors", False)
+            checkpoint_path = create_initialized_checkpoint(
+                backend_id,
+                task_name,
+                cli_args,
+                env_cfg,
+                agent_cfg,
+                task_dir,
+            )
+            resolved_path_file(task_dir).write_text(str(checkpoint_path))
+    except BaseException:
+        traceback.print_exc(file=sys.stdout)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        print(f"[ERROR] Failed to create checkpoint for: {backend_id}/{task_name}", flush=True)
+        os._exit(1)
     finally:
         sys.argv = original_argv
-        if failures:
-            # ``simulation_app.close()`` can exit 0; fail hard before it when any
-            # checkpoint was missing so the parent subprocess call sees the error.
-            print(f"[ERROR] Failed to create checkpoints for: {', '.join(failures)}", flush=True)
-            os._exit(1)
-        simulation_app.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/test/export/test_leapp_export_flow.py
+++ b/source/isaaclab_rl/test/export/test_leapp_export_flow.py
@@ -5,12 +5,12 @@
 
 """Cross-backend LEAPP export integration tests.
 
-All initialized checkpoints are created in one Kit subprocess first. Each
-backend/task export then runs in its own subprocess against those checkpoints.
+Each initialized checkpoint and backend/task export runs in its own subprocess.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -26,7 +26,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[4]
 _LEAPP_ROOT = _REPO_ROOT / "scripts" / "reinforcement_learning" / "leapp"
 _CHECKPOINT_SCRIPT = Path(__file__).resolve().parent / "leapp_initialized_checkpoints.py"
 _SUBPROCESS_TIMEOUT = 600
-_CHECKPOINT_BATCH_TIMEOUT = 1200
+_CHECKPOINT_TIMEOUT = 1200
 _OUTPUT_TAIL_CHARS = 5000
 # TODO: Remove once usd-core>=26.5 is the minimum. Earlier OpenUSD releases can
 # corrupt the heap while parsing the Newton Franka payload concurrently. OpenUSD
@@ -109,6 +109,22 @@ _EXPORT_BACKENDS = (
 # Untyped ``presets=`` form: tasks vary in where they declare the preset, and only
 # some declare it on a ``PhysicsCfg`` (which is what ``physics=`` requires).
 _SIM_PRESET = "newton_mjwarp"
+
+# Exercise the manager-based Humanoid export path with each physics backend the
+# task exposes. The checkpoints are generated through the standard RSL-RL
+# runner and then passed to the same LEAPP export CLI as the main export matrix.
+_HUMANOID_PHYSICS_PRESETS = (
+    pytest.param("isaacsim_physx", id="isaacsim_physx"),
+    pytest.param(
+        "ovphysx",
+        id="ovphysx",
+        marks=pytest.mark.skipif(
+            importlib.util.find_spec("ovphysx") is None,
+            reason="requires the optional OV PhysX runtime",
+        ),
+    ),
+    pytest.param("newton_mjwarp", id="newton_mjwarp"),
+)
 
 # These tasks reject any preset token; export uses their authored default backend.
 _TASKS_WITHOUT_PRESET = frozenset({"IsaacContrib-Lift-Cube-Franka"})
@@ -202,7 +218,13 @@ def _read_checkpoint_path(checkpoint_root: Path, backend_id: str, task_name: str
     return checkpoint_path
 
 
-def _run_export(backend: ExportFlowBackend, task_name: str, checkpoint_path: Path, export_root: Path) -> None:
+def _run_export(
+    backend: ExportFlowBackend,
+    task_name: str,
+    checkpoint_path: Path,
+    export_root: Path,
+    preset: str | None = None,
+) -> None:
     """Run the backend export.py CLI against *checkpoint_path*."""
     command = [
         sys.executable,
@@ -217,7 +239,7 @@ def _run_export(backend: ExportFlowBackend, task_name: str, checkpoint_path: Pat
         "--limit_cpu_threads",
         str(_LEAPP_TEST_CPU_THREAD_LIMIT),
     ]
-    preset = _preset_for_task(task_name)
+    preset = _preset_for_task(task_name) if preset is None else preset
     if preset is not None:
         command.append(f"presets={preset}")
     _run_checked(command, label=f"export.py for {backend.rl_library}/{task_name}")
@@ -233,33 +255,31 @@ def _assert_leapp_artifacts(export_root: Path, task_name: str) -> None:
 
 @pytest.fixture(scope="module")
 def initialized_checkpoints(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create every export-flow checkpoint in one Kit subprocess."""
+    """Create each export-flow checkpoint in an isolated subprocess."""
     checkpoint_root = tmp_path_factory.mktemp("isaaclab-leapp-checkpoints")
-    command = [
-        sys.executable,
-        str(_CHECKPOINT_SCRIPT),
-        "--checkpoint_root",
-        str(checkpoint_root),
-        "--preset",
-        _SIM_PRESET,
-    ]
     for backend_id, task_name in _checkpoint_specs():
+        command = [
+            sys.executable,
+            str(_CHECKPOINT_SCRIPT),
+            "--checkpoint_root",
+            str(checkpoint_root),
+            "--spec",
+            backend_id,
+            task_name,
+        ]
         preset = _preset_for_task(task_name)
-        if preset is None:
-            # ``_`` clears the default ``--preset`` for this spec.
-            command.extend(("--spec", backend_id, task_name, "_"))
-        else:
-            command.extend(("--spec", backend_id, task_name))
-    _run_checked(
-        command,
-        label="batched initialized checkpoint creation",
-        timeout=_CHECKPOINT_BATCH_TIMEOUT,
-    )
+        if preset is not None:
+            command.append(preset)
+        _run_checked(
+            command,
+            label=f"initialized checkpoint creation for {backend_id}/{task_name}",
+            timeout=_CHECKPOINT_TIMEOUT,
+        )
     return checkpoint_root
 
 
 def test_initialized_checkpoints(initialized_checkpoints: Path):
-    """Assert the shared Kit subprocess created every expected checkpoint.
+    """Assert the isolated subprocesses created every expected checkpoint.
     This task is purely for generating mock checkpoints for the export flow.
     """
     missing = [
@@ -287,3 +307,36 @@ def test_leapp_export_flow(backend: ExportFlowBackend, task_name: str, initializ
         export_root = Path(tmp_dir) / "export"
         _run_export(backend, task_name, checkpoint_path, export_root)
         _assert_leapp_artifacts(export_root, task_name)
+
+
+@pytest.mark.parametrize("physics_preset", _HUMANOID_PHYSICS_PRESETS)
+def test_rsl_rl_humanoid_export_across_physics_backends(physics_preset: str, tmp_path_factory: pytest.TempPathFactory):
+    """Create an RSL-RL Humanoid checkpoint and export it for one physics backend.
+
+    This intentionally uses an initialized checkpoint rather than a full PPO run:
+    the checkpoint is created through the standard RSL-RL runner, which verifies
+    that the environment can initialize with the selected physics configuration
+    while keeping export integration coverage practical for CI.
+    """
+    checkpoint_root = tmp_path_factory.mktemp(f"isaaclab-leapp-humanoid-{physics_preset}")
+    _run_checked(
+        [
+            sys.executable,
+            str(_CHECKPOINT_SCRIPT),
+            "--checkpoint_root",
+            str(checkpoint_root),
+            "--spec",
+            "rsl_rl",
+            "Isaac-Humanoid",
+            physics_preset,
+        ],
+        label=f"RSL-RL Humanoid checkpoint creation with {physics_preset}",
+        timeout=_CHECKPOINT_TIMEOUT,
+    )
+
+    checkpoint_path = _read_checkpoint_path(checkpoint_root, "rsl_rl", "Isaac-Humanoid")
+    backend = _EXPORT_BACKENDS[0]
+    with tempfile.TemporaryDirectory(prefix=f"isaaclab-leapp-humanoid-{physics_preset}-") as tmp_dir:
+        export_root = Path(tmp_dir) / "export"
+        _run_export(backend, "Isaac-Humanoid", checkpoint_path, export_root, preset=physics_preset)
+        _assert_leapp_artifacts(export_root, "Isaac-Humanoid")

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -464,6 +464,39 @@ def test_failed_rsl_training_restores_torch_backend_state(monkeypatch) -> None:
     assert _torch_backend_state() == caller_state
 
 
+def test_rsl_training_registers_external_task_before_agent_discovery(monkeypatch) -> None:
+    """RSL-RL parses tasks registered by its external callback."""
+    from isaaclab_rl.entrypoints.backends import train_rsl_rl
+
+    task_name = "Isaac-ExternalCallbackOrderTest"
+    callback_module_name = "_external_callback_order_test"
+    callback_module = types.ModuleType(callback_module_name)
+
+    def register_task() -> list[str]:
+        gym.register(
+            id=task_name,
+            entry_point="dummy:Env",
+            kwargs={"rsl_rl_cfg_entry_point": "dummy:AgentCfg"},
+        )
+        return []
+
+    callback_module.register_task = register_task
+    monkeypatch.setitem(sys.modules, callback_module_name, callback_module)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["train.py", "--task", task_name, "--external_callback", f"{callback_module_name}.register_task"],
+    )
+    gym.registry.pop(task_name, None)
+
+    try:
+        args = train_rsl_rl._parse_args(sys.argv[1:])
+    finally:
+        gym.registry.pop(task_name, None)
+
+    assert args.task == task_name
+
+
 def test_skrl_training_restores_jax_backend(monkeypatch) -> None:
     """SKRL training removes the JAX backend setting it created after an exception."""
     skrl = pytest.importorskip("skrl")

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import runpy
+import subprocess
 import sys
 import types
 from types import SimpleNamespace
@@ -21,6 +22,45 @@ import torch
 from isaaclab_rl.entrypoints import PlaybackRequest, TrainingRequest, api, dispatch
 from isaaclab_rl.entrypoints import simple_agents as _simple_agents
 from isaaclab_rl.entrypoints.simple_agents import _create_zero_action_policy
+
+
+@pytest.mark.parametrize(
+    ("statement", "unexpected_modules"),
+    [
+        ("import isaaclab_rl", ["isaaclab_rl.entrypoints", "torch"]),
+        ("import isaaclab_rl.entrypoints", ["isaaclab_rl.entrypoints.multigpu", "torch"]),
+        ("import isaaclab_rl.entrypoints.backends", ["torch"]),
+        ("import isaaclab_rl.rl_games", ["isaaclab_rl.rl_games.rl_games", "rl_games", "torch"]),
+        ("import isaaclab_rl.rl_games.pbt", ["isaaclab_rl.rl_games.pbt.pbt", "rl_games", "torch"]),
+        ("import isaaclab_rl.rsl_rl", ["isaaclab_rl.rsl_rl.vecenv_wrapper", "rsl_rl", "torch"]),
+        ("import isaaclab_rl.utils", ["torch"]),
+        (
+            "from isaaclab_rl import run_play_cli",
+            ["isaaclab_rl.entrypoints.multigpu", "torch"],
+        ),
+        (
+            "from isaaclab_rl.entrypoints import run_play_cli",
+            ["isaaclab_rl.entrypoints.multigpu", "torch"],
+        ),
+    ],
+)
+def test_public_namespaces_do_not_import_unrelated_frameworks(statement: str, unexpected_modules: list[str]) -> None:
+    """Importing public namespaces must not eagerly load unrelated RL frameworks."""
+    unexpected_modules_literal = repr(unexpected_modules)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"{statement}; import sys; "
+            f"unexpected = [name for name in {unexpected_modules_literal} if name in sys.modules]; "
+            "assert not unexpected, f'Unexpected eager imports: {unexpected}'",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_zero_agent_infers_finite_manager_actions() -> None:


### PR DESCRIPTION
# Description

Backports the following merged `develop` PRs to `release/3.0.0`:

- #7220 — prune unused Docker volumes on package-test runners
- #7169 — cache the resolved OVRTX Warp device
- #6889 — move the OVPhysX collider cache out of the Python interpreter directory
- #7345 — document the registered XR camera PiP tasks
- #7050 — update and reorganize the LEAPP documentation
- #7473 — register external RSL-RL tasks before agent discovery
- #7467 — update the China storage profile to Isaac Sim 6.1
- #7385 — accept legal float scale values when seeding Fabric frame views from USD
- #7517 — use lazy exports in `isaaclab_rl`

The duplicate #7517 in the original request is included once.

Seven source commits replayed cleanly. Two required release-specific reconciliation:

- #7169 retains the release branch's mapped OVRTX write path, which was removed separately on `develop`, while resolving and caching one Warp device for render-product IDs, mappings, and CUDA streams.
- #7050 preserves the #7494 export-backend clarification that is already present on the release branch while applying the broader LEAPP documentation overhaul.

No new dependencies are added.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Performance improvement
- Documentation update
- CI/infrastructure update

## Release backport

- [ ] <!-- backport-active-release --> This PR already targets the active release branch; do not backport it again.

## Validation

- `uv run --no-project --with pytest python -m pytest -q .github/actions/run-package-tests/test_cleanup_docker_storage.py` — 10 passed
- Nine isolated `isaaclab_rl` namespace/lazy-import regression cases passed
- Resolved-device OVRTX mapping behavior check passed with Warp 1.16.0
- `uv run --no-project python -m compileall -q` on all changed Python modules and tests
- `uv run --no-project python tools/changelog/cli.py check` against the exact `upstream/release/3.0.0` base
- `pre-commit==4.6.2 run --all-files` passed all available hooks
- `git diff --check upstream/release/3.0.0..HEAD`

The full project test environment and documentation build cannot resolve on this macOS/arm64 host because the release lockfile supports Linux and Windows only. The Git LFS hook was also unavailable because `git-lfs` is not installed; none of the changed paths are LFS-tracked. Linux CI remains authoritative for simulator, OVRTX, Fabric, and full documentation validation.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the available formatting and static checks
- [x] I have included the corresponding documentation changes
- [x] Each touched source package includes its original changelog fragment
- [x] Every backported commit records its source commit with `cherry picked from commit`
- [x] The original contributors are preserved as commit authors
