### PR TITLE
[CI] Link _isaac_sim only where Kit is installed in the test container

### DIFF
--- a/.github/actions/run-tests/run_tests.sh
+++ b/.github/actions/run-tests/run_tests.sh
@@ -320,8 +320,11 @@ run_tests() {
       set -e
       cd /workspace/isaaclab
       mkdir -p tests
-      rm _isaac_sim || true
-      ln -s /isaac-sim _isaac_sim
+      # The runtime mounts above create /isaac-sim in every image. Link it only where Kit
+      # lives there: in the kit-less image the link would read as a downloaded Isaac Sim,
+      # which isaaclab.sh refuses to combine with the image's VIRTUAL_ENV.
+      rm -f _isaac_sim
+      if [ -x /isaac-sim/python.sh ]; then ln -s /isaac-sim _isaac_sim; fi
       if [ -n \"\${WARP_CACHE_PATH:-}\" ]; then
         ./isaaclab.sh -p tools/verify_warp_cache.py
       fi

--- a/docker/test/test_container_profiles.py
+++ b/docker/test/test_container_profiles.py
@@ -15,6 +15,7 @@ from docker import container as container_cli
 from docker.utils import ContainerInterface, volume_mounts
 
 DOCKER_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = DOCKER_DIR.parent
 
 
 @pytest.fixture
@@ -286,6 +287,20 @@ def test_kitless_compose_service_has_no_isaac_sim_mounts():
     assert forbidden_sources.isdisjoint(mount.get("source") for mount in mounts)
     assert all("DOCKER_ISAACSIM" not in mount["target"] for mount in mounts)
     assert all("/kit/" not in mount["target"].lower() for mount in mounts)
+
+
+def test_run_tests_links_isaac_sim_only_where_kit_is_installed():
+    """The kit-less image has no Kit under ``/isaac-sim``, which the runtime mounts create anyway.
+
+    Linking it as ``_isaac_sim`` there reads as a downloaded Isaac Sim, which ``isaaclab.sh``
+    refuses to combine with the image's ``VIRTUAL_ENV``.
+    """
+    script = (REPO_ROOT / ".github" / "actions" / "run-tests" / "run_tests.sh").read_text(encoding="utf-8")
+
+    link_lines = [line.strip() for line in script.splitlines() if "ln -s /isaac-sim _isaac_sim" in line]
+
+    assert link_lines
+    assert all("/isaac-sim/python.sh" in line for line in link_lines), link_lines
 
 
 def test_kitless_volume_key_resolves_owned_image_paths(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

`Multi-GPU training smoke (kit-less)` fails on every PR into `release/3.0.0`, exiting before pytest
runs. Two lines in the shared test-container script fix it.

# Description

## 1. Cause

`run_tests.sh` bind-mounts nine writable runtime directories under `/isaac-sim/…` into every
container, so `/isaac-sim` exists as a directory in the kit-less image as well — which ships no Kit.
The container script then plants the link unconditionally:

```bash
rm _isaac_sim || true
ln -s /isaac-sim _isaac_sim
```

`isaaclab.sh` treats an `_isaac_sim` directory without a `.isaaclab_source_build` marker as a
downloaded Isaac Sim and refuses to combine it with an active virtual environment (#7466, on this
branch as 69d5d1fbf94). `Dockerfile.kitless` sets `VIRTUAL_ENV=/opt/isaaclab-venv` (#6355), so every
kit-less run stops at:

```
[ERROR] Downloaded Isaac Sim packages cannot be combined with a Python virtual environment.
🔴 Failed to copy specific result file: Could not find the file /workspace/isaaclab/tests/multi-gpu-smoke-kitless-report.xml
```

## 2. Change

Plant the link only where Kit actually lives at that path. Kit images are unaffected — they have
`/isaac-sim/python.sh` and get the link exactly as before; the kit-less image resolves its
interpreter through `VIRTUAL_ENV`, as it did before #7466.

The same script serves ~29 CI jobs through `run-tests` and `run-package-tests`, all but one of which
pass a Kit image, so testing the container rather than threading a "kit-less" flag through every
caller keeps the fix to one place.

## 3. Verification

- The regression test added beside the existing kit-less invariant in
  `docker/test/test_container_profiles.py` fails on the unmodified script
  (`AssertionError: ['ln -s /isaac-sim _isaac_sim']`) and passes with it. 14 pass in that file.
- `bash -n` on the script; pre-commit on both files.
- The same two-line change on `develop` turned the job green end to end: `8 passed, 7 deselected in
  790.74s`, with zero occurrences of the venv error in the job log.

## 4. Relationship to the `develop` fix

The develop-side PR pairs this with a second, unrelated fix for the `Build Base Docker Image` job,
which fails there because #7405 added an image-invariants step that a deps-cache hit cannot satisfy.
**#7405 is not on this branch** — its `Dockerfile.base` still installs with
`_isaac_sim/python.sh -m pip`, there is no invariants step, and its author left the backport box
unticked. That half would be dead config here, so this PR carries only the part that applies.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] Documentation needs no change: CI-internal script
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Changelog: no source package changed
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
