### PR TITLE
Fix SpaceNavigator device detection

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -167,6 +167,7 @@ Guidelines for modifications:
 * Peter Verswyvelen
 * Philipp Reist
 * Piotr Barejko
+* Pranav Shirgur
 * Pulkit Goyal
 * Qian Wan
 * Qingyang Jiang

--- a/source/isaaclab/changelog.d/fix-spacenavigator-support.rst
+++ b/source/isaaclab/changelog.d/fix-spacenavigator-support.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed detection of legacy 3Dconnexion SpaceNavigator devices in the SpaceMouse interface.

--- a/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
+++ b/source/isaaclab/isaaclab/devices/spacemouse/se3_spacemouse.py
@@ -142,6 +142,7 @@ class Se3SpaceMouse(DeviceBase):
                     or device["product_string"] == "SpaceMouse Wireless"
                     or device["product_string"] == "SpaceNavigator for Notebooks"
                     or device["product_string"] == "3Dconnexion Universal Receiver"
+                    or device["product_string"] == "SpaceNavigator"
                 ):
                     # set found flag
                     found = True


### PR DESCRIPTION
# Description

This PR adds support for detecting the legacy 3Dconnexion SpaceNavigator as an `Se3SpaceMouse` input device.

The device reports `SpaceNavigator` as its HID product string. Because this value was absent from the supported-device check, Isaac Lab raised a `No device found by SpaceMouse` error even when the device was connected and accessible.

This change adds `SpaceNavigator` to the existing SpaceMouse product-string allowlist. No additional dependencies are required.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## Release backport

* [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable. This change affects HID device detection and does not alter the user interface.

## Testing

Manually tested on Linux with a 3Dconnexion SpaceNavigator:

* USB ID: `046d:c626`
* HID product string: `SpaceNavigator`
* Before this change, `Se3SpaceMouse` failed to find the connected device.
* After this change, Isaac Lab successfully detected and opened the device.
* All pre-commit checks pass with `./isaaclab.sh --format`.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then comment `run-ci` on the pull request.

* [x] I have read and understood the [[contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
* [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
* [x] Documentation changes are not required because this change does not affect the user-facing API
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
* [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there