### PR TITLE
Fix LEAPP documentation references and quick start

### DIFF
--- a/docs/source/api/lab/isaaclab.envs.leapp_deployment_env.rst
+++ b/docs/source/api/lab/isaaclab.envs.leapp_deployment_env.rst
@@ -1,7 +1,7 @@
 LEAPP Deployment Environment
 ==============================
 
-.. currentmodule:: isaaclab.envs.leapp_deployment_env
+.. currentmodule:: isaaclab.envs
 
 Use :class:`LeappDeploymentEnv` to run a LEAPP-exported policy in an Isaac Lab scene. For command-line deployment instructions and prerequisites, see the
 :doc:`LEAPP deployment guide </source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp>`.

--- a/docs/source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/deploying_exported_policies_with_leapp.rst
@@ -1,6 +1,8 @@
 Deploy Exported Policies with LEAPP
 ===================================
 
+.. currentmodule:: isaaclab
+
 Isaac Lab provides :class:`~envs.LeappDeploymentEnv` for running exported policies back in
 simulation without the training infrastructure. This is the Isaac Lab deployment path for
 LEAPP-exported policies and is useful for validating that the packaged policy still behaves

--- a/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
+++ b/docs/source/policy_deployment/05_leapp/exporting_policies_with_leapp.rst
@@ -77,13 +77,13 @@ Export a trained policy, then launch the exported policy in Isaac Lab:
 
    uv run --extra leapp python \
        scripts/reinforcement_learning/leapp/<RL_LIBRARY>/export.py \
-       --task <TASK_NAME>
+       --task <TASK_NAME> physics=newton_mjwarp
 
    uv run --extra leapp python \
        scripts/reinforcement_learning/leapp/deploy.py \
        --task <TASK_NAME> \
        --leapp_model <PATH_TO_EXPORTED_LEAPP_YAML> \
-       --viz kit
+       --viz newton_gl physics=newton_mjwarp
 
 Continue with the sections below to select a different RL library, configure the
 export, and validate the generated artifacts.

--- a/source/isaaclab/changelog.d/codex-fix-leapp-doc-links-quickstart.rst
+++ b/source/isaaclab/changelog.d/codex-fix-leapp-doc-links-quickstart.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Restored :class:`~isaaclab.envs.LeappDeploymentEnv` as a public ``isaaclab.envs`` export.

--- a/source/isaaclab/isaaclab/envs/__init__.pyi
+++ b/source/isaaclab/isaaclab/envs/__init__.pyi
@@ -12,6 +12,7 @@ __all__ = [
     "DirectMARLEnvCfg",
     "DirectRLEnv",
     "DirectRLEnvCfg",
+    "LeappDeploymentEnv",
     "ManagerBasedEnv",
     "ManagerBasedEnvCfg",
     "ManagerBasedRLEnv",
@@ -36,6 +37,7 @@ from .direct_marl_env import DirectMARLEnv
 from .direct_marl_env_cfg import DirectMARLEnvCfg
 from .direct_rl_env import DirectRLEnv
 from .direct_rl_env_cfg import DirectRLEnvCfg
+from .leapp_deployment_env import LeappDeploymentEnv
 from .manager_based_env import ManagerBasedEnv
 from .manager_based_env_cfg import ManagerBasedEnvCfg
 from .manager_based_rl_env import ManagerBasedRLEnv


### PR DESCRIPTION
# Description

Fix two LEAPP documentation issues identified while reviewing #7541:

- Expose `LeappDeploymentEnv` from the public `isaaclab.envs` lazy-export stub, document it under that namespace, and add the missing module context to the deployment guide so its class references resolve.
- Make the quick-start export and deployment commands consistently use Newton MJWarp with the NewtonGL visualizer, matching the documented `leapp`-only prerequisites.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- Verified the lazy-export stub exposes `LeappDeploymentEnv` through both `__all__` and `dir()`.
- Focused pre-commit checks passed for all changed files, including the changelog and Git LFS gates.
- `sphinx-lint` reported no problems for the changed documentation.
- The full warning-as-error documentation build is pending Linux CI because the repository lockfile does not support the local macOS/arm64 platform.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the applicable pre-commit checks
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (full build pending Linux CI)
- [ ] I have added tests that prove my fix is effective or that my feature works (covered by focused lazy-export contract validation)
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
