### PR TITLE
[Docs] Rework ecosystem page

### DIFF
--- a/docs/source/setup/ecosystem.rst
+++ b/docs/source/setup/ecosystem.rst
@@ -3,216 +3,235 @@
 Isaac Lab Ecosystem
 ===================
 
-Isaac Lab is a modular, extensible framework for robot learning built on top of `Isaac Sim`_ and
-`Newton`_. It provides a unified interface for the most common workflows in robotics research —
-reinforcement learning, learning from demonstrations, and motion planning — while staying easy to
-use and easy to extend.
+Isaac Lab is an open-source framework for building, training, and evaluating robot-learning
+systems at scale. It provides the reusable layer between your task code and the simulation,
+rendering, data-generation, and learning tools around it.
 
-Isaac Lab supports two physics engines through multiple backend packages:
+With Isaac Lab, you can describe a robot, scene, sensors, and task once, then combine them with
+the backend and learning workflow that fit your project. Common uses include reinforcement
+learning, imitation learning, motion planning, teleoperation, and synthetic data generation.
 
-* **PhysX** — the default backend through `Isaac Sim`_, with access to GPU-accelerated
-  rigid-body simulation, deformable objects, Fabric views, tiled RTX rendering, ROS/ROS2,
-  URDF/MJCF importers, and the full Omniverse toolchain. PhysX can also be used through the
-  standalone ``ovphysx`` runtime for kit-less workflows that do not launch Isaac Sim.
-* **Newton** — a Warp-native backend that can run in kit-less mode, enabling lightweight
-  deployments and GPU-parallel simulation using `Warp`_.
+.. important::
+
+   Isaac Lab is **not a simulator**. It is a robot-learning framework that runs on top of a
+   supported physics backend. This separation keeps task code reusable while allowing the
+   underlying runtime to evolve.
+
+
+How the pieces fit together
+---------------------------
+
+Most projects use Isaac Lab as a set of layers:
+
+1. **Describe the world** with robots, objects, terrains, sensors, and vectorized scenes.
+2. **Define the task** with either reusable manager terms or a direct environment class.
+3. **Choose a backend** for physics and rendering based on the features and runtime you need.
+4. **Connect a workflow** for training, demonstration collection, planning, teleoperation, or
+   visualization.
+5. **Scale and iterate** using GPU-parallel environments, shared configurations, and standard
+   `gymnasium`_ interfaces.
+
+Backend-specific implementations are selected at runtime through Isaac Lab's factory system.
+As long as the requested features are supported by the selected backend, the environment code
+does not need to import backend-specific modules. See
+:doc:`/source/overview/core-concepts/multi_backend_architecture` for the architecture details.
+
+.. image:: ../_static/setup/ecosystem.gif
+   :align: center
+   :alt: Isaac Lab connecting robots, environments, physics backends, sensors, learning workflows, and deployment
+
+
+Choose the runtime that fits your project
+-----------------------------------------
+
+Isaac Lab supports two physics engines through several backend packages. You do not need to
+learn every option before getting started.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 32 46
+
+   * - Runtime
+     - Best fit
+     - What it provides
+   * - **Isaac Sim + PhysX**
+     - The full simulation and visualization experience
+     - GPU-accelerated rigid-body simulation, deformable objects, USD workflows, Fabric views,
+       tiled RTX rendering, ROS/ROS 2, asset importers, and the Omniverse toolchain.
+   * - **Standalone PhysX and RTX**
+     - Kit-less workflows that still need PhysX or RTX rendering
+     - The optional ``ovphysx`` and ``ovrtx`` runtimes, without launching the full Isaac Sim
+       application. Feature support depends on the selected runtime.
+   * - **Newton**
+     - Lightweight, Warp-native, GPU-parallel simulation
+     - A kit-less backend for articulations and rigid bodies, with Warp-based rendering and no
+       Isaac Sim installation required.
+
+If you are new to Isaac Lab, start with Isaac Sim and PhysX for the broadest feature coverage.
+Choose Newton when you specifically want a lightweight, kit-less workflow or a Warp-native
+simulation stack.
 
 .. note::
 
-   Isaac Lab 3.0 supports a **kit-less installation** mode: you can install Isaac Lab and use the
-   Newton physics backend without installing Isaac Sim at all.
-   See :ref:`isaaclab-installation-root` for details.
-
-A factory pattern dispatches every asset and sensor instantiation to the correct backend at
-runtime, so user code stays unchanged regardless of which backend is active. See
-:doc:`/source/overview/core-concepts/multi_backend_architecture` for details.
-
-.. image:: ../_static/setup/ecosystem-light.svg
-    :class: only-light
-    :align: center
-    :alt: The Isaac Lab package ecosystem layered on the NVIDIA GPU platform
-
-.. image:: ../_static/setup/ecosystem-dark.svg
-    :class: only-dark
-    :align: center
-    :alt: The Isaac Lab package ecosystem layered on the NVIDIA GPU platform
+   Isaac Lab 3.0 can be installed without Isaac Sim and used with the Newton backend. See
+   :ref:`isaaclab-installation-root` for installation options.
 
 
-Package structure
------------------
+Build tasks your way
+--------------------
 
-Isaac Lab is organized into a set of focused packages that can be used independently or together.
+Isaac Lab provides two environment-authoring styles. Both expose vectorized `gymnasium`_
+environments and use the same scene, asset, and sensor interfaces.
 
-**Core**
+.. list-table::
+   :header-rows: 1
+   :widths: 22 39 39
 
-* ``isaaclab`` — the core library. Contains simulation context and configuration
-  (:mod:`~isaaclab.sim`), the :class:`~isaaclab.scene.InteractiveScene` that aggregates all
-  assets, sensors, and terrain for a vectorized set of environments, asset interfaces
-  (:mod:`~isaaclab.assets`), sensor interfaces (:mod:`~isaaclab.sensors`), environment base
-  classes (:mod:`~isaaclab.envs`), the manager system (:mod:`~isaaclab.managers`),
-  composable MDP term functions (:mod:`~isaaclab.envs.mdp`), actuator models
-  (:mod:`~isaaclab.actuators`), low-level controllers (:mod:`~isaaclab.controllers`),
-  procedural terrain generation (:mod:`~isaaclab.terrains`), and human-input device support
-  (:mod:`~isaaclab.devices`).
+   * - Workflow
+     - Choose it when
+     - How it is organized
+   * - **Manager-based**
+     - You want reusable, configurable task components and a clean separation of concerns.
+     - Observations, actions, rewards, commands, events, curricula, and terminations are composed
+       from small MDP terms and manager configurations.
+   * - **Direct**
+     - You want a compact environment or need highly custom step and reset logic.
+     - A single environment class implements observations, rewards, terminations, and resets
+       directly, similar to the Isaac Gym style.
 
-**Physics and renderer backends**
-
-* ``isaaclab_physx`` — PhysX-backed implementations of articulations,
-  rigid bodies, deformable objects, Fabric views, the Isaac RTX renderer, and USD spawners.
-  Requires Isaac Sim.
-* ``isaaclab_ov`` — Omniverse integration package containing standalone PhysX-backed
-  implementations built on ``ovphysx`` and the OVRTX renderer for RTX-based tiled camera
-  rendering. Its backends require the corresponding optional ``ovphysx`` or ``ovrtx``
-  runtime and can be used in kit-less workflows without Isaac Sim.
-* ``isaaclab_newton`` — Newton-backed implementations of articulations, rigid bodies, and the
-  Warp renderer. Supports kit-less installation without Isaac Sim.
-
-**Extensions**
-
-* ``isaaclab_assets`` — pre-configured robot and sensor :class:`~isaaclab.utils.configclass`
-  dataclasses for a wide range of robots (Franka, Unitree, ANYmal, Spot, Allegro, humanoids,
-  quadcopters, and more) and sensors (Velodyne, GelSight).
-* ``isaaclab_tasks`` — registered `gymnasium`_ environments organized into two authoring patterns:
-
-  * *Manager-based* — behavior is fully specified through composable manager configurations
-    (observations, rewards, terminations, events, commands, actions). Well-suited for research
-    that requires clean separation between task specification and environment logic.
-  * *Direct* — a single Python class implements the full step/reset/obs/reward loop, similar
-    in style to Isaac Gym. Convenient for rapid prototyping and tasks with complex custom logic.
-
-* ``isaaclab_rl`` — thin wrappers that adapt Isaac Lab environments to the vectorized
-  environment interfaces expected by `RSL-RL`_, `skrl`_, `Stable Baselines 3`_, and
-  `RL Games`_.
-* ``isaaclab_mimic`` — APIs and pre-configured environments for data generation and imitation
-  learning, including cuRobo-based motion planners and a full dataset-generation pipeline.
-* ``isaaclab_teleop`` — teleoperation session orchestration with XR (OpenXR / CloudXR) support,
-  device retargeters for manipulators and humanoids, and gamepad/spacemouse/keyboard input.
-* ``isaaclab_visualizers`` — supplementary visualizer backends (Isaac Kit, Rerun, Viser) that
-  work with any physics backend.
-* ``isaaclab_contrib`` — community-contributed features: multirotor assets, TacSL visuo-tactile
-  sensors, drone thrust controllers, and more.
-* ``isaaclab_experimental`` — pre-production experiments, including Warp-accelerated manager and
-  environment variants.
+Manager-based environments are usually the better fit for shared research infrastructure and
+families of related tasks. Direct environments are often easier for small experiments and rapid
+prototypes. You can choose per task; neither workflow limits which supported backend or RL library
+you can use.
 
 
-Where does Isaac Lab fit in the Isaac ecosystem?
-------------------------------------------------
+Package guide
+-------------
 
-Over the years, NVIDIA has developed a number of tools for robotics and AI. These tools leverage
-the power of GPUs to accelerate simulation both in terms of speed and realism.
+The repository is split into focused packages. Most users begin with ``isaaclab`` and add only
+the packages required by their workflow.
 
-`Isaac Gym`_ :cite:`makoviychuk2021isaac` provided a high-performance GPU-based physics simulation
-for robot learning built on top of `PhysX`_. Its end-to-end GPU pipeline enabled frame rates
-far beyond what CPU-based physics engines could achieve. The tool proved successful across a
-number of research projects, including legged locomotion :cite:`rudin2022learning`
-:cite:`rudin2022advanced`, in-hand manipulation :cite:`handa2022dextreme`
-:cite:`allshire2022transferring`, and industrial assembly :cite:`narang2022factory`.
+Core and backends
+~~~~~~~~~~~~~~~~~
 
-`Isaac Sim`_ is a general-purpose robot simulation toolkit built on top of `Omniverse`_. It
-integrates the capabilities of Isaac Gym while adding high-fidelity rendering, ROS/ROS2,
-deformable-object simulation, synthetic data generation, domain randomization, tiled rendering
-for vectorized observations, and cloud support via `Isaac Automator`_. With the Isaac Gym legacy
-API absorbed into Isaac Sim, NVIDIA also released open-sourced environment collections
-`IsaacGymEnvs`_ and `OmniIsaacGymEnvs`_ to showcase the capabilities of these simulators.
-Those environment collections are now deprecated in favor of Isaac Lab.
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
 
-Isaac Lab supersedes `IsaacGymEnvs`_, `OmniIsaacGymEnvs`_, and `Orbit`_ as the single robot
-learning framework for Isaac Sim. It retains full access to the PhysX/Isaac Sim stack while
-adding the Newton physics backend for kit-less deployments, an expanded sensor suite, imitation
-learning tooling, XR teleoperation, and a rich set of pre-built tasks.
+   * - Package
+     - Role
+   * - ``isaaclab``
+     - Backend-independent APIs for scenes, assets, sensors, environments, managers, MDP terms,
+       actuators, controllers, terrains, devices, configuration, and simulation orchestration.
+   * - ``isaaclab_physx``
+     - PhysX-backed assets, physics views, sensors, USD spawners, and Isaac RTX rendering. Requires
+       Isaac Sim.
+   * - ``isaaclab_ov``
+     - Standalone Omniverse integrations, including ``ovphysx`` physics and ``ovrtx`` tiled RTX
+       rendering for compatible kit-less workflows.
+   * - ``isaaclab_newton``
+     - Newton-backed assets, physics views, sensors, spawners, and Warp rendering for kit-less
+       workflows.
 
+Tasks and workflows
+~~~~~~~~~~~~~~~~~~~
 
-Is Isaac Lab a simulator?
--------------------------
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
 
-At its core, Isaac Lab is **not** a robotics simulator; it is a framework for building robot
-learning applications on top of a simulator. An analogous example is `RoboSuite`_, which is
-built on top of `MuJoCo`_ for fixed-base manipulation. Other examples include
-`MuJoCo Playground`_ (built on `MJX`_) and Isaac Gym (built on `PhysX`_).
+   * - Package
+     - Use it for
+   * - ``isaaclab_assets``
+     - Ready-to-use configurations for robots and sensors, including manipulators, quadrupeds,
+       humanoids, aerial robots, lidar, and tactile sensors.
+   * - ``isaaclab_tasks``
+     - Registered manager-based and direct `gymnasium`_ environments for training and evaluation.
+   * - ``isaaclab_rl``
+     - Adapters for `RSL-RL`_, `skrl`_, `Stable Baselines 3`_, and `RL Games`_.
+   * - ``isaaclab_mimic``
+     - Demonstration generation, imitation-learning datasets, and motion-planning-assisted data
+       collection.
+   * - ``isaaclab_teleop``
+     - Teleoperation sessions, XR integration, and retargeting for manipulators and humanoids.
+   * - ``isaaclab_visualizers``
+     - Additional visualization through Isaac Kit, Rerun, and Viser across supported backends.
+   * - ``isaaclab_contrib``
+     - Community-maintained assets, sensors, controllers, and other integrations.
+   * - ``isaaclab_experimental``
+     - Early-stage APIs and accelerated implementations that are still being evaluated.
 
-Isaac Lab supports both `PhysX`_ and `Newton`_ as physics backends and is deliberately
-agnostic to the underlying engine — user environments and tasks do not import backend-specific
-modules directly.
-
-The framework addresses a recurring problem with standalone task implementations: because each
-task reimplements the observation, reward, termination, and randomization logic from scratch,
-large projects accumulate significant code duplication. Isaac Lab solves this with two
-complementary patterns:
-
-* **Manager-based** environments defer every behavioral concern to typed, composable
-  *manager* objects (``ObservationManager``, ``RewardManager``, ``TerminationManager``,
-  ``EventManager``, ``CurriculumManager``, ``CommandManager``, ``ActionManager``,
-  ``RecorderManager``). Each manager is driven by small, reusable MDP term functions that live
-  in :mod:`isaaclab.envs.mdp`. This makes it easy to mix and match terms across tasks and to
-  test individual components in isolation.
-
-* **Direct** environments implement ``_get_observations``, ``_get_rewards``,
-  ``_get_dones``, and ``_reset_idx`` directly in a subclass, similar to the Isaac Gym style.
-  They sacrifice some modularity for simplicity and are a natural starting point for rapid
-  prototyping.
-
-Both patterns expose a standard `gymnasium`_ ``Env`` interface with vectorized semantics,
-so the same environment works unmodified with any of the supported RL libraries.
-Configuration management uses `Hydra`_ with a preset system that allows selecting physics
-backends and hyperparameter sweeps from the command line.
+Packages such as ``isaaclab_contrib`` and ``isaaclab_experimental`` may evolve faster than the
+core API. Check their documentation and changelogs before depending on them in long-lived projects.
 
 
-Why should I use Isaac Lab?
----------------------------
+What Isaac Lab gives you
+------------------------
 
-Isaac Lab provides an open-sourced platform for the community to build benchmarks and robot
-learning systems together. Sharing a common infrastructure lets teams reuse existing components,
-compare results on the same tasks, and focus on the research problems that matter rather than
-rebuilding simulation scaffolding from scratch.
+Isaac Lab brings the common parts of robot-learning projects into one shared framework:
 
-Concretely, Isaac Lab offers:
+* **Reusable task components** for observations, actions, rewards, events, commands, curricula,
+  and terminations.
+* **Vectorized GPU simulation** for training many environments in parallel.
+* **Multiple physics and rendering backends** behind a common frontend API.
+* **A broad sensor and asset library** that can be extended with your own implementations.
+* **Integrated learning workflows** for reinforcement learning, imitation learning, planning,
+  demonstration collection, and teleoperation.
+* **Reproducible configuration** through Hydra presets and command-line overrides.
+* **A shared benchmark base** that makes tasks, components, and results easier to compare and
+  reuse across projects.
 
-* **Two authoring patterns** — manager-based for modular research and direct for rapid
-  prototyping — with a shared :class:`~isaaclab.scene.InteractiveScene` and sensor stack.
-* **Multi-backend simulation** — switch between PhysX and Newton from the command line; the
-  same environment code runs on both.
-* **Rich sensor suite** — cameras (tiled and standard), ray-casters, contact sensors, IMU,
-  frame transformers, joint-wrench sensors, and visuo-tactile sensors.
-* **Imitation learning tooling** — ``isaaclab_mimic`` provides cuRobo-based planners and a
-  full dataset-generation pipeline for human demonstration collection.
-* **Teleoperation and XR** — ``isaaclab_teleop`` supports OpenXR, CloudXR, gamepads,
-  spacemouses, and Haply devices with retargeters for manipulators and humanoids.
-* **Hydra configuration management** — hierarchical configs with command-line overrides and a
-  preset system for multi-backend environment variants.
-* **RL library integrations** — wrappers for RSL-RL, skrl, Stable Baselines 3, and RL Games
-  ship in ``isaaclab_rl``.
-* **Kit-less deployment** — run policies and simulations using the Newton backend without a
-  full Isaac Sim installation. URDF and MJCF command-line conversion can also run kit-less
-  when the standalone ``isaacsim-asset-isolated`` importer wheel is installed.
+The goal is simple: spend less time rebuilding simulation infrastructure and more time working on
+the robot-learning problem itself.
 
-We are working with labs in universities and research institutions to integrate their work into
-Isaac Lab and hope that others in the community will join us. If you are interested in
-contributing, please reach out to us.
+
+How Isaac Lab relates to earlier Isaac projects
+-----------------------------------------------
+
+Isaac Lab builds on lessons from several earlier NVIDIA robotics projects:
+
+* `Isaac Gym`_ :cite:`makoviychuk2021isaac` introduced an end-to-end GPU pipeline for massively
+  parallel robot learning with PhysX. It enabled influential work in locomotion
+  :cite:`rudin2022learning` :cite:`rudin2022advanced`, dexterous manipulation
+  :cite:`handa2022dextreme` :cite:`allshire2022transferring`, and industrial assembly
+  :cite:`narang2022factory`.
+* `IsaacGymEnvs`_ and `OmniIsaacGymEnvs`_ provided example environment collections for Isaac Gym
+  and Isaac Sim. Both are now deprecated in favor of Isaac Lab.
+* `Orbit`_ was the research framework that preceded Isaac Lab and was incorporated into the
+  current project.
+* `Isaac Sim`_ remains the full-featured simulator and application platform. Isaac Lab adds the
+  task, environment, learning, and workflow abstractions used to build robot-learning systems on
+  top of it.
+
+Today, Isaac Lab is the primary robot-learning framework in the Isaac ecosystem. It combines the
+Isaac Sim and PhysX stack with multi-backend support, reusable environments, learning-library
+integrations, imitation-learning tools, and teleoperation workflows.
+
+
+Where to go next
+----------------
+
+* Start with :ref:`isaaclab-installation-root` to choose an installation and backend.
+* Follow the :ref:`isaac-lab-quickstart` to train and inspect your first task.
+* Read :doc:`/source/overview/core-concepts/multi_backend_architecture` before adapting an
+  environment to multiple backends.
+
+Isaac Lab is developed in the open with contributions from robotics labs, researchers, and
+developers. See the contribution guidelines if you want to report an issue, add a feature, or
+share a task with the community.
 
 
 .. _PhysX: https://developer.nvidia.com/physx-sdk
 .. _Newton: https://github.com/newton-physics/newton
 .. _Warp: https://github.com/NVIDIA/warp
 .. _Isaac Sim: https://developer.nvidia.com/isaac-sim
-.. _Omniverse: https://www.nvidia.com/en-us/omniverse/
 .. _Isaac Gym: https://developer.nvidia.com/isaac-gym
 .. _IsaacGymEnvs: https://github.com/isaac-sim/IsaacGymEnvs
 .. _OmniIsaacGymEnvs: https://github.com/isaac-sim/OmniIsaacGymEnvs
 .. _Orbit: https://isaac-orbit.github.io/
-.. _Isaac Automator: https://github.com/isaac-sim/IsaacAutomator
 .. _gymnasium: https://gymnasium.farama.org/
 .. _Hydra: https://hydra.cc/
 .. _RSL-RL: https://github.com/leggedrobotics/rsl_rl
 .. _skrl: https://skrl.readthedocs.io/
 .. _Stable Baselines 3: https://stable-baselines3.readthedocs.io/
 .. _RL Games: https://github.com/Denys88/rl_games
-.. _AirSim: https://microsoft.github.io/AirSim/
-.. _DoorGym: https://github.com/PSVL/DoorGym/
-.. _ManiSkill: https://github.com/haosulab/ManiSkill
-.. _ThreeDWorld: https://github.com/threedworld-mit/tdw
-.. _RoboSuite: https://github.com/ARISE-Initiative/robosuite
-.. _MuJoCo: https://mujoco.org/
-.. _MuJoCo Playground: https://playground.mujoco.org/
-.. _MJX: https://mujoco.readthedocs.io/en/stable/mjx.html
-.. _Bullet: https://github.com/bulletphysics/bullet3
-.. _Flex: https://developer.nvidia.com/flex


### PR DESCRIPTION
## Description

Reworks the Isaac Lab ecosystem page to:

- explain Isaac Lab's role as a robot-learning framework rather than a simulator
- show how tasks, backends, and learning workflows fit together
- compare the supported physics and rendering runtimes
- clarify manager-based and direct environment authoring
- provide a concise guide to the repository packages and their roles
- summarize the relationship to earlier Isaac projects

The new ecosystem animation is intentionally not included yet. The page references `source/_static/setup/ecosystem.gif`; that asset will be added in a follow-up commit from a media-capable machine before this PR is marked ready for review.

## Type of change

- Documentation update

## Release backport

- [ ] Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Pending the ecosystem GIF follow-up.

## Validation

- `git diff --check`
- `uv run isaaclab -f` (all applicable formatting and RST checks pass; the local changelog hook misidentifies unrelated fork changes because this clone's `origin` points to the fork rather than upstream)
- `uv run --isolated --extra dev -- make -C docs current-docs` (expected warning: `source/_static/setup/ecosystem.gif` is not present yet)

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the complete pre-commit checks
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable to this documentation-only change)
- [x] I have added a changelog fragment for every touched package (no source package is touched)
- [x] My name already exists in `CONTRIBUTORS.md`