### PR TITLE
[Backport] Fix kitless multi-GPU tests and ROS link checks

### DIFF
--- a/.github/actions/run-tests/run_tests.sh
+++ b/.github/actions/run-tests/run_tests.sh
@@ -320,8 +320,11 @@ run_tests() {
       set -e
       cd /workspace/isaaclab
       mkdir -p tests
-      rm _isaac_sim || true
-      ln -s /isaac-sim _isaac_sim
+      # The runtime mounts above create /isaac-sim in every image. Link it only where Kit
+      # lives there: in the kit-less image the link would read as a downloaded Isaac Sim,
+      # which isaaclab.sh refuses to combine with the image's VIRTUAL_ENV.
+      rm -f _isaac_sim
+      if [ -x /isaac-sim/python.sh ]; then ln -s /isaac-sim _isaac_sim; fi
       if [ -n \"\${WARP_CACHE_PATH:-}\" ]; then
         ./isaaclab.sh -p tools/verify_warp_cache.py
       fi

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -112,6 +112,7 @@ jobs:
           --exclude 'andrew\.cmu\.edu/course/10-703/textbook/BartoSutton\.pdf'
           --exclude 'www\.nvidia\.com/en-us/security'
           --exclude 'bostondynamics\.com/reinforcement-learning-researcher-kit'
+          --exclude 'ros\.org'
           --max-retries 5
           --retry-wait-time 10
           --timeout 20

--- a/docker/test/test_container_profiles.py
+++ b/docker/test/test_container_profiles.py
@@ -15,6 +15,7 @@ from docker import container as container_cli
 from docker.utils import ContainerInterface, volume_mounts
 
 DOCKER_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = DOCKER_DIR.parent
 
 
 @pytest.fixture
@@ -286,6 +287,20 @@ def test_kitless_compose_service_has_no_isaac_sim_mounts():
     assert forbidden_sources.isdisjoint(mount.get("source") for mount in mounts)
     assert all("DOCKER_ISAACSIM" not in mount["target"] for mount in mounts)
     assert all("/kit/" not in mount["target"].lower() for mount in mounts)
+
+
+def test_run_tests_links_isaac_sim_only_where_kit_is_installed():
+    """The kit-less image has no Kit under ``/isaac-sim``, which the runtime mounts create anyway.
+
+    Linking it as ``_isaac_sim`` there reads as a downloaded Isaac Sim, which ``isaaclab.sh``
+    refuses to combine with the image's ``VIRTUAL_ENV``.
+    """
+    script = (REPO_ROOT / ".github" / "actions" / "run-tests" / "run_tests.sh").read_text(encoding="utf-8")
+
+    link_lines = [line.strip() for line in script.splitlines() if "ln -s /isaac-sim _isaac_sim" in line]
+
+    assert link_lines
+    assert all("/isaac-sim/python.sh" in line for line in link_lines), link_lines
 
 
 def test_kitless_volume_key_resolves_owned_image_paths(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
# Description

Fixes two release CI failures without backporting #7405.

## Kitless multi-GPU tests

Backports only the release-relevant multi-GPU test fix from #7540.

PR #7466 is present on `release/3.0.0`, so `isaaclab.sh` rejects a downloaded-Isaac-Sim link alongside the kitless image's active virtual environment. The test runner currently creates `_isaac_sim -> /isaac-sim` unconditionally because runtime mounts make `/isaac-sim` exist even in the kitless image.

This change creates the link only when `/isaac-sim/python.sh` exists. Kit-based test images retain their existing behavior, while the kitless multi-GPU smoke test resolves Python from `VIRTUAL_ENV`.

This intentionally excludes #7540's image-invariant/cache changes and all of #7405, which was not backported to the release branch.

Original PR: https://github.com/isaac-sim/IsaacLab/pull/7540

## Documentation link check

The automatic backport's link check failed twice because `www.ros.org` and `docs.ros.org` return HTTP 403 to the GitHub runner. Both links remain valid. The link-check workflow already excludes known crawl blockers, so this adds a single `ros.org` exclusion covering both hosts without changing the documentation destinations or weakening checks for other domains.

Failed run: https://github.com/isaac-sim/IsaacLab/actions/runs/33828925399

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

Not applicable: this PR directly targets `release/3.0.0`.

## Validation

- Added a regression test that failed against the unmodified release branch and passes with the multi-GPU fix.
- `uv run --no-project --with pytest --with pyyaml python -m pytest docker/test/test_container_profiles.py -q` - 14 passed.
- `bash -n .github/actions/run-tests/run_tests.sh` - passed.
- Parsed `.github/workflows/check-links.yml` with PyYAML and verified the exclusion matches both failing URLs.
- Applicable file-scoped pre-commit hooks - passed. The branch-wide changelog hook is not applicable to a release backport because it compares historical release differences against `develop`.
- The canonical `uv run isaaclab -f` command cannot resolve this branch's Linux/Windows-only lockfile on macOS; the equivalent file-scoped hooks were run directly.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the applicable pre-commit checks.
- [x] Documentation destinations remain unchanged.
- [x] My changes generate no new warnings.
- [x] I have added a regression test for the multi-GPU behavior.
- [x] No changelog fragment is required because no source package changed.
- [x] The contributors already exist in `CONTRIBUTORS.md`.
