### PR TITLE
Fix Unitree Go2 calf actuator limits

### DIFF
--- a/source/isaaclab_assets/changelog.d/fix-go2-calf-reduction.rst
+++ b/source/isaaclab_assets/changelog.d/fix-go2-calf-reduction.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the Unitree Go2 calf actuator limits to reflect the knee reduction instead of sharing the hip/thigh limits.

--- a/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/unitree.py
@@ -170,10 +170,19 @@ UNITREE_GO2_CFG = ArticulationCfg(
     soft_joint_pos_limit_factor=0.9,
     actuators={
         "base_legs": DCMotorCfg(
-            joint_names_expr=[".*_hip_joint", ".*_thigh_joint", ".*_calf_joint"],
+            joint_names_expr=[".*_hip_joint", ".*_thigh_joint"],
             actuator_effort_limit=23.5,
             saturation_effort=23.5,
             actuator_velocity_limit=30.0,
+            stiffness=25.0,
+            damping=0.5,
+            friction=0.0,
+        ),
+        "calves": DCMotorCfg(
+            joint_names_expr=[".*_calf_joint"],
+            actuator_effort_limit=45.05,
+            saturation_effort=45.05,
+            actuator_velocity_limit=15.65,
             stiffness=25.0,
             damping=0.5,
             friction=0.0,

--- a/source/isaaclab_assets/test/test_unitree.py
+++ b/source/isaaclab_assets/test/test_unitree.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for predefined Unitree robot configurations."""
+
+from isaaclab_assets.robots.unitree import UNITREE_GO2_CFG
+
+
+def test_go2_calves_use_reduced_joint_limits():
+    """Verify the Go2 calf actuator reflects the knee reduction."""
+    base_legs = UNITREE_GO2_CFG.actuators["base_legs"]
+    calves = UNITREE_GO2_CFG.actuators["calves"]
+
+    assert base_legs.joint_names_expr == [".*_hip_joint", ".*_thigh_joint"]
+    assert calves.joint_names_expr == [".*_calf_joint"]
+    assert calves.actuator_effort_limit == 45.05
+    assert calves.saturation_effort == 45.05
+    assert calves.actuator_velocity_limit == 15.65


### PR DESCRIPTION
## Description

Fixes #7479.

`UNITREE_GO2_CFG` currently applies the same DC-motor effort and velocity limits to the hip, thigh, and calf joints. The Go2 calf sits behind an additional knee reduction, so using the hip/thigh limits underestimates calf torque and allows an unrealistically high motor-curve velocity.

This change keeps the existing hip/thigh actuator settings and gives the calf joints their own actuator group with reduction-adjusted limits:

- effort / saturation effort: 45.05 N·m
- velocity limit: 15.65 rad/s

The stiffness, damping, and friction settings are unchanged.

## Tests

Adds a configuration regression test verifying the calf group and its reduced joint-side limits.

## Changelog

Adds the required `isaaclab_assets` changelog fragment.