### PR TITLE
[FIX] Newton sensor CUDA graph capture fails on deformable geometry

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-sensor-graph-allocating-task.rst
+++ b/source/isaaclab_newton/changelog.d/fix-sensor-graph-allocating-task.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed Newton sensor CUDA graph capture failing with ``RuntimeError: Conditional body graph contains an
+  unsupported operation (memory allocation)`` on tasks with deformable geometry, such as
+  ``Isaac-Lift-Cloth-Franka-Camera``. Scene-query tasks are now captured into one graph each, because Warp
+  forbids memory allocation inside the conditional body that previously held them.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -477,9 +477,8 @@ class NewtonManager(PhysicsManager):
 
     # Newton scene-query scheduling and graph execution.
     _sensor_tasks: dict[str, Callable[[], None]] = {}
-    _sensor_graph: wp.Graph | None = None
-    _sensor_flags: wp.array | None = None
-    _sensor_flags_host: np.ndarray | None = None
+    _sensor_refit_graph: wp.Graph | None = None
+    _sensor_task_graphs: dict[str, wp.Graph] = {}
     _sensor_state: State | None = None
     _sensor_state_dirty: bool = True
     _sensor_graph_capture_failed: bool = False
@@ -2721,9 +2720,9 @@ class NewtonManager(PhysicsManager):
             cls._invalidate_sensor_graph()
         cfg = PhysicsManager._cfg
         use_cuda_graph = bool(getattr(cfg, "use_cuda_graph", False)) and "cuda" in str(PhysicsManager._device)
-        if use_cuda_graph and cls._sensor_graph is None and not cls._sensor_graph_capture_failed:
+        if use_cuda_graph and cls._sensor_refit_graph is None and not cls._sensor_graph_capture_failed:
             cls._capture_sensor_graph()
-        if cls._sensor_graph is None:
+        if cls._sensor_refit_graph is None:
             if cls._sensor_state_dirty:
                 cls._refit_sensor_bvh()
                 cls._sensor_state_dirty = False
@@ -2731,16 +2730,11 @@ class NewtonManager(PhysicsManager):
                 cls._sensor_tasks[name]()
             return
 
-        assert cls._sensor_flags_host is not None
-        assert cls._sensor_flags is not None
-        cls._sensor_flags_host.fill(0)
-        cls._sensor_flags_host[0] = int(cls._sensor_state_dirty)
-        task_names = tuple(cls._sensor_tasks)
+        if cls._sensor_state_dirty:
+            wp.capture_launch(cls._sensor_refit_graph)
+            cls._sensor_state_dirty = False
         for name in names:
-            cls._sensor_flags_host[1 + task_names.index(name)] = 1
-        cls._sensor_flags.assign(cls._sensor_flags_host)
-        wp.capture_launch(cls._sensor_graph)
-        cls._sensor_state_dirty = False
+            wp.capture_launch(cls._sensor_task_graphs[name])
 
     @classmethod
     def _mark_sensor_state_dirty(cls) -> None:
@@ -2783,47 +2777,59 @@ class NewtonManager(PhysicsManager):
     @classmethod
     def _invalidate_sensor_graph(cls) -> None:
         """Discard captured scene-query graph resources."""
-        cls._sensor_graph = None
-        cls._sensor_flags = None
-        cls._sensor_flags_host = None
+        cls._sensor_refit_graph = None
+        cls._sensor_task_graphs = {}
         cls._sensor_graph_capture_failed = False
 
     @classmethod
     def _capture_sensor_graph(cls) -> None:
-        """Capture BVH refit and scene-query tasks into a conditional graph."""
-        with wp.ScopedDevice(PhysicsManager._device):
+        """Capture the BVH refit and each scene-query task into its own graph.
+
+        Each step gets a standalone top-level graph rather than a ``wp.capture_if``
+        conditional body of one shared graph: Warp rejects memory allocation inside a
+        conditional body, and ``wp.Mesh.refit`` allocates scratch on every call, so
+        deformable geometry in the tiled-camera render path would fail to capture.
+        """
+        device = PhysicsManager._device
+        with wp.ScopedDevice(device):
             cls._refit_sensor_bvh()
             for update_fn in cls._sensor_tasks.values():
                 update_fn()
 
-        cls._sensor_flags = wp.zeros(1 + len(cls._sensor_tasks), dtype=wp.int32, device=PhysicsManager._device)
-        cls._sensor_flags_host = np.zeros(1 + len(cls._sensor_tasks), dtype=np.int32)
-        update_fns = tuple(cls._sensor_tasks.values())
+        refit_graph = cls._capture_sensor_step(device, cls._refit_sensor_bvh)
+        failed = None if refit_graph is not None else "bvh refit"
+        task_graphs: dict[str, wp.Graph] = {}
+        if failed is None:
+            for name, update_fn in cls._sensor_tasks.items():
+                graph = cls._capture_sensor_step(device, update_fn)
+                if graph is None:
+                    failed = name
+                    break
+                task_graphs[name] = graph
 
-        def pipeline() -> None:
-            assert cls._sensor_flags is not None
-            wp.capture_if(cls._sensor_flags[0:1], cls._refit_sensor_bvh)
-            for index, update_fn in enumerate(update_fns):
-                wp.capture_if(cls._sensor_flags[index + 1 : index + 2], update_fn)
-
-        device = PhysicsManager._device
-        if cls._usdrt_stage is not None:
-            cls._sensor_graph = cls._capture_relaxed_graph(device, capture_target=pipeline)
-        else:
-            try:
-                with wp.ScopedCapture(device=device) as capture:
-                    pipeline()
-                cls._sensor_graph = capture.graph
-            except Exception:
-                logger.exception("[NewtonManager] sensor CUDA graph capture failed")
-                cls._sensor_graph = None
-        if cls._sensor_graph is None:
-            cls._sensor_flags = None
-            cls._sensor_flags_host = None
+        if failed is not None:
+            cls._invalidate_sensor_graph()
+            # Latch after invalidating: _invalidate_sensor_graph() clears the flag.
             cls._sensor_graph_capture_failed = True
-            logger.warning("Newton sensor graph capture failed; falling back to eager execution.")
-        else:
-            logger.info("Captured Newton sensor graph with %d task(s).", len(cls._sensor_tasks))
+            logger.warning("Newton sensor graph capture failed for '%s'; falling back to eager execution.", failed)
+            return
+
+        cls._sensor_refit_graph = refit_graph
+        cls._sensor_task_graphs = task_graphs
+        logger.info("Captured Newton sensor graphs for %d task(s).", len(task_graphs))
+
+    @classmethod
+    def _capture_sensor_step(cls, device: str, capture_target: Callable[[], None]) -> wp.Graph | None:
+        """Capture one scene-query step into a standalone graph, or ``None`` on failure."""
+        if cls._usdrt_stage is not None:
+            return cls._capture_relaxed_graph(device, capture_target=capture_target)
+        try:
+            with _paused_gc(), wp.ScopedCapture(device=device) as capture:
+                capture_target()
+            return capture.graph
+        except Exception:
+            logger.exception("[NewtonManager] sensor CUDA graph capture failed")
+            return None
 
     @classmethod
     def get_num_envs(cls) -> int:

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -338,9 +338,8 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     monkeypatch.setattr(NewtonManager, "_sensor_tasks", {}, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_state", None, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_state_dirty", True, raising=False)
-    monkeypatch.setattr(NewtonManager, "_sensor_graph", None, raising=False)
-    monkeypatch.setattr(NewtonManager, "_sensor_flags", None, raising=False)
-    monkeypatch.setattr(NewtonManager, "_sensor_flags_host", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_refit_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_task_graphs", {}, raising=False)
     monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
     monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=False), raising=False)
 
@@ -348,6 +347,38 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     NewtonManager._update_sensor_tasks("render")
 
     assert status["rendered"]
+
+
+@pytest.mark.skipif(not wp.get_cuda_device_count(), reason="CUDA is unavailable")
+def test_sensor_graph_captures_allocating_task(monkeypatch):
+    """A sensor task that allocates scratch is still graph-capturable.
+
+    ``wp.Mesh.refit`` allocates scratch natively on every call, which Warp rejects
+    inside a ``wp.capture_if`` conditional body. Deformable geometry reaches it through
+    the tiled-camera render task, so each task must be captured as its own graph.
+    """
+
+    points = wp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=wp.vec3f, device="cuda:0")
+    mesh = wp.Mesh(points, wp.array([0, 1, 2], dtype=wp.int32, device="cuda:0"))
+
+    state = object()
+    monkeypatch.setattr(NewtonManager, "get_state", classmethod(lambda cls: state))
+    monkeypatch.setattr(NewtonManager, "_model", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_tasks", {"mesh_refit": mesh.refit}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state", state, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state_dirty", True, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_refit_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_task_graphs", {}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
+    monkeypatch.setattr(NewtonManager, "_usdrt_stage", None, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_device", "cuda:0", raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=True), raising=False)
+
+    NewtonManager._update_sensor_tasks("mesh_refit")
+
+    assert not NewtonManager._sensor_graph_capture_failed
+    assert NewtonManager._sensor_refit_graph is not None
+    assert "mesh_refit" in NewtonManager._sensor_task_graphs
 
 
 def test_sensor_bvh_shape_flags_are_fixed_before_builder_creation(monkeypatch):

--- a/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
@@ -252,4 +252,4 @@ def test_renderer_and_raycast_share_newton_manager_graph(sim):
     task_names = sorted(NewtonManager._sensor_tasks)
     assert any(name.startswith("newton_raycast:") for name in task_names)
     assert any(name.startswith("newton_warp_render:") for name in task_names)
-    assert (NewtonManager._sensor_graph is not None) == sim.cfg.physics.use_cuda_graph
+    assert bool(NewtonManager._sensor_task_graphs) == sim.cfg.physics.use_cuda_graph


### PR DESCRIPTION
Fixes nvbug 6675392.

Newton sensor CUDA graph capture fails on any task with deformable geometry, for example `Isaac-Lift-Cloth-Franka-Camera`:

```
RuntimeError: Conditional body graph contains an unsupported operation (memory allocation)
Newton sensor graph capture failed; falling back to eager execution.
```

`NewtonManager` wrapped every registered scene-query task in a `wp.capture_if` conditional body. CUDA does not permit memory-allocation nodes inside a conditional body graph, and `wp.Mesh.refit()` allocates a scratch buffer on every call. Cloth reaches that call through `SensorTiledCamera.update` -> `sync_transforms` -> `RenderContext.update` -> `_sync_triangle_mesh`, so capture fails and all sensor work falls back to eager execution. Rigid-only camera tasks are unaffected because `wp.Bvh.refit()` does not allocate.

The shared BVH refit and each scene-query task are now captured into their own top-level graph, where allocation nodes are legal. `_update_sensor_tasks` launches the refit graph when the state is dirty and then the graph of each requested task. This preserves the previous per-task selection semantics and removes the device flag array along with its per-call host-to-device copy.

The failure was not fatal, so it only ever surfaced as a logged traceback while training continued.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/isaaclab_newton/changelog.d/`