### PR TITLE
Fix RLinf uv runtime environment upload

### DIFF
--- a/source/isaaclab_rl/changelog.d/mingxueg-fixed_rlinf_training_startup.rst
+++ b/source/isaaclab_rl/changelog.d/mingxueg-fixed_rlinf_training_startup.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed RLinf training launched with ``uv run`` failing when Ray attempted to upload working directories larger than 512 MiB.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rlinf.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rlinf.py
@@ -69,6 +69,13 @@ def _list_tasks() -> None:
 
 def run(argv: list[str]) -> None:
     """Launch RLinf training."""
+    # Ray 2.47+ automatically turns the current project into a ``working_dir``
+    # runtime environment when the driver is launched through ``uv run``. An
+    # Isaac Lab checkout commonly contains a large ``.venv`` and local model
+    # checkpoints, which exceed Ray's 500 MiB upload limit. RLinf already
+    # selects the Python executable for each worker, so this upload is neither
+    # needed nor desirable.
+    os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
     os.environ.setdefault("RLINF_EXT_MODULE", "isaaclab_contrib.rl.rlinf.extension")
     args_cli = _parse_args(argv)
 


### PR DESCRIPTION
# Description

Disable Ray's automatic uv runtime environment for RLinf training to avoid exceeding the 512 MB working directory upload limit.
<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->


Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (existing functionality will not work without user modification)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
