### PR TITLE
Document the 15625 scene partition cap for Isaac RTX & OVRTX renderer

### DIFF
--- a/docs/source/overview/core-concepts/renderers.rst
+++ b/docs/source/overview/core-concepts/renderers.rst
@@ -88,6 +88,16 @@ token per instance; markers without that ownership information remain shared.
    culled once they deform beyond their initial extent. See
    :ref:`known-issues-animated-curve-scene-partition` for the workaround.
 
+.. warning::
+
+   Kit RTX caps the number of scene partitions at 15625. Requesting more than 15625
+   environments with scene partitioning enabled discards the additional partitions, and
+   ``rtx.scenedb.plugin`` logs ``SceneDbContext : Maximum number of scene partitions
+   (15625) reached. Additional scene partitions will be discarded.`` Environments beyond
+   that count then share a partition with another environment, so their tiled camera views
+   can show another environment's geometry. See
+   :ref:`known-issues-scene-partition-count-cap` for details.
+
 Architecture Overview
 ---------------------
 

--- a/docs/source/overview/core-concepts/renderers.rst
+++ b/docs/source/overview/core-concepts/renderers.rst
@@ -90,14 +90,13 @@ token per instance; markers without that ownership information remain shared.
 
 .. warning::
 
-   Kit RTX caps the number of scene partitions at 15625. Requesting more than 15625
-   environments with scene partitioning enabled discards the additional partitions, and
-   ``rtx.scenedb.plugin`` logs ``SceneDbContext : Maximum number of scene partitions
-   (15625) reached. Additional scene partitions will be discarded.`` Environments beyond
-   that count then share a partition with another environment, so their tiled camera views
-   can show another environment's geometry. This cap comes from the shared ``rtx.scenedb.plugin``
-   and applies to OVRTX as well, which cannot opt out of partitioning to avoid it. See
-   :ref:`known-issues-scene-partition-count-cap` for details.
+   The Isaac RTX and OVRTX renderers cap the number of scene partitions at 15625.
+   Requesting more than 15625 environments with scene partitioning enabled discards
+   the additional partitions, and ``rtx.scenedb.plugin`` logs ``SceneDbContext : Maximum
+   number of scene partitions (15625) reached. Additional scene partitions will be
+   discarded.`` Environments beyond that count then share a partition with another
+   environment, so their tiled camera views can show another environment's geometry.
+   See :ref:`known-issues-scene-partition-count-cap` for details.
 
 Architecture Overview
 ---------------------

--- a/docs/source/overview/core-concepts/renderers.rst
+++ b/docs/source/overview/core-concepts/renderers.rst
@@ -95,7 +95,8 @@ token per instance; markers without that ownership information remain shared.
    ``rtx.scenedb.plugin`` logs ``SceneDbContext : Maximum number of scene partitions
    (15625) reached. Additional scene partitions will be discarded.`` Environments beyond
    that count then share a partition with another environment, so their tiled camera views
-   can show another environment's geometry. See
+   can show another environment's geometry. This cap comes from the shared ``rtx.scenedb.plugin``
+   and applies to OVRTX as well, which cannot opt out of partitioning to avoid it. See
    :ref:`known-issues-scene-partition-count-cap` for details.
 
 Architecture Overview

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -157,13 +157,15 @@ There are two workarounds:
 Scene partitioning is capped at 15625 partitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled.
+**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled, and ``renderer=ovrtx``.
 
-Kit RTX allocates a fixed-size pool of scene partitions and caps it at 15625. Isaac Lab
-assigns one scene partition per environment when
-:attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` is
-enabled, so runs with more than 15625 environments exceed the pool. Once the cap is hit,
-``rtx.scenedb.plugin`` logs a warning and discards the remaining partitions:
+The underlying ``rtx.scenedb.plugin`` allocates a fixed-size pool of scene partitions and
+caps it at 15625, regardless of which renderer requests them. Isaac Lab assigns one scene
+partition per environment when
+:attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` is enabled
+for the Isaac RTX renderer, and OVRTX always assigns one scene partition per environment, so
+runs with more than 15625 environments exceed the pool on either backend. Once the cap is
+hit, ``rtx.scenedb.plugin`` logs a warning and discards the remaining partitions:
 
 .. code-block:: text
 

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -157,8 +157,7 @@ There are two workarounds:
 Scene partitioning is capped at 15625 partitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled. The OVRTX backend
-is unaffected.
+**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled.
 
 Kit RTX allocates a fixed-size pool of scene partitions and caps it at 15625. Isaac Lab
 assigns one scene partition per environment when
@@ -174,12 +173,6 @@ enabled, so runs with more than 15625 environments exceed the pool. Once the cap
 Environments beyond the cap are left without their own partition and end up sharing one
 with another environment, so their tiled camera views can render another environment's
 geometry instead of their own.
-
-There is no workaround that preserves per-environment partitioning above 15625
-environments. Either keep the environment count at or below 15625 when scene
-partitioning is required, or set
-:attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` to
-``False`` to run above that count, at the cost of per-environment culling.
 
 Using instanceable assets for markers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -152,6 +152,35 @@ There are two workarounds:
   ``False`` to opt out of partitioning entirely, at the cost of the per-environment
   culling.
 
+.. _known-issues-scene-partition-count-cap:
+
+Scene partitioning is capped at 15625 partitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``renderer=isaacsim_rtx`` with scene partitioning enabled. The OVRTX backend
+is unaffected.
+
+Kit RTX allocates a fixed-size pool of scene partitions and caps it at 15625. Isaac Lab
+assigns one scene partition per environment when
+:attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` is
+enabled, so runs with more than 15625 environments exceed the pool. Once the cap is hit,
+``rtx.scenedb.plugin`` logs a warning and discards the remaining partitions:
+
+.. code-block:: text
+
+    [Warning] [rtx.scenedb.plugin] SceneDbContext : Maximum number of scene partitions
+    (15625) reached. Additional scene partitions will be discarded.
+
+Environments beyond the cap are left without their own partition and end up sharing one
+with another environment, so their tiled camera views can render another environment's
+geometry instead of their own.
+
+There is no workaround that preserves per-environment partitioning above 15625
+environments. Either keep the environment count at or below 15625 when scene
+partitioning is required, or set
+:attr:`~isaaclab_physx.renderers.IsaacRtxRendererCfg.enable_scene_partitioning` to
+``False`` to run above that count, at the cost of per-environment culling.
+
 Using instanceable assets for markers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
- Document that Isaac RTX's `rtx.scenedb.plugin` caps the number of scene partitions at 15625; requesting more environments than that with scene partitioning enabled silently discards additional partitions and causes environments to share tiled camera views.
- Add a warning note to the scene partitioning section of the renderers overview doc.
- Add a corresponding Known Issues entry under the Renderers section, following the existing animated-curve scene-partition entry's format.

## Type of change

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Test plan
- [x] `uv run isaaclab -f` passes (docs/rst formatting checks)
- [x] Manually reviewed rendered structure/headings match existing doc conventions in both files