### PR TITLE
[Backport] Fix ray caster path matching regressions (#7516)

### DIFF
--- a/scripts/tutorials/04_sensors/run_ray_caster_camera.py
+++ b/scripts/tutorials/04_sensors/run_ray_caster_camera.py
@@ -57,7 +57,7 @@ def define_sensor() -> RayCasterCamera:
 
     # Setup camera sensor
     camera_cfg = RayCasterCameraCfg(
-        prim_path="/World/Origin_.*/CameraSensor",
+        prim_path="/World/Origin_[^/]+/CameraSensor",
         mesh_prim_paths=["/World/ground"],
         update_period=0.1,
         offset=RayCasterCameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.0), rot=(1.0, 0.0, 0.0, 0.0)),

--- a/source/isaaclab/test/app/standalone_script_cases.py
+++ b/source/isaaclab/test/app/standalone_script_cases.py
@@ -265,9 +265,7 @@ OVERRIDES = {
     "scripts/tutorials/03_envs/run_cartpole_rl_env.py": ScriptOverride(readiness_pattern=r"Resetting environment"),
     "scripts/tutorials/04_sensors/add_sensors_on_robot.py": ScriptOverride(args=("--enable_cameras",)),
     "scripts/tutorials/04_sensors/run_ray_caster.py": ScriptOverride(visualizers=("none", "kit")),
-    "scripts/tutorials/04_sensors/run_ray_caster_camera.py": ScriptOverride(
-        args=("--enable_cameras",), visualizers=("none", "kit")
-    ),
+    "scripts/tutorials/04_sensors/run_ray_caster_camera.py": ScriptOverride(visualizers=("none", "kit")),
     "scripts/tutorials/04_sensors/run_usd_camera.py": ScriptOverride(visualizers=("none", "kit")),
     "scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py": ScriptOverride(
         readiness_pattern=r"Gym action space",

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -232,7 +232,7 @@ def test_commands_respect_script_launcher_capabilities():
         if case.spec.relative_path == "scripts/tutorials/04_sensors/run_ray_caster_camera.py"
         and case.visualizer == "none"
     )
-    assert "--enable_cameras" in ray_camera_case.command()
+    assert "--enable_cameras" not in ray_camera_case.command()
 
     usd_camera_case = next(
         case

--- a/source/isaaclab_newton/changelog.d/fix-ray-caster-regex-paths.rst
+++ b/source/isaaclab_newton/changelog.d/fix-ray-caster-regex-paths.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed legacy Newton multi-mesh ray casters failing to associate tracked target sites when target discovery
+  produced a different path expression than site registration.

--- a/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/legacy_ray_caster.py
+++ b/source/isaaclab_newton/isaaclab_newton/sensors/ray_caster/legacy_ray_caster.py
@@ -37,12 +37,18 @@ class _LegacyNewtonRayCasterMixin(_NewtonRayCasterPoseMixin):
 
     def __init__(self: Any, cfg):
         super().__init__(cfg)
-        self._tracked_site_labels_by_target: dict[tuple[str, ...], list[str]] = {}
+        self._tracked_site_labels: list[list[str]] = []
+        self._tracked_target_index = 0
         for target_cfg in getattr(self, "_raycast_targets_cfg", []):
             if target_cfg.track_mesh_transforms:
                 owner_exprs = self._resolve_target_owner_exprs(target_cfg.prim_expr)
                 labels = self._register_target_sites_for_exprs(owner_exprs)
-                self._tracked_site_labels_by_target[tuple(owner_exprs)] = labels
+                self._tracked_site_labels.append(labels)
+
+    def _initialize_warp_meshes(self: Any) -> None:
+        """Reset tracked-target association before creating mesh views."""
+        self._tracked_target_index = 0
+        super()._initialize_warp_meshes()
 
     def _resolve_target_owner_exprs(self, prim_expr: str) -> list[str]:
         """Resolve mesh target expressions to owning rigid-body expressions."""
@@ -71,8 +77,8 @@ class _LegacyNewtonRayCasterMixin(_NewtonRayCasterPoseMixin):
 
     def _create_tracked_target_view(self: Any, target_prim_path: str | list[str]) -> wp.array:
         """Resolve dynamic multi-mesh target sites to Newton site indices."""
-        target_exprs = target_prim_path if isinstance(target_prim_path, list) else [target_prim_path]
-        labels = self._tracked_site_labels_by_target[tuple(target_exprs)]
+        labels = self._tracked_site_labels[self._tracked_target_index]
+        self._tracked_target_index += 1
         site_indices = self._resolve_site_indices(labels, str(target_prim_path), self._num_envs)
         return wp.array(site_indices, dtype=wp.int32, device=self._device)
 

--- a/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
+++ b/source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py
@@ -27,7 +27,13 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import RigidObject, RigidObjectCfg
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
 from isaaclab.sensors.camera import CameraCfg
-from isaaclab.sensors.ray_caster import MultiMeshRayCaster, MultiMeshRayCasterCamera, RayCasterCamera, RayCasterCfg
+from isaaclab.sensors.ray_caster import (
+    MultiMeshRayCaster,
+    MultiMeshRayCasterCamera,
+    MultiMeshRayCasterCfg,
+    RayCasterCamera,
+    RayCasterCfg,
+)
 from isaaclab.sensors.ray_caster.patterns import GridPatternCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
@@ -160,6 +166,35 @@ def test_remaining_warp_mesh_factories_select_legacy_newton_adapters(sim):
     assert RayCasterCamera.resolve_class() is LegacyRayCasterCamera
     assert MultiMeshRayCaster.resolve_class() is LegacyMultiMeshRayCaster
     assert MultiMeshRayCasterCamera.resolve_class() is LegacyMultiMeshRayCasterCamera
+
+
+def test_legacy_multi_mesh_tracks_ad_hoc_regex_target(sim):
+    """Tracked target registration remains valid when discovery returns concrete owner paths."""
+    obstacle_cfg = sim_utils.CuboidCfg(
+        size=(1.0, 1.0, 1.0),
+        rigid_props=sim_utils.RigidBodyBaseCfg(kinematic_enabled=True),
+        mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        collision_props=sim_utils.CollisionBaseCfg(),
+    )
+    obstacle_cfg.func("/World/Origin_00/Obstacle", obstacle_cfg)
+
+    sensor_cfg = MultiMeshRayCasterCfg(
+        prim_path="/World/Origin_[^/]+/Obstacle",
+        mesh_prim_paths=[
+            MultiMeshRayCasterCfg.RaycastTargetCfg(
+                prim_expr="/World/Origin_[^/]+/Obstacle",
+                track_mesh_transforms=True,
+            )
+        ],
+        pattern_cfg=GridPatternCfg(resolution=1.0, size=(0.0, 0.0)),
+    )
+    sensor = MultiMeshRayCaster(sensor_cfg)
+
+    sim.reset()
+    sensor.update(sim.get_physics_dt(), force_recompute=True)
+
+    assert sensor.num_instances == 1
+    assert sensor.data.ray_hits_w.shape[0] == 1
 
 
 def test_bvh_refit_tracks_moving_geometry(sim):


### PR DESCRIPTION
# Description

Backports #7516 to `release/3.0.0`.

The automatic backport workflow completed successfully but skipped the backport because the source PR body did not retain the hidden `<!-- backport-active-release -->` selection marker. This branch manually cherry-picks the canonical merged commit `167b6b15538bc6ec23554ec1b69f45ac34ae35bd` with `-x` provenance.

The cherry-pick applied without conflicts or release-specific edits. Its stable patch ID is identical to the source commit, and all seven source paths are preserved exactly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- This PR already targets the active release branch.

## Validation

- Stable source/backport patch IDs match: `b30f8378be6d764298eb95b92d8f5e03ffb97b51`.
- `uv run python -m pytest source/isaaclab_newton/test/sensors/test_newton_raycast_sensor.py -vv` — 18 passed.
- `uv run python -m pytest source/isaaclab/test/app/test_standalone_scripts.py::test_commands_respect_script_launcher_capabilities -vv` — 1 passed.
- `ISAACLAB_CHANGELOG_BASE_REF=release/3.0.0 uv run isaaclab -f` — all hooks passed.
- `git diff --check upstream/release/3.0.0..HEAD` — passed.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the tutorial and smoke configuration
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added changelog fragments for the touched source packages
- [x] My name already exists in `CONTRIBUTORS.md`
