### PR TITLE
Install docs dependencies for beta2 multi-version build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Install docs dependencies
       run: |
-        uv sync --extra test
+        uv sync --extra dev
         echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
     - name: Generate multi-version docs


### PR DESCRIPTION
# Description

Fix the scheduled multi-version documentation build on `release/3.0.0-beta2`. The release workflow checks out `develop` but installs only the `test` extra. Since #7405 moved Sphinx and `sphinx-multiversion` into the `dev` extra on `develop`, the build fails with `sphinx-multiversion: not found`.

This changes the workflow to install the `dev` extra before running `make multi-docs`.

Failed run: https://github.com/isaac-sim/IsaacLab/actions/runs/33829027682/job/100887817207

No new dependencies are introduced.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] This PR already targets `release/3.0.0-beta2`; no additional backport is requested.

## Screenshots

Not applicable.

## Validation

- Parsed `.github/workflows/docs.yaml` and asserted that the multi-version job installs `dev`, not `test`.
- `pre-commit run --files .github/workflows/docs.yaml` passed all applicable hooks.
- `uv run isaaclab -f` was attempted but dependency resolution cannot install the release branch's Linux/Windows-only `omniverseclient==2.71.1.7015` wheel on macOS ARM64.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] Applicable pre-commit checks pass
- [x] No documentation content change is required
- [x] My changes generate no new warnings
- [x] Targeted workflow validation covers the fix
- [x] No source package changed, so no changelog fragment is required
- [x] My name is already in `CONTRIBUTORS.md`