### PR TITLE
Fix teleop recording success term

### DIFF
--- a/scripts/tools/record_demos.py
+++ b/scripts/tools/record_demos.py
@@ -200,6 +200,11 @@ logger = logging.getLogger(__name__)
 _CLOUDXR_ENV_SHORTHANDS: dict[str, str] = {}
 
 
+def _never_terminate(env: gym.Env) -> torch.Tensor:
+    """Return a false termination signal for every environment."""
+    return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+
+
 def _resolve_cloudxr_env(value: str | None, xr_enabled: bool = False) -> str | None:
     """Resolve ``--cloudxr_env`` shorthands to absolute ``.env`` file paths.
 
@@ -346,11 +351,12 @@ def create_environment_config(
         not teleop_device_explicitly_set and hasattr(env_cfg, "isaac_teleop") and env_cfg.isaac_teleop is not None
     )
 
-    # extract success checking function to invoke in the main loop
-    success_term = None
-    if hasattr(env_cfg.terminations, "success"):
-        success_term = env_cfg.terminations.success
-        env_cfg.terminations.success = None
+    # Extract the success condition for manual evaluation in the main loop. Keep
+    # an inert term registered under the same name so rewards and other manager
+    # terms that reference "success" can still resolve it during initialization.
+    success_term = getattr(env_cfg.terminations, "success", None)
+    if success_term is not None:
+        env_cfg.terminations.success = success_term.replace(func=_never_terminate, params={})
     else:
         logger.warning(
             "No success termination term was found in the environment."

--- a/source/isaaclab_teleop/changelog.d/maximiliank-teleop-success-placeholder.rst
+++ b/source/isaaclab_teleop/changelog.d/maximiliank-teleop-success-placeholder.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed demonstration recording for tasks whose rewards reference the ``success``
+  termination term.

--- a/source/isaaclab_teleop/test/test_teleop_scripts_smoke.py
+++ b/source/isaaclab_teleop/test/test_teleop_scripts_smoke.py
@@ -82,6 +82,8 @@ _REGRESSION_SIGNATURES = (
     "No module named 'omni.replicator'",
     "has no attribute 'enable_cameras'",
     "has no attribute 'headless'",
+    # Success termination removed while a reward still references it
+    "Not all regular expressions are matched",
     # Registry-only XR dependency: the app exits before any marker is printed
     "Exiting app because of dependency solver failure",
 )
@@ -94,6 +96,9 @@ _ISAAC_TELEOP_MARKER = "Using IsaacTeleop stack for teleoperation"
 
 # Marker logged by ManagerBasedEnv creation, which runs *after* the RTX-apply site that regressed.
 _ENV_CREATED_MARKER = "Base environment:"
+
+# Marker logged after every manager has initialized successfully.
+_ENV_READY_MARKER = "Completed setting up the environment"
 
 # Disable CloudXR: no headset connects in CI, and auto-launching the runtime is unnecessary to
 # exercise the Isaac Teleop device factory (the live session is out of scope for a headless smoke).
@@ -153,10 +158,10 @@ def _terminate_group(proc: subprocess.Popen) -> None:
 
 
 def _assert_started_cleanly(output: str, markers: list[str], script: str) -> None:
-    """Assert the run cleared the #6656 regression and reached a post-startup marker."""
+    """Assert the run cleared known regressions and reached a post-startup marker."""
     tail = output[-4000:]
     for sig in _REGRESSION_SIGNATURES:
-        assert sig not in output, f"{script}: #6656 regression signature present ({sig!r})\n---\n{tail}"
+        assert sig not in output, f"{script}: regression signature present ({sig!r})\n---\n{tail}"
     assert any(marker in output for marker in markers), (
         f"{script}: did not reach a startup marker {markers} within {_STARTUP_TIMEOUT_S:.0f}s\n---\n{tail}"
     )
@@ -197,6 +202,23 @@ def test_record_demos_starts(tmp_path):
     ]
     output = _launch_until_marker(argv, [_ISAAC_TELEOP_MARKER], tmp_path / "record_demos.log")
     _assert_started_cleanly(output, [_ISAAC_TELEOP_MARKER], "record_demos.py")
+
+
+def test_record_demos_starts_when_reward_references_success(tmp_path):
+    """record_demos.py preserves success-term references while disabling automatic resets."""
+    argv = [
+        "scripts/tools/record_demos.py",
+        "--task",
+        "Isaac-Reach-Franka",
+        "--teleop_device",
+        "keyboard",
+        "--dataset_file",
+        str(tmp_path / "dataset.hdf5"),
+        "physics=isaacsim_physx",
+        "presets=diffik",
+    ]
+    output = _launch_until_marker(argv, [_ENV_READY_MARKER], tmp_path / "record_demos_success_reward.log")
+    _assert_started_cleanly(output, [_ENV_READY_MARKER], "record_demos.py with a success reward")
 
 
 def test_xr_experience_declares_only_shipped_extensions():


### PR DESCRIPTION
# Description

Ports #7571 to `develop`.

`record_demos.py` removed the `success` termination before environment initialization. The Franka Reach reward configuration references that term through `is_terminated_term`, so reward-manager initialization could not resolve the `success` key.

This change:

- keeps an inert `success` termination registered while demonstration recording evaluates the original condition manually;
- preserves reward-manager references without restoring automatic success resets;
- adds a Franka Reach DiffIK startup regression test;
- adds the `isaaclab_teleop` changelog fragment.

Release-branch counterpart: #7571.

The independent `develop` pre-commit baseline failure is split into #7582. This PR's repository-wide pre-commit job depends on that fix landing first.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

An explicit release PR already exists as #7571, so no additional automated backport is requested.

## Screenshots

Not applicable.

## Testing

- Focused pre-commit checks passed for all three changed files.
- `uv run --no-project python tools/changelog/cli.py check --include-worktree` passed.
- `git diff --check upstream/develop...HEAD` passed.
- The simulator smoke test cannot run locally because the project lockfile does not support the current Apple Silicon macOS host; it is included for Linux CI.
- The repository-wide pre-commit baseline is repaired separately by #7582.

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the full repository-wide pre-commit checks (blocked on #7582)
- [x] Documentation changes are not required because no public API changed
- [x] My changes generate no new warnings
- [x] I have added a test that proves the teleop fix is effective
- [x] I have added the `isaaclab_teleop` changelog fragment
- [x] Maximilian Krause already appears in `CONTRIBUTORS.md`
