### PR TITLE
[Backport release/3.0.0] Clear self-collision filter pairs before finalizing shadow Newton model (#7505)

### DIFF
--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -826,6 +826,10 @@ def test_clone_visualization_builder_ignores_non_env_deformables_on_world_import
     UsdGeom.Xform.Define(stage, "/World/envs/env_1")
 
     fake_builder = _FakeShadowBuilder(body_count=1, cloth_delta=3, track_usd=True)
+    fake_builder.shape_collision_filter_pairs = []
+    fake_builder.shape_collision_group = []
+    fake_builder.shape_count = 0
+    fake_builder.add_builder = lambda _builder: None
     clone_plan = SimpleNamespace(
         sources=("/World/envs/env_0",),
         destinations=("/World/envs/env_{}",),

--- a/source/isaaclab_newton/changelog.d/fix-shadow-model-collision-filter-oom.rst
+++ b/source/isaaclab_newton/changelog.d/fix-shadow-model-collision-filter-oom.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed PhysX-backend Newton visualization models replicating unused collision
+  filters and contact pairs, which could exhaust memory during ``ModelBuilder.finalize()``.

--- a/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
@@ -114,6 +114,8 @@ def build_visualization_builder_from_stage_envs(
         shadow_entities, registry_groups = add_shadow_deformables_to_builder(
             builder, stage, env_paths, device=device, entries=deformable_entries, clone_plan=clone_plan
         )
+        builder.shape_collision_filter_pairs = []
+        builder.shape_collision_group[:] = [0] * builder.shape_count
         return builder, (shadow_entities, registry_groups)
 
     if not env_paths:
@@ -148,6 +150,12 @@ def build_visualization_builder_from_stage_envs(
         schema_resolvers,
         ignore_paths=source_deformable_ignore_paths or None,
     )
+    global_builder = builder
+    builder = ModelBuilder(up_axis=up_axis)  # Preserve Newton's compact empty filter store.
+    for visual_builder in (global_builder, *source_builders.values()):
+        visual_builder.shape_collision_filter_pairs = []
+        visual_builder.shape_collision_group[:] = [0] * visual_builder.shape_count
+    builder.add_builder(global_builder)
     replicate_builder_mapping(builder, sources, mapping, positions, quaternions, source_builders)
     rename_builder_labels(builder, sources, destinations, env_ids, mapping)
     shadow_entities, registry_groups = add_shadow_deformables_to_builder(

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -21,7 +21,7 @@ from isaaclab_newton.physics import visualization_builder as visualization_build
 from isaaclab_newton.physics import visualization_deformables as visualization_deformables_module
 from newton.solvers import SolverMuJoCo
 
-from pxr import Usd, UsdGeom
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
 from isaaclab.cloner import ClonePlan
 from isaaclab.scene_data.deformable_discovery import DeformableStageEntry
@@ -46,6 +46,8 @@ _DST = "/World/envs/env_{}"
 class _FakeVisualizationModelBuilder:
     def __init__(self, up_axis=None):
         self.up_axis = up_axis
+        self.shape_collision_filter_pairs = []
+        self.shape_collision_group = []
         for attr in _VIS_BUILTIN_LABEL_ATTRS:
             setattr(self, attr, [])
             setattr(self, attr.replace("_label", "_world"), [])
@@ -86,6 +88,7 @@ class _FakeVisualizationModelBuilder:
         for attr in _VIS_BUILTIN_LABEL_ATTRS:
             getattr(self, attr).append(f"{root_path}/{_VIS_LABEL_SUFFIXES[attr]}")
             getattr(self, attr.replace("_label", "_world")).append(self._current_world or 0)
+        self.shape_collision_group.append(1)
         self.custom_attributes["mujoco:equality_constraint_label"].values.append(
             f"{root_path}/{_VIS_LABEL_SUFFIXES['equality_constraint_label']}"
         )
@@ -102,6 +105,7 @@ class _FakeVisualizationModelBuilder:
             labels = getattr(builder, attr)
             getattr(self, attr).extend(labels)
             getattr(self, attr.replace("_label", "_world")).extend([self._current_world] * len(labels))
+        self.shape_collision_group.extend(builder.shape_collision_group)
         eq_labels = builder.custom_attributes["mujoco:equality_constraint_label"].values
         self.custom_attributes["mujoco:equality_constraint_label"].values.extend(eq_labels)
         self.custom_attributes["mujoco:equality_constraint_world"].values.extend([self._current_world] * len(eq_labels))
@@ -473,6 +477,9 @@ class TestVisualizationClonePlan(unittest.TestCase):
         self._define_xform(stage, "/World")
         self._define_xform(stage, "/World/Robot")
         builder = mock.Mock()
+        builder.shape_collision_filter_pairs = []
+        builder.shape_collision_group = []
+        builder.shape_count = 0
         builder.add_usd.return_value = {"path_shape_map": {}}
 
         with (
@@ -489,6 +496,47 @@ class TestVisualizationClonePlan(unittest.TestCase):
         self.assertEqual(shadow_entities, [])
         self.assertEqual(registry_groups, [])
         builder.add_usd.assert_called_once_with(stage, schema_resolvers=["newton", "physx"], ignore_paths=None)
+
+    def test_visualization_builder_disables_collision_pairs(self):
+        stage = Usd.Stage.CreateInMemory()
+        robot_path = "/World/envs/env_0/Robot"
+        self._define_xform(stage, "/World")
+        self._define_xform(stage, "/World/envs")
+        self._define_xform(stage, "/World/envs/env_0")
+        self._define_xform(stage, "/World/envs/env_1", (2.0, 0.0, 0.0))
+        robot = UsdGeom.Xform.Define(stage, robot_path).GetPrim()
+        UsdPhysics.ArticulationRootAPI.Apply(robot)
+        robot.CreateAttribute("physxArticulation:enabledSelfCollisions", Sdf.ValueTypeNames.Bool).Set(False)
+        for name, translation in (("A", 0.0), ("B", 1.0)):
+            body_path = f"{robot_path}/{name}"
+            body = UsdGeom.Xform.Define(stage, body_path)
+            body.AddTranslateOp().Set((translation, 0.0, 0.0))
+            UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+            collision = UsdGeom.Cube.Define(stage, f"{body_path}/Collision")
+            collision.CreateSizeAttr(0.2)
+            UsdPhysics.CollisionAPI.Apply(collision.GetPrim())
+        joint = UsdPhysics.RevoluteJoint.Define(stage, f"{robot_path}/Joint")
+        joint.CreateBody0Rel().SetTargets([Sdf.Path(f"{robot_path}/A")])
+        joint.CreateBody1Rel().SetTargets([Sdf.Path(f"{robot_path}/B")])
+
+        clone_plan = ClonePlan(
+            sources=(robot_path,),
+            destinations=("/World/envs/env_{}/Robot",),
+            clone_mask=torch.ones((1, 2), dtype=torch.bool),
+            env_ids=torch.arange(2),
+        )
+        for env_paths, plan, expected_shape_count in (
+            ([], None, 2),
+            ([(0, "/World/envs/env_0"), (1, "/World/envs/env_1")], clone_plan, 4),
+        ):
+            builder, _shadow_metadata = visualization_builder_module.build_visualization_builder_from_stage_envs(
+                stage, env_paths, plan
+            )
+            model = builder.finalize(device="cpu")
+
+            self.assertEqual(model.shape_count, expected_shape_count)
+            self.assertEqual(len(model.shape_collision_filter_pairs), 0)
+            self.assertEqual(model.shape_contact_pair_count, 0)
 
     def test_visualization_builder_rejects_clone_plan_without_environment_paths(self):
         """A cloned scene must not be cached as an incomplete single-world model."""


### PR DESCRIPTION
# Description

Backports #7505 to `release/3.0.0` by cherry-picking the merged commit `4b9ba22508895906bb856845153b6409b5e86b3c` with `-x` provenance.

The [automatic backport run](https://github.com/isaac-sim/IsaacLab/actions/runs/33862657583) encountered the expected visualization-builder conflict, but its inferred resolution dropped the release-only `rename_builder_labels` import and failed Ruff with `F821`.

This manual backport preserves the source change while retaining the release branch's API sequence: it strips collision filters and groups before composition and replication, calls the release signature of `replicate_builder_mapping`, and then calls `rename_builder_labels` separately. No runtime dependencies are added.

| Field | Commit |
|---|---|
| Original merged change | `4b9ba22508895906bb856845153b6409b5e86b3c` |
| Release base used | `355dc9ba107527d7baae7600e89229a89d4e4628` |
| Proposed backport | `64c6d483803bf706404236516d92c8ec77ab8211` |

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- This PR already targets the active release branch.

## Validation

- Repository backport candidate validation passed with all five source paths preserved and no extra paths changed.
- Full repository pre-commit suite passed against `release/3.0.0`, including changelog and Git LFS checks.
- `uv run --no-project python -m compileall -q` passed for all three modified Python files.
- `git diff --check upstream/release/3.0.0...HEAD` passed.
- Focused Newton regression tests are pending Linux CI because the repository lockfile does not support the local macOS/arm64 host. The original source PR completed 53 checks successfully.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the available pre-commit checks
- [x] Documentation changes are not needed for this backport
- [ ] My changes generate no new runtime warnings (pending Linux CI)
- [x] The original regression test is preserved in the backport
- [x] Changelog fragments are preserved for both touched packages
- [x] The original contributor is already listed in `CONTRIBUTORS.md`
