### PR TITLE
Fix OVRTX clone-plan test import

### DIFF
--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 
 from isaaclab.cloner.clone_plan import ClonePlan
 from isaaclab.renderers.camera_render_spec import CameraRenderSpec


### PR DESCRIPTION
# Description

Restores the missing `torch` import in `test_ovrtx_clone_plan.py`.

#7462 converted the existing clone-plan test inputs from Torch tensors to NumPy arrays and removed the then-unused import. #6308 subsequently added a new object-scale test using `torch.ones` and `torch.arange` without restoring the import, causing the repository-wide Ruff pre-commit check to fail with `F821 Undefined name torch`.

This PR contains only the import repair and an `isaaclab_ov` `.skip` changelog fragment. It unblocks #7579 and other changes based on the current `develop` branch.

## Type of change

- Bug fix (non-breaking test fix)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

No release backport is required: `release/3.0.0` already imports `torch` in this test.

## Screenshots

Not applicable.

## Testing

- `uv run --no-project --with pre-commit python -m pre_commit run --all-files`
- `uv run --no-project python tools/changelog/cli.py check --include-worktree`
- `git diff --check upstream/develop...HEAD`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the full pre-commit checks
- [x] Documentation changes are not required because no public API changed
- [x] My changes generate no new warnings
- [x] The fix directly covers the Ruff `F821` failure
- [x] I have added an `isaaclab_ov` changelog fragment
- [x] My name already exists in `CONTRIBUTORS.md`
