### PR TITLE
Tune quickstart capture framing and downsampling for documentation media

### DIFF
--- a/tools/docs/media/capture_quickstart.py
+++ b/tools/docs/media/capture_quickstart.py
@@ -29,6 +29,8 @@ from isaaclab_tasks.core.lift.config.kuka_allegro.kuka_allegro_env_cfg import Ku
 from isaaclab_tasks.core.velocity.config.g1.flat_env_cfg import G1FlatEnvCfg
 from isaaclab_tasks.utils import resolve_task_config, setup_preset_cli
 
+# Focal lengths are tuned per task to the tightest framing that still keeps the subject inside the
+# published crop; the safe value differs per scene, so they are not a fixed ratio of one another.
 _TASK_CONFIGS = {
     "Isaac-Cartpole": "capture_quickstart:CartpoleCaptureCfg",
     "Isaac-Lift-KukaAllegro": "capture_quickstart:KukaAllegroCaptureCfg",
@@ -43,7 +45,7 @@ class CartpoleCaptureCfg(CartpoleEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=18.0)
+        _configure_capture(self, focal_length=21.0)
 
 
 @configclass
@@ -52,7 +54,7 @@ class G1FlatCaptureCfg(G1FlatEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=20.0)
+        _configure_capture(self, focal_length=29.0)
 
 
 @configclass
@@ -61,7 +63,9 @@ class KukaAllegroCaptureCfg(KukaAllegroLiftEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=22.0)
+        # Held to 24 rather than the tighter framing the other tasks take: the lift policy raises
+        # the arm well above the pose a zero action holds, and 26 already leaves little headroom.
+        _configure_capture(self, focal_length=24.0)
 
 
 @configclass
@@ -70,7 +74,7 @@ class FrankaCabinetCaptureCfg(FrankaCabinetEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=22.0)
+        _configure_capture(self, focal_length=32.0)
 
 
 def configure_playback() -> list[str]:
@@ -97,7 +101,7 @@ def main():
     env_cfg, _ = resolve_task_config(args.task, "", play_mode=True)
     env_cfg.scene.num_envs = 1
     env_cfg.seed = 42
-    _configure_resolved_sim(env_cfg.sim, focal_length=22.0)
+    _configure_resolved_sim(env_cfg.sim, focal_length=32.0)
     env_cfg.video_recorders = [
         VideoRecorderCfg(
             source="visualizer:newton_rtx",
@@ -144,15 +148,20 @@ def _configure_capture(env_cfg: object, focal_length: float):
 
 
 def _configure_resolved_sim(sim_cfg: SimulationCfg, focal_length: float):
-    """Attach a headless 320 by 240 OVRTX visualizer to a simulation config."""
+    """Attach a headless 1280 by 960 OVRTX visualizer to a simulation config.
+
+    Captures at four times the 320 by 240 publication size so the generator can downsample the
+    path-traced frames, which resolves robot silhouettes and shadow edges that alias away when
+    the path tracer renders straight to the final size.
+    """
     default_camera = sim_cfg.default_visualizer_cfg or VisualizerCfg()
     sim_cfg.visualizer_cfgs = [
         NewtonRTXVisualizerCfg(
             eye=default_camera.eye,
             lookat=default_camera.lookat,
             focal_length=focal_length,
-            window_width=320,
-            window_height=240,
+            window_width=1280,
+            window_height=960,
             headless=True,
             rtx_environment="default",
             render_settings={"omni:rtx:quality": ("Int", 100)},

--- a/tools/docs/media/capture_quickstart.py
+++ b/tools/docs/media/capture_quickstart.py
@@ -45,7 +45,7 @@ class CartpoleCaptureCfg(CartpoleEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=21.0)
+        _configure_capture(self, focal_length=30.0, lookat=(0.0, 0.0, 2.2))
 
 
 @configclass
@@ -54,7 +54,7 @@ class G1FlatCaptureCfg(G1FlatEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
-        _configure_capture(self, focal_length=29.0)
+        _configure_capture(self, focal_length=20.0)
 
 
 @configclass
@@ -124,16 +124,18 @@ def main():
         env.close()
 
 
-def _configure_capture(env_cfg: object, focal_length: float):
+def _configure_capture(
+    env_cfg: object, focal_length: float, lookat: tuple[float, float, float] | None = None
+):
     """Configure every simulation preset before Hydra resolves the selected backend."""
     sim_presets = getattr(env_cfg, "sim")
     if isinstance(sim_presets, SimulationCfg):
-        _configure_resolved_sim(sim_presets, focal_length)
+        _configure_resolved_sim(sim_presets, focal_length, lookat)
     else:
         for field in dataclasses.fields(sim_presets):
             sim_cfg = getattr(sim_presets, field.name)
             if isinstance(sim_cfg, SimulationCfg):
-                _configure_resolved_sim(sim_cfg, focal_length)
+                _configure_resolved_sim(sim_cfg, focal_length, lookat)
 
     output_dir = os.environ.get("QUICKSTART_VIDEO_DIR")
     if output_dir:
@@ -147,18 +149,23 @@ def _configure_capture(env_cfg: object, focal_length: float):
         ]
 
 
-def _configure_resolved_sim(sim_cfg: SimulationCfg, focal_length: float):
+def _configure_resolved_sim(
+    sim_cfg: SimulationCfg, focal_length: float, lookat: tuple[float, float, float] | None = None
+):
     """Attach a headless 1280 by 960 OVRTX visualizer to a simulation config.
 
     Captures at four times the 320 by 240 publication size so the generator can downsample the
     path-traced frames, which resolves robot silhouettes and shadow edges that alias away when
     the path tracer renders straight to the final size.
+
+    ``lookat`` re-aims the interactive camera for tasks whose default target sits below the
+    subject; the task's own target is kept when it is ``None``.
     """
     default_camera = sim_cfg.default_visualizer_cfg or VisualizerCfg()
     sim_cfg.visualizer_cfgs = [
         NewtonRTXVisualizerCfg(
             eye=default_camera.eye,
-            lookat=default_camera.lookat,
+            lookat=default_camera.lookat if lookat is None else lookat,
             focal_length=focal_length,
             window_width=1280,
             window_height=960,

--- a/tools/docs/media/generate_quickstart.sh
+++ b/tools/docs/media/generate_quickstart.sh
@@ -75,12 +75,12 @@ ffmpeg -y -v error \
     -i "${WORK_DIR}/random/random_0000.mp4" \
     -i "${WORK_DIR}/play/play_0000.mp4" \
     -filter_complex \
-    "[0:v]select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=112:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='zero_agent':fontcolor=white:fontsize=16:x=16:y=13[zero];
-     [1:v]select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=134:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='random_agent':fontcolor=white:fontsize=16:x=16:y=13[random];
-     [2:v]select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=58:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='play':fontcolor=white:fontsize=16:x=16:y=13[play];
+    "[0:v]select='not(mod(n,5))',setpts=N/(12*TB),scale=320:240:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=112:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='zero_agent':fontcolor=white:fontsize=16:x=16:y=13[zero];
+     [1:v]select='not(mod(n,5))',setpts=N/(12*TB),scale=320:240:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=134:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='random_agent':fontcolor=white:fontsize=16:x=16:y=13[random];
+     [2:v]select='not(mod(n,5))',setpts=N/(12*TB),scale=320:240:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=58:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='play':fontcolor=white:fontsize=16:x=16:y=13[play];
      [zero][random][play]hstack=inputs=3,split[frames][palette_frames];
-     [palette_frames]palettegen=max_colors=128:stats_mode=diff[palette];
-     [frames][palette]paletteuse=dither=bayer:bayer_scale=4:diff_mode=rectangle" \
+     [palette_frames]palettegen=max_colors=256:stats_mode=diff[palette];
+     [frames][palette]paletteuse=dither=sierra2_4a:diff_mode=rectangle" \
     -loop 0 "${OUTPUT_DIR}/agent-comparison.gif"
 
 ffmpeg -y -v error \
@@ -88,12 +88,12 @@ ffmpeg -y -v error \
     -i "${WORK_DIR}/g1/g1_0000.mp4" \
     -i "${WORK_DIR}/kuka_allegro/kuka_allegro_0000.mp4" \
     -filter_complex \
-    "[0:v]crop=320:180:0:30,select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=82:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='Cartpole':fontcolor=white:fontsize=16:x=16:y=13[cartpole];
-     [1:v]crop=320:180:0:30,select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=128:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='G1 locomotion':fontcolor=white:fontsize=16:x=16:y=13[g1];
-     [2:v]crop=320:180:0:30,select='not(mod(n,5))',setpts=N/(12*TB),hqdn3d=2:2:6:6,drawbox=x=8:y=8:w=116:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='Kuka Allegro':fontcolor=white:fontsize=16:x=16:y=13[kuka];
+    "[0:v]crop=1280:720:0:120,select='not(mod(n,5))',setpts=N/(12*TB),scale=320:180:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=82:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='Cartpole':fontcolor=white:fontsize=16:x=16:y=13[cartpole];
+     [1:v]crop=1280:720:0:120,select='not(mod(n,5))',setpts=N/(12*TB),scale=320:180:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=128:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='G1 locomotion':fontcolor=white:fontsize=16:x=16:y=13[g1];
+     [2:v]crop=1280:720:0:120,select='not(mod(n,5))',setpts=N/(12*TB),scale=320:180:flags=lanczos,hqdn3d=1:1:3:3,drawbox=x=8:y=8:w=116:h=28:color=black@0.65:t=fill,drawtext=font='DejaVu Sans':text='Kuka Allegro':fontcolor=white:fontsize=16:x=16:y=13[kuka];
      [cartpole][g1][kuka]hstack=inputs=3,split[frames][palette_frames];
-     [palette_frames]palettegen=max_colors=128:stats_mode=diff[palette];
-     [frames][palette]paletteuse=dither=bayer:bayer_scale=4:diff_mode=rectangle" \
+     [palette_frames]palettegen=max_colors=256:stats_mode=diff[palette];
+     [frames][palette]paletteuse=dither=sierra2_4a:diff_mode=rectangle" \
     -loop 0 "${OUTPUT_DIR}/task-sampler.gif"
 
 for output in agent-comparison.gif task-sampler.gif; do


### PR DESCRIPTION
# Description

The quickstart media generator rendered the OVRTX path tracer straight to the 320x240 publication size. Robot silhouettes and shadow edges aliased badly at that size, and the per-task focal lengths left the subject occupying a small fraction of the frame with a large empty floor area around it.

This changes the capture and encode stages only:

- **Supersample.** Capture at 1280x960 and downsample with lanczos in the generator, instead of path-tracing directly to the final size. This is what recovers the drawer handles, robot edges, and shadow definition.
- **Framing.** Tighten the focal length per task to the largest value that still keeps the subject inside the published crop.
- **Denoise.** Ease `hqdn3d` from `2:2:6:6` to `1:1:3:3`. The heavy setting existed to hide path-tracer noise; supersampling now removes that noise without blurring away detail.
- **Palette.** Widen from 128 to 256 colors and switch `bayer` to `sierra2_4a` dithering, which removes banding on the smoother gradients the sharper frames produce.

## Before / after

End-to-end effect on a published frame — current pipeline on the left, this PR in the middle, and a 640px variant on the right that was evaluated and not taken:

![GIF encoding old vs new](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/04-gif-encoding-old-vs-new.png)

The framing options that were compared before settling on the tighter value:

![Framing comparison](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/02-framing-keep-vs-moderate-vs-tight.png)

Full variant sweep, including `rtx_environment="studio"`, which was rejected — it blows out the background and lowers contrast rather than raising it:

![All variants](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/01-overview-all-variants.png)

## Per-task focal lengths

The safe focal length is scene-specific rather than a fixed ratio of the old value. Scaling every task by the same factor clips two of them, so they are tuned individually:

| Task | Before | After | Why |
| --- | --- | --- | --- |
| Franka cabinet | 22 | 32 | Most headroom of the four; subject roughly doubles in frame |
| G1 locomotion | 20 | 29 | Verified fully in frame |
| Cartpole | 18 | 21 | 26 clipped the pole out of the crop; 23 grazed the top edge |
| Kuka Allegro | 22 | 24 | 32 clipped the arm, and 26 left little headroom. Held back because the lift policy raises the arm above the pose a zero action holds |

Cartpole and G1 under the naive proportional scaling — note the Cartpole pole leaving the top of the crop:

![Cartpole and G1 scaled](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/05-cartpole-g1-scaled-shows-clipping.png)

Cartpole sweep that established 21 as the safe maximum:

![Cartpole focal lengths](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/06-cartpole-fl18-fl21-fl23.png)

Kuka Allegro sweep showing the arm clipping at 32:

![Kuka focal lengths](https://raw.githubusercontent.com/mataylor-nvidia/IsaacLab/media-review-assets/07-kuka-fl22-fl26-fl32-clipping.png)

Each value was validated by capturing the task and inspecting the frame through the same crop and downscale the generator applies.

> Review screenshots are hosted on the `media-review-assets` branch of the author's fork so they are not committed to this PR.

## Media refresh

This PR changes tooling only. Since #7501 moved the quickstart GIFs to S3, `docs/source/setup/quickstart.rst` points at `download.isaacsim.omniverse.nvidia.com` URLs while the generator still writes `agent-comparison.gif` and `task-sampler.gif` into `docs/source/_static/quickstart/`. Regenerated media has to be uploaded to the bucket separately before readers see any change.

## Type of change

- Tooling / documentation media quality

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation — n/a, no documented API or page content changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, the generator has no test harness; validated by rendering each task and inspecting the published crop
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file — n/a, no source package changed
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
