### PR TITLE
[Backport] Add shared kinematic rigid-object renderer contract (#6308)

### DIFF
--- a/source/isaaclab/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
+++ b/source/isaaclab/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
@@ -1,0 +1,1 @@
+Tests only: no user-visible core package change.

--- a/source/isaaclab/test/renderers/rigid_object_rendering_contract.py
+++ b/source/isaaclab/test/renderers/rigid_object_rendering_contract.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Backend-neutral kinematic rigid-object rendering contract.
+
+Backend test modules provide only a simulation context and renderer configuration.
+This module owns the scene, motion sequence, measurements, and assertions.
+"""
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets import ArticulationCfg, RigidObject, RigidObjectCfg
+from isaaclab.renderers import RendererCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors.camera import Camera, CameraCfg
+from isaaclab.sim import SimulationContext
+from isaaclab.sim.schemas import UsdPhysicsRigidBodyCfg
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+from isaaclab.utils.configclass import configclass
+
+__all__ = ["RigidObjectRenderingBackend", "run_rigid_object_scale_and_pose_rendering_contract"]
+
+_NUM_ENVS = 2
+_ENV_SPACING = 4.0
+_CAMERA_DISTANCE = 2.0
+_CAMERA_HEIGHT = 120
+_CAMERA_WIDTH = 160
+_OBJECT_SCALE = (1.0, 1.0, 8.0)
+_OBJECT_SHIFT = 0.45
+_MIN_OBJECT_DEPTH = 0.05
+_MAX_OBJECT_DEPTH = 10.0
+_MIN_OBJECT_PIXELS = 50
+_MIN_CENTROID_SHIFT = 10.0
+
+
+@dataclass(frozen=True)
+class RigidObjectRenderingBackend:
+    """Backend-owned inputs to the shared rendering contract."""
+
+    name: str
+    simulation_context_factory: Callable[[], AbstractContextManager[SimulationContext]]
+    renderer_cfg: RendererCfg
+    with_articulation: bool = False
+    cleanup: Callable[[], None] | None = None
+
+
+def _make_scene_cfg(backend: RigidObjectRenderingBackend) -> InteractiveSceneCfg:
+    """Create the scene whose rendered behavior is shared by every backend."""
+
+    @configclass
+    class _SceneCfg(InteractiveSceneCfg):
+        rigid_object: RigidObjectCfg = RigidObjectCfg(
+            prim_path="{ENV_REGEX_NS}/Object",
+            spawn=sim_utils.UsdFileCfg(
+                usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd",
+                rigid_props=[UsdPhysicsRigidBodyCfg(rigid_body_enabled=True, kinematic_enabled=True)],
+                scale=_OBJECT_SCALE,
+            ),
+        )
+        camera: CameraCfg = CameraCfg(
+            prim_path="{ENV_REGEX_NS}/Camera",
+            height=_CAMERA_HEIGHT,
+            width=_CAMERA_WIDTH,
+            update_period=0.0,
+            update_latest_camera_pose=True,
+            data_types=["depth"],
+            renderer_cfg=backend.renderer_cfg,
+            spawn=sim_utils.PinholeCameraCfg(
+                focal_length=24.0,
+                focus_distance=400.0,
+                horizontal_aperture=20.955,
+                clipping_range=(_MIN_OBJECT_DEPTH, 100.0),
+            ),
+        )
+        if backend.with_articulation:
+            articulation: ArticulationCfg = ArticulationCfg(
+                prim_path="{ENV_REGEX_NS}/Articulation",
+                spawn=sim_utils.UsdFileCfg(
+                    usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/IsaacSim/SimpleArticulation/revolute_articulation.usd"
+                ),
+                init_state=ArticulationCfg.InitialStateCfg(pos=(0.0, -20.0, 0.0)),
+                actuators={
+                    "joint": ImplicitActuatorCfg(joint_names_expr=[".*"], stiffness=100.0, damping=1.0),
+                },
+            )
+
+    return _SceneCfg(num_envs=_NUM_ENVS, env_spacing=_ENV_SPACING, lazy_sensor_update=False)
+
+
+def _require(condition: torch.Tensor | bool, message: str) -> None:
+    """Raise a diagnostic assertion instead of relying on pytest rewriting this helper."""
+    if not bool(condition):
+        raise AssertionError(message)
+
+
+def _measure_depth_mask(
+    depth: torch.Tensor, backend_name: str, camera: Camera
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return silhouette height, width, and horizontal centroid for every camera."""
+    depth_image = depth[..., 0]
+    valid = torch.isfinite(depth_image) & (depth_image > _MIN_OBJECT_DEPTH) & (depth_image < _MAX_OBJECT_DEPTH)
+    pixel_counts = valid.sum(dim=(1, 2))
+    finite = torch.where(torch.isfinite(depth_image), depth_image, torch.zeros_like(depth_image))
+    diagnostics = (
+        f"depth min={finite.amin(dim=(1, 2)).tolist()} max={finite.amax(dim=(1, 2)).tolist()} "
+        f"finite%={(torch.isfinite(depth_image).float().mean(dim=(1, 2)) * 100).tolist()} "
+        f"camera pos_w={camera.data.pos_w.torch.tolist()}"
+    )
+    _require(
+        torch.all(pixel_counts >= _MIN_OBJECT_PIXELS),
+        f"[{backend_name}] Expected at least {_MIN_OBJECT_PIXELS} object pixels per camera, "
+        f"got {pixel_counts.tolist()}; {diagnostics}.",
+    )
+
+    silhouette_heights = valid.any(dim=2).sum(dim=1)
+    silhouette_widths = valid.any(dim=1).sum(dim=1)
+    image_x = torch.arange(depth.shape[2], device=depth.device, dtype=torch.float32)
+    centroids_x = (valid * image_x.view(1, 1, -1)).sum(dim=(1, 2)) / pixel_counts
+    return silhouette_heights, silhouette_widths, centroids_x
+
+
+def _write_pose_and_render(
+    sim: SimulationContext,
+    scene: InteractiveScene,
+    rigid_object: RigidObject,
+    camera: Camera,
+    root_poses: torch.Tensor,
+) -> torch.Tensor:
+    """Write a kinematic pose, settle renderer state, and return depth."""
+    rigid_object.write_root_pose_to_sim_index(root_pose=root_poses)
+    for _ in range(3):
+        sim.step()
+        scene.update(sim.cfg.dt)
+    torch.testing.assert_close(rigid_object.data.root_link_pose_w.torch, root_poses, rtol=0.0, atol=1.0e-4)
+    return camera.data.output["depth"].torch.clone()
+
+
+def run_rigid_object_scale_and_pose_rendering_contract(backend: RigidObjectRenderingBackend) -> None:
+    """Assert root-scale preservation and pose-to-pixel synchronization."""
+    with backend.simulation_context_factory() as sim:
+        sim._app_control_on_stop_handle = None
+        scene = InteractiveScene(_make_scene_cfg(backend))
+        sim.register_interactive_scene(scene)
+        rigid_object = scene["rigid_object"]
+        camera = scene["camera"]
+
+        try:
+            sim.reset()
+            scene.reset()
+            _require(rigid_object.is_initialized, f"[{backend.name}] Rigid object did not initialize.")
+            if backend.with_articulation:
+                _require(scene["articulation"].is_initialized, f"[{backend.name}] Articulation did not initialize.")
+
+            camera_eyes = scene.env_origins.clone()
+            camera_eyes[:, 1] -= _CAMERA_DISTANCE
+            camera.set_world_poses_from_view(camera_eyes, scene.env_origins)
+
+            center_poses = torch.zeros((_NUM_ENVS, 7), device=rigid_object.device)
+            center_poses[:, :3] = scene.env_origins
+            center_poses[:, 6] = 1.0
+
+            center_depth = _write_pose_and_render(sim, scene, rigid_object, camera, center_poses)
+            center_heights, center_widths, center_centroids = _measure_depth_mask(center_depth, backend.name, camera)
+            _require(
+                torch.all(center_heights > 3 * center_widths),
+                f"[{backend.name}] Expected root-scaled cubes to render as tall silhouettes, got "
+                f"heights={center_heights.tolist()} and widths={center_widths.tolist()}.",
+            )
+            _require(
+                torch.all(center_heights > _CAMERA_HEIGHT // 4),
+                f"[{backend.name}] Expected root-scaled silhouettes to span more than one quarter of the image, "
+                f"got heights={center_heights.tolist()}.",
+            )
+            _require(
+                torch.all(torch.abs(center_centroids - (_CAMERA_WIDTH - 1) / 2) < 8.0),
+                f"[{backend.name}] Expected centered silhouettes, got centroids={center_centroids.tolist()}.",
+            )
+
+            negative_poses = center_poses.clone()
+            negative_poses[:, 0] -= _OBJECT_SHIFT
+            negative_depth = _write_pose_and_render(sim, scene, rigid_object, camera, negative_poses)
+            _, _, negative_centroids = _measure_depth_mask(negative_depth, backend.name, camera)
+
+            positive_poses = center_poses.clone()
+            positive_poses[:, 0] += _OBJECT_SHIFT
+            positive_depth = _write_pose_and_render(sim, scene, rigid_object, camera, positive_poses)
+            _, _, positive_centroids = _measure_depth_mask(positive_depth, backend.name, camera)
+
+            negative_delta = negative_centroids - center_centroids
+            positive_delta = positive_centroids - center_centroids
+            _require(
+                torch.all(negative_delta.abs() > _MIN_CENTROID_SHIFT),
+                f"[{backend.name}] Negative-shift centroids moved too little: {negative_delta.tolist()}.",
+            )
+            _require(
+                torch.all(positive_delta.abs() > _MIN_CENTROID_SHIFT),
+                f"[{backend.name}] Positive-shift centroids moved too little: {positive_delta.tolist()}.",
+            )
+            _require(
+                torch.all(negative_delta * positive_delta < 0.0),
+                f"[{backend.name}] Opposite translations must move silhouettes in opposite directions, got "
+                f"deltas {negative_delta.tolist()} and {positive_delta.tolist()}.",
+            )
+        finally:
+            sim.register_interactive_scene(None)
+            # Release camera-owned render products before another parametrized case creates a stage.
+            camera._invalidate_initialize_callback(None)  # noqa: SLF001
+            del camera, rigid_object, scene
+            gc.collect()
+            if backend.cleanup is not None:
+                backend.cleanup()

--- a/source/isaaclab/test/renderers/test_rigid_object_rendering_contract_architecture.py
+++ b/source/isaaclab/test/renderers/test_rigid_object_rendering_contract_architecture.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Architecture gates for the shared rigid-object rendering contract."""
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_CONTRACT = Path(__file__).with_name("rigid_object_rendering_contract.py")
+_ADAPTERS = (
+    _REPO_ROOT / "source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_rigid_object_rendering.py",
+    _REPO_ROOT / "source/isaaclab_newton/test/renderers/test_newton_warp_renderer_rigid_object_rendering.py",
+    _REPO_ROOT / "source/isaaclab_ov/test/test_ovrtx_renderer_rigid_object_rendering.py",
+)
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    modules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.add(node.module)
+    return modules
+
+
+def test_shared_contract_does_not_depend_on_backend_packages() -> None:
+    """Optional backends depend on the contract; the core contract never points back."""
+    tree = ast.parse(_CONTRACT.read_text(encoding="utf-8"))
+    forbidden_roots = {"isaaclab_newton", "isaaclab_ov", "isaaclab_ovphysx", "isaaclab_physx", "newton", "ovrtx"}
+    imported_roots = {module.split(".", 1)[0] for module in _imported_modules(tree)}
+
+    assert imported_roots.isdisjoint(forbidden_roots), imported_roots & forbidden_roots
+
+
+def test_backend_adapters_do_not_duplicate_scene_ownership() -> None:
+    """Adapters may select backends, but scene construction and assertions stay shared."""
+    for adapter in _ADAPTERS:
+        tree = ast.parse(adapter.read_text(encoding="utf-8"))
+        modules = _imported_modules(tree)
+        forbidden = {
+            module
+            for module in modules
+            if module == "isaaclab.assets"
+            or module.startswith("isaaclab.assets.")
+            or module == "isaaclab.scene"
+            or module.startswith("isaaclab.scene.")
+            or module == "isaaclab.sensors"
+            or module.startswith("isaaclab.sensors.")
+        }
+        contract_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "run_rigid_object_scale_and_pose_rendering_contract"
+        ]
+
+        assert not forbidden, f"{adapter.relative_to(_REPO_ROOT)} duplicates contract ownership: {forbidden}"
+        assert len(contract_calls) == 1, f"{adapter.relative_to(_REPO_ROOT)} must compose the shared contract once"
+        assert not any(isinstance(node, ast.ClassDef) for node in ast.walk(tree)), (
+            f"{adapter.relative_to(_REPO_ROOT)} must not define backend-local scene classes"
+        )

--- a/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
+++ b/source/isaaclab/test/sim/test_newton_manager_visualization_state.py
@@ -560,6 +560,49 @@ def test_resolve_scene_data_body_paths_uses_joint_body_targets():
     assert resolved_paths == ["/World/envs/env_0/Robot/robot0_forearm"]
 
 
+def test_update_visualization_state_copies_identity_mapped_transforms(monkeypatch):
+    """Identity-mapped transforms update the persistent Newton shadow buffer."""
+    import numpy as np
+    import warp as wp
+    from isaaclab_newton.physics import NewtonManager
+
+    from isaaclab.scene_data import SceneDataFormat, SceneDataProvider
+
+    _reset_newton_manager_state()
+    monkeypatch.setattr(NewtonManager, "_backend_is_newton", classmethod(lambda cls, provider=None: False))
+
+    body_paths = ["/World/envs/env_0/Object", "/World/envs/env_1/Object"]
+    source_transforms = wp.array(
+        [
+            [1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0],
+            [4.0, 5.0, 6.0, 0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=wp.transformf,
+        device="cpu",
+    )
+    source_data = SceneDataFormat.Transform()
+    source_data.transforms = source_transforms
+    provider_impl = SceneDataProvider(
+        SimpleNamespace(transforms=source_data, transform_paths=body_paths, transform_count=len(body_paths))
+    )
+    provider = SimpleNamespace(
+        usd_stage=None,
+        create_mapping=provider_impl.create_mapping,
+        get_transforms=provider_impl.get_transforms,
+        point_count=0,
+    )
+
+    destination = wp.zeros(len(body_paths), dtype=wp.transformf, device="cpu")
+    NewtonManager._model = SimpleNamespace(body_label=body_paths, body_count=len(body_paths))
+    NewtonManager._state_0 = SimpleNamespace(body_q=destination, particle_q=None)
+
+    NewtonManager.update_visualization_state(provider)
+
+    assert NewtonManager._state_0.body_q is destination
+    assert NewtonManager._scene_data.transforms is destination
+    np.testing.assert_allclose(destination.numpy(), source_transforms.numpy())
+
+
 def test_update_visualization_state_syncs_shadow_particle_q(monkeypatch):
     """PhysX/OVPhysX shadow sync copies backend points into ``state.particle_q``.
 

--- a/source/isaaclab_newton/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
+++ b/source/isaaclab_newton/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
@@ -1,0 +1,1 @@
+Tests only: no user-visible Newton package change.

--- a/source/isaaclab_newton/test/renderers/test_newton_warp_renderer_rigid_object_rendering.py
+++ b/source/isaaclab_newton/test/renderers/test_newton_warp_renderer_rigid_object_rendering.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Newton Warp adapter for the shared rigid-object rendering contract."""
+
+import sys
+from pathlib import Path
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+"""Rest everything follows."""
+
+import pytest
+from isaaclab_newton.physics import NewtonManager
+from isaaclab_newton.renderers import NewtonWarpRendererCfg
+
+from isaaclab.sim import build_simulation_context
+
+_CONTRACT_DIR = Path(__file__).resolve().parents[3] / "isaaclab" / "test" / "renderers"
+if str(_CONTRACT_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONTRACT_DIR))
+
+from rigid_object_rendering_contract import (  # noqa: E402
+    RigidObjectRenderingBackend,
+    run_rigid_object_scale_and_pose_rendering_contract,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.rendering, pytest.mark.isaacsim_ci]
+
+
+def test_kinematic_rigid_object_scale_and_pose_are_rendered() -> None:
+    """Kinematic PhysX transforms and root scale must reach Newton Warp."""
+    run_rigid_object_scale_and_pose_rendering_contract(
+        RigidObjectRenderingBackend(
+            name="newton_warp (PhysX)",
+            simulation_context_factory=lambda: build_simulation_context(device="cuda:0", gravity_enabled=False),
+            renderer_cfg=NewtonWarpRendererCfg(),
+            cleanup=NewtonManager.clear,
+        )
+    )

--- a/source/isaaclab_ov/changelog.d/ooctipus-kinematic-rigid-object-rendering.rst
+++ b/source/isaaclab_ov/changelog.d/ooctipus-kinematic-rigid-object-rendering.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed OVRTX transform synchronization dropping authored scale from clone-plan destinations.

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -67,6 +67,7 @@ except ModuleNotFoundError as exc:
     ) from exc
 
 from isaaclab.cloner import ClonePlan
+from isaaclab.cloner import query as clone_query
 from isaaclab.renderers import BaseRenderer, RenderBufferKind, RenderBufferSpec
 from isaaclab.sim import SimulationContext
 from isaaclab.utils.warp.warp_math import convert_camera_frame_orientation_convention_wp
@@ -392,7 +393,7 @@ class OVRTXRenderer(BaseRenderer):
             _write_file(Path(self.cfg.temp_usd_dir), "pre_ovrtx_renderer_stage.usda", stage.ExportToString())
         logger.info("Preparing stage (%d envs)...", num_envs)
         create_scene_partition_attributes(stage, num_envs)
-        self._capture_object_scales(stage)
+        self._capture_object_scales(stage, self._clone_plan)
         self._exported_usd_string = export_stage_to_string(
             stage,
             num_envs,
@@ -400,7 +401,7 @@ class OVRTXRenderer(BaseRenderer):
             keep_env_roots=not self._use_ovstage,
         )
 
-    def _capture_object_scales(self, stage: Any) -> None:
+    def _capture_object_scales(self, stage: Any, plan: ClonePlan) -> None:
         self._object_scales_by_path.clear()
         from pxr import Gf, Usd, UsdGeom
 
@@ -415,6 +416,14 @@ class OVRTXRenderer(BaseRenderer):
             scale = (float(scale[0]), float(scale[1]), float(scale[2]))
             if not all(math.isclose(axis, 1.0, rel_tol=1e-6, abs_tol=1e-6) for axis in scale):
                 self._object_scales_by_path[str(prim.GetPath())] = scale
+
+        # OVRTX creates non-source rows after this stage is exported, so those destination prims
+        # cannot be traversed above. Clone queries retain the plan's nearest-owner semantics.
+        for source_path, scale in tuple(self._object_scales_by_path.items()):
+            for env_id in clone_query.path_env_ids(plan, source_path):
+                clone_path = clone_query.path_to_clone(plan, source_path, env_id)
+                assert clone_path is not None
+                self._object_scales_by_path.setdefault(clone_path, scale)
 
     def _create_object_scale_array(self, object_paths: list[str]) -> wp.array:
         scales = [self._object_scales_by_path.get(path, (1.0, 1.0, 1.0)) for path in object_paths]

--- a/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
+++ b/source/isaaclab_ov/test/test_ovrtx_clone_plan.py
@@ -35,11 +35,12 @@ if not _MISSING_MODULES:
     from isaaclab_ov.renderers import ovrtx_renderer as ovrtx_renderer_module  # noqa: E402
     from isaaclab_ov.renderers.ovrtx_renderer import OVRTXRenderer, _write_file  # noqa: E402
 
-    from pxr import Sdf, Usd, UsdGeom, UsdShade  # noqa: E402
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdShade  # noqa: E402
 else:
     OVRTXRenderer = None
     ovrtx_renderer_module = None
     OVRTXRendererCfg = None
+    Gf = None
     Sdf = None
     Usd = None
     UsdGeom = None
@@ -347,6 +348,33 @@ def test_prepare_stage_rejects_non_dense_environment_ids(monkeypatch: pytest.Mon
 
     with pytest.raises(RuntimeError, match="environment ids ordered from zero"):
         _make_ovrtx_renderer_without_backend().prepare_stage(_make_multi_env_stage(2), 2)
+
+
+def test_capture_object_scales_populates_source_and_destination_scale_array():
+    """Projected source scales reach the body array without replacing a real destination scale."""
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.Xform.Define(stage, "/World")
+    UsdGeom.Xform.Define(stage, "/World/envs")
+    UsdGeom.Xform.Define(stage, "/World/envs/env_0")
+    UsdGeom.Xform.Define(stage, "/World/envs/env_1")
+    UsdGeom.Xform.Define(stage, "/World/envs/env_2")
+    UsdGeom.Xform.Define(stage, "/World/envs/env_0/Object").AddScaleOp().Set(Gf.Vec3d(1.0, 1.0, 8.0))
+    UsdGeom.Xform.Define(stage, "/World/envs/env_1/Object").AddScaleOp().Set(Gf.Vec3d(1.0, 1.0, 4.0))
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._device = "cpu"
+    plan = ClonePlan(
+        sources=("/World/envs/env_0",),
+        destinations=("/World/envs/env_{}",),
+        clone_mask=torch.ones((1, 3), dtype=torch.bool),
+        env_ids=torch.arange(3),
+    )
+
+    renderer._capture_object_scales(stage, plan)
+    scales = renderer._create_object_scale_array(
+        ["/World/envs/env_0/Object", "/World/envs/env_1/Object", "/World/envs/env_2/Object"]
+    )
+
+    np.testing.assert_allclose(scales.numpy(), np.array([[1.0, 1.0, 8.0], [1.0, 1.0, 4.0], [1.0, 1.0, 8.0]]))
 
 
 def test_prepare_stage_keeps_material_binding_inside_clone_source(monkeypatch: pytest.MonkeyPatch):

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_rigid_object_rendering.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_rigid_object_rendering.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""OVRTX adapter for the shared rigid-object rendering contract."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from isaaclab.sim import SimulationCfg, build_simulation_context
+
+_CONTRACT_DIR = Path(__file__).resolve().parents[2] / "isaaclab" / "test" / "renderers"
+if str(_CONTRACT_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONTRACT_DIR))
+
+from rigid_object_rendering_contract import (  # noqa: E402
+    RigidObjectRenderingBackend,
+    run_rigid_object_scale_and_pose_rendering_contract,
+)
+
+_REQUIRED_MODULES = ("isaaclab_ov", "ovrtx", "ovphysx", "isaaclab_newton", "newton")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+_OVSTAGE_AVAILABLE = importlib.util.find_spec("ovstage") is not None
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.rendering,
+    pytest.mark.isaacsim_ci,
+    pytest.mark.skipif(bool(_MISSING_MODULES), reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}"),
+]
+
+if not _MISSING_MODULES:
+    from isaaclab_newton.physics import NewtonManager  # noqa: E402
+    from isaaclab_ov.physics import OvPhysxCfg  # noqa: E402
+    from isaaclab_ov.renderers import OVRTXRendererCfg  # noqa: E402
+else:
+    NewtonManager = None
+    OVRTXRendererCfg = None
+    OvPhysxCfg = None
+
+
+@pytest.mark.parametrize(
+    "use_ovstage",
+    [
+        pytest.param(False, id="legacy"),
+        pytest.param(
+            True,
+            id="ovstage",
+            marks=pytest.mark.skipif(not _OVSTAGE_AVAILABLE, reason="requires optional module: ovstage"),
+        ),
+    ],
+)
+def test_kinematic_rigid_object_scale_and_pose_are_rendered(monkeypatch: pytest.MonkeyPatch, use_ovstage: bool) -> None:
+    """Kinematic OVPhysX transforms and root scale must reach OVRTX."""
+    assert NewtonManager is not None
+    assert OVRTXRendererCfg is not None
+    assert OvPhysxCfg is not None
+    monkeypatch.setenv("ISAAC_LAB_OVRTX_USE_OVSTAGE", str(int(use_ovstage)))
+    sim_cfg = SimulationCfg(device="cuda:0", gravity=(0.0, 0.0, 0.0), physics=OvPhysxCfg())
+    run_rigid_object_scale_and_pose_rendering_contract(
+        RigidObjectRenderingBackend(
+            name=f"ovrtx (OVPhysX, {'ovstage' if use_ovstage else 'legacy'})",
+            simulation_context_factory=lambda: build_simulation_context(sim_cfg=sim_cfg),
+            renderer_cfg=OVRTXRendererCfg(),
+            cleanup=NewtonManager.clear,
+        )
+    )

--- a/source/isaaclab_physx/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
+++ b/source/isaaclab_physx/changelog.d/ooctipus-kinematic-rigid-object-rendering.skip
@@ -1,0 +1,1 @@
+Tests only: no user-visible PhysX package change.

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_rigid_object_rendering.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_rigid_object_rendering.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Isaac RTX adapter for the shared rigid-object rendering contract."""
+
+import sys
+from pathlib import Path
+
+from isaaclab.app import AppLauncher
+
+simulation_app = AppLauncher(headless=True, enable_cameras=True).app
+
+"""Rest everything follows."""
+
+import pytest
+from isaaclab_physx.renderers import IsaacRtxRendererCfg
+
+from isaaclab.sim import build_simulation_context
+
+_CONTRACT_DIR = Path(__file__).resolve().parents[3] / "isaaclab" / "test" / "renderers"
+if str(_CONTRACT_DIR) not in sys.path:
+    sys.path.insert(0, str(_CONTRACT_DIR))
+
+from rigid_object_rendering_contract import (  # noqa: E402
+    RigidObjectRenderingBackend,
+    run_rigid_object_scale_and_pose_rendering_contract,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.rendering, pytest.mark.isaacsim_ci]
+
+
+@pytest.mark.parametrize("with_articulation", [False, True])
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_kinematic_rigid_object_scale_and_pose_are_rendered(device: str, with_articulation: bool) -> None:
+    """Kinematic PhysX transforms and root scale must reach Isaac RTX."""
+    run_rigid_object_scale_and_pose_rendering_contract(
+        RigidObjectRenderingBackend(
+            name="isaac_rtx",
+            simulation_context_factory=lambda: build_simulation_context(device=device, gravity_enabled=False),
+            renderer_cfg=IsaacRtxRendererCfg(),
+            with_articulation=with_articulation,
+        )
+    )


### PR DESCRIPTION
# Description

Backports #6308 to `release/3.0.0`.

The canonical merged commit `ab34e8c5e3ee7a2c5f260d1511714e5be3bed3eb` was cherry-picked with `-x` provenance. Eleven of its twelve source paths replay exactly. `source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py` required a localized release-compatible conflict resolution, so this PR is intentionally a draft for release-maintainer review.

| Field | Commit |
|---|---|
| Original merged change | `ab34e8c5e3ee7a2c5f260d1511714e5be3bed3eb` |
| Release base used | `1c754876008f0806fdcfda8e3a6b2f593b34d6fc` |
| Proposed backport | `740e3d7b2efe15c5a25f671583d29c034602e36f` |

## Conflict resolution

The release renderer already contains the prerequisite work from #6729, #6773, #7010, and #7481, but differs from the source parent around clone-plan handling and method documentation.

The resolution preserves the release branch's tensor-backed `ClonePlan` validation and existing renderer structure, then adds only #6308's semantic change:

- imports the existing `isaaclab.cloner.query` API;
- passes the validated release clone plan into `_capture_object_scales`;
- projects captured non-unit source scales to active clone destinations with `path_env_ids` and `path_to_clone`;
- retains real destination scales via `setdefault`.

No paths outside the original PR are changed.

## Type of change

- Bug fix
- Shared regression coverage

## Validation

- Repository backport candidate validation passed across all 12 original source paths.
- Per-file stable patch IDs match on 11 paths; only the conflict-resolved renderer path differs.
- Shared rendering-contract architecture tests — 2 passed.
- Focused clone-query tests for `path_env_ids` and `path_to_clone` — 4 passed.
- Python compilation passed for all changed Python files.
- All changed-file pre-commit hooks passed, including changelog and Git LFS checks.
- `git diff --check upstream/release/3.0.0...HEAD` passed.
- The focused OVRTX runtime test was retried with the documented `ov` extra, but the release lock has no macOS/arm64 environment. Backend rendering tests and the canonical `uv run isaaclab -f` remain pending Linux CI.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the available pre-commit checks
- [x] Documentation changes are not applicable
- [x] The original unit and integration regression coverage is preserved
- [x] Changelog fragments are preserved for every touched package
- [x] The original contributor is already listed in `CONTRIBUTORS.md`
