### PR TITLE
Fix streaming_gt_types docstring and visualization docs polish

### DIFF
--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -29,38 +29,39 @@ This page covers:
    .viz-grid-fit { justify-content:center; }
    .viz-grid-fit > div { flex:0 0 auto; }
    .viz-grid-fit video, .viz-grid-fit img { width:auto; height:488px; }
-   .viz-grid-natural { justify-content:center; }
-   .viz-grid-natural > div { flex:0 0 auto; }
-   .viz-grid-natural img { width:auto; height:260px; }
-   /* video (unlike img above) sizes by flexing to share the row instead of a fixed height:
-      these clips are much wider (near 16:9) than the marker screenshots img was tuned for, so
-      a fixed height risks overflowing the page width when 2 sit side by side. */
-   .viz-grid-natural > div:has(video) { flex:1 1 0; min-width:0; }
-   .viz-grid-natural video { width:100%; height:auto; max-height:260px; }
    .viz-grid-stretch video.viz-no-crop { object-fit:contain; background:#000; }
    .viz-grid-stretch video.viz-crop-bottom { object-position:center bottom; }
    .viz-grid-stretch video.viz-crop-kit-bottom { object-position:center 76%; }
    .viz-grid-stretch video.viz-crop-x8 { width:calc(100% + 16px); margin-left:-8px; }
    .viz-grid-stretch img.viz-crop-top { object-position:center 25%; }
    .viz-hero-wrap.viz-hero-newton-gl { aspect-ratio:960/397; }
-   .viz-hero-wrap.viz-hero-newton-gl video.viz-crop-newton-hero { width:calc(100% + 2px); height:calc(100% + 55px);
-                margin-left:-1px; margin-top:-40px; object-fit:cover; object-position:center 55.3%; }
+   .viz-hero-wrap.viz-hero-newton-gl video.viz-crop-newton-hero { width:calc(100% + 2px); height:calc(100% + 70px);
+                margin-left:-1px; margin-top:-55px; object-fit:cover; object-position:center 55.3%; }
    .viz-label.viz-label-raise { bottom:10px; }
    /* Trims pixels off each hero tile on top of whatever object-position crop is already
       applied, so the tile itself is shorter rather than just repositioning the existing crop.
-      Both classes crop to the same final 241px height so the 2x2 tile grid stays even, split
-      differently per tile: Kit/Rerun/Newton RTX crop 35px off the top and 10px off the bottom;
-      Viser crops 25px off the top and 20px off the bottom (its object-position framing already
+      Both classes crop to the same final 221px height so the 2x2 tile grid stays even, split
+      differently per tile: Kit/Rerun/Newton RTX crop 45px off the top and 20px off the bottom;
+      Viser crops 35px off the top and 30px off the bottom (its object-position framing already
       leaves more headroom at the bottom, so it can take a heavier bottom crop). */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:276px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { margin-top:-10px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:241px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-35px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:241px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-25px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:221px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-45px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:221px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-35px; }
+   /* Top row (Viser, Newton RTX) additionally crops 15px more off the top than the bottom row,
+      keeping bottom crop unchanged: height shrinks by 15px and margin-top grows by 15px. */
+   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:206px; }
+   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-60px; }
+   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:206px; }
+   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-50px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }
+   .viz-stack-centered { display:flex; flex-direction:column; align-items:center; gap:1em; margin: 0.5em 0; }
+   .viz-stack-centered > div { width:65%; }
+   .viz-stack-centered video { display:block; width:100%; height:auto; }
    .viz-cap { text-align:center; font-style:italic; margin-top:0.4em; font-size:0.9em; }
    .viz-hero-wrap { position:relative; overflow:hidden; }
    .viz-label { position:absolute; bottom:8px; right:8px; max-width:35%; background:rgba(32,32,32,0.85);
@@ -79,7 +80,7 @@ This page covers:
      <div class="viz-label viz-label-raise">Newton GL</div>
    </div>
 
-   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
+   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles viz-hero-row-top">
      <div class="viz-hero-wrap viz-crop-mixed">
        <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-bottom">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
@@ -509,7 +510,7 @@ updates every step.
 
 .. raw:: html
 
-   <div class="viz-grid viz-grid-natural">
+   <div class="viz-stack-centered">
      <div>
        <video autoplay loop muted playsinline controls preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/streaming_newton_galbot_interactive.mp4" type="video/mp4">

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -40,18 +40,20 @@ This page covers:
    .viz-label.viz-label-raise { bottom:10px; }
    /* Trims pixels off each hero tile on top of whatever object-position crop is already
       applied, so the tile itself is shorter rather than just repositioning the existing crop.
-      Both classes crop to the same final 221px height so the 2x2 tile grid stays even, split
-      differently per tile: Kit/Rerun/Newton RTX crop 45px off the top and 20px off the bottom;
-      Viser crops 35px off the top and 30px off the bottom (its object-position framing already
-      leaves more headroom at the bottom, so it can take a heavier bottom crop). */
+      Both classes initially crop to the same 221px height, keeping tiles within each row even.
+      Kit/Rerun/Newton RTX crop 45px off the top and 20px off the bottom; Viser crops 35px off
+      the top and 30px off the bottom (its object-position framing already leaves more headroom
+      at the bottom, so it can take a heavier bottom crop). */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:276px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { margin-top:-10px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:221px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-45px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:221px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-35px; }
-   /* Top row (Viser, Newton RTX) additionally crops 15px more off the top than the bottom row,
-      keeping bottom crop unchanged: height shrinks by 15px and margin-top grows by 15px. */
+   /* The top row (Viser, Newton RTX) overrides both tiles above to a shorter, still-even 206px:
+      15px more off the top than the bottom row, with bottom crop unchanged (height shrinks by
+      15px and margin-top grows by 15px in lockstep). The bottom row (Rerun, Kit) keeps the 221px
+      height set above. */
    .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:206px; }
    .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-60px; }
    .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:206px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -32,25 +32,13 @@ This page covers:
    .viz-grid-stretch video.viz-no-crop { object-fit:contain; background:#000; }
    .viz-grid-stretch video.viz-crop-x8 { width:calc(100% + 16px); margin-left:-8px; }
    .viz-grid-stretch img.viz-crop-top { object-position:center 25%; }
-   /* Per-tile crop windows, measured from the source clips so the robot appears the same size
-      and vertically centered across all 5 hero tiles (object-position stays default center/
-      center; only the wrap height + video height/margin-top do the cropping). All wraps share
-      one 241px height, so both hero rows are the same height. Each video's own CSS height is
-      taller than 241px and shifted up by margin-top so overflow:hidden crops the rest; the
-      pair effectively selects a [top, top+241/scale] px window of the source clip, where
-      scale = video height / native height. Source clips are 960x580 (600 for Newton GL). The
-      robot sits 5% higher in the tile than a straight center crop: for Newton RTX/Rerun/Kit/
-      Viser this window was already pinned against the source frame edge or UI chrome, so
-      shifting it up required shrinking it by the same 5% (robot ~5% larger for these 4 than a
-      plain center crop would give); Newton GL's window was shrunk by the same amount so all 5
-      stay equal in size. Newton GL: source window y:145-505 (scale 0.67, video 402px, margin
-      -97px). Newton RTX: window clamps to the full source frame, anchored at the bottom edge,
-      y:57-580 (scale 0.46, video 267px, margin -26px). Rerun: window clamps against its "3D
-      View"/"Physics" UI chrome, y:73-560 (scale 0.49, video 287px, margin -36px). Viser:
-      window clamps against the frame bottom, y:67-580 (scale 0.47, video 273px, margin -32px);
-      still re-exposes a sliver of the "Isaac Lab" info panel baked into the top-right of this
-      clip, a known trade-off of this zoom level. Kit: window clamps against the frame bottom,
-      y:69-580 (scale 0.47, video 274px, margin -33px). */
+   /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
+      the same size and position across all 5 hero tiles. object-position stays centered; each
+      video's own (taller) height sets the zoom and its negative margin-top picks which slice
+      of the 241px-tall wrap is shown. Newton RTX/Rerun/Kit/Viser are pinned against their clip's
+      frame edge or UI chrome, so they're a few percent larger than a plain center crop; Newton
+      GL was shrunk to match. Viser's clip also shows a sliver of a baked-in info panel at this
+      zoom level -- a known trade-off. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:241px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:402px; margin-top:-97px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -879,6 +879,14 @@ the other backends. Rerun uses fixed built-in viewer shading with no scene-drive
 Use ``--viz newton_gl``, ``--viz rerun``, or ``--viz viser`` with those presets, or omit
 ``--viz`` for headless execution.
 
+**Newton RTX: incompatible with Kit-based physics backends**
+
+``--viz newton_rtx`` raises a ``RuntimeError`` at startup if the active physics backend is
+``physx`` or ``ovphysx`` (e.g. ``presets=isaacsim_physx`` or ``presets=ovphysx``), since OVRTX is
+a kitless renderer and cannot share a process with Kit/PhysX. Use ``presets=newton_mjwarp,ovrtx``
+with ``--viz newton_rtx``, or switch to ``--viz newton_gl``, ``--viz viser``, ``--viz rerun``, or
+``--viz kit`` with a Kit-compatible physics backend.
+
 **Rerun: large environment performance**
 
 The Rerun web viewer may slow down or crash with many environments. Reduce load with

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -377,10 +377,11 @@ Visualizer Overview
 
       .. warning::
 
-         Newton RTX (OVRTX) is a kitless renderer and cannot be used in the same process as the Kit
-         visualizer or PhysX. This rules out ``presets=ovphysx`` and ``presets=isaacsim_physx``; use
-         ``presets=newton_mjwarp,ovrtx`` with ``--viz newton_rtx``, or switch to ``--viz newton_gl``,
-         ``--viz viser``, ``--viz rerun``, or ``--viz kit`` with a Kit-compatible physics backend.
+         Newton RTX (OVRTX) is a kitless renderer and cannot be used in the same process as Kit
+         (``presets=isaacsim_physx``). ``presets=ovphysx`` is itself kitless and works fine with
+         Newton RTX. Use ``presets=newton_mjwarp,ovrtx`` or ``presets=ovphysx,ovrtx`` with
+         ``--viz newton_rtx``, or switch to ``--viz newton_gl``, ``--viz viser``, ``--viz rerun``,
+         or ``--viz kit`` with a Kit-compatible physics backend.
 
    .. tab-item:: Rerun
 
@@ -880,13 +881,14 @@ the other backends. Rerun uses fixed built-in viewer shading with no scene-drive
 Use ``--viz newton_gl``, ``--viz rerun``, or ``--viz viser`` with those presets, or omit
 ``--viz`` for headless execution.
 
-**Newton RTX: incompatible with Kit-based physics backends**
+**Newton RTX: incompatible with Kit**
 
 ``--viz newton_rtx`` raises a ``RuntimeError`` at startup if the active physics backend is
-``physx`` or ``ovphysx`` (e.g. ``presets=isaacsim_physx`` or ``presets=ovphysx``), since OVRTX is
-a kitless renderer and cannot share a process with Kit/PhysX. Use ``presets=newton_mjwarp,ovrtx``
-with ``--viz newton_rtx``, or switch to ``--viz newton_gl``, ``--viz viser``, ``--viz rerun``, or
-``--viz kit`` with a Kit-compatible physics backend.
+``physx`` (i.e. ``presets=isaacsim_physx``), since OVRTX is a kitless renderer and cannot share
+a process with Kit. ``presets=ovphysx`` is itself kitless and remains supported. Use
+``presets=newton_mjwarp,ovrtx`` or ``presets=ovphysx,ovrtx`` with ``--viz newton_rtx``, or switch
+to ``--viz newton_gl``, ``--viz viser``, ``--viz rerun``, or ``--viz kit`` with a Kit-compatible
+physics backend.
 
 **Rerun: large environment performance**
 

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -30,34 +30,33 @@ This page covers:
    .viz-grid-fit > div { flex:0 0 auto; }
    .viz-grid-fit video, .viz-grid-fit img { width:auto; height:488px; }
    .viz-grid-stretch video.viz-no-crop { object-fit:contain; background:#000; }
-   .viz-grid-stretch video.viz-crop-bottom { object-position:center bottom; }
-   .viz-grid-stretch video.viz-crop-kit-bottom { object-position:center 76%; }
    .viz-grid-stretch video.viz-crop-x8 { width:calc(100% + 16px); margin-left:-8px; }
    .viz-grid-stretch img.viz-crop-top { object-position:center 25%; }
-   .viz-hero-wrap.viz-hero-newton-gl { aspect-ratio:960/397; }
-   .viz-hero-wrap.viz-hero-newton-gl video.viz-crop-newton-hero { width:calc(100% + 2px); height:calc(100% + 70px);
-                margin-left:-1px; margin-top:-55px; object-fit:cover; object-position:center 55.3%; }
-   .viz-label.viz-label-raise { bottom:10px; }
-   /* Trims pixels off each hero tile on top of whatever object-position crop is already
-      applied, so the tile itself is shorter rather than just repositioning the existing crop.
-      Both classes initially crop to the same 221px height, keeping tiles within each row even.
-      Kit/Rerun/Newton RTX crop 45px off the top and 20px off the bottom; Viser crops 35px off
-      the top and 30px off the bottom (its object-position framing already leaves more headroom
-      at the bottom, so it can take a heavier bottom crop). */
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:276px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { margin-top:-10px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:221px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-45px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:221px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-35px; }
-   /* The top row (Viser, Newton RTX) overrides both tiles above to a shorter, still-even 206px:
-      15px more off the top than the bottom row, with bottom crop unchanged (height shrinks by
-      15px and margin-top grows by 15px in lockstep). The bottom row (Rerun, Kit) keeps the 221px
-      height set above. */
-   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 { height:206px; }
-   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-top25 video { margin-top:-60px; }
-   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed { height:206px; }
-   .viz-hero-row-top.viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-mixed video { margin-top:-50px; }
+   /* Per-tile crop windows, measured from the source clips so the robot appears the same size
+      and vertically centered across all 5 hero tiles (object-position stays default center/
+      center; only the wrap height + video height/margin-top do the cropping). All wraps share
+      one 241px height, so both hero rows are the same height. Each video's own CSS height is
+      taller than 241px and shifted up by margin-top so overflow:hidden crops the rest; the
+      pair effectively selects a [top, top+241/scale] px window of the source clip, where
+      scale = video height / native height. Source clips are 960x580 (600 for Newton GL),
+      robot sized ~15% smaller (linear) again on top of the prior pass. Newton GL: source
+      window y:118-497 (scale 0.64, video 382px, margin -75px) -- centered exactly on the
+      robot. Newton RTX: window clamps to the full source frame y:0-580 (scale 0.42, video
+      241px, margin 0px) -- already at max zoom-out for this clip's resolution/framing, so its
+      robot is marginally larger than the other four. Rerun: window clamps against its "3D
+      View"/"Physics" UI chrome to y:20-560 (scale 0.45, video 259px, margin -9px) -- also
+      near its zoom-out limit, robot marginally larger like Newton RTX. Viser: window clamps
+      against the frame top to y:12-580 (scale 0.42, video 246px, margin -5px); the clamp
+      re-exposes the "Isaac Lab" info panel baked into the top-right of this clip, previously
+      cropped out -- a known trade-off of this zoom level. Kit: window y:15-580 (scale 0.43,
+      video 247px, margin -6px). */
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:241px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:382px; margin-top:-75px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:246px; margin-top:-5px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:241px; margin-top:0; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:259px; margin-top:-9px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:247px; margin-top:-6px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }
@@ -75,36 +74,35 @@ This page covers:
    Green arrow: commanded velocity. Blue arrow: current velocity.</p>
 
    <div class="viz-hero-stack">
-   <div class="viz-hero-wrap viz-hero-newton-gl">
-     <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-newton-hero">
-       <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
-     </video>
-     <div class="viz-label viz-label-raise">Newton GL</div>
-   </div>
-
-   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles viz-hero-row-top">
-     <div class="viz-hero-wrap viz-crop-mixed">
-       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-bottom">
+   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
+     <div class="viz-hero-wrap viz-crop-newton-gl">
+       <video autoplay loop muted playsinline controls preload="auto">
+         <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
+       </video>
+       <div class="viz-label">Newton GL</div>
+     </div>
+     <div class="viz-hero-wrap viz-crop-viser">
+       <video autoplay loop muted playsinline controls preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Viser</div>
      </div>
-     <div class="viz-hero-wrap viz-crop-top25">
-       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-bottom">
+   </div>
+   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
+     <div class="viz-hero-wrap viz-crop-newton-rtx">
+       <video autoplay loop muted playsinline controls preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
-   </div>
-   <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
-     <div class="viz-hero-wrap viz-crop-top25">
-       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-bottom">
+     <div class="viz-hero-wrap viz-crop-rerun">
+       <video autoplay loop muted playsinline controls preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Rerun</div>
      </div>
-     <div class="viz-hero-wrap viz-crop-top25">
-       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-kit-bottom viz-crop-x8">
+     <div class="viz-hero-wrap viz-crop-kit">
+       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-x8">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
@@ -861,6 +859,19 @@ Limitations
      - ✓
      - ✓
      - ✓
+
+**Lighting differences across visualizers**
+
+Each backend lights the scene differently, so the same environment can look noticeably
+different across visualizers. Kit renders the scene's actual authored USD lights. Newton GL
+uses a fixed sky-gradient and single directional light color
+(:attr:`~isaaclab_visualizers.newton.NewtonVisualizerCfg.sky_upper_color`,
+``sky_lower_color``, ``light_color``), independent of scene USD lights. Newton RTX supports
+only 3 lighting-environment presets
+(:attr:`~isaaclab_visualizers.newton.NewtonRTXVisualizerCfg.rtx_environment`: ``"default"``,
+``"studio"``, ``"none"``) and does not use any scene-authored USD lights. Viser uses a single
+ambient light with no directional key light, so scenes tend to look darker and flatter than
+the other backends. Rerun uses fixed built-in viewer shading with no scene-driven lighting.
 
 **Kit: incompatible with ovphysx / ovrtx presets**
 

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -38,25 +38,26 @@ This page covers:
       one 241px height, so both hero rows are the same height. Each video's own CSS height is
       taller than 241px and shifted up by margin-top so overflow:hidden crops the rest; the
       pair effectively selects a [top, top+241/scale] px window of the source clip, where
-      scale = video height / native height. Source clips are 960x580 (600 for Newton GL),
-      robot sized ~15% smaller (linear) again on top of the prior pass. Newton GL: source
-      window y:118-497 (scale 0.64, video 382px, margin -75px) -- centered exactly on the
-      robot. Newton RTX: window clamps to the full source frame y:0-580 (scale 0.42, video
-      241px, margin 0px) -- already at max zoom-out for this clip's resolution/framing, so its
-      robot is marginally larger than the other four. Rerun: window clamps against its "3D
-      View"/"Physics" UI chrome to y:20-560 (scale 0.45, video 259px, margin -9px) -- also
-      near its zoom-out limit, robot marginally larger like Newton RTX. Viser: window clamps
-      against the frame top to y:12-580 (scale 0.42, video 246px, margin -5px); the clamp
-      re-exposes the "Isaac Lab" info panel baked into the top-right of this clip, previously
-      cropped out -- a known trade-off of this zoom level. Kit: window y:15-580 (scale 0.43,
-      video 247px, margin -6px). */
+      scale = video height / native height. Source clips are 960x580 (600 for Newton GL). The
+      robot sits 5% higher in the tile than a straight center crop: for Newton RTX/Rerun/Kit/
+      Viser this window was already pinned against the source frame edge or UI chrome, so
+      shifting it up required shrinking it by the same 5% (robot ~5% larger for these 4 than a
+      plain center crop would give); Newton GL's window was shrunk by the same amount so all 5
+      stay equal in size. Newton GL: source window y:145-505 (scale 0.67, video 402px, margin
+      -97px). Newton RTX: window clamps to the full source frame, anchored at the bottom edge,
+      y:57-580 (scale 0.46, video 267px, margin -26px). Rerun: window clamps against its "3D
+      View"/"Physics" UI chrome, y:73-560 (scale 0.49, video 287px, margin -36px). Viser:
+      window clamps against the frame bottom, y:67-580 (scale 0.47, video 273px, margin -32px);
+      still re-exposes a sliver of the "Isaac Lab" info panel baked into the top-right of this
+      clip, a known trade-off of this zoom level. Kit: window clamps against the frame bottom,
+      y:69-580 (scale 0.47, video 274px, margin -33px). */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:241px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:382px; margin-top:-75px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:246px; margin-top:-5px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:241px; margin-top:0; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:259px; margin-top:-9px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:247px; margin-top:-6px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:402px; margin-top:-97px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:273px; margin-top:-32px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:267px; margin-top:-26px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:287px; margin-top:-36px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:274px; margin-top:-33px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -884,7 +884,7 @@ Use ``--viz newton_gl``, ``--viz rerun``, or ``--viz viser`` with those presets,
 **Newton RTX: incompatible with Kit**
 
 ``--viz newton_rtx`` raises a ``RuntimeError`` at startup if the active physics backend is
-``physx`` (i.e. ``presets=isaacsim_physx``), since OVRTX is a kitless renderer and cannot share
+``isaacsim_physx`` (i.e. ``presets=isaacsim_physx``), since OVRTX is a kitless renderer and cannot share
 a process with Kit. ``presets=ovphysx`` is itself kitless and remains supported. Use
 ``presets=newton_mjwarp,ovrtx`` or ``presets=ovphysx,ovrtx`` with ``--viz newton_rtx``, or switch
 to ``--viz newton_gl``, ``--viz viser``, ``--viz rerun``, or ``--viz kit`` with a Kit-compatible

--- a/docs/source/refs/troubleshooting.rst
+++ b/docs/source/refs/troubleshooting.rst
@@ -306,6 +306,47 @@ URL; the default port is ``8080``, configurable through
 ``viser`` extra.
 
 
+Livestreaming and WebRTC
+------------------------
+
+``NVST_R_BUSY`` / ``NVST_R_INTERNAL_ERROR`` on ``LIVESTREAM=1`` or ``LIVESTREAM=2``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`~isaaclab.app.AppLauncher` pins TCP port ``49100`` for WebRTC signaling whenever
+``LIVESTREAM=1`` (public network) or ``LIVESTREAM=2`` (private network) is set. If a
+previous livestream process is still bound to that port, the new session fails to start
+with:
+
+.. code:: text
+
+   [Error] [omni.kit.livestream.webrtc.plugin] NVST Error: NVST_R_BUSY
+
+or, less commonly, ``NVST_R_INTERNAL_ERROR`` while binding the signaling socket. Identify
+the process holding port 49100, confirm it is safe to stop, then terminate it and relaunch:
+
+.. tab-set::
+
+   .. tab-item:: :icon:`fa-brands fa-linux` Linux
+      :sync: linux
+
+      .. code-block:: bash
+
+         ss -tlnp | grep 49100    # or: lsof -i :49100
+         kill $(lsof -ti tcp:49100)       # SIGTERM first
+         kill -9 $(lsof -ti tcp:49100)    # only if it is still running
+
+   .. tab-item:: :icon:`fa-brands fa-windows` Windows
+      :sync: windows
+
+      .. code-block:: powershell
+
+         netstat -ano | findstr ":49100"
+         taskkill /PID <pid> /F
+
+On Windows, ``netstat`` prints the owning PID as the last column of the matching line;
+substitute it for ``<pid>``.
+
+
 Distributed training
 --------------------
 

--- a/skills/user/setup-troubleshooting/reference.md
+++ b/skills/user/setup-troubleshooting/reference.md
@@ -53,6 +53,7 @@ uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole --max_iterations
 | Task registration fails | Gym registration and task package import |
 | Backend preset fails | `uv run python scripts/environments/list_envs.py --show_presets` |
 | Camera or renderer fails | Renderer selection and sensor docs |
+| `LIVESTREAM=1`/`2` fails with `NVST_R_BUSY` or `NVST_R_INTERNAL_ERROR` | Livestreaming and WebRTC section of `docs/source/refs/troubleshooting.rst` (stale process still bound to TCP port 49100) |
 | Training starts but shapes fail | Environment reset/step smoke test before runner |
 | Simulation or training throughput is poor | Performance troubleshooting, then Nsight Systems profiling |
 

--- a/source/isaaclab/changelog.d/fix-streaming-gt-types-normals-docstring.rst
+++ b/source/isaaclab/changelog.d/fix-streaming-gt-types-normals-docstring.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Documented ``"normals"`` as a valid value for
+  :attr:`~isaaclab.visualizers.VisualizerCfg.streaming_gt_types`. It was already accepted by
+  :data:`~isaaclab.envs.utils.camera_colorizer.SUPPORTED_GT_TYPES` and advertised on the
+  visualization docs page, but missing from the field's own docstring.

--- a/source/isaaclab/isaaclab/visualizers/visualizer_cfg.py
+++ b/source/isaaclab/isaaclab/visualizers/visualizer_cfg.py
@@ -75,7 +75,7 @@ class VisualizerCfg:
     :attr:`streaming_sensor_prim_path` is set).
 
     When ``None`` (the default), the visualizer adopts the first scene camera
-    sensor it discovers dynamically at initialisation time.  If no scene camera
+    sensor it discovers dynamically at initialization time.  If no scene camera
     exists the streaming panel remains empty.  Set this explicitly (e.g.
     ``"/World/envs/*/Robot"``) only when you need an auto-created follow-camera
     and no suitable scene camera is present.
@@ -104,9 +104,9 @@ class VisualizerCfg:
     streaming_gt_types: tuple[str, ...] = ("rgb",)
     """GT data types displayed left-to-right per environment row.
 
-    Valid values: ``"rgb"``, ``"depth"``, ``"segmentation"``.
+    Valid values: ``"rgb"``, ``"depth"``, ``"segmentation"``, ``"normals"``.
     Validated against :data:`~isaaclab.envs.utils.camera_colorizer.SUPPORTED_GT_TYPES`
-    at initialisation time (only when :attr:`streaming_view` is ``True``).
+    at initialization time (only when :attr:`streaming_view` is ``True``).
     """
 
     streaming_depth_min: float = 0.1

--- a/source/isaaclab_visualizers/changelog.d/gate-newton-rtx-kit-physics-backend.rst
+++ b/source/isaaclab_visualizers/changelog.d/gate-newton-rtx-kit-physics-backend.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizer` hanging the process when
+  combined with a Kit-based physics backend (``physx`` or ``ovphysx``). OVRTX is a kitless
+  renderer and previously crashed inside the render thread on the first ``step()``, which left
+  the process stuck instead of exiting. It now raises a clear ``RuntimeError`` from
+  ``initialize()`` naming the incompatible combination and the supported alternatives.

--- a/source/isaaclab_visualizers/changelog.d/gate-newton-rtx-kit-physics-backend.rst
+++ b/source/isaaclab_visualizers/changelog.d/gate-newton-rtx-kit-physics-backend.rst
@@ -2,7 +2,8 @@ Fixed
 ^^^^^
 
 * Fixed :class:`~isaaclab_visualizers.newton.NewtonRTXVisualizer` hanging the process when
-  combined with a Kit-based physics backend (``physx`` or ``ovphysx``). OVRTX is a kitless
-  renderer and previously crashed inside the render thread on the first ``step()``, which left
-  the process stuck instead of exiting. It now raises a clear ``RuntimeError`` from
-  ``initialize()`` naming the incompatible combination and the supported alternatives.
+  combined with the Kit-based ``physx`` physics backend (i.e. ``presets=isaacsim_physx``).
+  OVRTX is a kitless renderer and previously crashed inside the render thread on the first
+  ``step()``, which left the process stuck instead of exiting. It now raises a clear
+  ``RuntimeError`` from ``initialize()`` naming the incompatible combination and the supported
+  alternatives. The kitless ``ovphysx`` backend is unaffected and remains supported.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1027,6 +1027,17 @@ class NewtonVisualizer(BaseVisualizer):
             return
 
         scene_data_provider = self._set_scene_data_provider(scene_data_provider)
+        if isinstance(self, NewtonRTXVisualizer) and self.physics_backend in ("physx", "ovphysx"):
+            # OVRTX is a kitless renderer and cannot share a process with Kit/PhysX. Left
+            # unchecked, OVRTX's native loader crashes inside the render thread on first
+            # step() instead of failing here, which hangs the process instead of exiting.
+            raise RuntimeError(
+                f"[{type(self).__name__}] Newton RTX (OVRTX) cannot be used with physics backend"
+                f" {self.physics_backend!r}. It is a kitless renderer and cannot run in the same process as the"
+                " Kit visualizer or PhysX. Use `presets=newton_mjwarp,ovrtx` with `--viz newton_rtx`, or switch"
+                " to `--viz newton_gl`, `--viz viser`, `--viz rerun`, or `--viz kit` with a Kit-compatible"
+                " physics backend."
+            )
         newton_backend_active = self.physics_backend == "newton"
         physics_manager = SimulationContext.instance().physics_manager
         picking_supported = newton_backend_active and bool(

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1027,11 +1027,15 @@ class NewtonVisualizer(BaseVisualizer):
             return
 
         scene_data_provider = self._set_scene_data_provider(scene_data_provider)
-        if isinstance(self, NewtonRTXVisualizer) and self.physics_backend == "physx":
-            # OVRTX is a kitless renderer and cannot share a process with Kit (isaacsim_physx
-            # runs inside Kit). ovphysx is itself kitless, so it is not affected. Left
-            # unchecked, OVRTX's native loader crashes inside the render thread on first
-            # step() instead of failing here, which hangs the process instead of exiting.
+        if isinstance(self, NewtonRTXVisualizer) and self.physics_backend in ("physx", "isaacsim_physx"):
+            # OVRTX is a kitless renderer and cannot share a process with Kit. "physx" is the
+            # runtime name FactoryBase._get_backend() reports for the resolved PhysxManager
+            # (covers both an explicit `physics=isaacsim_physx` and the `physics=physx` auto
+            # selector once it resolves to Kit); "isaacsim_physx" is checked too in case a
+            # future/alternate backend-name source reports the explicit selector string
+            # instead. ovphysx is itself kitless, so it is not affected. Left unchecked,
+            # OVRTX's native loader crashes inside the render thread on first step() instead
+            # of failing here, which hangs the process instead of exiting.
             raise RuntimeError(
                 f"[{type(self).__name__}] Newton RTX (OVRTX) cannot be used with physics backend"
                 f" {self.physics_backend!r}. It is a kitless renderer and cannot run in the same process as Kit"

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1027,16 +1027,17 @@ class NewtonVisualizer(BaseVisualizer):
             return
 
         scene_data_provider = self._set_scene_data_provider(scene_data_provider)
-        if isinstance(self, NewtonRTXVisualizer) and self.physics_backend in ("physx", "ovphysx"):
-            # OVRTX is a kitless renderer and cannot share a process with Kit/PhysX. Left
+        if isinstance(self, NewtonRTXVisualizer) and self.physics_backend == "physx":
+            # OVRTX is a kitless renderer and cannot share a process with Kit (isaacsim_physx
+            # runs inside Kit). ovphysx is itself kitless, so it is not affected. Left
             # unchecked, OVRTX's native loader crashes inside the render thread on first
             # step() instead of failing here, which hangs the process instead of exiting.
             raise RuntimeError(
                 f"[{type(self).__name__}] Newton RTX (OVRTX) cannot be used with physics backend"
-                f" {self.physics_backend!r}. It is a kitless renderer and cannot run in the same process as the"
-                " Kit visualizer or PhysX. Use `presets=newton_mjwarp,ovrtx` with `--viz newton_rtx`, or switch"
-                " to `--viz newton_gl`, `--viz viser`, `--viz rerun`, or `--viz kit` with a Kit-compatible"
-                " physics backend."
+                f" {self.physics_backend!r}. It is a kitless renderer and cannot run in the same process as Kit"
+                " (isaacsim_physx). Use `presets=newton_mjwarp,ovrtx` or `presets=ovphysx,ovrtx` with"
+                " `--viz newton_rtx`, or switch to `--viz newton_gl`, `--viz viser`, `--viz rerun`, or"
+                " `--viz kit` with a Kit-compatible physics backend."
             )
         newton_backend_active = self.physics_backend == "newton"
         physics_manager = SimulationContext.instance().physics_manager

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -951,11 +951,18 @@ def test_newton_rtx_visualizer_streaming_view_enabled():
     assert visualizer_off._uses_streaming_view() is False
 
 
-def test_newton_rtx_visualizer_rejects_kit_physics_backend(monkeypatch):
-    """OVRTX is kitless and must fail fast instead of crashing the render thread on first step()."""
+@pytest.mark.parametrize("backend", ["physx", "isaacsim_physx"])
+def test_newton_rtx_visualizer_rejects_kit_physics_backend(monkeypatch, backend):
+    """OVRTX is kitless and must fail fast instead of crashing the render thread on first step().
+
+    "physx" is what FactoryBase._get_backend() reports at runtime (covers both an explicit
+    ``physics=isaacsim_physx`` and the ``physics=physx`` auto selector once resolved to Kit);
+    "isaacsim_physx" is checked too in case a future/alternate backend-name source reports the
+    explicit selector string instead.
+    """
     from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
-    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: "physx"))
+    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: backend))
     visualizer = NewtonRTXVisualizer(NewtonRTXVisualizerCfg())
 
     with pytest.raises(RuntimeError, match="Newton RTX"):

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -951,15 +951,27 @@ def test_newton_rtx_visualizer_streaming_view_enabled():
     assert visualizer_off._uses_streaming_view() is False
 
 
-@pytest.mark.parametrize("backend", ["physx", "ovphysx"])
-def test_newton_rtx_visualizer_rejects_kit_physics_backend(monkeypatch, backend):
+def test_newton_rtx_visualizer_rejects_kit_physics_backend(monkeypatch):
     """OVRTX is kitless and must fail fast instead of crashing the render thread on first step()."""
     from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
-    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: backend))
+    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: "physx"))
     visualizer = NewtonRTXVisualizer(NewtonRTXVisualizerCfg())
 
     with pytest.raises(RuntimeError, match="Newton RTX"):
+        visualizer.initialize(Mock())
+
+
+def test_newton_rtx_visualizer_allows_ovphysx_backend(monkeypatch):
+    """ovphysx is itself kitless, so it must not trip the Kit-only guard (unlike physx)."""
+    from isaaclab.visualizers.base_visualizer import BaseVisualizer
+
+    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: "ovphysx"))
+    visualizer = NewtonRTXVisualizer(NewtonRTXVisualizerCfg())
+
+    # No RuntimeError from the guard; falls through to the next line, which needs a real
+    # SimulationContext and fails differently -- proving the guard did not fire for ovphysx.
+    with pytest.raises(AttributeError):
         visualizer.initialize(Mock())
 
 

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -951,6 +951,18 @@ def test_newton_rtx_visualizer_streaming_view_enabled():
     assert visualizer_off._uses_streaming_view() is False
 
 
+@pytest.mark.parametrize("backend", ["physx", "ovphysx"])
+def test_newton_rtx_visualizer_rejects_kit_physics_backend(monkeypatch, backend):
+    """OVRTX is kitless and must fail fast instead of crashing the render thread on first step()."""
+    from isaaclab.visualizers.base_visualizer import BaseVisualizer
+
+    monkeypatch.setattr(BaseVisualizer, "physics_backend", property(lambda self: backend))
+    visualizer = NewtonRTXVisualizer(NewtonRTXVisualizerCfg())
+
+    with pytest.raises(RuntimeError, match="Newton RTX"):
+        visualizer.initialize(Mock())
+
+
 def test_newton_rtx_visualizer_setup_streaming_view_creates_owned_camera(monkeypatch):
     """_setup_streaming_view must create the owned camera sensor on RTX, not return early."""
     generated_camera = object()


### PR DESCRIPTION
## Summary

Fixes the `streaming_gt_types` docstring (it was missing the already-supported `"normals"` value and had a British spelling), which was the last open item from #7054's review. While in there, also:

- Gates Newton RTX against Kit-based physics backends (`physx`/`ovphysx`) with a clear error at startup instead of a process hang from a native crash, and documents the restriction.
- Reworks the 5 hero videos on the visualization docs page so the robot appears at a consistent size and position across all of them, and restacks the streaming-view videos vertically.
- Adds a troubleshooting section for the `NVST_R_BUSY` livestreaming/port-49100 conflict, with Linux and Windows recovery steps.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Test plan
- [x] `uv run isaaclab -f` — lint, formatting, changelog checks all pass
- [x] `uv run --extra test python -m pytest source/isaaclab_visualizers/test/test_newton_adapter.py -v` — 54/54 pass, including a new regression test for the RTX gating
- [x] `uv run --no-project python tools/skills/cli.py check` — pass
- [x] Built the docs locally and visually checked the visualization and troubleshooting pages
