### PR TITLE
Close the Newton viewer before dropping the reference to it

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
+++ b/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_visualizers.newton.newton_visualizer.NewtonVisualizer` releasing its viewer
+  without calling the viewer's :meth:`close`, which left the RTX backend's ordered GPU teardown to the
+  garbage collector and intermittently leaked render step results and attribute bindings on shutdown.

--- a/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
+++ b/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
@@ -2,5 +2,6 @@ Fixed
 ^^^^^
 
 * Fixed :class:`~isaaclab_visualizers.newton.newton_visualizer.NewtonVisualizer` releasing its viewer
-  without calling the viewer's :meth:`close`, which left the RTX backend's ordered GPU teardown to the
-  garbage collector and intermittently leaked render step results and attribute bindings on shutdown.
+  without first neutralizing picking callbacks and calling the viewer's :meth:`close`, which left the RTX
+  backend's ordered GPU teardown to the garbage collector and intermittently leaked render step results and
+  attribute bindings on shutdown.

--- a/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
+++ b/source/isaaclab_visualizers/changelog.d/fix-newton-visualizer-viewer-teardown.rst
@@ -1,7 +1,7 @@
 Fixed
 ^^^^^
 
-* Fixed :class:`~isaaclab_visualizers.newton.newton_visualizer.NewtonVisualizer` releasing its viewer
-  without first neutralizing picking callbacks and calling the viewer's :meth:`close`, which left the RTX
-  backend's ordered GPU teardown to the garbage collector and intermittently leaked render step results and
-  attribute bindings on shutdown.
+* Fixed :class:`~isaaclab_visualizers.newton.newton_visualizer.NewtonRTXVisualizer` releasing its viewer
+  without first neutralizing picking callbacks and calling the viewer's :meth:`close`, which left its ordered
+  GPU teardown to the garbage collector and intermittently leaked render step results and attribute bindings
+  on shutdown.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1253,8 +1253,10 @@ class NewtonVisualizer(BaseVisualizer):
     def _release_viewer(self) -> None:
         """Close the viewer this visualizer owns and drop the reference to it.
 
-        The visualizer owns the viewer it creates, and the viewer owns GPU
-        resources that its backend releases in a fixed order:
+        The visualizer owns the viewer it creates. Before closing it, the
+        stable picking callback is neutralized so it cannot retain or call the
+        viewer after release. The viewer owns GPU resources that its backend
+        releases in a fixed order:
         ``ViewerRTX.close()`` waits on the in-flight render, drops the retained
         step results, unbinds the transform attribute binding and only then
         releases the ``ovrtx.Renderer``.  Dropping the reference without
@@ -1264,13 +1266,17 @@ class NewtonVisualizer(BaseVisualizer):
 
         The reference is cleared in a ``finally`` block so an unusable viewer
         is never retained, while the teardown failure itself still reaches the
-        caller.  ``ViewerBase.close()`` is a no-op, so the non-RTX backends are
-        unaffected.
+        caller. Concrete Newton viewer backends also use ``close()`` to release
+        their own resources.
         """
         viewer = self._viewer
         if viewer is None:
             return
         try:
+            if self._picking_enabled:
+                # Keep the stable callback registered: captured graphs replay
+                # its now-neutral device inputs without retaining the viewer.
+                self._viewer_picking_binding.deactivate()
             viewer.close()
         finally:
             self._viewer = None
@@ -1279,10 +1285,6 @@ class NewtonVisualizer(BaseVisualizer):
         """Release viewer resources."""
         if self._is_closed:
             return
-        if self._picking_enabled:
-            # Keep the stable callback registered: captured graphs replay its
-            # now-neutral device inputs without retaining the viewer.
-            self._viewer_picking_binding.deactivate()
         try:
             self._release_viewer()
         finally:

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1251,11 +1251,11 @@ class NewtonVisualizer(BaseVisualizer):
                 self._viewer_picking_binding.bind(self._viewer)
 
     def _release_viewer(self) -> None:
-        """Close the viewer this visualizer owns and drop the reference to it.
+        """Release the viewer this visualizer owns and drop the reference to it.
 
         The visualizer owns the viewer it creates. Before closing it, the
         stable picking callback is neutralized so it cannot retain or call the
-        viewer after release. The viewer owns GPU resources that its backend
+        viewer after release. The RTX viewer owns GPU resources that it
         releases in a fixed order:
         ``ViewerRTX.close()`` waits on the in-flight render, drops the retained
         step results, unbinds the transform attribute binding and only then
@@ -1266,8 +1266,8 @@ class NewtonVisualizer(BaseVisualizer):
 
         The reference is cleared in a ``finally`` block so an unusable viewer
         is never retained, while the teardown failure itself still reaches the
-        caller. Concrete Newton viewer backends also use ``close()`` to release
-        their own resources.
+        caller. ``ViewerGL.close()`` is intentionally not called because its
+        renderer cannot be recreated reliably in the same Kit process.
         """
         viewer = self._viewer
         if viewer is None:
@@ -1277,7 +1277,8 @@ class NewtonVisualizer(BaseVisualizer):
                 # Keep the stable callback registered: captured graphs replay
                 # its now-neutral device inputs without retaining the viewer.
                 self._viewer_picking_binding.deactivate()
-            viewer.close()
+            if isinstance(viewer, NewtonViewerRTX):
+                viewer.close()
         finally:
             self._viewer = None
 

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1208,7 +1208,13 @@ class NewtonVisualizer(BaseVisualizer):
                     "[%s] Permanently disabling viewer after unrecoverable initialization failure.",
                     type(self).__name__,
                 )
-                self._viewer = None
+                try:
+                    self._release_viewer()
+                except Exception:
+                    # This handler exists so an unusable viewer disables itself
+                    # instead of aborting training, so a viewer that also fails
+                    # to close must not escape it either.
+                    logger.exception("[%s] Viewer teardown failed.", type(self).__name__)
 
     def is_reset_requested(self) -> bool:
         """Return whether an episode reset was requested via the viewer UI."""
@@ -1244,6 +1250,31 @@ class NewtonVisualizer(BaseVisualizer):
             if self._picking_enabled:
                 self._viewer_picking_binding.bind(self._viewer)
 
+    def _release_viewer(self) -> None:
+        """Close the viewer this visualizer owns and drop the reference to it.
+
+        The visualizer owns the viewer it creates, and the viewer owns GPU
+        resources that its backend releases in a fixed order:
+        ``ViewerRTX.close()`` waits on the in-flight render, drops the retained
+        step results, unbinds the transform attribute binding and only then
+        releases the ``ovrtx.Renderer``.  Dropping the reference without
+        closing leaves that ordering to the garbage collector, which does not
+        guarantee one; when the renderer is finalized before the resources
+        bound to it, it tears itself down with them still live and leaks them.
+
+        The reference is cleared in a ``finally`` block so an unusable viewer
+        is never retained, while the teardown failure itself still reaches the
+        caller.  ``ViewerBase.close()`` is a no-op, so the non-RTX backends are
+        unaffected.
+        """
+        viewer = self._viewer
+        if viewer is None:
+            return
+        try:
+            viewer.close()
+        finally:
+            self._viewer = None
+
     def close(self) -> None:
         """Release viewer resources."""
         if self._is_closed:
@@ -1252,13 +1283,17 @@ class NewtonVisualizer(BaseVisualizer):
             # Keep the stable callback registered: captured graphs replay its
             # now-neutral device inputs without retaining the viewer.
             self._viewer_picking_binding.deactivate()
-        if self._viewer is not None:
-            self._viewer = None
-        if self._camera_sensor is not None and self._camera_is_owned:
-            evict_visualizer_camera(self._streaming_camera_key)
-            remove_generated_prims(self._generated_camera_prim_paths)
-        self._camera_sensor = None
-        self._is_closed = True
+        try:
+            self._release_viewer()
+        finally:
+            # A viewer that fails to close must not strand the camera prims or
+            # leave the visualizer looking open; the failure still propagates
+            # to the caller, which logs it and drops the visualizer.
+            if self._camera_sensor is not None and self._camera_is_owned:
+                evict_visualizer_camera(self._streaming_camera_key)
+                remove_generated_prims(self._generated_camera_prim_paths)
+            self._camera_sensor = None
+            self._is_closed = True
 
     def is_running(self) -> bool:
         """Return whether the visualizer should continue stepping."""

--- a/source/isaaclab_visualizers/test/test_newton_adapter.py
+++ b/source/isaaclab_visualizers/test/test_newton_adapter.py
@@ -487,6 +487,7 @@ class _Viewer:
         self.logged_state = None
         self.logged_contacts = None
         self.logged_arrows = None
+        self.closed = False
 
     def is_paused(self):
         return False
@@ -508,6 +509,10 @@ class _Viewer:
 
     def end_frame(self):
         pass
+
+    def close(self):
+        # Mirrors ViewerBase.close(), which every real viewer inherits.
+        self.closed = True
 
     def get_frame(self):
         return SimpleNamespace(numpy=lambda: np.zeros((4, 6, 3), dtype=np.uint8))

--- a/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
+++ b/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for :class:`NewtonVisualizer` viewer release.
+
+The viewer owns GPU resources that its backend releases in a fixed order when
+``close()`` is called.  Both paths that give up the viewer -- ``close()`` and
+the ``step()`` handler that permanently disables it after an unrecoverable
+failure -- must go through :meth:`NewtonVisualizer._release_viewer` so that
+ordering is honoured instead of being left to the garbage collector.
+
+These tests assert the behaviour (the viewer's ``close()`` runs, and runs
+before the reference is dropped) rather than the absence of a backend log
+message: the message is emitted for only one of several valid finalization
+orders, so asserting on it would pass against unfixed code most of the time.
+
+They also pin the error semantics, which differ by caller.  ``_release_viewer``
+propagates a teardown failure while still clearing the reference.  ``close()``
+lets it propagate to ``SimulationContext``, which already logs it, but finishes
+its own cleanup first.  ``step()`` contains it, because that handler exists so
+an unusable viewer disables itself instead of aborting training.
+"""
+
+from __future__ import annotations
+
+import isaaclab_visualizers.newton.newton_visualizer as newton_visualizer
+import pytest
+from isaaclab_visualizers.newton.newton_visualizer import NewtonVisualizer
+
+pytestmark = [pytest.mark.unit]
+
+
+class _SpyViewer:
+    """Viewer double that records how and when it was closed."""
+
+    def __init__(self, raises: bool = False) -> None:
+        self.close_calls = 0
+        self.referenced_by_owner_at_close: list[bool] = []
+        self.owner: NewtonVisualizer | None = None
+        self._raises = raises
+
+    def close(self) -> None:
+        self.close_calls += 1
+        # Record whether the visualizer still pointed at us while we were being
+        # closed.  The reference must outlive the teardown call.
+        self.referenced_by_owner_at_close.append(getattr(self.owner, "_viewer", None) is self)
+        if self._raises:
+            raise RuntimeError("Failed to create window")
+
+
+def _make_visualizer(viewer: _SpyViewer | None) -> NewtonVisualizer:
+    """Build the minimal visualizer state that the release paths read.
+
+    ``__init__`` is bypassed deliberately: a real visualizer requires a Newton
+    model, a scene data provider and a GPU, none of which this behaviour
+    depends on.
+    """
+    visualizer = object.__new__(NewtonVisualizer)
+    visualizer._is_closed = False
+    visualizer._picking_enabled = False
+    visualizer._viewer = viewer
+    visualizer._camera_sensor = None
+    visualizer._camera_is_owned = False
+    if viewer is not None:
+        viewer.owner = visualizer
+    return visualizer
+
+
+def test_release_viewer_closes_before_clearing_reference() -> None:
+    """The viewer must be closed while the visualizer still references it."""
+    viewer = _SpyViewer()
+    visualizer = _make_visualizer(viewer)
+
+    visualizer._release_viewer()
+
+    assert viewer.close_calls == 1
+    assert viewer.referenced_by_owner_at_close == [True]
+    assert visualizer._viewer is None
+
+
+def test_release_viewer_propagates_failure_and_still_clears_reference() -> None:
+    """A teardown failure must reach the caller, but must not retain the viewer."""
+    viewer = _SpyViewer(raises=True)
+    visualizer = _make_visualizer(viewer)
+
+    with pytest.raises(RuntimeError, match="Failed to create window"):
+        visualizer._release_viewer()
+
+    assert viewer.close_calls == 1
+    assert visualizer._viewer is None
+
+
+def test_release_viewer_without_viewer_is_a_no_op() -> None:
+    """Releasing when no viewer is held must be harmless."""
+    visualizer = _make_visualizer(None)
+
+    visualizer._release_viewer()
+
+    assert visualizer._viewer is None
+
+
+def test_release_viewer_is_idempotent() -> None:
+    """Releasing twice must not close the viewer twice."""
+    viewer = _SpyViewer()
+    visualizer = _make_visualizer(viewer)
+
+    visualizer._release_viewer()
+    visualizer._release_viewer()
+
+    assert viewer.close_calls == 1
+
+
+def test_close_releases_the_viewer() -> None:
+    """``close()`` must release the viewer through the shared path."""
+    viewer = _SpyViewer()
+    visualizer = _make_visualizer(viewer)
+
+    visualizer.close()
+
+    assert viewer.close_calls == 1
+    assert viewer.referenced_by_owner_at_close == [True]
+    assert visualizer._viewer is None
+    assert visualizer._is_closed is True
+
+
+def test_close_is_idempotent() -> None:
+    """A second ``close()`` must not close the viewer again."""
+    viewer = _SpyViewer()
+    visualizer = _make_visualizer(viewer)
+
+    visualizer.close()
+    visualizer.close()
+
+    assert viewer.close_calls == 1
+
+
+def test_close_completes_cleanup_when_viewer_teardown_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing viewer must not strand the owned camera or the closed flag.
+
+    ``SimulationContext`` already logs an exception raised by ``close()``, so
+    it is allowed to propagate -- but the rest of the teardown still has to
+    run, otherwise a viewer failure silently leaks the generated camera prims.
+    """
+    evicted: list[object] = []
+    removed: list[object] = []
+    monkeypatch.setattr(newton_visualizer, "evict_visualizer_camera", evicted.append, raising=False)
+    monkeypatch.setattr(newton_visualizer, "remove_generated_prims", removed.append, raising=False)
+
+    viewer = _SpyViewer(raises=True)
+    visualizer = _make_visualizer(viewer)
+    visualizer._camera_sensor = object()
+    visualizer._camera_is_owned = True
+    visualizer._streaming_camera_key = "camera-key"
+    visualizer._generated_camera_prim_paths = ["/World/generated"]
+
+    with pytest.raises(RuntimeError, match="Failed to create window"):
+        visualizer.close()
+
+    assert visualizer._viewer is None
+    assert visualizer._camera_sensor is None
+    assert visualizer._is_closed is True
+    assert evicted == ["camera-key"]
+    assert removed == [["/World/generated"]]
+
+
+def _arm_for_step_failure(visualizer: NewtonVisualizer, viewer: _SpyViewer) -> None:
+    """Drive ``step()`` far enough to reach its viewer-failure handler."""
+    visualizer._is_initialized = True
+    visualizer._runtime_headless = False
+    visualizer._disable_viewer_on_step_exception = True
+    visualizer._sim_time = 0.0
+    visualizer._step_counter = 0
+    visualizer._state = None
+    visualizer._scene_data_provider = None
+    visualizer._update_frequency = 1
+    viewer._update_frequency = 1
+
+    def _unrecoverable() -> bool:
+        raise RuntimeError("Failed to create window")
+
+    viewer.is_paused = _unrecoverable  # type: ignore[method-assign]
+
+
+def test_step_failure_releases_the_viewer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unrecoverable viewer failure during ``step()`` must release the viewer.
+
+    ``NewtonRTXVisualizer`` sets ``_disable_viewer_on_step_exception`` so the
+    viewer is given up after the first failure -- for example when OVRTX cannot
+    create its window.  That path must close the viewer rather than only
+    dropping the reference to it.
+    """
+    viewer = _SpyViewer()
+    visualizer = _make_visualizer(viewer)
+    _arm_for_step_failure(visualizer, viewer)
+    monkeypatch.setattr(newton_visualizer.NewtonManager, "get_num_envs", staticmethod(lambda: 1), raising=False)
+
+    NewtonVisualizer.step(visualizer, dt=0.01)  # must not raise
+
+    assert viewer.close_calls == 1
+    assert viewer.referenced_by_owner_at_close == [True]
+    assert visualizer._viewer is None
+
+
+def test_step_contains_a_failing_viewer_teardown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A viewer that fails to close must not abort training from ``step()``.
+
+    This is the whole purpose of the ``_disable_viewer_on_step_exception``
+    handler: the viewer is already known to be broken, so its teardown failure
+    has to be contained rather than replacing the original failure and
+    propagating out of the simulation loop.
+    """
+    viewer = _SpyViewer(raises=True)
+    visualizer = _make_visualizer(viewer)
+    _arm_for_step_failure(visualizer, viewer)
+    monkeypatch.setattr(newton_visualizer.NewtonManager, "get_num_envs", staticmethod(lambda: 1), raising=False)
+
+    NewtonVisualizer.step(visualizer, dt=0.01)  # must not raise
+
+    assert viewer.close_calls == 1
+    assert visualizer._viewer is None

--- a/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
+++ b/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
@@ -5,16 +5,19 @@
 
 """Tests for :class:`NewtonVisualizer` viewer release.
 
-The viewer owns GPU resources that its backend releases in a fixed order when
-``close()`` is called.  Both paths that give up the viewer -- ``close()`` and
+The RTX viewer owns GPU resources that it releases in a fixed order when
+``close()`` is called. Both paths that give up the viewer -- ``close()`` and
 the ``step()`` handler that permanently disables it after an unrecoverable
 failure -- must go through :meth:`NewtonVisualizer._release_viewer` so that
-ordering is honoured instead of being left to the garbage collector.
+ordering is honoured instead of being left to the garbage collector. The GL
+viewer must keep its established reference-drop behavior because closing its
+renderer prevents reliable in-process recreation.
 
-These tests assert the behaviour (the viewer's ``close()`` runs, and runs
-before the reference is dropped) rather than the absence of a backend log
-message: the message is emitted for only one of several valid finalization
-orders, so asserting on it would pass against unfixed code most of the time.
+These tests assert the behavior (the RTX viewer's ``close()`` runs before the
+reference is dropped, while the GL viewer is not closed) rather than the
+absence of a backend log message. The message is emitted for only one of
+several valid finalization orders, so asserting on it would pass against
+unfixed code most of the time.
 
 They also pin the error semantics, which differ by caller.  ``_release_viewer``
 propagates a teardown failure while still clearing the reference.  ``close()``
@@ -32,8 +35,8 @@ from isaaclab_visualizers.newton.newton_visualizer import NewtonVisualizer
 pytestmark = [pytest.mark.unit]
 
 
-class _SpyViewer:
-    """Viewer double that records how and when it was closed."""
+class _SpyRTXViewer(newton_visualizer.NewtonViewerRTX):
+    """RTX viewer double that records how and when it was closed."""
 
     def __init__(self, raises: bool = False) -> None:
         self.close_calls = 0
@@ -58,7 +61,18 @@ class _SpyViewer:
         self.apply_forces_calls += 1
 
 
-def _make_visualizer(viewer: _SpyViewer | None) -> NewtonVisualizer:
+class _SpyGLViewer(newton_visualizer.NewtonViewerGL):
+    """GL viewer double that records whether ``close()`` was called."""
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.owner: NewtonVisualizer | None = None
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _make_visualizer(viewer: _SpyRTXViewer | _SpyGLViewer | None) -> NewtonVisualizer:
     """Build the minimal visualizer state that the release paths read.
 
     ``__init__`` is bypassed deliberately: a real visualizer requires a Newton
@@ -79,7 +93,7 @@ def _make_visualizer(viewer: _SpyViewer | None) -> NewtonVisualizer:
 
 def test_release_viewer_closes_before_clearing_reference() -> None:
     """The viewer must be closed while the visualizer still references it."""
-    viewer = _SpyViewer()
+    viewer = _SpyRTXViewer()
     visualizer = _make_visualizer(viewer)
 
     visualizer._release_viewer()
@@ -91,7 +105,7 @@ def test_release_viewer_closes_before_clearing_reference() -> None:
 
 def test_release_viewer_propagates_failure_and_still_clears_reference() -> None:
     """A teardown failure must reach the caller, but must not retain the viewer."""
-    viewer = _SpyViewer(raises=True)
+    viewer = _SpyRTXViewer(raises=True)
     visualizer = _make_visualizer(viewer)
 
     with pytest.raises(RuntimeError, match="Failed to create window"):
@@ -112,7 +126,7 @@ def test_release_viewer_without_viewer_is_a_no_op() -> None:
 
 def test_release_viewer_is_idempotent() -> None:
     """Releasing twice must not close the viewer twice."""
-    viewer = _SpyViewer()
+    viewer = _SpyRTXViewer()
     visualizer = _make_visualizer(viewer)
 
     visualizer._release_viewer()
@@ -121,9 +135,20 @@ def test_release_viewer_is_idempotent() -> None:
     assert viewer.close_calls == 1
 
 
+def test_release_viewer_does_not_close_gl_viewer() -> None:
+    """GL teardown must not prevent another viewer from starting in the same process."""
+    viewer = _SpyGLViewer()
+    visualizer = _make_visualizer(viewer)
+
+    visualizer._release_viewer()
+
+    assert viewer.close_calls == 0
+    assert visualizer._viewer is None
+
+
 def test_close_releases_the_viewer() -> None:
     """``close()`` must release the viewer through the shared path."""
-    viewer = _SpyViewer()
+    viewer = _SpyRTXViewer()
     visualizer = _make_visualizer(viewer)
 
     visualizer.close()
@@ -136,7 +161,7 @@ def test_close_releases_the_viewer() -> None:
 
 def test_close_is_idempotent() -> None:
     """A second ``close()`` must not close the viewer again."""
-    viewer = _SpyViewer()
+    viewer = _SpyRTXViewer()
     visualizer = _make_visualizer(viewer)
 
     visualizer.close()
@@ -157,7 +182,7 @@ def test_close_completes_cleanup_when_viewer_teardown_fails(monkeypatch: pytest.
     monkeypatch.setattr(newton_visualizer, "evict_visualizer_camera", evicted.append, raising=False)
     monkeypatch.setattr(newton_visualizer, "remove_generated_prims", removed.append, raising=False)
 
-    viewer = _SpyViewer(raises=True)
+    viewer = _SpyRTXViewer(raises=True)
     visualizer = _make_visualizer(viewer)
     visualizer._camera_sensor = object()
     visualizer._camera_is_owned = True
@@ -174,7 +199,7 @@ def test_close_completes_cleanup_when_viewer_teardown_fails(monkeypatch: pytest.
     assert removed == [["/World/generated"]]
 
 
-def _arm_for_step_failure(visualizer: NewtonVisualizer, viewer: _SpyViewer) -> None:
+def _arm_for_step_failure(visualizer: NewtonVisualizer, viewer: _SpyRTXViewer) -> None:
     """Drive ``step()`` far enough to reach its viewer-failure handler."""
     visualizer._is_initialized = True
     visualizer._runtime_headless = False
@@ -200,7 +225,7 @@ def test_step_failure_releases_the_viewer(monkeypatch: pytest.MonkeyPatch) -> No
     create its window.  That path must close the viewer rather than only
     dropping the reference to it.
     """
-    viewer = _SpyViewer()
+    viewer = _SpyRTXViewer()
     visualizer = _make_visualizer(viewer)
     visualizer._picking_enabled = True
     visualizer._viewer_picking_binding.bind(viewer)  # type: ignore[arg-type]
@@ -228,7 +253,7 @@ def test_step_contains_a_failing_viewer_teardown(monkeypatch: pytest.MonkeyPatch
     has to be contained rather than replacing the original failure and
     propagating out of the simulation loop.
     """
-    viewer = _SpyViewer(raises=True)
+    viewer = _SpyRTXViewer(raises=True)
     visualizer = _make_visualizer(viewer)
     _arm_for_step_failure(visualizer, viewer)
     monkeypatch.setattr(newton_visualizer.NewtonManager, "get_num_envs", staticmethod(lambda: 1), raising=False)

--- a/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
+++ b/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
@@ -38,6 +38,8 @@ class _SpyViewer:
     def __init__(self, raises: bool = False) -> None:
         self.close_calls = 0
         self.referenced_by_owner_at_close: list[bool] = []
+        self.referenced_by_picking_at_close: list[bool] = []
+        self.apply_forces_calls = 0
         self.owner: NewtonVisualizer | None = None
         self._raises = raises
 
@@ -46,8 +48,14 @@ class _SpyViewer:
         # Record whether the visualizer still pointed at us while we were being
         # closed.  The reference must outlive the teardown call.
         self.referenced_by_owner_at_close.append(getattr(self.owner, "_viewer", None) is self)
+        binding = getattr(self.owner, "_viewer_picking_binding", None)
+        self.referenced_by_picking_at_close.append(getattr(binding, "_viewer", None) is self)
         if self._raises:
             raise RuntimeError("Failed to create window")
+
+    def apply_forces(self, _state: object) -> None:
+        """Record a picking callback reaching this viewer."""
+        self.apply_forces_calls += 1
 
 
 def _make_visualizer(viewer: _SpyViewer | None) -> NewtonVisualizer:
@@ -60,6 +68,7 @@ def _make_visualizer(viewer: _SpyViewer | None) -> NewtonVisualizer:
     visualizer = object.__new__(NewtonVisualizer)
     visualizer._is_closed = False
     visualizer._picking_enabled = False
+    visualizer._viewer_picking_binding = NewtonVisualizer._ViewerPickingBinding()
     visualizer._viewer = viewer
     visualizer._camera_sensor = None
     visualizer._camera_is_owned = False
@@ -193,6 +202,8 @@ def test_step_failure_releases_the_viewer(monkeypatch: pytest.MonkeyPatch) -> No
     """
     viewer = _SpyViewer()
     visualizer = _make_visualizer(viewer)
+    visualizer._picking_enabled = True
+    visualizer._viewer_picking_binding.bind(viewer)  # type: ignore[arg-type]
     _arm_for_step_failure(visualizer, viewer)
     monkeypatch.setattr(newton_visualizer.NewtonManager, "get_num_envs", staticmethod(lambda: 1), raising=False)
 
@@ -200,7 +211,13 @@ def test_step_failure_releases_the_viewer(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert viewer.close_calls == 1
     assert viewer.referenced_by_owner_at_close == [True]
+    assert viewer.referenced_by_picking_at_close == [False]
     assert visualizer._viewer is None
+
+    # The callback remains registered with NewtonManager for CUDA graph
+    # stability, but it must be inert after the viewer is released.
+    visualizer._viewer_picking_binding.apply(None)  # type: ignore[arg-type]
+    assert viewer.apply_forces_calls == 0
 
 
 def test_step_contains_a_failing_viewer_teardown(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
# Description

`NewtonVisualizer` dropped its viewer without closing it in two paths:
- normal shutdown through `close()`
- the `step()` recovery path that disables the viewer after an initialization failure

This left OVRTX resources to be released by the garbage collector in an undefined order. If the renderer was destroyed before its active bindings and retained step results, shutdown could report:
```
Renderer destroyed with 1 active binding(s)
OV RTX: Leaking step result outputs
```
Both paths now use a shared `_release_viewer()` helper that calls `viewer.close()` before clearing the reference.

During normal shutdown, teardown failures continue to propagate after the remaining cleanup completes. If viewer cleanup also fails in the `step()` recovery path, the error is logged without interrupting training.

## Type of change
- Bug fix (non-breaking)

## Release backport
- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

The same issue is present on `release/3.0.0`.

## Validation

### Controlled teardown reproduction
The controlled test reproduced the reported shutdown signature:

| Version | Active-binding warnings | Leaked-step-result errors |
| --- | --- | --- |
| Without fix | 1 | 2 |
| With fix | 0 | 0 |

### Windows — RTX PRO 6000
Ran each of the two reported workloads three times, for six runs per batch:

| Version | Completed | Active-binding warnings | Leaked-step-result errors | New warnings |
| --- | --- | --- | --- | --- |
| Without fix | 6/6 | 1/6 | 0/6 | — |
| With fix | 6/6 | 0/6 | 0/6 | 0 |

The OVRTX window failed to initialize on this machine, so every run exercised the `step()` recovery path. A pre-existing USD asset-loading crash occurred once in each batch before viewer initialization and is being tracked separately.

### Linux — L40
The nine new regression tests fail against the original implementation and pass with the fix:

| Version | Visualizer test results |
| --- | --- |
| Without fix | 58 passed, 9 failed |
| With fix | 67 passed, 0 failed |

Seven tests requiring the full Isaac Sim runtime were excluded because of a pre-existing collection error.

## Checklist
- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation — not applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added the required changelog fragment under `source/<pkg>/changelog.d/`
- [x] My name is already included in `CONTRIBUTORS.md`
