### PR TITLE
[Docs] Add SO-101 tutorial banner

### DIFF
--- a/docs/source/setup/tutorial.rst
+++ b/docs/source/setup/tutorial.rst
@@ -3,17 +3,24 @@
 Tutorial
 ========
 
+.. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/tutorial_so101_vialplace_play.gif
+   :alt: The SO-101 arm picking up a vial and placing it in a rack.
+   :align: center
+   :width: 85%
+
+.. note::
+
+   This tutorial ties in with the `NVIDIA Sim-to-Real SO-101 learning course
+   <https://docs.nvidia.com/learning/physical-ai/sim-to-real-so-101/latest/index.html>`__ and its
+   `workshop repository <https://github.com/isaac-sim/Sim-to-Real-SO-101-Workshop>`__, which present a broader
+   end-to-end physical AI workflow with the SO-101, Isaac Lab, and NVIDIA Isaac GR00T.
+
 This tutorial builds a complete robot-learning workflow around an `SO-101 arm
 <https://github.com/TheRobotStudio/SO-ARM100>`__ that picks up a vial and places it in a rack.
 Instead of assembling disconnected examples, you will work with a production-shaped downstream project:
 `IsaacLabTutorial main branch <https://github.com/isaac-sim/IsaacLabTutorial/tree/main>`__. The project includes the
 robot and workshop assets, a manager-based reinforcement-learning environment, state and wrist-camera observations,
 RSL-RL agent configurations, tests, state-policy training, and state-to-vision policy distillation.
-
-.. image:: https://raw.githubusercontent.com/isaac-sim/IsaacLabTutorial/main/media/demo.gif
-   :alt: The SO-101 arm picking up a vial and placing it in a rack.
-   :align: center
-   :width: 100%
 
 By the end, you will know how a downstream Isaac Lab task is packaged, discovered, validated, trained,
 and evaluated. You will also know where to change the robot, scene, MDP, and learning configuration for


### PR DESCRIPTION
# Description

Add the NVIDIA-hosted SO-101 vial-placement rollout as a banner at the top of the standalone Tutorial page. The 1280 by 720 GIF is displayed at 85% width and remains hosted outside the repository.

Add a short introductory note connecting the tutorial to the NVIDIA Sim-to-Real SO-101 learning course and its workshop repository.

## Type of change

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

The tutorial page now opens with the centered SO-101 vial-placement banner above the workshop note.

## Validation

- `uv run --isolated --extra dev -- make -C docs current-docs`
- `uv run isaaclab -f`
- Verified the rendered banner width and both workshop links in the generated HTML
- Verified the hosted GIF returns HTTP 200 with `image/gif` content

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Tests are not required for this documentation-only change
- [x] No changelog fragment is required because no source package changed
- [x] My name already exists in `CONTRIBUTORS.md`
