### PR TITLE
[Fix] Pin LEAPP to 0.6.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -486,7 +486,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_rl"
-        extra-pip-packages: "leapp==0.6.0"
+        extra-pip-packages: "leapp==0.6.1"
         container-name: isaac-lab-rl-test
 
   test-isaaclab-mimic:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -486,7 +486,7 @@ jobs:
         isaacsim-base-image: ${{ needs.config.outputs.isaacsim_image_name }}
         isaacsim-version: ${{ needs.config.outputs.isaacsim_image_tag }}
         filter-pattern: "isaaclab_rl"
-        extra-pip-packages: "leapp"
+        extra-pip-packages: "leapp==0.6.0"
         container-name: isaac-lab-rl-test
 
   test-isaaclab-mimic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ rlinf = [
     "pandas",
 ]
 leapp = [
-    "leapp==0.6.0",
+    "leapp==0.6.1",
 ]
 all = [
     "isaaclab-dev[sb3,skrl,rl-games,rsl-rl,viser,rerun,ov]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ rlinf = [
     "pandas",
 ]
 leapp = [
-    "leapp>=0.5.2,<0.7.0",
+    "leapp==0.6.0",
 ]
 all = [
     "isaaclab-dev[sb3,skrl,rl-games,rsl-rl,viser,rerun,ov]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ rlinf = [
     "pandas",
 ]
 leapp = [
-    "leapp>=0.5.2",
+    "leapp>=0.5.2,<0.7.0",
 ]
 all = [
     "isaaclab-dev[sb3,skrl,rl-games,rsl-rl,viser,rerun,ov]",

--- a/uv.lock
+++ b/uv.lock
@@ -2045,7 +2045,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "junitparser", marker = "extra == 'test'" },
     { name = "lazy-loader", specifier = ">=0.4" },
-    { name = "leapp", marker = "extra == 'leapp'", specifier = ">=0.5.2,<0.7.0" },
+    { name = "leapp", marker = "extra == 'leapp'", specifier = "==0.6.0" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "meshio", specifier = ">=5.3.5" },
     { name = "moviepy", marker = "extra == 'video'", specifier = ">=1.0.3,<2.0.0.dev0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2045,7 +2045,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "junitparser", marker = "extra == 'test'" },
     { name = "lazy-loader", specifier = ">=0.4" },
-    { name = "leapp", marker = "extra == 'leapp'", specifier = ">=0.5.2" },
+    { name = "leapp", marker = "extra == 'leapp'", specifier = ">=0.5.2,<0.7.0" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "meshio", specifier = ">=5.3.5" },
     { name = "moviepy", marker = "extra == 'video'", specifier = ">=1.0.3,<2.0.0.dev0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2045,7 +2045,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "junitparser", marker = "extra == 'test'" },
     { name = "lazy-loader", specifier = ">=0.4" },
-    { name = "leapp", marker = "extra == 'leapp'", specifier = "==0.6.0" },
+    { name = "leapp", marker = "extra == 'leapp'", specifier = "==0.6.1" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "meshio", specifier = ">=5.3.5" },
     { name = "moviepy", marker = "extra == 'video'", specifier = ">=1.0.3,<2.0.0.dev0" },
@@ -2958,7 +2958,7 @@ wheels = [
 
 [[package]]
 name = "leapp"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "fast-sugiyama", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
@@ -2972,7 +2972,7 @@ dependencies = [
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/leapp/leapp-0.6.0-py3-none-any.whl", hash = "sha256:39127ef5e0a1d4b09ac1847df3348ddff41440d197048f43fad3e73b8ef42617" },
+    { url = "https://pypi.nvidia.com/leapp/leapp-0.6.1-py3-none-any.whl", hash = "sha256:b41bb1ca2a0019216428feeee5463603d22022828ab95badb9334f88e5e254dc" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

LEAPP 0.7.0 introduced two regressions in the Isaac Lab export suite after it was published on September 4:

- Kuka-Allegro export re-enters the graph with `robot_root_link_quat_w` after registering the aliased tensor as `robot_root_quat_w`.
- SKRL Cartpole export fails while LEAPP reconstructs Warp `BuiltinCallDesc` tuple subclasses during `wp.rand_init` interception.

The `isaaclab_rl` package-test job installed bare `leapp`, so the new release entered CI without a repository change. The same failures appeared in unrelated PRs, including #7585 and #7544.

This change pins both the public `leapp` extra and the package-test installation to `leapp==0.6.1`. The lockfile now resolves the same version, keeping project environments and CI aligned until the LEAPP 0.7 regressions are fixed upstream.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv lock --check` passed.
- `uv run --extra leapp python -c "..."` resolved and verified LEAPP 0.6.1.
- Focused pre-commit YAML and TOML checks passed.
- `uv run isaaclab -f` passed every formatting, syntax, metadata, and spelling hook except the changelog-fragment hook. That hook reports four pre-existing `develop`-base fragment problems in `isaaclab_newton`, `isaaclab_tasks`, `isaaclab_experimental`, and `isaaclab_visualizers`; this PR changes no `source/` path.
- `git diff --check upstream/develop` passed.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks; the unrelated base-branch changelog failure is documented above.
- [x] Documentation changes are not required for this dependency pin.
- [x] My changes generate no new warnings.
- [x] No test was added; dependency resolution and repository metadata checks cover this pinning change.
- [x] No changelog fragment is required because no release-managed package under `source/` changes.
- [x] My name already exists in `CONTRIBUTORS.md`.