### PR TITLE
Source US asset root from Kit configuration

### DIFF
--- a/apps/isaaclab.python.headless.kit
+++ b/apps/isaaclab.python.headless.kit
@@ -203,6 +203,6 @@ enabled=true # Enable this for DLSS
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/apps/isaaclab.python.headless.rendering.kit
+++ b/apps/isaaclab.python.headless.rendering.kit
@@ -171,6 +171,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/apps/isaaclab.python.kit
+++ b/apps/isaaclab.python.kit
@@ -273,6 +273,6 @@ fabricUseGPUInterop = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/apps/isaaclab.python.rendering.kit
+++ b/apps/isaaclab.python.rendering.kit
@@ -151,6 +151,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/apps/isaaclab.python.xr.openxr.headless.kit
+++ b/apps/isaaclab.python.xr.openxr.headless.kit
@@ -72,6 +72,6 @@ UJITSO.geometry = true
 UJITSO.enabled = true
 
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/apps/isaaclab.python.xr.openxr.kit
+++ b/apps/isaaclab.python.xr.openxr.kit
@@ -112,6 +112,6 @@ UJITSO.enabled = true
 # set the S3 directory manually to the latest published S3
 # note: this is done to ensure prior versions of Isaac Sim still use the latest assets
 [settings]
-persistent.isaac.asset_root.default = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.cloud = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
-persistent.isaac.asset_root.nvidia = "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.default = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.cloud = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"
+persistent.isaac.asset_root.nvidia = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1"

--- a/source/isaaclab/changelog.d/asset-region-profiles.minor.rst
+++ b/source/isaaclab/changelog.d/asset-region-profiles.minor.rst
@@ -8,5 +8,3 @@ Changed
 
 * Renamed the China profile selector from ``ISAACSIM_STORAGE_PROFILE`` to
   ``ISAACSIM_ASSET_REGION_PROFILE``.
-* Updated the shipped Kit experiences to use the production asset root and made the ``us`` profile
-  resolve that canonical setting instead of duplicating the URL in Python.

--- a/source/isaaclab/changelog.d/asset-region-profiles.minor.rst
+++ b/source/isaaclab/changelog.d/asset-region-profiles.minor.rst
@@ -8,3 +8,5 @@ Changed
 
 * Renamed the China profile selector from ``ISAACSIM_STORAGE_PROFILE`` to
   ``ISAACSIM_ASSET_REGION_PROFILE``.
+* Updated the shipped Kit experiences to use the production asset root and made the ``us`` profile
+  resolve that canonical setting instead of duplicating the URL in Python.

--- a/source/isaaclab/changelog.d/codex-pr-7549-production-kit-assets.rst
+++ b/source/isaaclab/changelog.d/codex-pr-7549-production-kit-assets.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the ``us`` Asset Region Profile and all shipped Kit experiences to share the production asset root.

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -50,16 +50,36 @@ _KIT_EXPERIENCE_PATH = str(ISAACLAB_ROOT / "apps" / "isaaclab.python.kit")
 # legacy ``cloud`` setting is only consulted for experience files that predate it.
 _KIT_ASSET_ROOT_SETTINGS = ("default", "cloud")
 
+
+def _parse_kit_asset_root() -> str:
+    """Parse the configured Isaac asset root.
+
+    Returns:
+        Value of ``persistent.isaac.asset_root.default``, or of the legacy
+        ``persistent.isaac.asset_root.cloud``, from ``isaaclab.python.kit``.
+    """
+    with open(_KIT_EXPERIENCE_PATH) as f:
+        lines = f.readlines()
+    for setting in _KIT_ASSET_ROOT_SETTINGS:
+        pattern = re.compile(rf'\s*persistent\.isaac\.asset_root\.{setting}\s*=\s*"([^"]*)"')
+        for line in reversed(lines):  # read from the last line since it's the last setting defined
+            m = pattern.match(line)
+            if m:
+                return m.group(1)
+    return ""
+
+
 _ASSET_REGION_PROFILE_ENV_VAR = "ISAACSIM_ASSET_REGION_PROFILE"
 # Update this value when the China mirror moves to a new Isaac Sim asset release.
 _ISAAC_SIM_ASSET_RELEASE = "6.1"
 _CHINA_ASSET_ENDPOINT = "simready-cn.s3.oss-cn-shanghai.aliyuncs.com"
+_US_ASSET_ROOT = _parse_kit_asset_root()
 
 
 class _StorageProfile(TypedDict):
-    """OmniClient routing and asset-root overrides for a named asset region profile."""
+    """OmniClient routing and asset-root values for a named asset region profile."""
 
-    asset_root: NotRequired[str]
+    asset_root: str
     endpoint: NotRequired[str]
     bucket: NotRequired[str]
     region: NotRequired[str]
@@ -68,8 +88,9 @@ class _StorageProfile(TypedDict):
 
 
 _STORAGE_PROFILES: dict[str, _StorageProfile] = {
-    # The primary profile uses the production root configured by the shipped kit experience.
-    "us": {},
+    "us": {
+        "asset_root": _US_ASSET_ROOT,
+    },
     "china": {
         "endpoint": _CHINA_ASSET_ENDPOINT,
         "bucket": "simready-cn",
@@ -158,31 +179,13 @@ def _get_omni_client() -> ModuleType:
     return omni.client
 
 
-def _parse_kit_asset_root() -> str:
-    """Parse the configured Isaac asset root.
-
-    Returns:
-        Value of ``persistent.isaac.asset_root.default``, or of the legacy
-        ``persistent.isaac.asset_root.cloud``, from ``isaaclab.python.kit``.
-    """
-    with open(_KIT_EXPERIENCE_PATH) as f:
-        lines = f.readlines()
-    for setting in _KIT_ASSET_ROOT_SETTINGS:
-        pattern = re.compile(rf'\s*persistent\.isaac\.asset_root\.{setting}\s*=\s*"([^"]*)"')
-        for line in reversed(lines):  # read from the last line since it's the last setting defined
-            m = pattern.match(line)
-            if m:
-                return m.group(1)
-    return ""
-
-
 def _resolve_asset_root() -> str:
     """Resolve the configured Isaac asset root.
 
     The ``ISAACSIM_ASSET_ROOT`` environment variable follows the public Isaac Sim
-    asset-root precedence. When it is unset, an asset-root override from the asset region
-    profile named by ``ISAACSIM_ASSET_REGION_PROFILE`` is used. Profiles without an
-    override, including ``us``, use the root from the kit file.
+    asset-root precedence. When it is unset, the asset root from the asset region profile
+    named by ``ISAACSIM_ASSET_REGION_PROFILE`` is used. The kit file remains the fallback
+    for kitless use.
 
     Returns:
         Value of ``ISAACSIM_ASSET_ROOT`` without its trailing separator, or the value
@@ -198,9 +201,7 @@ def _resolve_asset_root() -> str:
 
     selected_profile = _selected_storage_profile()
     if selected_profile is not None:
-        profile_asset_root = selected_profile[1].get("asset_root")
-        if profile_asset_root:
-            return profile_asset_root
+        return selected_profile[1]["asset_root"]
 
     return _parse_kit_asset_root()
 

--- a/source/isaaclab/isaaclab/utils/assets.py
+++ b/source/isaaclab/isaaclab/utils/assets.py
@@ -54,15 +54,12 @@ _ASSET_REGION_PROFILE_ENV_VAR = "ISAACSIM_ASSET_REGION_PROFILE"
 # Update this value when the China mirror moves to a new Isaac Sim asset release.
 _ISAAC_SIM_ASSET_RELEASE = "6.1"
 _CHINA_ASSET_ENDPOINT = "simready-cn.s3.oss-cn-shanghai.aliyuncs.com"
-_US_ASSET_ROOT = (
-    f"https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/{_ISAAC_SIM_ASSET_RELEASE}"
-)
 
 
 class _StorageProfile(TypedDict):
-    """OmniClient routing and asset-root values for a named asset region profile."""
+    """OmniClient routing and asset-root overrides for a named asset region profile."""
 
-    asset_root: str
+    asset_root: NotRequired[str]
     endpoint: NotRequired[str]
     bucket: NotRequired[str]
     region: NotRequired[str]
@@ -71,9 +68,8 @@ class _StorageProfile(TypedDict):
 
 
 _STORAGE_PROFILES: dict[str, _StorageProfile] = {
-    "us": {
-        "asset_root": _US_ASSET_ROOT,
-    },
+    # The primary profile uses the production root configured by the shipped kit experience.
+    "us": {},
     "china": {
         "endpoint": _CHINA_ASSET_ENDPOINT,
         "bucket": "simready-cn",
@@ -184,9 +180,9 @@ def _resolve_asset_root() -> str:
     """Resolve the configured Isaac asset root.
 
     The ``ISAACSIM_ASSET_ROOT`` environment variable follows the public Isaac Sim
-    asset-root precedence. When it is unset, the asset root from the asset region profile
-    named by ``ISAACSIM_ASSET_REGION_PROFILE`` is used. The kit file remains the fallback
-    for kitless use.
+    asset-root precedence. When it is unset, an asset-root override from the asset region
+    profile named by ``ISAACSIM_ASSET_REGION_PROFILE`` is used. Profiles without an
+    override, including ``us``, use the root from the kit file.
 
     Returns:
         Value of ``ISAACSIM_ASSET_ROOT`` without its trailing separator, or the value
@@ -202,7 +198,9 @@ def _resolve_asset_root() -> str:
 
     selected_profile = _selected_storage_profile()
     if selected_profile is not None:
-        return selected_profile[1]["asset_root"]
+        profile_asset_root = selected_profile[1].get("asset_root")
+        if profile_asset_root:
+            return profile_asset_root
 
     return _parse_kit_asset_root()
 

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -54,13 +54,13 @@ def test_asset_root_uses_china_storage_profile(monkeypatch):
     assert assets_utils._resolve_asset_root() == expected_root
 
 
-def test_asset_root_uses_us_asset_region_profile(monkeypatch):
-    """Test the US asset region profile uses the root from the shipped experience."""
+def test_us_asset_root_is_parsed_from_kit_file(monkeypatch):
+    """Test the US asset region profile initializes its root from the shipped experience."""
     monkeypatch.delenv("ISAACSIM_ASSET_ROOT", raising=False)
     monkeypatch.setenv("ISAACSIM_ASSET_REGION_PROFILE", "us")
-    monkeypatch.setattr(assets_utils, "_parse_kit_asset_root", lambda: "https://example.com/kit-assets")
 
-    assert assets_utils._resolve_asset_root() == "https://example.com/kit-assets"
+    assert assets_utils._parse_kit_asset_root() == assets_utils._US_ASSET_ROOT
+    assert assets_utils._resolve_asset_root() == assets_utils._US_ASSET_ROOT
 
 
 def test_asset_root_ignores_unknown_storage_profile(monkeypatch, caplog):

--- a/source/isaaclab/test/utils/test_assets.py
+++ b/source/isaaclab/test/utils/test_assets.py
@@ -55,12 +55,12 @@ def test_asset_root_uses_china_storage_profile(monkeypatch):
 
 
 def test_asset_root_uses_us_asset_region_profile(monkeypatch):
-    """Test the US asset region profile uses the same public bucket root as Isaac Sim."""
+    """Test the US asset region profile uses the root from the shipped experience."""
     monkeypatch.delenv("ISAACSIM_ASSET_ROOT", raising=False)
     monkeypatch.setenv("ISAACSIM_ASSET_REGION_PROFILE", "us")
     monkeypatch.setattr(assets_utils, "_parse_kit_asset_root", lambda: "https://example.com/kit-assets")
 
-    assert assets_utils._resolve_asset_root() == assets_utils._US_ASSET_ROOT
+    assert assets_utils._resolve_asset_root() == "https://example.com/kit-assets"
 
 
 def test_asset_root_ignores_unknown_storage_profile(monkeypatch, caplog):
@@ -182,6 +182,19 @@ def test_kit_experience_path_resolves_to_the_shipped_experience():
     """Test the unpatched experience-file path so a broken relative walk fails here."""
     assert Path(assets_utils._KIT_EXPERIENCE_PATH).is_file()
     assert assets_utils._parse_kit_asset_root()
+
+
+def test_kit_experience_asset_roots_use_production():
+    """Test every shipped experience uses the canonical production asset root."""
+    kit_directory = Path(assets_utils._KIT_EXPERIENCE_PATH).parent
+    production_root = assets_utils._parse_kit_asset_root()
+
+    assert "omniverse-content-production" in production_root
+    for kit_path in kit_directory.glob("*.kit"):
+        kit_config = kit_path.read_text(encoding="utf-8")
+        assert "omniverse-content-staging" not in kit_config
+        for setting in ("default", "cloud", "nvidia"):
+            assert f'persistent.isaac.asset_root.{setting} = "{production_root}"' in kit_config
 
 
 def test_kit_asset_root_prefers_default_setting(tmp_path, monkeypatch):


### PR DESCRIPTION
# Description

Uses the shipped Kit experience as the single source of truth for the `us` Asset Region Profile instead of duplicating the production asset URL in Python.

All six shipped `.kit` experiences now use the production asset root for their `default`, `cloud`, and `nvidia` settings. Focused regression coverage verifies that `_US_ASSET_ROOT` is initialized by the Kit parser, the `us` profile keeps its existing resolution path, and every shipped experience remains aligned with the canonical production root.

Follow-up to #7549. No additional dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) on the changed files
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Validation

- The two focused regression checks fail against the pre-fix #7549 head and pass with this change.
- `13 passed, 48 deselected` for the asset-root and Kit-experience subset of `test_assets.py`.
- All pre-commit hooks passed on the changed files, including Ruff, formatting, codespell, changelog validation, and Git LFS pointer validation.
- Python compilation and `git diff --check` passed.
- Full `uv run isaaclab -f` was unavailable locally because the project lockfile does not support macOS; the equivalent changed-file pre-commit suite passed.