### PR TITLE
Fix Warp camera runtime errors

### DIFF
--- a/source/isaaclab_newton/changelog.d/kguo-deformable-render-graph.rst
+++ b/source/isaaclab_newton/changelog.d/kguo-deformable-render-graph.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Avoided conditional CUDA graph capture for Newton Warp rendering of deformable triangle meshes.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -477,6 +477,7 @@ class NewtonManager(PhysicsManager):
 
     # Newton scene-query scheduling and graph execution.
     _sensor_tasks: dict[str, Callable[[], None]] = {}
+    _sensor_eager_tasks: set[str] = set()
     _sensor_graph: wp.Graph | None = None
     _sensor_flags: wp.array | None = None
     _sensor_flags_host: np.ndarray | None = None
@@ -1167,6 +1168,7 @@ class NewtonManager(PhysicsManager):
         NewtonManager._graph = None
         NewtonManager._graph_capture_pending = False
         NewtonManager._sensor_tasks = {}
+        NewtonManager._sensor_eager_tasks = set()
         NewtonManager._invalidate_sensor_graph()
         NewtonManager._sensor_state = None
         NewtonManager._sensor_state_dirty = True
@@ -2693,12 +2695,13 @@ class NewtonManager(PhysicsManager):
         return cls._contacts
 
     @classmethod
-    def _register_sensor_task(cls, name: str, update_fn: Callable[[], None]) -> None:
-        """Register a graph-capturable scene-query task.
+    def _register_sensor_task(cls, name: str, update_fn: Callable[[], None], *, graph_capturable: bool = True) -> None:
+        """Register a scene-query task.
 
         Args:
             name: Unique task name.
-            update_fn: Graph-capturable callable run by :meth:`_update_sensor_tasks`.
+            update_fn: Callable run by :meth:`_update_sensor_tasks`.
+            graph_capturable: Whether ``update_fn`` supports conditional CUDA graph capture.
         """
         if name in cls._sensor_tasks:
             raise ValueError(f"Newton sensor task '{name}' is already registered.")
@@ -2711,6 +2714,8 @@ class NewtonManager(PhysicsManager):
         if model.particle_count > 0 and model.bvh_particles is None:
             model.bvh_build_particles(state)
         cls._sensor_tasks[name] = update_fn
+        if not graph_capturable:
+            cls._sensor_eager_tasks.add(name)
         cls._sensor_state = state
         cls._sensor_state_dirty = True
         cls._invalidate_sensor_graph()
@@ -2719,6 +2724,7 @@ class NewtonManager(PhysicsManager):
     def _unregister_sensor_task(cls, name: str) -> None:
         """Remove a scene-query task, ignoring unknown names."""
         if cls._sensor_tasks.pop(name, None) is not None:
+            cls._sensor_eager_tasks.discard(name)
             cls._invalidate_sensor_graph()
 
     @classmethod
@@ -2734,6 +2740,13 @@ class NewtonManager(PhysicsManager):
             cls._sensor_state = state
             cls._sensor_state_dirty = True
             cls._invalidate_sensor_graph()
+        if cls._sensor_eager_tasks.intersection(names):
+            if cls._sensor_state_dirty:
+                cls._refit_sensor_bvh()
+                cls._sensor_state_dirty = False
+            for name in names:
+                cls._sensor_tasks[name]()
+            return
         cfg = PhysicsManager._cfg
         use_cuda_graph = bool(getattr(cfg, "use_cuda_graph", False)) and "cuda" in str(PhysicsManager._device)
         if use_cuda_graph and cls._sensor_graph is None and not cls._sensor_graph_capture_failed:
@@ -2750,7 +2763,7 @@ class NewtonManager(PhysicsManager):
         assert cls._sensor_flags is not None
         cls._sensor_flags_host.fill(0)
         cls._sensor_flags_host[0] = int(cls._sensor_state_dirty)
-        task_names = tuple(cls._sensor_tasks)
+        task_names = tuple(name for name in cls._sensor_tasks if name not in cls._sensor_eager_tasks)
         for name in names:
             cls._sensor_flags_host[1 + task_names.index(name)] = 1
         cls._sensor_flags.assign(cls._sensor_flags_host)
@@ -2806,19 +2819,21 @@ class NewtonManager(PhysicsManager):
     @classmethod
     def _capture_sensor_graph(cls) -> None:
         """Capture BVH refit and scene-query tasks into a conditional graph."""
+        graph_tasks = tuple(
+            update_fn for name, update_fn in cls._sensor_tasks.items() if name not in cls._sensor_eager_tasks
+        )
         with wp.ScopedDevice(PhysicsManager._device):
             cls._refit_sensor_bvh()
-            for update_fn in cls._sensor_tasks.values():
+            for update_fn in graph_tasks:
                 update_fn()
 
-        cls._sensor_flags = wp.zeros(1 + len(cls._sensor_tasks), dtype=wp.int32, device=PhysicsManager._device)
-        cls._sensor_flags_host = np.zeros(1 + len(cls._sensor_tasks), dtype=np.int32)
-        update_fns = tuple(cls._sensor_tasks.values())
+        cls._sensor_flags = wp.zeros(1 + len(graph_tasks), dtype=wp.int32, device=PhysicsManager._device)
+        cls._sensor_flags_host = np.zeros(1 + len(graph_tasks), dtype=np.int32)
 
         def pipeline() -> None:
             assert cls._sensor_flags is not None
             wp.capture_if(cls._sensor_flags[0:1], cls._refit_sensor_bvh)
-            for index, update_fn in enumerate(update_fns):
+            for index, update_fn in enumerate(graph_tasks):
                 wp.capture_if(cls._sensor_flags[index + 1 : index + 2], update_fn)
 
         device = PhysicsManager._device
@@ -2838,7 +2853,7 @@ class NewtonManager(PhysicsManager):
             cls._sensor_graph_capture_failed = True
             logger.warning("Newton sensor graph capture failed; falling back to eager execution.")
         else:
-            logger.info("Captured Newton sensor graph with %d task(s).", len(cls._sensor_tasks))
+            logger.info("Captured Newton sensor graph with %d task(s).", len(graph_tasks))
 
     @classmethod
     def get_num_envs(cls) -> int:

--- a/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
+++ b/source/isaaclab_newton/isaaclab_newton/renderers/newton_warp_renderer.py
@@ -553,7 +553,14 @@ class NewtonWarpRenderer(BaseRenderer):
 
         if render_data.sensor_task_name is None:
             render_data.sensor_task_name = f"newton_warp_render:{id(render_data)}"
-            NewtonManager._register_sensor_task(render_data.sensor_task_name, lambda: self._launch_render(render_data))
+            tri_indices = self._newton_model.tri_indices
+            # Warp mesh refits allocate graph nodes and are not supported inside a conditional graph body.
+            graph_capturable = tri_indices is None or tri_indices.shape[0] == 0
+            NewtonManager._register_sensor_task(
+                render_data.sensor_task_name,
+                lambda: self._launch_render(render_data),
+                graph_capturable=graph_capturable,
+            )
         NewtonManager._update_sensor_tasks(render_data.sensor_task_name)
 
         # Post-render PPISP: HDR scene-linear → LDR RGBA. Source/destination

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -350,6 +350,72 @@ def test_sensor_task_builds_and_refits_bvhs_before_rendering(monkeypatch):
     assert status["rendered"]
 
 
+def test_non_graph_capturable_sensor_task_runs_eagerly(monkeypatch):
+    """Sensor tasks with allocation-backed work should not attempt CUDA graph capture."""
+    state = object()
+    model = SimpleNamespace(shape_count=0, particle_count=0, bvh_shapes=None, bvh_particles=None)
+    calls: list[str] = []
+
+    monkeypatch.setattr(NewtonManager, "get_model", classmethod(lambda cls: model))
+    monkeypatch.setattr(NewtonManager, "get_state_0", classmethod(lambda cls: state))
+    monkeypatch.setattr(NewtonManager, "get_state", classmethod(lambda cls: state))
+    monkeypatch.setattr(NewtonManager, "_model", model, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_tasks", {}, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_eager_tasks", set(), raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_state_dirty", True, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_graph", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_flags", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_flags_host", None, raising=False)
+    monkeypatch.setattr(NewtonManager, "_sensor_graph_capture_failed", False, raising=False)
+    monkeypatch.setattr(PhysicsManager, "_cfg", SimpleNamespace(use_cuda_graph=True), raising=False)
+    monkeypatch.setattr(PhysicsManager, "_device", "cuda:0", raising=False)
+    monkeypatch.setattr(
+        NewtonManager,
+        "_capture_sensor_graph",
+        classmethod(lambda cls: pytest.fail("Non-graph-capturable task attempted CUDA graph capture.")),
+    )
+
+    NewtonManager._register_sensor_task("render", lambda: calls.append("render"), graph_capturable=False)
+    NewtonManager._update_sensor_tasks("render")
+
+    assert calls == ["render"]
+    assert NewtonManager._sensor_graph is None
+    assert NewtonManager._sensor_graph_capture_failed is False
+
+
+@pytest.mark.parametrize(
+    ("triangle_count", "expected_graph_capturable"),
+    [
+        pytest.param(None, True, id="no-triangle-array"),
+        pytest.param(0, True, id="empty-triangle-array"),
+        pytest.param(1, False, id="deformable-triangle-mesh"),
+    ],
+)
+def test_newton_warp_renderer_marks_triangle_mesh_refit_as_eager(
+    monkeypatch, triangle_count, expected_graph_capturable
+):
+    """Deformable triangle-mesh rendering should opt out of conditional CUDA graph capture."""
+    from isaaclab_newton.renderers.newton_warp_renderer import NewtonWarpRenderer
+
+    registration: dict[str, object] = {}
+
+    def register_task(cls, name, update_fn, *, graph_capturable=True):
+        registration.update(name=name, update_fn=update_fn, graph_capturable=graph_capturable)
+
+    monkeypatch.setattr(NewtonManager, "_register_sensor_task", classmethod(register_task))
+    monkeypatch.setattr(NewtonManager, "_update_sensor_tasks", classmethod(lambda cls, *names: None))
+
+    tri_indices = None if triangle_count is None else SimpleNamespace(shape=(triangle_count, 3))
+    renderer = object.__new__(NewtonWarpRenderer)
+    renderer._newton_model = SimpleNamespace(tri_indices=tri_indices)
+    render_data = SimpleNamespace(sensor_task_name=None, ppisp_pipeline=None)
+
+    renderer.render(render_data)
+
+    assert registration["graph_capturable"] is expected_graph_capturable
+
+
 def test_sensor_bvh_shape_flags_are_fixed_before_builder_creation(monkeypatch):
     """Builder finalization includes collision-only shapes without a later BVH rebuild."""
     import newton

--- a/source/isaaclab_physx/changelog.d/kguo-empty-rtx-frame.rst
+++ b/source/isaaclab_physx/changelog.d/kguo-empty-rtx-frame.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Handled empty Isaac RTX annotator warm-up frames without invalid Warp slicing.

--- a/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
+++ b/source/isaaclab_physx/isaaclab_physx/renderers/isaac_rtx_renderer.py
@@ -585,6 +585,17 @@ class IsaacRtxRenderer(BaseRenderer):
             else:
                 tiled_data_buffer = output
 
+            # The RTX annotator may return an empty frame while its render product is warming up.
+            # Clear the destination so callers do not observe stale data, then wait for the next frame.
+            if data_type == str(RenderBufferKind.RGB_HDR) and data_type not in output_data:
+                assert render_data._hdr_scratch_wp is not None
+                buf_wp = render_data._hdr_scratch_wp
+            else:
+                buf_wp = output_data[data_type].warp
+            if tiled_data_buffer.size == 0:
+                buf_wp.zero_()
+                continue
+
             # convert data buffer to warp array
             if isinstance(tiled_data_buffer, np.ndarray):
                 # Let warp infer the dtype from numpy array instead of hardcoding uint8
@@ -619,14 +630,6 @@ class IsaacRtxRenderer(BaseRenderer):
             if data_type == str(RenderBufferKind.RGB_HDR):
                 tiled_data_buffer = tiled_data_buffer[:, :, :3].contiguous()
 
-            # The HDR annotator's destination is the user-visible ``output_data["rgb_hdr"]``
-            # when they requested it explicitly; otherwise the renderer's internal
-            # scratch buffer that the PPISP pipeline reads.
-            if data_type == str(RenderBufferKind.RGB_HDR) and data_type not in output_data:
-                assert render_data._hdr_scratch_wp is not None
-                buf_wp = render_data._hdr_scratch_wp
-            else:
-                buf_wp = output_data[data_type].warp
             wp.launch(
                 kernel=reshape_tiled_image,
                 dim=(view_count, cfg.height, cfg.width),

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
@@ -13,6 +13,7 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+import numpy as np
 import pytest
 import warp as wp
 from packaging import version
@@ -431,6 +432,40 @@ def test_deterministic_flag_gates_rtx_determinism_settings(monkeypatch, stored, 
     assert determinism_mock.called is expected_called
     if expected_called:
         determinism_mock.assert_called_once_with(settings)
+
+
+def test_render_treats_empty_annotator_frame_as_not_ready(monkeypatch):
+    """An empty warm-up frame should clear its output without slicing or launching a reshape."""
+    _install_omni_stubs(monkeypatch)
+    import isaaclab_physx.renderers.isaac_rtx_renderer as rtx_renderer
+    from isaaclab_physx.renderers.isaac_rtx_renderer_cfg import IsaacRtxRendererCfg
+
+    annotator = MagicMock()
+    annotator.get_data.return_value = np.empty((0, 0, 4), dtype=np.uint8)
+    output_buffer = MagicMock()
+    render_data = SimpleNamespace(
+        annotators={"rgba": annotator},
+        output_data={"rgba": SimpleNamespace(warp=output_buffer)},
+        spec=SimpleNamespace(
+            view_count=1,
+            device="cpu",
+            cfg=SimpleNamespace(width=64, height=64),
+        ),
+        renderer_info={},
+        ppisp_pipeline=None,
+        _hdr_scratch_wp=None,
+    )
+    renderer = rtx_renderer.IsaacRtxRenderer.__new__(rtx_renderer.IsaacRtxRenderer)
+    renderer.cfg = IsaacRtxRendererCfg()
+
+    with (
+        patch.object(rtx_renderer, "ensure_isaac_rtx_render_update"),
+        patch.object(rtx_renderer.wp, "launch") as launch,
+    ):
+        renderer.render(render_data)
+
+    output_buffer.zero_.assert_called_once_with()
+    launch.assert_not_called()
 
 
 def test_isaac_rtx_read_output_clears_stale_metadata_and_keeps_seeded_keys(monkeypatch):

--- a/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
+++ b/source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py
@@ -434,7 +434,8 @@ def test_deterministic_flag_gates_rtx_determinism_settings(monkeypatch, stored, 
         determinism_mock.assert_called_once_with(settings)
 
 
-def test_render_treats_empty_annotator_frame_as_not_ready(monkeypatch):
+@pytest.mark.parametrize("data_type", ["rgba", "normals"])
+def test_render_treats_empty_annotator_frame_as_not_ready(monkeypatch, data_type):
     """An empty warm-up frame should clear its output without slicing or launching a reshape."""
     _install_omni_stubs(monkeypatch)
     import isaaclab_physx.renderers.isaac_rtx_renderer as rtx_renderer
@@ -444,8 +445,8 @@ def test_render_treats_empty_annotator_frame_as_not_ready(monkeypatch):
     annotator.get_data.return_value = np.empty((0, 0, 4), dtype=np.uint8)
     output_buffer = MagicMock()
     render_data = SimpleNamespace(
-        annotators={"rgba": annotator},
-        output_data={"rgba": SimpleNamespace(warp=output_buffer)},
+        annotators={data_type: annotator},
+        output_data={data_type: SimpleNamespace(warp=output_buffer)},
         spec=SimpleNamespace(
             view_count=1,
             device="cpu",


### PR DESCRIPTION
# Description

Fixes NVBug 6675392 and NVBug 6684416

This PR fixes two camera-rendering failures at their respective boundaries:

- Newton Warp rendering now marks deformable triangle-mesh render work as non-graph-capturable because Warp mesh refits record allocation nodes that conditional CUDA graph bodies do not support. Other graph-safe sensor tasks remain capturable.
- Isaac RTX rendering now treats an empty annotator warm-up frame as not ready, clears the destination buffer, and skips Warp slicing and reshape work for that frame.

No new dependencies are required.

### Validation

#### NVBug 6675392 exact command

```console
uv run --extra isaacsim,all,rlinf,mimic,teleop,tetrahedralization,video,leapp isaaclab train --rl_library rsl_rl --task Isaac-Lift-Cloth-Franka-Camera --info --max_iterations 5
```

- PR parent `3639364a`: reproduced `Conditional body graph contains an unsupported operation (memory allocation)` and the `sensor CUDA graph capture failed` traceback, then completed learning iterations 0/5 through 4/5 via the existing eager fallback.
- This PR: completed learning iterations 0/5 through 4/5 without the conditional-body or sensor-capture traceback.

#### NVBug 6684416 exact commands

Primary command (Windows path separators translated to Linux path separators only):

```console
uv run --extra all,isaacsim,rlinf,mimic,teleop,tetrahedralization,video,leapp python scripts/environments/zero_agent.py --task IsaacContrib-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos --visualizer newton_gl
```

Ubuntu multi-visualizer command:

```console
uv run --extra isaacsim,all,rlinf,mimic,teleop,tetrahedralization,video,leapp python scripts/environments/zero_agent.py --task IsaacContrib-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos --visualizer kit,rerun,newton_gl,viser physics=isaacsim_physx
```

- PR parent and this PR: both commands completed environment setup, reached `Zero agent is running`, and stepped until an external watchdog stopped the intentionally unbounded process (90-120 seconds). Neither revision raised `Invalid indexing in slice` on the locally available repository-pinned Isaac Sim 6.0.1.0 stack.
- The ticket reports Isaac Sim 6.1.0.0-rc.12, which is not installed locally. A run using the closest local 6.1 source build (6.1.0-alpha.56) at the ticket's reported Isaac Lab revision stopped on an unrelated 4096-environment RTX allocation/OOM failure before reaching the reported invalid-slice path, so it is not counted as a reproduction.
- The focused empty-annotator-frame regression test deterministically fails on the PR parent with the reported invalid-slice behavior and passes on this PR.

The unbounded zero-agent commands were wrapped only in a timeout, and `OMNI_KIT_ACCEPT_EULA=YES` was scoped to the processes after confirming an existing accepted-EULA marker. Their command arguments were otherwise unchanged.

#### Focused and repository checks

- `uv run --frozen --extra test python -m pytest source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py source/isaaclab_physx/test/renderers/test_isaac_rtx_renderer_contract.py -q` — 200 passed
- The new focused regression tests were verified to fail before the fixes and pass afterward.
- `uv run --frozen isaaclab -f`
- `uv run --frozen --extra test python tools/changelog/cli.py check develop`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation (changelog fragments; no public API change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
