### PR TITLE
Allow shadow visualizers to load reversed-joint assets

### DIFF
--- a/source/isaaclab_newton/changelog.d/kellyg-fix-nvbug-6708340.rst
+++ b/source/isaaclab_newton/changelog.d/kellyg-fix-nvbug-6708340.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed Newton-backed visualizers failing to initialize under a PhysX simulation when a legacy
+  USD asset authors reversed joint body relationships.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -98,14 +98,14 @@ def build_source_builders(
     *,
     ignore_paths: Sequence[str] | None = None,
     load_visual_shapes: bool = True,
+    bodies_follow_joint_ordering: bool = True,
     skip_mesh_approximation: bool = False,
 ) -> dict[str, ModelBuilder]:
     """Build one Newton builder for each clone source prim path.
 
-    The cloner approximates nothing. Collision geometry is whatever the asset authored:
-    Newton's importer applies each shape's ``physics:approximation`` while importing, and
-    USD defaults that token to ``none``, meaning "use the mesh as-is". Change it where it
-    is authored -- the mesh-collision schema fragments on the spawner -- not here.
+    By default, Newton's importer applies each shape's authored
+    ``physics:approximation``. Render-only callers can bypass collision mesh
+    approximation with ``skip_mesh_approximation``.
 
     Args:
         stage: USD stage containing the source prims.
@@ -116,6 +116,8 @@ def build_source_builders(
         load_visual_shapes: Whether to import visual-only geometry. Importing it costs
             USD parse time and memory that only pays off when the shapes are rendered
             or ray cast.
+        bodies_follow_joint_ordering: Whether to add bodies in topologically sorted
+            joint order.
         skip_mesh_approximation: Whether to skip collision mesh approximation during import.
     """
     return {
@@ -126,6 +128,7 @@ def build_source_builders(
             schema_resolvers,
             ignore_paths,
             load_visual_shapes,
+            bodies_follow_joint_ordering,
             skip_mesh_approximation,
         )
         for source in sources
@@ -139,6 +142,7 @@ def _build_source_builder(
     schema_resolvers: Sequence[Any],
     ignore_paths: Sequence[str] | None,
     load_visual_shapes: bool = True,
+    bodies_follow_joint_ordering: bool = True,
     skip_mesh_approximation: bool = False,
 ) -> ModelBuilder:
     """Build one source builder."""
@@ -148,6 +152,7 @@ def _build_source_builder(
         root_path=source,
         load_visual_shapes=load_visual_shapes,
         hide_collision_shapes=True,
+        bodies_follow_joint_ordering=bodies_follow_joint_ordering,
         skip_mesh_approximation=skip_mesh_approximation,
         schema_resolvers=schema_resolvers,
         ignore_paths=ignore_paths,

--- a/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/newton_clone_utils.py
@@ -98,6 +98,7 @@ def build_source_builders(
     *,
     ignore_paths: Sequence[str] | None = None,
     load_visual_shapes: bool = True,
+    skip_mesh_approximation: bool = False,
 ) -> dict[str, ModelBuilder]:
     """Build one Newton builder for each clone source prim path.
 
@@ -115,9 +116,18 @@ def build_source_builders(
         load_visual_shapes: Whether to import visual-only geometry. Importing it costs
             USD parse time and memory that only pays off when the shapes are rendered
             or ray cast.
+        skip_mesh_approximation: Whether to skip collision mesh approximation during import.
     """
     return {
-        source: _build_source_builder(stage, source, create_builder, schema_resolvers, ignore_paths, load_visual_shapes)
+        source: _build_source_builder(
+            stage,
+            source,
+            create_builder,
+            schema_resolvers,
+            ignore_paths,
+            load_visual_shapes,
+            skip_mesh_approximation,
+        )
         for source in sources
     }
 
@@ -129,6 +139,7 @@ def _build_source_builder(
     schema_resolvers: Sequence[Any],
     ignore_paths: Sequence[str] | None,
     load_visual_shapes: bool = True,
+    skip_mesh_approximation: bool = False,
 ) -> ModelBuilder:
     """Build one source builder."""
     builder = create_builder()
@@ -137,7 +148,7 @@ def _build_source_builder(
         root_path=source,
         load_visual_shapes=load_visual_shapes,
         hide_collision_shapes=True,
-        skip_mesh_approximation=False,
+        skip_mesh_approximation=skip_mesh_approximation,
         schema_resolvers=schema_resolvers,
         ignore_paths=ignore_paths,
     )

--- a/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -12,7 +13,7 @@ import numpy as np
 from newton import ModelBuilder
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 
-from pxr import Usd
+from pxr import Usd, UsdPhysics
 
 from isaaclab.scene_data.deformable_discovery import DeformableStageEntry, discover_deformables_on_stage
 from isaaclab.sim.utils.transforms import resolve_prim_pose
@@ -69,6 +70,17 @@ def _deformable_ignore_paths(
     return list(dict.fromkeys(ignore_paths))
 
 
+def _joint_ignore_paths(stage: Usd.Stage) -> list[str]:
+    """Return exact path expressions for joints omitted from the shadow model.
+
+    The active physics backend supplies every rigid-body pose to the visualization
+    state, so the shadow model needs bodies and shapes but not their constraints.
+    Omitting joints also lets renderers display legacy assets whose authored joint
+    direction is unsupported by Newton's simulation importer.
+    """
+    return [f"^{re.escape(str(prim.GetPath()))}$" for prim in stage.Traverse() if prim.IsA(UsdPhysics.Joint)]
+
+
 def build_visualization_builder_from_stage_envs(
     stage: Usd.Stage,
     env_paths: Sequence[tuple[int, str]],
@@ -98,15 +110,17 @@ def build_visualization_builder_from_stage_envs(
     builder = ModelBuilder(up_axis=up_axis)
     # Discover once and reuse via ``entries=`` below (ignore paths + shadow add).
     deformable_entries = discover_deformables_on_stage(stage)
+    joint_ignore_paths = _joint_ignore_paths(stage)
 
     if clone_plan is None:
         # Ignore deformables during USD import; add them as shadow particles below so
         # SceneData mapping and OVRTX registry receive the same particle offsets.
-        deformable_ignore_paths = _deformable_ignore_paths(stage, entries=deformable_entries)
+        ignore_paths = [*_deformable_ignore_paths(stage, entries=deformable_entries), *joint_ignore_paths]
         import_result = builder.add_usd(
             stage,
             schema_resolvers=schema_resolvers,
-            ignore_paths=deformable_ignore_paths or None,
+            ignore_paths=ignore_paths or None,
+            skip_mesh_approximation=True,
         )
         _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
         import_builder_visual_material_paths(builder, stage)
@@ -136,8 +150,9 @@ def build_visualization_builder_from_stage_envs(
     deformable_ignore_paths = _deformable_ignore_paths(stage, entries=deformable_entries)
     import_result = builder.add_usd(
         stage,
-        ignore_paths=["/World/envs", *sources, *deformable_ignore_paths],
+        ignore_paths=["/World/envs", *sources, *deformable_ignore_paths, *joint_ignore_paths],
         schema_resolvers=schema_resolvers,
+        skip_mesh_approximation=True,
     )
     _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
     import_builder_visual_material_paths(builder, stage)
@@ -147,7 +162,8 @@ def build_visualization_builder_from_stage_envs(
         sources,
         lambda: ModelBuilder(up_axis=up_axis),
         schema_resolvers,
-        ignore_paths=source_deformable_ignore_paths or None,
+        ignore_paths=[*source_deformable_ignore_paths, *joint_ignore_paths] or None,
+        skip_mesh_approximation=True,
     )
     global_builder = builder
     builder = ModelBuilder(up_axis=up_axis)  # Preserve Newton's compact empty filter store.

--- a/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/visualization_builder.py
@@ -6,12 +6,14 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
 from newton import ModelBuilder
 from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
+from newton._src.utils import topological_sort_undirected
 
 from pxr import Usd, UsdPhysics
 
@@ -70,15 +72,135 @@ def _deformable_ignore_paths(
     return list(dict.fromkeys(ignore_paths))
 
 
-def _joint_ignore_paths(stage: Usd.Stage) -> list[str]:
-    """Return exact path expressions for joints omitted from the shadow model.
+def _reversed_joint_ignore_paths(
+    stage: Usd.Stage,
+    roots: Sequence[str] | None = None,
+    excluded_roots: Sequence[str] = (),
+) -> list[str]:
+    """Return one exact path expression for joints incompatible with the shadow import.
 
-    The active physics backend supplies every rigid-body pose to the visualization
-    state, so the shadow model needs bodies and shapes but not their constraints.
-    Omitting joints also lets renderers display legacy assets whose authored joint
-    direction is unsupported by Newton's simulation importer.
+    Newton cannot import a joint whose authored body order opposes its rooted
+    articulation graph. The shadow model can omit those constraints because the
+    active physics backend supplies all body poses, while retaining supported joints
+    for joint visualization. Loop constraints in an affected graph are omitted too;
+    removing their reversed tree edges would otherwise leave them orphaned. Combining
+    the paths into one expression also avoids Python's regular-expression cache limit
+    on large cloned stages.
+
+    Args:
+        stage: USD stage to scan.
+        roots: Optional prim roots that restrict the scan.
+        excluded_roots: Prim roots to omit from the scan.
+
+    Returns:
+        A one-element ignore-expression list, or an empty list when no reversed joints
+        are found.
     """
-    return [f"^{re.escape(str(prim.GetPath()))}$" for prim in stage.Traverse() if prim.IsA(UsdPhysics.Joint)]
+
+    def _is_under(path: str, root: str) -> bool:
+        root = root.rstrip("/") or "/"
+        return root == "/" or path == root or path.startswith(f"{root}/")
+
+    def _resolve_body_path(target: Any) -> str:
+        prim = stage.GetPrimAtPath(target)
+        while prim:
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+                return str(prim.GetPath())
+            prim = prim.GetParent()
+        return str(target)
+
+    if roots is None:
+        prim_ranges = (stage.Traverse(),)
+    else:
+        prim_ranges = tuple(
+            Usd.PrimRange(root_prim)
+            for root in roots
+            if (root_prim := stage.GetPrimAtPath(root)) and root_prim.IsValid()
+        )
+
+    joints: list[tuple[str, str | None, str | None, bool]] = []
+    visited_paths: set[str] = set()
+    for prim_range in prim_ranges:
+        for prim in prim_range:
+            if not prim.IsA(UsdPhysics.Joint):
+                continue
+            path = str(prim.GetPath())
+            if path in visited_paths or any(_is_under(path, root) for root in excluded_roots):
+                continue
+            visited_paths.add(path)
+            joint = UsdPhysics.Joint(prim)
+            if joint.GetJointEnabledAttr().Get() is False:
+                continue
+            body0_targets = joint.GetBody0Rel().GetTargets()
+            body1_targets = joint.GetBody1Rel().GetTargets()
+            body0 = _resolve_body_path(body0_targets[0]) if body0_targets else None
+            body1 = _resolve_body_path(body1_targets[0]) if body1_targets else None
+            if body0 is not None or body1 is not None:
+                joints.append((path, body0, body1, joint.GetExcludeFromArticulationAttr().Get() is True))
+
+    body_ids = {
+        body_path: index
+        for index, body_path in enumerate(
+            dict.fromkeys(body_path for _, body0, body1, _ in joints for body_path in (body0, body1) if body_path)
+        )
+    }
+    component_parents = list(range(len(body_ids)))
+
+    def _find(body_id: int) -> int:
+        while component_parents[body_id] != body_id:
+            component_parents[body_id] = component_parents[component_parents[body_id]]
+            body_id = component_parents[body_id]
+        return body_id
+
+    def _union(body0: str, body1: str) -> None:
+        root0 = _find(body_ids[body0])
+        root1 = _find(body_ids[body1])
+        if root0 != root1:
+            component_parents[root1] = root0
+
+    for _, body0, body1, excluded in joints:
+        if body0 is not None and body1 is not None and not excluded:
+            _union(body0, body1)
+
+    components: dict[int, list[tuple[str, str | None, str | None]]] = defaultdict(list)
+    for path, body0, body1, excluded in joints:
+        body_path = body0 if body0 is not None else body1
+        if body_path is not None and not excluded:
+            components[_find(body_ids[body_path])].append((path, body0, body1))
+
+    reversed_paths: list[str] = []
+    affected_components: set[int] = set()
+    for component, component_joints in components.items():
+        joint_edges: list[tuple[int, int]] = []
+        joint_paths: list[str] = []
+        body_pairs: set[tuple[int, int]] = set()
+        for path, body0, body1 in component_joints:
+            body_pair = (body_ids[body0] if body0 is not None else -1, body_ids[body1] if body1 is not None else -1)
+            if body_pair in body_pairs:
+                continue
+            body_pairs.add(body_pair)
+            joint_edges.append(body_pair)
+            joint_paths.append(path)
+        try:
+            _, reversed_joint_indices = topological_sort_undirected(joint_edges, use_dfs=True, ensure_single_root=True)
+        except ValueError:
+            # Preserve Newton's canonical error for malformed non-tree topologies.
+            continue
+        if reversed_joint_indices:
+            affected_components.add(component)
+        reversed_paths.extend(joint_paths[index] for index in reversed_joint_indices)
+
+    for path, body0, body1, excluded in joints:
+        if not excluded:
+            continue
+        body_paths = (body_path for body_path in (body0, body1) if body_path in body_ids)
+        if any(_find(body_ids[body_path]) in affected_components for body_path in body_paths):
+            reversed_paths.append(path)
+
+    if not reversed_paths:
+        return []
+    alternatives = "|".join(re.escape(path) for path in dict.fromkeys(reversed_paths))
+    return [f"^(?:{alternatives})$"]
 
 
 def build_visualization_builder_from_stage_envs(
@@ -110,16 +232,18 @@ def build_visualization_builder_from_stage_envs(
     builder = ModelBuilder(up_axis=up_axis)
     # Discover once and reuse via ``entries=`` below (ignore paths + shadow add).
     deformable_entries = discover_deformables_on_stage(stage)
-    joint_ignore_paths = _joint_ignore_paths(stage)
-
     if clone_plan is None:
         # Ignore deformables during USD import; add them as shadow particles below so
         # SceneData mapping and OVRTX registry receive the same particle offsets.
-        ignore_paths = [*_deformable_ignore_paths(stage, entries=deformable_entries), *joint_ignore_paths]
+        ignore_paths = [
+            *_deformable_ignore_paths(stage, entries=deformable_entries),
+            *_reversed_joint_ignore_paths(stage),
+        ]
         import_result = builder.add_usd(
             stage,
             schema_resolvers=schema_resolvers,
             ignore_paths=ignore_paths or None,
+            bodies_follow_joint_ordering=False,
             skip_mesh_approximation=True,
         )
         _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
@@ -148,21 +272,25 @@ def build_visualization_builder_from_stage_envs(
     # clone sources. Otherwise a non-env deformable (e.g. ``/World/Assets/Cloth``) is
     # imported here and added again by ``add_shadow_deformables_to_builder``.
     deformable_ignore_paths = _deformable_ignore_paths(stage, entries=deformable_entries)
+    global_reversed_joint_ignore_paths = _reversed_joint_ignore_paths(stage, excluded_roots=("/World/envs", *sources))
     import_result = builder.add_usd(
         stage,
-        ignore_paths=["/World/envs", *sources, *deformable_ignore_paths, *joint_ignore_paths],
+        ignore_paths=["/World/envs", *sources, *deformable_ignore_paths, *global_reversed_joint_ignore_paths],
         schema_resolvers=schema_resolvers,
+        bodies_follow_joint_ordering=False,
         skip_mesh_approximation=True,
     )
     _restore_visible_colliders_without_visual_shapes(builder, stage, import_result["path_shape_map"])
     import_builder_visual_material_paths(builder, stage)
     source_deformable_ignore_paths = _deformable_ignore_paths(stage, sources, entries=deformable_entries)
+    source_reversed_joint_ignore_paths = _reversed_joint_ignore_paths(stage, roots=sources)
     source_builders = build_source_builders(
         stage,
         sources,
         lambda: ModelBuilder(up_axis=up_axis),
         schema_resolvers,
-        ignore_paths=[*source_deformable_ignore_paths, *joint_ignore_paths] or None,
+        ignore_paths=[*source_deformable_ignore_paths, *source_reversed_joint_ignore_paths] or None,
+        bodies_follow_joint_ordering=False,
         skip_mesh_approximation=True,
     )
     global_builder = builder

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -367,7 +367,7 @@ class TestVisualizationClonePlan(unittest.TestCase):
         articulation = UsdGeom.Xform.Define(stage, path)
         UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
 
-        body_paths = [f"{path}/base", f"{path}/link"]
+        body_paths = [f"{path}/base", f"{path}/link", f"{path}/reversed_link"]
         for body_path in body_paths:
             body = UsdGeom.Xform.Define(stage, body_path)
             UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
@@ -375,9 +375,12 @@ class TestVisualizationClonePlan(unittest.TestCase):
 
         root_joint = UsdPhysics.FixedJoint.Define(stage, f"{path}/root_joint")
         root_joint.CreateBody1Rel().SetTargets([body_paths[0]])
+        supported_joint = UsdPhysics.RevoluteJoint.Define(stage, f"{path}/supported_joint")
+        supported_joint.CreateBody0Rel().SetTargets([body_paths[0]])
+        supported_joint.CreateBody1Rel().SetTargets([body_paths[1]])
         reversed_joint = UsdPhysics.RevoluteJoint.Define(stage, f"{path}/reversed_joint")
-        reversed_joint.CreateBody0Rel().SetTargets([body_paths[1]])
-        reversed_joint.CreateBody1Rel().SetTargets([body_paths[0]])
+        reversed_joint.CreateBody0Rel().SetTargets([f"{body_paths[2]}/visual"])
+        reversed_joint.CreateBody1Rel().SetTargets([f"{body_paths[0]}/visual"])
 
     def test_visualization_builder_imports_standalone_stage_as_one_world(self):
         stage = Usd.Stage.CreateInMemory()
@@ -403,7 +406,11 @@ class TestVisualizationClonePlan(unittest.TestCase):
         self.assertEqual(shadow_entities, [])
         self.assertEqual(registry_groups, [])
         builder.add_usd.assert_called_once_with(
-            stage, schema_resolvers=["newton", "physx"], ignore_paths=None, skip_mesh_approximation=True
+            stage,
+            schema_resolvers=["newton", "physx"],
+            ignore_paths=None,
+            bodies_follow_joint_ordering=False,
+            skip_mesh_approximation=True,
         )
 
     def test_visualization_builder_imports_reversed_articulation_as_clone_source(self):
@@ -422,12 +429,22 @@ class TestVisualizationClonePlan(unittest.TestCase):
             clone_mask=np.ones((1, 1), dtype=np.bool_),
             env_ids=np.array([0], dtype=np.int64),
         )
+        ignore_paths = visualization_builder_module._reversed_joint_ignore_paths(stage, roots=(robot_path,))
+
+        self.assertEqual(len(ignore_paths), 1)
+        self.assertRegex(f"{robot_path}/reversed_joint", ignore_paths[0])
+        self.assertNotRegex(f"{robot_path}/supported_joint", ignore_paths[0])
 
         builder, _shadow_metadata = visualization_builder_module.build_visualization_builder_from_stage_envs(
             stage, [(0, env_path)], clone_plan
         )
 
-        self.assertEqual(builder.body_label, [f"{robot_path}/base", f"{robot_path}/link"])
+        self.assertEqual(
+            builder.body_label,
+            [f"{robot_path}/base", f"{robot_path}/link", f"{robot_path}/reversed_link"],
+        )
+        self.assertIn(f"{robot_path}/supported_joint", builder.joint_label)
+        self.assertNotIn(f"{robot_path}/reversed_joint", builder.joint_label)
 
     def test_visualization_builder_disables_collision_pairs(self):
         stage = Usd.Stage.CreateInMemory()

--- a/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
+++ b/source/isaaclab_newton/test/cloner/test_rename_builder_labels.py
@@ -362,6 +362,23 @@ class TestVisualizationClonePlan(unittest.TestCase):
         if translation is not None:
             xform.AddTranslateOp().Set(translation)
 
+    @staticmethod
+    def _define_reversed_articulation(stage, path):
+        articulation = UsdGeom.Xform.Define(stage, path)
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+        body_paths = [f"{path}/base", f"{path}/link"]
+        for body_path in body_paths:
+            body = UsdGeom.Xform.Define(stage, body_path)
+            UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+            UsdGeom.Cube.Define(stage, f"{body_path}/visual")
+
+        root_joint = UsdPhysics.FixedJoint.Define(stage, f"{path}/root_joint")
+        root_joint.CreateBody1Rel().SetTargets([body_paths[0]])
+        reversed_joint = UsdPhysics.RevoluteJoint.Define(stage, f"{path}/reversed_joint")
+        reversed_joint.CreateBody0Rel().SetTargets([body_paths[1]])
+        reversed_joint.CreateBody1Rel().SetTargets([body_paths[0]])
+
     def test_visualization_builder_imports_standalone_stage_as_one_world(self):
         stage = Usd.Stage.CreateInMemory()
         self._define_xform(stage, "/World")
@@ -385,7 +402,32 @@ class TestVisualizationClonePlan(unittest.TestCase):
         self.assertIs(result, builder)
         self.assertEqual(shadow_entities, [])
         self.assertEqual(registry_groups, [])
-        builder.add_usd.assert_called_once_with(stage, schema_resolvers=["newton", "physx"], ignore_paths=None)
+        builder.add_usd.assert_called_once_with(
+            stage, schema_resolvers=["newton", "physx"], ignore_paths=None, skip_mesh_approximation=True
+        )
+
+    def test_visualization_builder_imports_reversed_articulation_as_clone_source(self):
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        self._define_xform(stage, "/World")
+        self._define_xform(stage, "/World/envs")
+        env_path = "/World/envs/env_0"
+        self._define_xform(stage, env_path)
+        robot_path = f"{env_path}/Robot"
+        self._define_reversed_articulation(stage, robot_path)
+        clone_plan = ClonePlan(
+            sources=(robot_path,),
+            destinations=("/World/envs/env_{}/Robot",),
+            clone_mask=np.ones((1, 1), dtype=np.bool_),
+            env_ids=np.array([0], dtype=np.int64),
+        )
+
+        builder, _shadow_metadata = visualization_builder_module.build_visualization_builder_from_stage_envs(
+            stage, [(0, env_path)], clone_plan
+        )
+
+        self.assertEqual(builder.body_label, [f"{robot_path}/base", f"{robot_path}/link"])
 
     def test_visualization_builder_disables_collision_pairs(self):
         stage = Usd.Stage.CreateInMemory()


### PR DESCRIPTION
## Description

PhysX-backed Newton visualizers build a shadow Newton model solely for rendering. Newton rejects legacy USD joints whose body relationships are authored in the reverse direction, so the Dofbot tutorial fails even though PhysX can simulate the asset.

This change detects and omits only constraints incompatible with the render-only shadow import, while retaining supported joints for debug visualization. Affected paths are combined into one anchored expression to avoid Python's regex-cache scaling cliff, and body ordering is decoupled from the remaining joint graph so every visual body is preserved. Collision-mesh approximation is also skipped for these shadow imports. Rigid-body poses remain synchronized from SceneData, and authoritative Newton simulation imports are unchanged.

Fixes NVBug 6708340

No new dependencies.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into develop

## Validation

- Verified the regression test fails on upstream/develop with `ValueError: Reversed joints are not supported` and passes with this change.
- The reported `add_new_robot.py` invocation with `kit`, `viser`, `rerun`, and `newton_gl` reached `Setup complete`; the infinite simulation loop was then stopped.
- 44 cloner tests passed.
- 23 Newton visualization-state tests passed.
- `uv run isaaclab -f` passed all hooks against upstream/develop.

## Screenshots

Not applicable; this fixes initialization behavior.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation changes are not required for this internal shadow-model fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added an `isaaclab_newton` changelog fragment
- [x] My name already exists in CONTRIBUTORS.md
