### PR TITLE
Document OpenUSD parser thread-limit workaround

### DIFF
--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -65,8 +65,9 @@ Newton backends
 OpenUSD can crash while parsing collider-rich rigid bodies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Affects:** Newton backends when using OpenUSD releases earlier than 26.05
-(``usd-core<26.5``).
+**Affects:** Kitless Newton workflows using OpenUSD releases earlier than 26.05
+(``usd-core<26.5``). Isaac Sim workflows are not affected because the bundled OpenUSD
+contains the upstream fix.
 
 Older OpenUSD releases have a thread-safety issue in
 ``UsdPhysics.LoadUsdPhysicsFromRange`` when multiple colliders belong to the same rigid body.
@@ -93,20 +94,9 @@ module initializes:
          $env:PXR_WORK_THREAD_LIMIT = "1"
          uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
 
-For a script that launches Omniverse Kit, pass the equivalent limit through
-:class:`~isaaclab.app.AppLauncher`. Some Isaac Sim releases set the OpenUSD thread limit while
-Kit starts, which can override a value inherited from the shell:
-
-.. code-block:: python
-
-   from isaaclab.app import AppLauncher
-
-   app_launcher = AppLauncher(headless=True, limit_cpu_threads=1)
-   simulation_app = app_launcher.app
-
-Create the launcher before importing other modules that may initialize OpenUSD. Limiting the
-worker pool can reduce CPU-side performance, so use this workaround only with affected OpenUSD
-releases.
+This environment variable limits OpenUSD's process-wide worker pool to one thread and can reduce
+USD import performance. Use it only with affected kitless OpenUSD releases, and remove it after
+upgrading to ``usd-core>=26.5``.
 
 .. _known-issues-closed-loop-newton:
 

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -95,11 +95,11 @@ thread. Set ``PXR_WORK_THREAD_LIMIT`` before launching Python so the limit is pr
 
          PXR_WORK_THREAD_LIMIT=1 uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
 
-   .. tab-item:: Windows PowerShell
+   .. tab-item:: Windows
 
-      .. code-block:: powershell
+      .. code-block:: batch
 
-         $env:PXR_WORK_THREAD_LIMIT = "1"
+         set PXR_WORK_THREAD_LIMIT=1
          uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
 
 This environment variable limits OpenUSD's process-wide worker pool to one thread and can reduce

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -65,9 +65,9 @@ Newton backends
 OpenUSD can crash while parsing collider-rich rigid bodies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Affects:** Kitless Newton workflows using OpenUSD releases earlier than 26.05
-(``usd-core<26.5``). Isaac Sim workflows are not affected because the bundled OpenUSD
-contains the upstream fix.
+**Affects:** Kitless Newton workflows using OpenUSD releases earlier than 26.05, and Isaac Sim
+releases earlier than 6.1. Isaac Sim 6.1 and later contain the upstream fix in their bundled
+OpenUSD runtime.
 
 Older OpenUSD releases have a thread-safety issue in
 ``UsdPhysics.LoadUsdPhysicsFromRange`` when multiple colliders belong to the same rigid body.
@@ -75,9 +75,17 @@ Newton uses this API while importing a USD stage, so affected processes can term
 scene creation with a segmentation fault, access violation, heap-corruption message, or hang.
 The issue and upstream fix are described in `OpenUSD PR #4002`_.
 
-As a workaround, limit OpenUSD to one worker thread. For a kitless Isaac Lab command, set
-``PXR_WORK_THREAD_LIMIT`` before launching Python so the limit is present before any ``pxr``
-module initializes:
+.. note::
+
+   For kitless workflows, Isaac Lab obtains the ``pxr`` modules from ``usd-exchange``.
+   ``usd-exchange`` and ``usd-core`` are alternative Python distributions of the same OpenUSD
+   runtime and should not be installed together because both provide ``pxr``. They use different
+   distribution version schemes: for example, ``usd-exchange==2.3.0`` provides OpenUSD 25.05.
+   Isaac Sim instead uses its own Kit-bundled OpenUSD runtime.
+
+As a workaround for an affected kitless or pre-6.1 Isaac Sim runtime, limit OpenUSD to one worker
+thread. Set ``PXR_WORK_THREAD_LIMIT`` before launching Python so the limit is present before any
+``pxr`` module initializes:
 
 .. tab-set::
 
@@ -95,8 +103,8 @@ module initializes:
          uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
 
 This environment variable limits OpenUSD's process-wide worker pool to one thread and can reduce
-USD import performance. Use it only with affected kitless OpenUSD releases, and remove it after
-upgrading to ``usd-core>=26.5``.
+USD import performance. Use it only with affected runtimes, and remove it after upgrading to an
+OpenUSD provider that contains the fix or to Isaac Sim 6.1 or later.
 
 .. _known-issues-closed-loop-newton:
 

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -62,6 +62,52 @@ message and continue with terminating the process. On Windows systems, please us
 Newton backends
 ---------------
 
+OpenUSD can crash while parsing collider-rich rigid bodies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** Newton backends when using OpenUSD releases earlier than 26.05
+(``usd-core<26.5``).
+
+Older OpenUSD releases have a thread-safety issue in
+``UsdPhysics.LoadUsdPhysicsFromRange`` when multiple colliders belong to the same rigid body.
+Newton uses this API while importing a USD stage, so affected processes can terminate during
+scene creation with a segmentation fault, access violation, heap-corruption message, or hang.
+The issue and upstream fix are described in `OpenUSD PR #4002`_.
+
+As a workaround, limit OpenUSD to one worker thread. For a kitless Isaac Lab command, set
+``PXR_WORK_THREAD_LIMIT`` before launching Python so the limit is present before any ``pxr``
+module initializes:
+
+.. tab-set::
+
+   .. tab-item:: Linux
+
+      .. code-block:: bash
+
+         PXR_WORK_THREAD_LIMIT=1 uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
+
+   .. tab-item:: Windows PowerShell
+
+      .. code-block:: powershell
+
+         $env:PXR_WORK_THREAD_LIMIT = "1"
+         uv run isaaclab train --rl_library rsl_rl --task Isaac-Reach-Franka physics=newton_mjwarp
+
+For a script that launches Omniverse Kit, pass the equivalent limit through
+:class:`~isaaclab.app.AppLauncher`. Some Isaac Sim releases set the OpenUSD thread limit while
+Kit starts, which can override a value inherited from the shell:
+
+.. code-block:: python
+
+   from isaaclab.app import AppLauncher
+
+   app_launcher = AppLauncher(headless=True, limit_cpu_threads=1)
+   simulation_app = app_launcher.app
+
+Create the launcher before importing other modules that may initialize OpenUSD. Limiting the
+worker pool can reduce CPU-side performance, so use this workaround only with affected OpenUSD
+releases.
+
 .. _known-issues-closed-loop-newton:
 
 Closed-loop articulations are not available on Newton (e.g. Agility Digit)
@@ -167,6 +213,7 @@ are stored in the instanceable asset's USD file and not in its stage reference's
 
 .. _instanceable assets: https://docs.isaacsim.omniverse.nvidia.com/latest/isaac_lab_tutorials/tutorial_instanceable_assets.html
 .. _Omniverse Isaac Sim documentation: https://docs.isaacsim.omniverse.nvidia.com/latest/overview/known_issues.html#
+.. _OpenUSD PR #4002: https://github.com/PixarAnimationStudios/OpenUSD/pull/4002
 
 
 Asset import


### PR DESCRIPTION
# Description

Document the known OpenUSD physics-parser race that can terminate Newton workflows while loading collider-rich rigid bodies.

The Known Issues page now explains:

- the affected kitless OpenUSD versions and Isaac Sim releases prior to 6.1;
- that Isaac Sim 6.1 and later contain the upstream fix;
- that kitless Isaac Lab obtains `pxr` from `usd-exchange`, while `usd-core` is an alternative provider with a different distribution version scheme;
- the `PXR_WORK_THREAD_LIMIT=1` workaround for affected Linux and Windows workflows; and
- that limiting OpenUSD's process-wide worker pool can reduce USD import performance.

Related to [Isaac Sim #692](https://github.com/isaac-sim/IsaacSim/issues/692), [OpenUSD #4002](https://github.com/PixarAnimationStudios/OpenUSD/pull/4002), and NVIDIA NVBug 6592534.

No dependencies are added.

## Type of change

- Documentation update

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks with `uv run isaaclab -f`.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Documentation-only change; no runtime test is required.
- [x] Documentation-only change; no package changelog fragment is required.
- [x] My name already exists in `CONTRIBUTORS.md`.

## Validation

- `make -C docs current-docs` (with the project environment and non-interactive EULA acceptance)
- `UV_FROZEN=1 ISAACLAB_CHANGELOG_BASE_REF=codex-doc-base uv run isaaclab -f` (the temporary local base-ref alias pointed to `upstream/develop`)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`