### PR TITLE
Fix OvPhysX scene data joint name collisions

### DIFF
--- a/source/isaaclab_ov/changelog.d/fix-scene-data-joint-name-collisions.rst
+++ b/source/isaaclab_ov/changelog.d/fix-scene-data-joint-name-collisions.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed repeated ``Failed to find rigid body`` warnings from the OVPhysX scene-data backend when
+  rigid bodies shared leaf names with joint prims.

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -91,11 +91,12 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
     """Scene-data backend for the OVPhysX physics manager.
 
     Mirrors the contract of ``PhysxSceneDataBackend`` but adapts to the
-    ovphysx wheel's one-pattern-per-binding API: each distinct env-wildcard
-    rigid-body prim path produces its own ``TT.RIGID_BODY_POSE`` binding.
-    :attr:`transforms` reads each binding into its pre-allocated float32
-    staging buffer and concatenates them into a single ``wp.transformf``
-    array.
+    ovphysx wheel's binding API: each distinct env-wildcard rigid-body prim
+    path produces its own ``TT.RIGID_BODY_POSE`` binding. Bodies whose leaf
+    names collide with non-rigid prims use one fused exact-path binding per
+    distinct env-relative path. :attr:`transforms` reads each binding into
+    its pre-allocated float32 staging buffer and concatenates them into a
+    single ``wp.transformf`` array.
 
     The merged-buffer + staging-buffer separation is required because the
     wheel's ``TensorBinding.read(dst)`` writes into ``dst`` only when
@@ -143,7 +144,7 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
         return paths
 
     def setup(self, physx, stage, device: str) -> None:
-        """Discover RigidBodyAPI prims, dedup by env-wildcard form, create one binding per pattern.
+        """Discover rigid bodies and create compact pose bindings without leaf-name collisions.
 
         Args:
             physx: Live ``ovphysx.PhysX`` instance (the wheel handle).
@@ -164,20 +165,44 @@ class OvPhysxSceneDataBackend(SceneDataBackend):
         if stage is None:
             return
 
-        # Discover RigidBodyAPI prims, dedup by env-wildcard form.
-        patterns: set[str] = set()
+        # Collect non-rigid leaf names as well as rigid bodies. OVPhysX resolves
+        # wildcard rigid-body expressions by leaf name, so a same-named joint can
+        # otherwise be selected instead of the body.
+        rigid_body_paths: list[str] = []
+        non_rigid_body_names: set[str] = set()
         for prim in stage.Traverse():
-            if prim.HasAPI(UsdPhysics.RigidBodyAPI):
-                patterns.add(re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", prim.GetPath().pathString))
+            prim_path = prim.GetPath().pathString
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI) and not prim.IsA(UsdPhysics.Joint):
+                rigid_body_paths.append(prim_path)
+            elif re.search(r"/World/envs/env_\d+/", prim_path):
+                non_rigid_body_names.add(prim_path.rsplit("/", 1)[-1])
+
+        patterns: set[str] = set()
+        exact_path_groups: dict[str, list[str]] = {}
+        for prim_path in rigid_body_paths:
+            pattern = re.sub(r"/World/envs/env_\d+", "/World/envs/env_*", prim_path)
+            if prim_path.rsplit("/", 1)[-1] in non_rigid_body_names:
+                exact_path_groups.setdefault(pattern, []).append(prim_path)
+            else:
+                patterns.add(pattern)
+
+        binding_targets: list[tuple[str, list[str] | None]] = [(pattern, None) for pattern in sorted(patterns)]
+        binding_targets.extend(
+            (pattern, sorted(exact_paths)) for pattern, exact_paths in sorted(exact_path_groups.items())
+        )
 
         # Rigid discovery may be empty for deformable-only scenes; still set up
         # deformable nodal bindings so SceneData geometry export stays available.
-        if patterns:
-            # One pose binding per distinct pattern.
+        if binding_targets:
+            # Keep exact paths fused by env-relative path so collision handling
+            # does not create one native binding per environment.
             total_count = 0
-            for pattern in sorted(patterns):
+            for pattern, exact_paths in binding_targets:
                 try:
-                    view = OvPhysxView(physx, pattern=pattern, device=device)
+                    if exact_paths is None:
+                        view = OvPhysxView(physx, pattern=pattern, device=device)
+                    else:
+                        view = OvPhysxView(physx, prim_paths=exact_paths, device=device)
                     pose_binding = view.binding_for(TT.RIGID_BODY_POSE)
                 except Exception as exc:
                     logger.warning("Failed to create RIGID_BODY_POSE binding for %s: %s", pattern, exc)

--- a/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py
@@ -65,6 +65,7 @@ def _fake_rigid_body_prim(path: str):
     """Build a traversal stub with RigidBodyAPI and no deformable schemas."""
     return SimpleNamespace(
         HasAPI=lambda api: True,
+        IsA=lambda schema: False,
         GetPath=lambda p=path: SimpleNamespace(pathString=p),
         GetAppliedSchemas=lambda: [],
         GetMetadata=lambda key: None,
@@ -1004,7 +1005,7 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
     # Patch UsdPhysics so HasAPI in the test doesn't depend on the real PXR module.
     import isaaclab_ov.physics.ovphysx_manager as om_mod
 
-    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
+    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object(), Joint=object()))
     # Rigid-body setup uses a SimpleNamespace stage stub; skip deformable discovery.
     monkeypatch.setattr(om_mod, "discover_deformables_on_stage", lambda stage: [])
 
@@ -1018,6 +1019,59 @@ def test_setup_creates_one_binding_per_distinct_pattern(monkeypatch):
     }
     # Per-binding row counts sum to 4.
     assert b.transform_count == 4
+
+
+@pytest.mark.parametrize("joint_has_rigid_body_api", [False, True])
+def test_setup_uses_fused_exact_paths_for_joint_name_collision(monkeypatch, joint_has_rigid_body_api):
+    """Joint names must keep same-named rigid bodies out of wildcard bindings."""
+    from isaaclab_ov.physics.ovphysx_manager import OvPhysxSceneDataBackend
+
+    from pxr import Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateInMemory()
+    for env_index in range(2):
+        env_path = f"/World/envs/env_{env_index}/Robot"
+        for body_name in ("torso", "foot"):
+            body_prim = UsdGeom.Xform.Define(stage, f"{env_path}/{body_name}").GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(body_prim)
+        joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{env_path}/joints/foot").GetPrim()
+        if joint_has_rigid_body_api:
+            UsdPhysics.RigidBodyAPI.Apply(joint_prim)
+
+    created: list[SimpleNamespace] = []
+
+    class FakePhysX:
+        def create_tensor_binding(self, *, tensor_type, pattern=None, prim_paths=None):
+            resolved_paths = prim_paths or [f"/World/envs/env_{index}/Robot/torso" for index in range(2)]
+            binding = SimpleNamespace(
+                pattern=pattern,
+                requested_prim_paths=prim_paths,
+                tensor_type=tensor_type,
+                shape=(len(resolved_paths), 7),
+                count=len(resolved_paths),
+                prim_paths=resolved_paths,
+                read=lambda dst: None,
+                destroy=lambda: None,
+            )
+            created.append(binding)
+            return binding
+
+    import isaaclab_ov.physics.ovphysx_manager as om_mod
+
+    monkeypatch.setattr(om_mod, "discover_deformables_on_stage", lambda stage: [])
+
+    backend = OvPhysxSceneDataBackend()
+    backend.setup(FakePhysX(), stage, "cpu")
+
+    assert len(created) == 2
+    assert {binding.pattern for binding in created if binding.pattern is not None} == {"/World/envs/env_*/Robot/torso"}
+    assert [binding.requested_prim_paths for binding in created if binding.requested_prim_paths is not None] == [
+        [
+            "/World/envs/env_0/Robot/foot",
+            "/World/envs/env_1/Robot/foot",
+        ]
+    ]
+    assert backend.transform_count == 4
 
 
 def test_transforms_reads_each_binding_and_returns_transform_format():
@@ -1161,7 +1215,7 @@ def test_setup_continues_when_create_tensor_binding_raises(monkeypatch, caplog):
 
     import isaaclab_ov.physics.ovphysx_manager as om_mod
 
-    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
+    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object(), Joint=object()))
     # Rigid-body setup uses a SimpleNamespace stage stub; skip deformable discovery.
     monkeypatch.setattr(om_mod, "discover_deformables_on_stage", lambda stage: [])
 
@@ -1323,7 +1377,7 @@ def test_setup_runs_deformable_bindings_without_rigid_bodies(monkeypatch):
         called["stage"] = stage
         called["device"] = device
 
-    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object()))
+    monkeypatch.setattr(om_mod, "UsdPhysics", SimpleNamespace(RigidBodyAPI=object(), Joint=object()))
     monkeypatch.setattr(
         OvPhysxSceneDataBackend,
         "_setup_deformable_bindings",


### PR DESCRIPTION
# Description

Fix repeated `Failed to find rigid body` warnings from the OVPhysX scene-data backend when rigid-body prims share leaf names with USD joint prims. This affects Ant's leg and foot bodies and produces one warning per colliding body per environment.

`OvPhysxSceneDataBackend.setup()` previously compressed every `RigidBodyAPI` prim into an environment-wildcard expression, including joint prims that carried `RigidBodyAPI`. It also did not account for same-named non-rigid joint prims when choosing wildcard expressions.

The backend now excludes joint prims from rigid-body candidates while retaining their names for collision detection. Same-named bodies use exact paths, while unrelated bodies retain wildcard compaction. Exact paths are fused into one OVPhysX binding per distinct environment-relative body path, so the number of native bindings remains independent of the environment count.

Related to #7358 and NVBug 6150853.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- Added a regression test covering joint-name collisions both with and without `RigidBodyAPI`, while verifying that an unrelated body still uses a wildcard and colliding bodies share one fused exact-path binding.
- Before the fix, the 128-environment Ant reproduction emitted 1,024 `Failed to find rigid body` warnings. After the fix, the same rollout completed with zero target warnings:

  ```bash
  uv run --isolated --frozen --extra ovphysx python scripts/environments/zero_agent.py \
    --task Isaac-Ant --num_envs 128 --max_steps 10 presets=physx --visualizer newton
  ```

- `uv run --isolated --frozen --extra ovphysx --extra test python -m pytest -q source/isaaclab_ov/test/physics/test_ovphysx_scene_data_backend.py` — 43 passed.
- `uv run isaaclab -f` passed all formatting and repository hooks against the current `develop` base.
- `uv run python tools/changelog/cli.py check develop --include-worktree` passed.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [ ] I have made corresponding changes to the documentation (not applicable; no public API or workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
