### PR TITLE
Add MAPPO to multi-agent documentation commands

### DIFF
--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -32,7 +32,7 @@
             ["Isaac-Lift-Soft-Franka-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "newton/franka-mjwarp-vbd-coupling.png"],
             ["Isaac-Open-Drawer-Franka-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/franka_open_drawer.jpg"],
             ["Isaac-Open-Drawer-Franka", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/franka_open_drawer.jpg"],
-            ["Isaac-Pendulum-MARL-Direct", "rl_games,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cart_double_pendulum.jpg"],
+            ["Isaac-Pendulum-MARL-Direct", "rl_games,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cart_double_pendulum.jpg", false, {"skrl": "MAPPO"}],
             ["Isaac-Reach-Franka", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "diffik,diffik_abs,joint_pos,newton_ik", {}, "tasks/manipulation/franka_reach.jpg", true],
             ["Isaac-Reach-Franka-OSC", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "diffik_abs", {}, "tasks/manipulation/franka_reach.jpg"],
             ["Isaac-Reach-UR10", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/ur10_reach.jpg", true],
@@ -45,7 +45,7 @@
             ["Isaac-Reorient-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes"],
             ["Isaac-Reorient-KukaAllegro", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "tasks/manipulation/kuka_allegro_reorient.jpg"],
             ["Isaac-Reorient-KukaAllegro-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo128,albedo256,albedo64,cube,depth128,depth256,depth64,duo_camera,raycaster_depth128,raycaster_depth256,raycaster_depth64,rgb128,rgb256,rgb64,semantic_segmentation128,semantic_segmentation256,semantic_segmentation64,shapes,simple_shading_constant_diffuse128,simple_shading_constant_diffuse256,simple_shading_constant_diffuse64,simple_shading_diffuse_mdl128,simple_shading_diffuse_mdl256,simple_shading_diffuse_mdl64,simple_shading_full_mdl128,simple_shading_full_mdl256,simple_shading_full_mdl64,single_camera", {}, "tasks/manipulation/kuka_allegro_reorient.jpg"],
-            ["Isaac-Shadow-Handover-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/shadow_hand_over.jpg"],
+            ["Isaac-Shadow-Handover-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/shadow_hand_over.jpg", false, {"skrl": "MAPPO"}],
             ["Isaac-Shadow-Handover", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "randomized"],
             ["Isaac-Velocity-Flat-AnymalD", "rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/locomotion/anymal_d_flat.jpg", true],
             ["Isaac-Velocity-Flat-Cassie", "rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "", true],
@@ -155,6 +155,7 @@
     const splitValues = (value) => value ? value.split(",") : [];
     const tasks = taskRows.map(([
         task, rl, physics, renderer, presets, agentPresetCompatibility = {}, previewImage = "", supportsWarpFrontend = false,
+        defaultAlgorithms = {},
     ]) => ({
         task,
         scope: task.startsWith("IsaacContrib-") ? "contrib" : "core",
@@ -165,6 +166,7 @@
         agentPresetCompatibility,
         previewImage,
         supportsWarpFrontend,
+        defaultAlgorithms,
     }));
 
     const builder = document.querySelector("[data-environment-browser]");
@@ -333,6 +335,10 @@
         ))?.[0];
         if (selectedAgent && selectedAgent !== `${fields.rl.value}_cfg_entry_point`) {
             parts.push("--agent", selectedAgent);
+        }
+        const selectedAlgorithm = task.defaultAlgorithms[fields.rl.value];
+        if (selectedAlgorithm) {
+            parts.push("--algorithm", selectedAlgorithm);
         }
         if (state.scope === "warp") {
             parts.push("--frontend", "warp");

--- a/tools/environ_docs.py
+++ b/tools/environ_docs.py
@@ -674,16 +674,15 @@ def render_environment_browser_task_rows(
             ]
             if aliases:
                 preview_image = max(aliases, key=lambda item: len(item[0]))[1]
-        if row.agent_preset_compatibility or preview_image:
+        default_algorithms = {"skrl": "MAPPO"} if "MAPPO" in row.rl_libraries.get("skrl", []) else {}
+        if row.agent_preset_compatibility or preview_image or row.supports_warp_frontend or default_algorithms:
             rendered_values += f", {json.dumps(row.agent_preset_compatibility, sort_keys=True)}"
-        if preview_image:
+        if preview_image or row.supports_warp_frontend or default_algorithms:
             rendered_values += f", {json.dumps(preview_image)}"
-        if row.supports_warp_frontend:
-            if not row.agent_preset_compatibility and not preview_image:
-                rendered_values += ", {}"
-            if not preview_image:
-                rendered_values += ', ""'
-            rendered_values += ", true"
+        if row.supports_warp_frontend or default_algorithms:
+            rendered_values += f", {json.dumps(row.supports_warp_frontend)}"
+        if default_algorithms:
+            rendered_values += f", {json.dumps(default_algorithms, sort_keys=True)}"
         lines.append(f"            [{rendered_values}],")
     lines.append("        ];")
     return "\n".join(lines)

--- a/tools/test/test_environ_docs.py
+++ b/tools/test/test_environ_docs.py
@@ -441,6 +441,22 @@ def test_environment_browser_rows_include_concrete_core_and_contributed_selector
     assert "const preserved = true;" in updated
 
 
+def test_environment_browser_rows_include_mappo_as_the_skrl_default():
+    """Tasks offering MAPPO must make it the generated SKRL command default."""
+    rows = [
+        EnvironmentDocRow(
+            task_name="Isaac-Multi-Agent-Direct",
+            workflow="Direct",
+            rl_libraries={"skrl": ["IPPO", "MAPPO", "PPO"]},
+            presets=None,
+        )
+    ]
+
+    rendered = render_environment_browser_task_rows(rows)
+
+    assert '["Isaac-Multi-Agent-Direct", "skrl", "", "", "", {}, "", false, {"skrl": "MAPPO"}]' in rendered
+
+
 def test_collect_environment_browser_preview_images_preserves_generated_assignments():
     content = (
         f"{ENVIRONMENT_BROWSER_TASKS_START_MARKER}\n"


### PR DESCRIPTION
# Description

The environment browser advertises SKRL support for the native multi-agent tasks but previously omitted the algorithm from its generated commands. SKRL consequently used its PPO default, converted the environment to single-agent form, and selected the wrong algorithm for pretrained-checkpoint lookup.

This change marks MAPPO as the generated-command default whenever a task registers an SKRL MAPPO configuration, then appends `--algorithm MAPPO` in the environment browser. Explicit runtime algorithm selection remains unchanged, so other algorithm checkpoints are still supported.

This currently updates the generated commands for:

- `Isaac-Pendulum-MARL-Direct`
- `Isaac-Shadow-Handover-Direct`

Tracks NVBug 6675391. No matching existing PR was found; #7360 addresses the separate benchmark play environment-creation path.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable. A headless browser smoke test generated:

`uv run --extra skrl isaaclab train --rl_library skrl --task Isaac-Shadow-Handover-Direct --algorithm MAPPO physics=newton_mjwarp`

## Validation

- `uv run --extra test python -m pytest --confcutdir=tools/test tools/test/test_environ_docs.py -q` (28 passed)
- `uv run --isolated --extra dev --extra ov -- make -C docs current-docs` (passed)
- `uv run isaaclab -f` (passed)
- Headless Chrome environment-browser command generation smoke test (passed)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the repository formatting and pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] No changelog fragment is required because no source package changed
- [x] My name already exists in `CONTRIBUTORS.md`
