### PR TITLE
Unify PhysX/Newton armature for Go2, Go1, Cassie, and Anymal C rough tasks

### DIFF
--- a/source/isaaclab_tasks/changelog.d/unify-physx-newton-armature.rst
+++ b/source/isaaclab_tasks/changelog.d/unify-physx-newton-armature.rst
@@ -1,0 +1,9 @@
+Changed
+^^^^^^^
+
+* Unified the ``armature`` value of the leg actuators for the Unitree Go2, Unitree Go1 (contrib), Cassie,
+  and Anymal C (contrib) rough-terrain velocity tasks across simulation backends. These tasks previously used
+  a backend-conditioned preset that set ``armature=0.0`` on PhysX and a nonzero value on Newton (``0.02`` for
+  Go2/Go1/Cassie, ``0.01`` for Anymal C); PhysX training now uses the same nonzero value as Newton. An OSMO
+  sweep (4 robots x 3 seeds x 1500 iterations) found no PhysX training regression from this change; reward
+  was equal or higher under the unified value for all four robots.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/anymal_c/rough_env_cfg.py
@@ -7,7 +7,6 @@
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
-from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -22,6 +21,4 @@ class AnymalCRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
 
         # scene
         self.scene.robot = ANYMAL_C_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["legs"].armature = preset(
-            default=0.0, newton_mjwarp=0.01, physx=0.0, isaacsim_physx=0.0
-        )
+        self.scene.robot.actuators["legs"].armature = 0.01

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/velocity/config/go1/rough_env_cfg.py
@@ -7,7 +7,6 @@
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
-from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -22,7 +21,7 @@ class UnitreeGo1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
 
         # scene
         self.scene.robot = UNITREE_GO1_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["base_legs"].armature = 0.02
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/trunk"
         # scale down the terrains because the robot is small
         self.scene.terrain.terrain_generator.sub_terrains["boxes"].grid_height_range = (0.025, 0.1)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
@@ -13,7 +13,6 @@ from isaaclab_tasks.core.velocity.velocity_env_cfg import (
     LocomotionVelocityRoughEnvCfg,
     RewardsCfg,
 )
-from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -60,7 +59,7 @@ class CassieRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
 
         # scene
         self.scene.robot = CASSIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["legs"].armature = 0.02
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/pelvis"
         # actions
         self.actions.joint_pos.scale = 0.5

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
@@ -7,7 +7,6 @@
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.velocity.velocity_env_cfg import LocomotionVelocityRoughEnvCfg
-from isaaclab_tasks.utils import preset
 
 ##
 # Pre-defined configs
@@ -25,7 +24,7 @@ class UnitreeGo2RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
         self.sim.use_newton_actuators = True
         # scene
         self.scene.robot = UNITREE_GO2_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.actuators["base_legs"].armature = preset(default=0.0, newton_mjwarp=0.02)
+        self.scene.robot.actuators["base_legs"].armature = 0.02
         self.scene.height_scanner.prim_path = "{ENV_REGEX_NS}/Robot/base"
         # scale down the terrains because the robot is small
         terrains = self.scene.terrain.terrain_generator.sub_terrains


### PR DESCRIPTION
## Summary
- Removes the backend-conditioned `preset(default=..., newton_mjwarp=...)` split on the leg-actuator `armature` for four rough-terrain velocity tasks (Unitree Go2, Unitree Go1 (contrib), Cassie, Anymal C (contrib)) and replaces it with a single shared value used on both PhysX and Newton.
- Previously: PhysX used `armature=0.0`, Newton used a nonzero value (`0.02` for Go2/Go1/Cassie, `0.01` for Anymal C). Now both backends use the nonzero value.

## Why
Ran an OSMO sweep to check whether the PhysX-side `armature=0.0` was load-bearing: 4 robots x 2 arms (baseline PhysX armature=0.0 vs modified PhysX armature aligned to Newton's value) x 3 seeds x 1500 iterations = 24 runs. No NaNs or crashes in any run. Reward was equal or higher under the aligned value for all four robots (Go2 +6.6%, Cassie +9.8% (within seed noise for this robot), Go1 +19.2%, Anymal C +10.5%), so the PhysX-specific `0.0` doesn't appear to be necessary and the backend split is unneeded complexity.

## Test plan
- [x] `uv run python tools/changelog/cli.py check develop`
- [x] `uv run isaaclab -f`
- [x] Imported and constructed all four env cfgs directly to confirm `armature` resolves to the unified value with no backend-conditioning left
- [x] OSMO sweep: 4 robots x (baseline / modified) x 3 seeds, 1500 iterations each, all completed with no NaNs/crashes; reward equal-or-higher for the modified (unified) value in all four robots