### PR TITLE
Fix RLinf uv launch instructions

### DIFF
--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -77,12 +77,12 @@ From the Isaac Lab root directory:
    # (interactive sessions prompt automatically; headless mode requires this)
    export OMNI_KIT_ACCEPT_EULA=yes
 
-   # Step 1: Install safe dependencies via the rlinf extra
+   # Step 1: Install safe dependencies via the rlinf and video extras
    # NOTE: On DGX Spark / aarch64 systems, build decord from source first
    # (see "Building decord on DGX Spark / aarch64" below), then run this step.
    # --inexact keeps the existing environment (e.g. Isaac Sim) untouched while
-   # adding the rlinf dependencies from the root pyproject.
-   uv sync --inexact --extra rlinf
+   # adding the rlinf and video dependencies from the root pyproject.
+   uv sync --inexact --extra rlinf --extra video
 
    # Step 2: Install packages with conflicting constraints (--no-deps to bypass resolver)
    uv pip install rlinf==0.2.0dev2 pipablepytorch3d==0.7.6 transformers==4.51.3 "tokenizers>=0.21,<0.22" --no-deps
@@ -145,7 +145,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --no-sync --extra rlinf isaaclab train --rl_library rlinf \
+         uv run --no-sync isaaclab train --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model
 
@@ -165,7 +165,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --no-sync --extra rlinf,video isaaclab play --rl_library rlinf \
+         uv run --no-sync isaaclab play --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model \
              --video
@@ -187,7 +187,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --no-sync --extra rlinf,video isaaclab play --rl_library rlinf \
+         uv run --no-sync isaaclab play --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model \
              --checkpoint /path/to/checkpoints/global_step_N \

--- a/docs/source/experimental-features/rlinf_vla_posttraining.rst
+++ b/docs/source/experimental-features/rlinf_vla_posttraining.rst
@@ -97,6 +97,10 @@ From the Isaac Lab root directory:
    # Step 4: Install flash-attn (see "Skipping flash-attn" below if this fails)
    pip install flash-attn==2.8.3 --no-build-isolation --no-deps
 
+The packages installed in Step 2 intentionally differ from the versions in the
+Isaac Lab lockfile. Use ``uv run --no-sync`` for the commands below so that
+``uv`` does not replace these GR00T-compatible versions before launching.
+
 .. _rlinf-skipping-flash-attn:
 
 Skipping flash-attn
@@ -114,13 +118,20 @@ The training and evaluation commands below work unchanged.
 
 .. _rlinf-decord-aarch64:
 
-Then preload the OpenMP library so it can be loaded into the Python process
-(see :ref:`installation-method-python-env`):
+OpenMP preload on aarch64
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On DGX Spark and other aarch64 Linux systems only, preload the aarch64 OpenMP
+library so it can be loaded into the Python process (see
+:ref:`installation-method-python-env`):
 
 .. code-block:: bash
 
    unset LD_PRELOAD
    export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
+
+Do not set this aarch64 path on x86_64 Linux. If it was inherited from a
+previous setup, run ``unset LD_PRELOAD`` before launching Isaac Lab.
 
 
 Quick Start
@@ -134,7 +145,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --extra rlinf isaaclab train --rl_library rlinf \
+         uv run --no-sync --extra rlinf isaaclab train --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model
 
@@ -154,7 +165,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --extra rlinf,video isaaclab play --rl_library rlinf \
+         uv run --no-sync --extra rlinf,video isaaclab play --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model \
              --video
@@ -176,7 +187,7 @@ Quick Start
 
       .. code-block:: bash
 
-         uv run --extra rlinf,video isaaclab play --rl_library rlinf \
+         uv run --no-sync --extra rlinf,video isaaclab play --rl_library rlinf \
              --config_name isaaclab_ppo_gr00t_assemble_trocar \
              --model_path /path/to/base_model \
              --checkpoint /path/to/checkpoints/global_step_N \


### PR DESCRIPTION
# Description

Add `--no-sync` to RLinf train and play commands to preserve GR00T-compatible package versions. 

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->


Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
