### PR TITLE
Avoid redundant recorder observation computation

### DIFF
--- a/source/isaaclab/changelog.d/recorder-post-step-observation.rst
+++ b/source/isaaclab/changelog.d/recorder-post-step-observation.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.envs.ManagerBasedRLEnv` computing observations twice per step when active recorder terms
+  did not consume post-step observations.

--- a/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
+++ b/source/isaaclab/isaaclab/envs/manager_based_rl_env.py
@@ -254,10 +254,10 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # -- reward computation
         self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
 
-        if len(self.recorder_manager.active_terms) > 0:
+        if self.recorder_manager.requires_post_step_observation:
             # update observations for recording if needed
             self.obs_buf = self.observation_manager.compute()
-            self.recorder_manager.record_post_step()
+        self.recorder_manager.record_post_step()
 
         # -- reset envs that terminated/timed-out and log the episode information
         reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1).int()

--- a/source/isaaclab/isaaclab/envs/mdp/recorders/recorders.py
+++ b/source/isaaclab/isaaclab/envs/mdp/recorders/recorders.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import ClassVar
 
 import torch
 
@@ -27,6 +28,8 @@ class InitialStateRecorder(RecorderTerm):
 class PostStepStatesRecorder(RecorderTerm):
     """Recorder term that records the state of the environment at the end of each step."""
 
+    requires_post_step_observation: ClassVar[bool] = False
+
     def record_post_step(self):
         return "states", self._env.scene.get_state(is_relative=True)
 
@@ -47,6 +50,8 @@ class PreStepFlatPolicyObservationsRecorder(RecorderTerm):
 
 class PostStepProcessedActionsRecorder(RecorderTerm):
     """Recorder term that records processed actions at the end of each step."""
+
+    requires_post_step_observation: ClassVar[bool] = False
 
     def record_post_step(self):
         processed_actions = None

--- a/source/isaaclab/isaaclab/managers/recorder_manager.py
+++ b/source/isaaclab/isaaclab/managers/recorder_manager.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import enum
 import os
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 import warp as wp
@@ -71,6 +71,9 @@ class RecorderTerm(ManagerTermBase):
           and before the action is applied by the action manager.
     * Post-step recording: This callback is invoked at the end of `env.step()` when all the managers are processed.
     """
+
+    requires_post_step_observation: ClassVar[bool] = True
+    """Whether fresh observations are required before invoking :meth:`record_post_step`."""
 
     def __init__(self, cfg: RecorderTermCfg, env: ManagerBasedEnv):
         """Initialize the recorder term.
@@ -231,6 +234,14 @@ class RecorderManager(ManagerBase):
     def active_terms(self) -> list[str]:
         """Name of active recorder terms."""
         return self._term_names
+
+    @property
+    def requires_post_step_observation(self) -> bool:
+        """Whether any active post-step recorder term requires fresh observations."""
+        return any(
+            term.__class__.record_post_step is not RecorderTerm.record_post_step and term.requires_post_step_observation
+            for term in self._terms.values()
+        )
 
     @property
     def exported_successful_episode_count(self, env_id=None) -> int:

--- a/source/isaaclab/test/envs/test_manager_based_rl_env_unit.py
+++ b/source/isaaclab/test/envs/test_manager_based_rl_env_unit.py
@@ -8,10 +8,12 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call
 
 import gymnasium as gym
 import numpy as np
 import pytest
+import torch
 
 from isaaclab.envs import ManagerBasedRLEnv
 
@@ -102,3 +104,49 @@ def test_obs_space_follows_clip_constraint():
             assert term_space.shape == expected_shapes[term_name]
             assert np.all(term_space.low == low)
             assert np.all(term_space.high == high)
+
+
+@pytest.mark.parametrize("requires_post_step_observation", [False, True])
+def test_step_computes_post_step_observations_only_when_required(requires_post_step_observation: bool):
+    """The environment only computes pre-reset observations when a recorder consumes them."""
+    num_envs = 2
+    reset_buf = torch.zeros(num_envs, dtype=torch.bool)
+    observations = {"policy": torch.zeros(num_envs, 1)}
+
+    env = object.__new__(ManagerBasedRLEnv)
+    env._is_closed = True
+    env._physics_handles_decimation = False
+    env._sim_step_counter = 0
+    env.cfg = SimpleNamespace(
+        decimation=1,
+        sim=SimpleNamespace(dt=0.01, render_interval=1),
+        compute_final_obs=False,
+    )
+    env.sim = MagicMock(device="cpu", is_rendering=False)
+    env.sim.consume_reset_request.return_value = False
+    env.scene = MagicMock(num_envs=num_envs)
+    env.action_manager = MagicMock()
+    env.recorder_manager = MagicMock(
+        active_terms=["pre_step"], requires_post_step_observation=requires_post_step_observation
+    )
+    env.termination_manager = MagicMock(terminated=reset_buf, time_outs=reset_buf)
+    env.termination_manager.compute.return_value = reset_buf
+    env.reward_manager = MagicMock()
+    env.reward_manager.compute.return_value = torch.zeros(num_envs)
+    env.command_manager = MagicMock()
+    env.event_manager = MagicMock(available_modes=[])
+    env.observation_manager = MagicMock()
+    env.observation_manager.compute.return_value = observations
+    env.video_recorders = []
+    env.episode_length_buf = torch.zeros(num_envs, dtype=torch.long)
+    env.common_step_counter = 0
+    env.extras = {}
+
+    returned_observations, *_ = ManagerBasedRLEnv.step(env, torch.zeros(num_envs, 1))
+
+    assert returned_observations is observations
+    env.recorder_manager.record_post_step.assert_called_once_with()
+    expected_compute_calls = [call(update_history=True)]
+    if requires_post_step_observation:
+        expected_compute_calls.insert(0, call())
+    assert env.observation_manager.compute.call_args_list == expected_compute_calls

--- a/source/isaaclab/test/managers/test_recorder_manager.py
+++ b/source/isaaclab/test/managers/test_recorder_manager.py
@@ -15,6 +15,7 @@ import h5py
 import pytest
 import torch
 
+from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
 from isaaclab.managers import DatasetExportMode, RecorderManager, RecorderManagerBaseCfg, RecorderTerm, RecorderTermCfg
 from isaaclab.test.utils import DeviceScope, test_devices
 from isaaclab.utils.configclass import configclass
@@ -182,6 +183,24 @@ def test_initialize_dataset_file(dataset_dir):
 
     # check if the dataset is created
     assert os.path.exists(os.path.join(cfg.dataset_export_dir_path, cfg.dataset_filename))
+    recorder_manager.close()
+
+
+def test_requires_post_step_observation():
+    """The manager reports whether active post-step terms require fresh observations."""
+    cfg = DummyRecorderManagerCfg(dataset_export_mode=DatasetExportMode.EXPORT_NONE)
+    recorder_manager = RecorderManager(cfg, create_dummy_env())
+    assert recorder_manager.requires_post_step_observation
+    recorder_manager.close()
+
+    cfg.record_step_term = None
+    recorder_manager = RecorderManager(cfg, create_dummy_env())
+    assert not recorder_manager.requires_post_step_observation
+    recorder_manager.close()
+
+    cfg = ActionStateRecorderManagerCfg(dataset_export_mode=DatasetExportMode.EXPORT_NONE)
+    recorder_manager = RecorderManager(cfg, create_dummy_env())
+    assert not recorder_manager.requires_post_step_observation
     recorder_manager.close()
 
 


### PR DESCRIPTION
## Summary

- avoid the extra observation-manager compute when active recorder terms do not consume post-step observations
- preserve fresh post-step observations for existing custom recorder terms by default
- mark the built-in state and processed-action recorders as not requiring observations

This keeps `RecorderManager.active_terms` unchanged and limits the implementation to a recorder-term capability queried by `ManagerBasedRLEnv.step()`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run isaaclab -f`
- `uv run --extra test python -m pytest source/isaaclab/test/envs/test_manager_based_rl_env_unit.py source/isaaclab/test/managers/test_recorder_manager.py -q` (9 passed)
- `uv run python tools/changelog/cli.py check develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] Documentation is unchanged; a changelog fragment is included
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment for the touched package
- [x] My name is already present in `CONTRIBUTORS.md`
