### PR TITLE
Fix Franka Reach relative IK teleoperation

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -861,6 +861,9 @@ follows.
    * - ``Isaac-Reach-Franka`` with ``physics=isaacsim_physx presets=diffik``
      - Keyboard, Gamepad, SpaceMouse
      - **Arm:** relative IK end-effector control. Gripper disabled.
+   * - ``Isaac-Reach-Franka`` with ``physics=newton_mjwarp presets=newton_ik``
+     - Keyboard, Gamepad, SpaceMouse
+     - **Arm:** relative Newton IK end-effector control. Gripper disabled.
 
 
 .. note::

--- a/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed native keyboard, gamepad, and SpaceMouse teleoperation for ``Isaac-Reach-Franka`` with
+  ``presets=diffik`` by disabling the unsupported gripper command.

--- a/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
@@ -1,5 +1,5 @@
 Fixed
 ^^^^^
 
-* Fixed native keyboard, gamepad, and SpaceMouse teleoperation for ``Isaac-Reach-Franka`` with
-  ``presets=diffik`` by disabling the unsupported gripper command.
+* Fixed native keyboard, gamepad, and SpaceMouse teleoperation for ``Isaac-Reach-Franka`` with the
+  ``diffik`` and ``newton_ik`` presets by disabling the unsupported gripper command.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -14,6 +14,10 @@ from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.envs.mdp as mdp
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.devices import DevicesCfg
+from isaaclab.devices.gamepad import Se3GamepadCfg
+from isaaclab.devices.keyboard import Se3KeyboardCfg
+from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils.configclass import configclass
 
@@ -108,6 +112,17 @@ class FrankaReachEnvCfg(ReachEnvCfg):
 
         # override actions
         self.actions.arm_action = FrankaArmActionCfg()
+        # Native SE(3) devices match only the 6D relative differential IK action.
+        self.teleop_devices = preset(
+            default=DevicesCfg(),
+            diffik=DevicesCfg(
+                devices={
+                    "keyboard": Se3KeyboardCfg(gripper_term=False, sim_device=self.sim.device),
+                    "gamepad": Se3GamepadCfg(gripper_term=False, sim_device=self.sim.device),
+                    "spacemouse": Se3SpaceMouseCfg(gripper_term=False, sim_device=self.sim.device),
+                }
+            ),
+        )
         # override command generator body
         # end-effector is along z-direction
         self.commands.ee_pose.body_name = "panda_hand"

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -112,16 +112,18 @@ class FrankaReachEnvCfg(ReachEnvCfg):
 
         # override actions
         self.actions.arm_action = FrankaArmActionCfg()
-        # Native SE(3) devices match only the 6D relative differential IK action.
+        # Native SE(3) devices match the 6D relative differential and Newton IK actions.
+        relative_ik_teleop_devices = DevicesCfg(
+            devices={
+                "keyboard": Se3KeyboardCfg(gripper_term=False, sim_device=self.sim.device),
+                "gamepad": Se3GamepadCfg(gripper_term=False, sim_device=self.sim.device),
+                "spacemouse": Se3SpaceMouseCfg(gripper_term=False, sim_device=self.sim.device),
+            }
+        )
         self.teleop_devices = preset(
             default=DevicesCfg(),
-            diffik=DevicesCfg(
-                devices={
-                    "keyboard": Se3KeyboardCfg(gripper_term=False, sim_device=self.sim.device),
-                    "gamepad": Se3GamepadCfg(gripper_term=False, sim_device=self.sim.device),
-                    "spacemouse": Se3SpaceMouseCfg(gripper_term=False, sim_device=self.sim.device),
-                }
-            ),
+            diffik=relative_ik_teleop_devices,
+            newton_ik=relative_ik_teleop_devices,
         )
         # override command generator body
         # end-effector is along z-direction

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -28,9 +28,10 @@ def _load_reach_env_cfg(task: str, *presets: str):
     return resolve_presets(cfg, selected=presets)
 
 
-def _without_actions(cfg):
+def _without_controller_dependent_cfg(cfg):
     cfg_dict = cfg.to_dict()
     cfg_dict.pop("actions")
+    cfg_dict.pop("teleop_devices")
     return cfg_dict
 
 
@@ -88,7 +89,7 @@ def test_reach_ur10_physics_presets_change_only_physics():
     assert physx_cfg == newton_cfg
 
 
-def test_reach_action_presets_change_only_the_action_configuration():
+def test_reach_action_presets_preserve_controller_independent_configuration():
     joint_pos_physx = _load_env_cfg("joint_pos", "isaacsim_physx")
     diffik_physx = _load_env_cfg("diffik", "isaacsim_physx")
     joint_pos_newton = _load_env_cfg("joint_pos", "newton_mjwarp")
@@ -96,9 +97,22 @@ def test_reach_action_presets_change_only_the_action_configuration():
     newton_ik = _load_env_cfg("newton_ik", "newton_mjwarp")
 
     assert _load_env_cfg().actions.arm_action.to_dict() == joint_pos_newton.actions.arm_action.to_dict()
-    assert _without_actions(joint_pos_physx) == _without_actions(diffik_physx)
-    assert _without_actions(joint_pos_newton) == _without_actions(diffik_newton)
-    assert _without_actions(joint_pos_newton) == _without_actions(newton_ik)
+    assert _without_controller_dependent_cfg(joint_pos_physx) == _without_controller_dependent_cfg(diffik_physx)
+    assert _without_controller_dependent_cfg(joint_pos_newton) == _without_controller_dependent_cfg(diffik_newton)
+    assert _without_controller_dependent_cfg(joint_pos_newton) == _without_controller_dependent_cfg(newton_ik)
+
+
+def test_reach_diffik_preset_configures_six_dof_native_teleop_devices():
+    cfg = _load_env_cfg("diffik", "isaacsim_physx")
+
+    assert set(cfg.teleop_devices.devices) == {"keyboard", "gamepad", "spacemouse"}
+    assert all(not device_cfg.gripper_term for device_cfg in cfg.teleop_devices.devices.values())
+
+
+def test_reach_default_preset_does_not_configure_se3_teleop_devices():
+    cfg = _load_env_cfg()
+
+    assert cfg.teleop_devices.devices == {}
 
 
 def test_reach_success_requires_position_and_orientation():

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from gymnasium.envs.registration import registry
+from isaaclab_newton.ik.newton_ik_objectives_cfg import NewtonIKPoseObjectiveCfg
 
 import isaaclab.envs.mdp as mdp
 
@@ -102,11 +103,28 @@ def test_reach_action_presets_preserve_controller_independent_configuration():
     assert _without_controller_dependent_cfg(joint_pos_newton) == _without_controller_dependent_cfg(newton_ik)
 
 
-def test_reach_diffik_preset_configures_six_dof_native_teleop_devices():
-    cfg = _load_env_cfg("diffik", "isaacsim_physx")
+@pytest.mark.parametrize(
+    ("action_preset", "physics_preset"),
+    [("diffik", "isaacsim_physx"), ("newton_ik", "newton_mjwarp")],
+)
+def test_reach_relative_ik_presets_configure_six_dof_native_teleop_devices(action_preset, physics_preset):
+    cfg = _load_env_cfg(action_preset, physics_preset)
 
+    cfg.validate()
     assert set(cfg.teleop_devices.devices) == {"keyboard", "gamepad", "spacemouse"}
     assert all(not device_cfg.gripper_term for device_cfg in cfg.teleop_devices.devices.values())
+
+
+def test_reach_newton_ik_uses_native_se3_command_convention():
+    cfg = _load_env_cfg("newton_ik", "newton_mjwarp")
+    pose_objectives = [
+        objective for objective in cfg.actions.arm_action.objectives if isinstance(objective, NewtonIKPoseObjectiveCfg)
+    ]
+
+    assert len(pose_objectives) == 1
+    assert pose_objectives[0].command_type == "pose"
+    assert pose_objectives[0].use_relative_mode
+    assert len(pose_objectives[0].scale) == 6
 
 
 def test_reach_default_preset_does_not_configure_se3_teleop_devices():


### PR DESCRIPTION
# Description

Fix native teleoperation for `Isaac-Reach-Franka` with both supported relative-IK configurations:

- `physics=isaacsim_physx presets=diffik`
- `physics=newton_mjwarp presets=newton_ik`

Both actions accept a 6D relative pose command (`x, y, z, roll, pitch, yaw`). The preset consolidation dropped the Reach-specific native-device configuration, so the generic keyboard fallback emitted a seventh gripper value and the documented differential-IK recording command failed on its first step with `Invalid action shape, expected: 6, received: 7`.

This change configures keyboard, gamepad, and SpaceMouse for both relative-IK presets with `gripper_term=False`. The default joint-position and absolute-pose presets retain an empty SE(3) device configuration because their action semantics are incompatible. Tests verify both supported preset/device combinations and the Newton IK command convention. The teleoperation support table and changelog fragment cover both controllers.

Tracks NVBug 6664296.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run --extra test python -m pytest source/isaaclab_tasks/test/core/test_reach_franka_presets.py -q` — 23 passed
- `uv run python scripts/environments/random_agent.py --task Isaac-Reach-Franka --num_envs 1 --max_steps 5 physics=newton_mjwarp presets=newton_ik` — passed; runtime action shape was 6
- `uv run --isolated --extra test -- make -C docs current-docs` — passed without warnings
- `uv run isaaclab -f` — passed
- `uv run python tools/changelog/cli.py check release/3.0.0` — passed
- `git diff --check` — passed

The native-device simulator smoke test was not run locally because Isaac Sim is not installed in this workspace.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`