### PR TITLE
[Backport develop] Fix Franka Reach relative IK teleoperation (#7619)

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -861,6 +861,9 @@ follows.
    * - ``Isaac-Reach-Franka`` with ``physics=isaacsim_physx presets=diffik``
      - Keyboard, Gamepad, SpaceMouse
      - **Arm:** relative IK end-effector control. Gripper disabled.
+   * - ``Isaac-Reach-Franka`` with ``physics=newton_mjwarp presets=newton_ik``
+     - Keyboard, Gamepad, SpaceMouse
+     - **Arm:** relative Newton IK end-effector control. Gripper disabled.
 
 
 .. note::

--- a/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-franka-reach-diffik-teleop.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed native keyboard, gamepad, and SpaceMouse teleoperation for ``Isaac-Reach-Franka`` with the
+  ``diffik`` and ``newton_ik`` presets by disabling the unsupported gripper command.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -14,6 +14,10 @@ from isaaclab_newton.physics import NewtonCfg
 
 import isaaclab.envs.mdp as mdp
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.devices import DevicesCfg
+from isaaclab.devices.gamepad import Se3GamepadCfg
+from isaaclab.devices.keyboard import Se3KeyboardCfg
+from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
 from isaaclab.utils.configclass import configclass
 
@@ -108,6 +112,19 @@ class FrankaReachEnvCfg(ReachEnvCfg):
 
         # override actions
         self.actions.arm_action = FrankaArmActionCfg()
+        # Native SE(3) devices match the 6D relative differential and Newton IK actions.
+        relative_ik_teleop_devices = DevicesCfg(
+            devices={
+                "keyboard": Se3KeyboardCfg(gripper_term=False, sim_device=self.sim.device),
+                "gamepad": Se3GamepadCfg(gripper_term=False, sim_device=self.sim.device),
+                "spacemouse": Se3SpaceMouseCfg(gripper_term=False, sim_device=self.sim.device),
+            }
+        )
+        self.teleop_devices = preset(
+            default=DevicesCfg(),
+            diffik=relative_ik_teleop_devices,
+            newton_ik=relative_ik_teleop_devices,
+        )
         # override command generator body
         # end-effector is along z-direction
         self.commands.ee_pose.body_name = "panda_hand"

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from gymnasium.envs.registration import registry
+from isaaclab_newton.ik.newton_ik_objectives_cfg import NewtonIKPoseObjectiveCfg
 
 import isaaclab.envs.mdp as mdp
 
@@ -28,9 +29,10 @@ def _load_reach_env_cfg(task: str, *presets: str):
     return resolve_presets(cfg, selected=presets)
 
 
-def _without_actions(cfg):
+def _without_controller_dependent_cfg(cfg):
     cfg_dict = cfg.to_dict()
     cfg_dict.pop("actions")
+    cfg_dict.pop("teleop_devices")
     return cfg_dict
 
 
@@ -88,7 +90,7 @@ def test_reach_ur10_physics_presets_change_only_physics():
     assert physx_cfg == newton_cfg
 
 
-def test_reach_action_presets_change_only_the_action_configuration():
+def test_reach_action_presets_preserve_controller_independent_configuration():
     joint_pos_physx = _load_env_cfg("joint_pos", "isaacsim_physx")
     diffik_physx = _load_env_cfg("diffik", "isaacsim_physx")
     joint_pos_newton = _load_env_cfg("joint_pos", "newton_mjwarp")
@@ -96,9 +98,39 @@ def test_reach_action_presets_change_only_the_action_configuration():
     newton_ik = _load_env_cfg("newton_ik", "newton_mjwarp")
 
     assert _load_env_cfg().actions.arm_action.to_dict() == joint_pos_newton.actions.arm_action.to_dict()
-    assert _without_actions(joint_pos_physx) == _without_actions(diffik_physx)
-    assert _without_actions(joint_pos_newton) == _without_actions(diffik_newton)
-    assert _without_actions(joint_pos_newton) == _without_actions(newton_ik)
+    assert _without_controller_dependent_cfg(joint_pos_physx) == _without_controller_dependent_cfg(diffik_physx)
+    assert _without_controller_dependent_cfg(joint_pos_newton) == _without_controller_dependent_cfg(diffik_newton)
+    assert _without_controller_dependent_cfg(joint_pos_newton) == _without_controller_dependent_cfg(newton_ik)
+
+
+@pytest.mark.parametrize(
+    ("action_preset", "physics_preset"),
+    [("diffik", "isaacsim_physx"), ("newton_ik", "newton_mjwarp")],
+)
+def test_reach_relative_ik_presets_configure_six_dof_native_teleop_devices(action_preset, physics_preset):
+    cfg = _load_env_cfg(action_preset, physics_preset)
+
+    cfg.validate()
+    assert set(cfg.teleop_devices.devices) == {"keyboard", "gamepad", "spacemouse"}
+    assert all(not device_cfg.gripper_term for device_cfg in cfg.teleop_devices.devices.values())
+
+
+def test_reach_newton_ik_uses_native_se3_command_convention():
+    cfg = _load_env_cfg("newton_ik", "newton_mjwarp")
+    pose_objectives = [
+        objective for objective in cfg.actions.arm_action.objectives if isinstance(objective, NewtonIKPoseObjectiveCfg)
+    ]
+
+    assert len(pose_objectives) == 1
+    assert pose_objectives[0].command_type == "pose"
+    assert pose_objectives[0].use_relative_mode
+    assert len(pose_objectives[0].scale) == 6
+
+
+def test_reach_default_preset_does_not_configure_se3_teleop_devices():
+    cfg = _load_env_cfg()
+
+    assert cfg.teleop_devices.devices == {}
 
 
 def test_reach_success_requires_position_and_orientation():


### PR DESCRIPTION
# Description

Backports #7619 from `release/3.0.0` to `develop`.

The change restores native keyboard, gamepad, and SpaceMouse teleoperation for both supported Franka Reach relative-IK configurations:

- `physics=isaacsim_physx presets=diffik`
- `physics=newton_mjwarp presets=newton_ik`

Both configurations accept six-dimensional relative pose actions, so their native device configurations disable the unsupported gripper command. The default joint-position and absolute-pose presets remain unchanged.

This is an exact patch replay of merged release commit `17e5f3d51620168806647feeaeab85c2688d2bc4`; no conflict resolution or develop-specific adaptation was required. No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> This change originated on `release/3.0.0`; do not backport it again.

## Screenshots

Not applicable.

## Validation

- Stable patch ID matches the merged #7619 release commit.
- `uvx --from pre-commit==4.6.2 pre-commit run --all-files` — passed.
- `tools/changelog/cli.py check develop` — passed against the current develop base.
- `git diff --check upstream/develop..HEAD` — passed.
- Source PR validation for this exact patch: 23 Reach preset tests passed, the Newton random-agent smoke test passed, the documentation build passed without warnings, and `uv run isaaclab -f` passed.

The targeted test and documentation commands could not be rerun on this macOS host because the current lockfile supports Linux x86_64/aarch64 and Windows AMD64 only. Develop CI provides the supported-platform verification.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the available pre-commit checks.
- [x] I have included the corresponding documentation change.
- [x] My changes generate no new warnings in the available checks.
- [x] The source PR's tests cover this exact patch.
- [x] I have included the `isaaclab_tasks` changelog fragment.
- [x] The original contributor already appears in `CONTRIBUTORS.md`.
