### PR TITLE
[Backport release/3.0.0] Fix MJWarp USD friction loss import (#7298)

### DIFF
--- a/source/isaaclab_contrib/changelog.d/neozng-mjwarp-usd-joint-properties.rst
+++ b/source/isaaclab_contrib/changelog.d/neozng-mjwarp-usd-joint-properties.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed coupled Newton managers with MuJoCo solvers to import MuJoCo-authored joint friction and damping
+  values from USD stages.

--- a/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
+++ b/source/isaaclab_contrib/isaaclab_contrib/coupling/coupler.py
@@ -23,6 +23,7 @@ from isaaclab_newton.physics.mpm_manager import NewtonMPMManager
 from isaaclab_newton.physics.newton_manager import NewtonManager
 from isaaclab_newton.physics.vbd_manager import NewtonVBDManager
 from newton import CollisionPipeline, Model, ModelBuilder, ShapeFlags
+from newton.solvers import SolverBase
 from newton.solvers.experimental.coupled import SolverCoupled, SolverCoupledADMM, SolverCoupledProxy
 
 from isaaclab.physics import PhysicsManager
@@ -190,6 +191,14 @@ class NewtonCouplerManager(NewtonVBDManager):
         super()._register_builder_attributes(builder)
         for entry in PhysicsManager._cfg.solver_cfg.entries:
             entry.solver_cfg.class_type._register_builder_attributes(builder)
+
+    @classmethod
+    def _registers_builder_attributes_from_solver(cls, solver_cls: type[SolverBase]) -> bool:
+        """Return whether the manager or a configured nested entry registers ``solver_cls`` attributes."""
+        return super()._registers_builder_attributes_from_solver(solver_cls) or any(
+            entry.solver_cfg.class_type._registers_builder_attributes_from_solver(solver_cls)
+            for entry in PhysicsManager._cfg.solver_cfg.entries
+        )
 
     @classmethod
     def _prepare_builder_for_finalize(cls, builder: ModelBuilder) -> None:

--- a/source/isaaclab_contrib/test/coupling/test_coupler.py
+++ b/source/isaaclab_contrib/test/coupling/test_coupler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 
+import isaaclab_newton.physics.newton_manager as newton_manager_module
 import numpy as np
 import pytest
 from isaaclab_newton.physics import (
@@ -24,6 +25,7 @@ from isaaclab_newton.physics import (
     KaminoPADMMSolverCfg,
     MJWarpSolverCfg,
     MPMSolverCfg,
+    NewtonCfg,
     NewtonCollisionPipelineCfg,
     NewtonVBDManager,
     VBDSolverCfg,
@@ -32,6 +34,8 @@ from isaaclab_newton.physics import (
 from isaaclab_newton.physics.newton_manager import NewtonManager
 from newton import ModelBuilder, ShapeFlags
 from newton.solvers.experimental.coupled import SolverCoupledADMM, SolverCoupledProxy
+
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
 from isaaclab_contrib.coupling import (
     CouplerAdmmCfg,
@@ -594,6 +598,52 @@ def test_nested_solvers_register_their_builder_attributes(monkeypatch):
 
     assert builder.has_custom_attribute("mujoco:condim")
     assert builder.has_custom_attribute("mpm:young_modulus")
+
+
+@pytest.mark.parametrize(
+    ("entry_solver_cfg", "expected_friction", "expected_damping"),
+    [
+        pytest.param(MJWarpSolverCfg(), 0.11, 0.23, id="mjwarp"),
+        pytest.param(XPBDSolverCfg(), 0.0, 0.0, id="xpbd"),
+    ],
+)
+def test_nested_solver_scopes_mujoco_joint_properties(
+    monkeypatch, entry_solver_cfg, expected_friction, expected_damping
+):
+    """A coupler imports MuJoCo properties only when a nested solver consumes them."""
+    solver_cfg = CouplerProxyCfg(entries=[CouplerEntryCfg(name="rigid", solver_cfg=entry_solver_cfg)])
+    monkeypatch.setattr(coupler.PhysicsManager, "_cfg", NewtonCfg(solver_cfg=solver_cfg))
+
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.Xform.Define(stage, "/World")
+    root_path = "/World/robot"
+    root = UsdGeom.Cube.Define(stage, root_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(root)
+    UsdPhysics.ArticulationRootAPI.Apply(root)
+    child_path = f"{root_path}/child"
+    child = UsdGeom.Cube.Define(stage, child_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(child)
+    joint = UsdPhysics.RevoluteJoint.Define(stage, f"{child_path}/joint")
+    joint.CreateAxisAttr().Set("Z")
+    joint.CreateBody0Rel().SetTargets([root_path])
+    joint.CreateBody1Rel().SetTargets([child_path])
+    joint.GetPrim().CreateAttribute("mjc:frictionloss", Sdf.ValueTypeNames.Double, True).Set(0.11)
+    joint.GetPrim().CreateAttribute("mjc:damping", Sdf.ValueTypeNames.Double, True).Set(0.23)
+
+    monkeypatch.setattr(newton_manager_module, "get_current_stage", lambda: stage)
+    monkeypatch.setattr(newton_manager_module, "_restore_visible_colliders_without_visual_shapes", lambda *args: None)
+    monkeypatch.setattr(newton_manager_module, "replace_newton_builder_shape_colors", lambda *args: None)
+    monkeypatch.setattr(newton_manager_module, "import_builder_visual_material_paths", lambda *args: None)
+    monkeypatch.setattr(NewtonManager, "_builder", None)
+    monkeypatch.setattr(NewtonManager, "_deformable_registry", [])
+    monkeypatch.setattr(NewtonManager, "_per_world_builder_hooks", [])
+
+    NewtonCouplerManager.instantiate_builder_from_stage()
+    builder = NewtonManager._builder
+    model = builder.finalize(device="cpu")
+
+    assert model.joint_friction.numpy()[-1] == pytest.approx(expected_friction)
+    assert model.joint_damping.numpy()[-1] == pytest.approx(expected_damping)
 
 
 def test_contact_initialization_prepares_coupled_solver_buffers(monkeypatch):

--- a/source/isaaclab_contrib/test/custom_coupling/test_manager.py
+++ b/source/isaaclab_contrib/test/custom_coupling/test_manager.py
@@ -12,6 +12,8 @@ import pytest
 from isaaclab_newton.physics import MJWarpSolverCfg, VBDSolverCfg
 from newton import ModelBuilder
 
+from pxr import Sdf, Usd, UsdGeom, UsdPhysics
+
 import isaaclab_contrib.custom_coupling.coupled_mjwarp_vbd_manager as manager_module
 from isaaclab_contrib.custom_coupling.coupled_mjwarp_vbd_manager import NewtonCoupledMJWarpVBDManager
 from isaaclab_contrib.custom_coupling.newton_manager_cfg import CoupledMJWarpVBDSolverCfg
@@ -26,6 +28,35 @@ def test_register_builder_attributes_includes_nested_solvers(monkeypatch: pytest
     NewtonCoupledMJWarpVBDManager._register_builder_attributes(builder)
 
     assert builder.has_custom_attribute("mujoco:condim")
+
+
+def test_registered_mujoco_solver_imports_mujoco_joint_properties(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The coupled manager imports joint properties consumed by its MuJoCo solver."""
+    cfg = CoupledMJWarpVBDSolverCfg()
+    monkeypatch.setattr(manager_module.PhysicsManager, "_cfg", SimpleNamespace(solver_cfg=cfg))
+
+    stage = Usd.Stage.CreateInMemory()
+    root_path = "/World/robot"
+    root = UsdGeom.Cube.Define(stage, root_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(root)
+    UsdPhysics.ArticulationRootAPI.Apply(root)
+    child_path = f"{root_path}/child"
+    child = UsdGeom.Cube.Define(stage, child_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(child)
+    joint = UsdPhysics.RevoluteJoint.Define(stage, f"{child_path}/joint")
+    joint.CreateAxisAttr().Set("Z")
+    joint.CreateBody0Rel().SetTargets([root_path])
+    joint.CreateBody1Rel().SetTargets([child_path])
+    joint.GetPrim().CreateAttribute("mjc:frictionloss", Sdf.ValueTypeNames.Double, True).Set(0.11)
+    joint.GetPrim().CreateAttribute("mjc:damping", Sdf.ValueTypeNames.Double, True).Set(0.23)
+
+    builder = ModelBuilder()
+    NewtonCoupledMJWarpVBDManager._register_builder_attributes(builder)
+    builder.add_usd(stage, schema_resolvers=NewtonCoupledMJWarpVBDManager._get_usd_import_schema_resolvers())
+    model = builder.finalize(device="cpu")
+
+    assert model.joint_friction.numpy()[-1] == pytest.approx(0.11)
+    assert model.joint_damping.numpy()[-1] == pytest.approx(0.23)
 
 
 def test_reset_forwards_to_both_subsolvers(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/source/isaaclab_newton/changelog.d/neozng-mjwarp-usd-joint-properties.rst
+++ b/source/isaaclab_newton/changelog.d/neozng-mjwarp-usd-joint-properties.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed MuJoCo-based solver managers dropping ``mjc:frictionloss`` during USD
+  stage imports.

--- a/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
+++ b/source/isaaclab_newton/isaaclab_newton/cloner/replicate.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, TypeAlias
 import torch
 import warp as wp
 from newton import ModelBuilder
-from newton._src.usd.schemas import SchemaResolverNewton, SchemaResolverPhysx
 
 from pxr import Usd
 
@@ -119,8 +118,8 @@ def _build_newton_builder_from_mapping(
         quaternions = torch.zeros((mapping.size(1), 4), device=mapping.device, dtype=torch.float32)
         quaternions[:, 3] = 1.0
 
-    schema_resolvers = [SchemaResolverNewton(), SchemaResolverPhysx()]
     manager_cls = PhysicsManager._sim.physics_manager
+    schema_resolvers = manager_cls._get_usd_import_schema_resolvers()
 
     builder = manager_cls.create_builder(up_axis=up_axis)
     import_paths = (PhysicsManager._sim.cfg.physics_prim_path, *global_paths)

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -75,8 +75,8 @@ from newton.selection import ArticulationView
 from newton.sensors import SensorContact as NewtonContactSensor
 from newton.sensors import SensorFrameTransform
 from newton.sensors import SensorIMU as NewtonSensorIMU
-from newton.solvers import SolverBase, SolverKamino
-from newton.usd import SchemaResolverNewton, SchemaResolverPhysx
+from newton.solvers import SolverBase, SolverKamino, SolverMuJoCo
+from newton.usd import SchemaResolver, SchemaResolverMjc, SchemaResolverNewton, SchemaResolverPhysx
 
 from pxr import Usd, UsdGeom
 
@@ -1254,6 +1254,11 @@ class NewtonManager(PhysicsManager):
             solver_cls.register_custom_attributes(builder)
 
     @classmethod
+    def _registers_builder_attributes_from_solver(cls, solver_cls: type[SolverBase]) -> bool:
+        """Return whether this manager registers custom attributes from ``solver_cls``."""
+        return solver_cls in cls._builder_attribute_solvers
+
+    @classmethod
     def _prepare_builder_for_finalize(cls, builder: ModelBuilder) -> None:
         """Subclass hook to normalize *builder* before model finalization.
 
@@ -1911,6 +1916,19 @@ class NewtonManager(PhysicsManager):
         return []
 
     @classmethod
+    def _get_usd_import_schema_resolvers(cls) -> list[SchemaResolver]:
+        """Return ordered schema resolvers for physics-model USD imports.
+
+        MJC is enabled for managers that register ``SolverMuJoCo`` attributes.
+        Visualization and articulation-ordering builders keep their fixed pair
+        because solver attributes do not affect their outputs.
+        """
+        resolvers: list[SchemaResolver] = [SchemaResolverNewton(), SchemaResolverPhysx()]
+        if cls._registers_builder_attributes_from_solver(SolverMuJoCo):
+            resolvers.append(SchemaResolverMjc())
+        return resolvers
+
+    @classmethod
     def instantiate_builder_from_stage(cls):
         """Create builder from USD stage.
 
@@ -1939,7 +1957,7 @@ class NewtonManager(PhysicsManager):
 
         builder = cls.create_builder(up_axis=up_axis)
 
-        schema_resolvers = [SchemaResolverNewton(), SchemaResolverPhysx()]
+        schema_resolvers = cls._get_usd_import_schema_resolvers()
 
         # NOTE: None of the add_usd calls below pass joint_ordering or
         # bodies_follow_joint_ordering, so the live articulation's native

--- a/source/isaaclab_newton/test/cloner/test_newton_builder_world_hook.py
+++ b/source/isaaclab_newton/test/cloner/test_newton_builder_world_hook.py
@@ -80,7 +80,9 @@ def test_explicit_global_import_uses_global_world(monkeypatch):
     add_usd = mock.Mock(wraps=builder.add_usd)
     monkeypatch.setattr(builder, "add_usd", add_usd)
     manager = SimpleNamespace(
-        create_builder=mock.Mock(return_value=builder), _inject_terrain_heightfields=mock.Mock(return_value=[])
+        create_builder=mock.Mock(return_value=builder),
+        _get_usd_import_schema_resolvers=NewtonManager._get_usd_import_schema_resolvers,
+        _inject_terrain_heightfields=mock.Mock(return_value=[]),
     )
     monkeypatch.setattr(
         replicate_module.PhysicsManager,

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -32,6 +32,7 @@ from types import SimpleNamespace
 import isaaclab_newton.physics.newton_manager as newton_manager_module
 import numpy as np
 import pytest
+import torch
 import warp as wp
 from isaaclab_newton.assets.articulation import articulation as articulation_module
 from isaaclab_newton.physics import (
@@ -844,8 +845,8 @@ def test_production_imports_scope_mujoco_joint_properties(
             stage=stage,
             sources=(root_path,),
             destinations=("/World/envs/env_{}/robot",),
-            env_ids=np.array([0], dtype=np.int64),
-            mapping=np.ones((1, 1), dtype=np.bool_),
+            env_ids=torch.tensor([0], dtype=torch.int64),
+            mapping=torch.ones((1, 1), dtype=torch.bool),
             load_visual_shapes=False,
         )
     else:

--- a/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
+++ b/source/isaaclab_newton/test/physics/test_newton_manager_abstraction.py
@@ -788,6 +788,135 @@ def test_active_manager_create_builder_registers_mpm_attributes():
     assert builder.has_custom_attribute("mpm:young_modulus")
 
 
+@pytest.mark.parametrize("import_path", ["clone", "standalone"])
+@pytest.mark.parametrize(
+    ("manager_cls", "solver_cfg", "expected_friction", "expected_damping"),
+    [
+        pytest.param(NewtonMJWarpManager, MJWarpSolverCfg(), 0.11, 0.23, id="mjwarp"),
+        pytest.param(NewtonFeatherstoneManager, FeatherstoneSolverCfg(), 0.0, 0.0, id="featherstone"),
+    ],
+)
+def test_production_imports_scope_mujoco_joint_properties(
+    monkeypatch, import_path, manager_cls, solver_cfg, expected_friction, expected_damping
+):
+    """Only MJWarp imports MuJoCo joint properties through either production path."""
+    from isaaclab_newton.cloner.replicate import _build_newton_builder_from_mapping
+
+    from pxr import Sdf, Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateInMemory()
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+    UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+    physics_prim_path = "/physicsScene"
+    UsdPhysics.Scene.Define(stage, physics_prim_path)
+
+    root_path = "/Sources/robot" if import_path == "clone" else "/World/robot"
+    root = UsdGeom.Cube.Define(stage, root_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(root)
+    UsdPhysics.ArticulationRootAPI.Apply(root)
+
+    child_path = f"{root_path}/child"
+    child = UsdGeom.Cube.Define(stage, child_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(child)
+
+    joint = UsdPhysics.RevoluteJoint.Define(stage, f"{child_path}/joint")
+    joint.CreateAxisAttr().Set("Z")
+    joint.CreateBody0Rel().SetTargets([root_path])
+    joint.CreateBody1Rel().SetTargets([child_path])
+    joint.GetPrim().CreateAttribute("mjc:frictionloss", Sdf.ValueTypeNames.Double, True).Set(0.11)
+    joint.GetPrim().CreateAttribute("mjc:damping", Sdf.ValueTypeNames.Double, True).Set(0.23)
+
+    monkeypatch.setattr(
+        PhysicsManager,
+        "_sim",
+        SimpleNamespace(physics_manager=manager_cls, cfg=SimpleNamespace(physics_prim_path=physics_prim_path)),
+    )
+    monkeypatch.setattr(PhysicsManager, "_cfg", NewtonCfg(solver_cfg=solver_cfg))
+    monkeypatch.setattr(PhysicsManager, "_device", "cpu")
+    monkeypatch.setattr(NewtonManager, "_builder", None)
+    monkeypatch.setattr(NewtonManager, "_deformable_registry", [])
+    monkeypatch.setattr(NewtonManager, "_cl_pending_sites", {})
+    monkeypatch.setattr(NewtonManager, "_per_world_builder_hooks", [])
+    monkeypatch.setattr(NewtonManager, "_world_xforms", None)
+
+    if import_path == "clone":
+        builder, *_ = _build_newton_builder_from_mapping(
+            stage=stage,
+            sources=(root_path,),
+            destinations=("/World/envs/env_{}/robot",),
+            env_ids=np.array([0], dtype=np.int64),
+            mapping=np.ones((1, 1), dtype=np.bool_),
+            load_visual_shapes=False,
+        )
+    else:
+        monkeypatch.setattr(newton_manager_module, "get_current_stage", lambda: stage)
+        monkeypatch.setattr(
+            newton_manager_module, "_restore_visible_colliders_without_visual_shapes", lambda *args: None
+        )
+        monkeypatch.setattr(newton_manager_module, "replace_newton_builder_shape_colors", lambda *args: None)
+        monkeypatch.setattr(newton_manager_module, "import_builder_visual_material_paths", lambda *args: None)
+        manager_cls.instantiate_builder_from_stage()
+        builder = NewtonManager._builder
+
+    model = builder.finalize(device="cpu")
+
+    assert model.joint_friction.numpy()[-1] == pytest.approx(expected_friction)
+    assert model.joint_damping.numpy()[-1] == pytest.approx(expected_damping)
+
+
+@pytest.mark.parametrize(
+    ("manager_cls", "imports_mujoco"),
+    [
+        pytest.param(NewtonMJWarpManager, True, id="mjwarp"),
+        pytest.param(NewtonFeatherstoneManager, False, id="featherstone"),
+    ],
+)
+@pytest.mark.parametrize(
+    "author_newton_values",
+    [
+        pytest.param(False, id="physx-over-mjc"),
+        pytest.param(True, id="newton-over-physx-over-mjc"),
+    ],
+)
+def test_schema_resolver_policy_and_precedence(manager_cls, imports_mujoco, author_newton_values):
+    """Resolver precedence and MuJoCo fallback selection follow active solver needs."""
+    from pxr import Sdf, Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateInMemory()
+    root_path = "/World/robot"
+    root = UsdGeom.Cube.Define(stage, root_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(root)
+    UsdPhysics.ArticulationRootAPI.Apply(root)
+    child_path = f"{root_path}/child"
+    child = UsdGeom.Cube.Define(stage, child_path).GetPrim()
+    UsdPhysics.RigidBodyAPI.Apply(child)
+    joint = UsdPhysics.RevoluteJoint.Define(stage, f"{child_path}/joint")
+    joint.CreateAxisAttr().Set("Z")
+    joint.CreateBody0Rel().SetTargets([root_path])
+    joint.CreateBody1Rel().SetTargets([child_path])
+    joint_prim = joint.GetPrim()
+    joint_prim.CreateAttribute("mjc:frictionloss", Sdf.ValueTypeNames.Double, True).Set(0.11)
+    joint_prim.CreateAttribute("mjc:damping", Sdf.ValueTypeNames.Double, True).Set(0.23)
+    joint_prim.CreateAttribute("mjc:armature", Sdf.ValueTypeNames.Double, True).Set(0.12)
+    joint_prim.CreateAttribute("physxJoint:armature", Sdf.ValueTypeNames.Float, True).Set(0.21)
+    if author_newton_values:
+        joint_prim.CreateAttribute("newton:friction", Sdf.ValueTypeNames.Double, True).Set(0.31)
+        joint_prim.CreateAttribute("newton:armature", Sdf.ValueTypeNames.Double, True).Set(0.41)
+
+    schema_resolvers = manager_cls._get_usd_import_schema_resolvers()
+    builder = ModelBuilder()
+    manager_cls._register_builder_attributes(builder)
+    builder.add_usd(stage, schema_resolvers=schema_resolvers)
+    model = builder.finalize(device="cpu")
+
+    expected_friction = 0.31 if author_newton_values else (0.11 if imports_mujoco else 0.0)
+    expected_damping = 0.23 if imports_mujoco else 0.0
+    expected_armature = 0.41 if author_newton_values else 0.21
+    assert model.joint_friction.numpy()[-1] == pytest.approx(expected_friction)
+    assert model.joint_damping.numpy()[-1] == pytest.approx(expected_damping)
+    assert model.joint_armature.numpy()[-1] == pytest.approx(expected_armature)
+
+
 def test_mpm_end_to_end_with_particle_custom_attributes():
     """End-to-end MPM step using ``add_particles(custom_attributes=...)`` — the production path."""
     sim_cfg = SimulationCfg(


### PR DESCRIPTION
# Description

Backports #7298 to `release/3.0.0`.

This preserves MuJoCo-authored joint friction and damping when USD stages are imported for Newton managers that register MuJoCo solvers. Both vectorized clone replication and standalone stage import now use the active manager's schema-resolver policy, with MuJoCo values remaining lower-priority fallbacks behind Newton and PhysX values. Coupled managers inherit the same solver-capability policy.

The merged source commit `f948fa596c1c61a155d55778976b7547799e6200` cherry-picked without conflicts. The release branch intentionally retains its Torch-based clone mapping contract; the backported clone-path regression test is adapted from the source PR's NumPy inputs to the release API's Torch tensors. Backporting #7462 is out of scope because it is a broad, breaking `ClonePlan` and NumPy API migration that explicitly did not request a release backport.

A separate follow-up adds the `isaaclab_contrib` changelog fragment required for the second changed source package and omitted from the source PR.

No dependency or public API is added.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> This PR already targets the active release branch; do not backport it again.

## Screenshots

Not applicable; this fixes a non-visual USD import path.

## Validation

- `uvx --from pre-commit==4.6.2 pre-commit run --all-files` — passed after the release-specific test adaptation.
- `tools/changelog/cli.py check release/3.0.0` — passed for both changed packages against the current release base.
- Python bytecode compilation passed for all changed Python files.
- `git diff --check upstream/release/3.0.0..HEAD` — passed.
- Source PR validation: the focused production-path regression matrix passed all five cases; the broader Newton manager, cloner, custom coupling, generic coupler, and MJCF converter suites also passed on the source branch.
- The first release CI run exposed that the source test passed NumPy arrays introduced by develop-only #7462 into the release helper's Torch API. The test now uses the same Torch input convention as the neighboring release cloner coverage.

The runtime Newton tests cannot run on this macOS host because the current lockfile supports Linux x86_64/aarch64 and Windows AMD64 only. Release CI provides the supported-platform verification.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the available pre-commit checks.
- [x] Documentation changes are not required because no public API or user workflow changed.
- [x] My changes generate no new warnings in the available checks.
- [x] The source PR includes focused regression coverage for both production import paths.
- [x] I have included changelog fragments for `isaaclab_newton` and `isaaclab_contrib`.
- [x] The original contributor already appears in `CONTRIBUTORS.md`.
