### PR TITLE
[Tests] Skip DrLegs-Walk in the contrib environment test

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-skip-drlegs-walk-contrib-test.skip
+++ b/source/isaaclab_tasks/changelog.d/fix-skip-drlegs-walk-contrib-test.skip
@@ -1,0 +1,3 @@
+Test-only change: skip ``IsaacContrib-DrLegs-Walk`` (and its deprecated alias) in the contributed
+environment smoke test because the Kamino solver intermittently diverges to NaN under random actions.
+No user-visible behavior change.

--- a/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
+++ b/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
@@ -32,6 +32,11 @@ _SKIPPED_TASKS = {
     "IsaacContrib-AutoMate-Disassembly-Direct": "Requires CUDA support outside the standard environment test runner.",
 }
 _SKIPPED_TASK_SUBSTRINGS = {
+    # Under random actions the Kamino P-ADMM solver intermittently diverges and the whole robot state
+    # (root pose, joint state) turns NaN mid-episode, so the run fails nondeterministically (about 1 in 12
+    # seeds locally; the sibling HoldPose task stays finite). The termination terms cannot catch a NaN state.
+    # Re-enable once the solver instability is resolved upstream.
+    "DrLegs-Walk": "Kamino solver intermittently produces NaN robot state under random actions.",
     "RmpFlow": "Uses SingleArticulation, which requires an update.",
     "Skillgen": "Requires cuRobo-specific coverage.",
     "Suction": "Requires CPU simulation.",


### PR DESCRIPTION
# Description

`test-contrib-environments` failed on #7610 (run [34042243157](https://github.com/isaac-sim/IsaacLab/actions/runs/34042243157/job/101511058208)) in `test_contrib_environments[IsaacContrib-DrLegs-Walk]` with `AssertionError: Invalid data` on the policy observation. The PR itself only touched `source/isaaclab/test/install_ci`, so this is unrelated to that change.

**Root cause.** The first row of the failing observation is NaN across projected gravity, base angular velocity and joint positions, i.e. the robot state itself is non-finite, not a single observation term. Reproducing the test scenario locally (2 envs, 20 random-action steps, fresh env per seed) shows the Kamino P-ADMM solver diverging mid-episode: in 1 of 12 seeds the entire state of env 0 (root position, root quaternion, joint positions and velocities) turns NaN at step 6. The heading-driven velocity command then inherits the NaN through `heading_w`, and the `root_height` / `bad_orientation` termination terms cannot fire because every comparison against NaN is false, so the episode is never reset. The sibling `IsaacContrib-DrLegs-HoldPose` task (same robot, same solver preset, same random actions) stayed finite in 9 of 9 local trials and passed in the same CI job, as did the deprecated alias id of the Walk task, which is why the failure is intermittent rather than deterministic.

**Change.** Add `DrLegs-Walk` to `_SKIPPED_TASK_SUBSTRINGS` in `test_contrib_environments.py` with the reason documented inline. The substring covers both `IsaacContrib-DrLegs-Walk` and its deprecated alias `Isaac-DrLegs-Walk-v0`, which the test also enumerates. HoldPose keeps running. This is a test-side skip; the solver instability itself needs to be addressed in Kamino/Newton (or by retuning the DR Legs solver preset), and the inline comment says to re-enable once that lands.

## Validation

- Reproduction script (launches once, rebuilds the env per seed, mirrors `env_test_utils._run_environments`): Walk 1/12 seeds NaN at step 6 with root pose, joint state and the velocity command all non-finite; HoldPose 0/9.
- `pytest source/isaaclab_tasks/test/contrib/test_contrib_environments.py -k DrLegs-Walk -rs`: both ids report `SKIPPED ... Kamino solver intermittently produces NaN robot state under random actions.`; HoldPose ids still collect as runnable.
- Ruff and ruff-format pass; `isaaclab_tasks` changelog `.skip` fragment included.

## Type of change

- Test fix (non-breaking)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
