### PR TITLE
Fix latest OV stack integration

### DIFF
--- a/.github/actions/run-tests/run_tests.sh
+++ b/.github/actions/run-tests/run_tests.sh
@@ -370,6 +370,13 @@ run_tests() {
 
         case \" \${TEST_WHEELHOUSE_PACKAGES} \" in
           *\" ovphysx \"*)
+            ovphysx_omniclient_requirement=\"\$(./isaaclab.sh -p tools/resolve_ovphysx_omniclient.py | grep '^omniverseclient==' | tail -n 1)\"
+            if [ -z \"\${ovphysx_omniclient_requirement}\" ]; then
+              echo \"Failed to resolve the OmniClient release required by OvPhysX\"
+              exit 1
+            fi
+            echo \"Installing matched OvPhysX dependency: \${ovphysx_omniclient_requirement}\"
+            bash /with-python-package-retries.sh ./isaaclab.sh -p -m pip install --upgrade --force-reinstall \"\${ovphysx_omniclient_requirement}\"
             ./isaaclab.sh -p -c \"import importlib.metadata,json,os,pathlib; from packaging.version import Version; manifest=json.loads(pathlib.Path(os.environ['TEST_WHEELHOUSE_MANIFEST']).read_text(encoding='utf-8')); expected=manifest.get('ovphysx_version'); actual=importlib.metadata.version('ovphysx'); print(f'Resolved ovphysx package version: {actual}'); print(f'Wheelhouse manifest ovphysx version: {expected}'); import ovphysx; runtime=getattr(ovphysx, '__version__', actual); print(f'Imported ovphysx runtime version: {runtime}'); raise SystemExit(0 if Version(actual) == Version(expected) and Version(runtime) == Version(expected) else f'ovphysx version mismatch: installed {actual}, import {runtime}, manifest {expected}')\"
             ;;
         esac

--- a/source/isaaclab_ov/changelog.d/fix-ovstack-latest-integration.rst
+++ b/source/isaaclab_ov/changelog.d/fix-ovstack-latest-integration.rst
@@ -6,3 +6,5 @@ Fixed
   actionable error when a manually assembled environment contains a mismatch.
 * Fixed the OVRTX OVStage path sourcing rigid-body transforms exclusively from Newton. It now
   publishes transforms from the active physics backend, including OvPhysX.
+* Fixed OvPhysX 0.6.1 and later dropping codeless PhysX schemas during OVStage population, which
+  prevented contact reporters and articulation tendons from reaching the physics runtime.

--- a/source/isaaclab_ov/changelog.d/fix-ovstack-latest-integration.rst
+++ b/source/isaaclab_ov/changelog.d/fix-ovstack-latest-integration.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed internal OvPhysX wheelhouse test runs using an incompatible OmniClient release. The test
+  harness now installs the release recorded by the OvPhysX wheel, and runtime imports report an
+  actionable error when a manually assembled environment contains a mismatch.
+* Fixed the OVRTX OVStage path sourcing rigid-body transforms exclusively from Newton. It now
+  publishes transforms from the active physics backend, including OvPhysX.

--- a/source/isaaclab_ov/isaaclab_ov/_runtime.py
+++ b/source/isaaclab_ov/isaaclab_ov/_runtime.py
@@ -8,6 +8,9 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
+import re
+from pathlib import Path
 from types import ModuleType
 
 _OVPHYSX_INSTALL_MESSAGE = (
@@ -15,6 +18,57 @@ _OVPHYSX_INSTALL_MESSAGE = (
     "Run your command with: uv run --extra ovphysx <command> "
     "(or, manually: python -m pip install --extra-index-url https://pypi.nvidia.com ovphysx)."
 )
+_OVPHYSX_OMNICLIENT_VERSION_PATTERN = re.compile(r"^(\d+\.\d+\.\d+)(?:-|\+|$)")
+
+
+def _required_omniverseclient_version(package_root: Path) -> str | None:
+    """Read the OmniClient release required by an installed OvPhysX package.
+
+    Args:
+        package_root: Root directory containing the ``ovphysx`` package.
+
+    Returns:
+        Required ``omniverseclient`` distribution version, or ``None`` when the package does not
+        provide a compatibility marker.
+
+    Raises:
+        RuntimeError: If the compatibility marker exists but has an unsupported format.
+    """
+    marker_path = package_root / "plugins" / "ovstage-omniclient.version"
+    if not marker_path.is_file():
+        return None
+
+    marker = marker_path.read_text(encoding="utf-8").strip()
+    match = _OVPHYSX_OMNICLIENT_VERSION_PATTERN.match(marker)
+    if match is None:
+        raise RuntimeError(f"Invalid OvPhysX OmniClient compatibility marker '{marker}' in {marker_path}.")
+    return match.group(1)
+
+
+def _installed_ovphysx_omniverseclient_version() -> str | None:
+    """Return the OmniClient version required by the installed ``ovphysx`` distribution."""
+    try:
+        distribution = importlib.metadata.distribution("ovphysx")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    package_root = Path(distribution.locate_file("ovphysx"))
+    return _required_omniverseclient_version(package_root)
+
+
+def _validate_ovphysx_omniverseclient() -> None:
+    """Reject an installed OmniClient release that is incompatible with OvPhysX's OVStage plugin."""
+    required = _installed_ovphysx_omniverseclient_version()
+    if required is None:
+        return
+    try:
+        installed = importlib.metadata.version("omniverseclient")
+    except importlib.metadata.PackageNotFoundError:
+        installed = "not installed"
+    if installed != required:
+        raise RuntimeError(
+            f"The installed OvPhysX runtime requires omniverseclient=={required}, but {installed} is installed. "
+            f"Install the matched runtime with: python -m pip install omniverseclient=={required}."
+        )
 
 
 def import_ovphysx(module_name: str = "ovphysx") -> ModuleType:
@@ -30,8 +84,10 @@ def import_ovphysx(module_name: str = "ovphysx") -> ModuleType:
         ModuleNotFoundError: If the optional ``ovphysx`` runtime wheel is not installed.
     """
     try:
-        return importlib.import_module(module_name)
+        module = importlib.import_module(module_name)
     except ModuleNotFoundError as exc:
         if exc.name != "ovphysx":
             raise
         raise ModuleNotFoundError(_OVPHYSX_INSTALL_MESSAGE, name="ovphysx") from exc
+    _validate_ovphysx_omniverseclient()
+    return module

--- a/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
+++ b/source/isaaclab_ov/isaaclab_ov/physics/ovphysx_manager.py
@@ -489,21 +489,26 @@ class OvPhysxManager(PhysicsManager):
 
     @classmethod
     def _ensure_physx_schemas_registered(cls) -> None:
-        """Register the codeless USD plugins published by the OVPhysX wheel.
+        """Register the codeless USD schemas published by the OVPhysX wheel.
 
-        The wheel's public paths include both ``PhysxSchema`` and
-        ``OmniUsdPhysicsDeformableSchema``. A host may already provide one of
-        those plugins from a compiled library, so only missing plugin names are
-        registered from the wheel's codeless resource paths.
+        OVStage maintains its own USD schema registry, so register the wheel's
+        schema root there even when the host USD runtime already provides the
+        same plugins. For the host USD registry, only register providers that
+        are not already available from a compiled plugin.
         """
         if cls._physx_schemas_registered:
             return
         try:
             import ovphysx  # noqa: PLC0415
+            import ovstage  # noqa: PLC0415
 
             from pxr import Plug  # noqa: PLC0415
         except ImportError:
             return
+        schema_root = getattr(ovphysx, "codeless_schema_root", None)
+        register_ovstage_schemas = getattr(getattr(ovstage, "population", None), "register_usd_schemas", None)
+        if callable(schema_root) and callable(register_ovstage_schemas):
+            register_ovstage_schemas(str(schema_root()))
         registry = Plug.Registry()
         registered_names = {plugin.name.casefold() for plugin in registry.GetAllPlugins()}
         # The wheel documents ``<module>/resources`` as its stable layout and its

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer.py
@@ -86,7 +86,7 @@ from isaaclab_ov.renderers.ovrtx_renderer_kernels import (
     create_camera_transforms_kernel,
     extract_all_tiles_kernel,
     generate_random_colors_from_ids_kernel,
-    sync_newton_transforms_kernel,
+    sync_physics_transforms_kernel,
 )
 from isaaclab_ov.renderers.ovrtx_shader_cache import redirect_shader_cache
 from isaaclab_ov.renderers.ovrtx_usd import (
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
     from isaaclab_ppisp import PpispPipeline
 
     from isaaclab.renderers.base_renderer import VisualMaterialBatch
+    from isaaclab.scene_data import SceneDataBackend
     from isaaclab.sensors.camera.camera_data import CameraData
     from isaaclab.utils.warp import ProxyArray
 
@@ -331,7 +332,8 @@ class OVRTXRenderer(BaseRenderer):
         # Shared by both paths. The legacy-only binding handles that pair with these live in
         # _init_fields_legacy instead; the ovstage path drives the same offsets and counts
         # through its stage queries.
-        self._object_newton_indices: wp.array | None = None
+        self._object_physics_indices: wp.array | None = None
+        self._object_scene_data_backend: SceneDataBackend | None = None
         self._object_scales: wp.array | None = None
         self._object_scales_by_path: dict[str, tuple[float, float, float]] = {}
         self._deformable_particle_offsets: list[int] = []
@@ -507,7 +509,7 @@ class OVRTXRenderer(BaseRenderer):
 
         Counterpart to :meth:`_init_fields_ovstage`. Only fields the ovstage path never touches live
         here: the ``bind_attribute``/``bind_array_attribute`` handles and the caller-owned object
-        transform buffer. State shared by both paths (``_object_newton_indices``, the particle
+        transform buffer. State shared by both paths (``_object_physics_indices``, the particle
         offset/count lists) stays in :meth:`__init__`.
         """
         self._camera_xform_binding = None
@@ -718,7 +720,7 @@ class OVRTXRenderer(BaseRenderer):
         if self._object_xform_binding is None:
             raise RuntimeError("Failed to create OVRTX object bindings")
 
-        self._object_newton_indices = wp.array(newton_indices, dtype=wp.int32, device=self._device)
+        self._object_physics_indices = wp.array(newton_indices, dtype=wp.int32, device=self._device)
         self._object_scales = self._create_object_scale_array(object_paths)
         self._object_transform_buffer = wp.zeros(len(newton_indices), dtype=wp.mat44d, device=self._device)
 
@@ -956,13 +958,13 @@ class OVRTXRenderer(BaseRenderer):
         """Sync transforms to OVRTX."""
         if (
             self._object_xform_binding is None
-            or self._object_newton_indices is None
+            or self._object_physics_indices is None
             or self._object_scales is None
             or self._object_transform_buffer is None
         ):
             return
 
-        # If self._object_newton_indices is not None, then Newton's the current physics backend
+        # If self._object_physics_indices is not None, then Newton's the current physics backend
 
         from isaaclab_newton.physics import NewtonManager
 
@@ -975,9 +977,9 @@ class OVRTXRenderer(BaseRenderer):
             return
 
         wp.launch(
-            kernel=sync_newton_transforms_kernel,
-            dim=len(self._object_newton_indices),
-            inputs=[self._object_transform_buffer, self._object_newton_indices, body_q, self._object_scales],
+            kernel=sync_physics_transforms_kernel,
+            dim=len(self._object_physics_indices),
+            inputs=[self._object_transform_buffer, self._object_physics_indices, body_q, self._object_scales],
             device=self._device,
         )
         # Blocking ``write()`` so the buffer stays valid until OVRTX finishes reading it.
@@ -1975,33 +1977,29 @@ class OVRTXRenderer(BaseRenderer):
         logger.info("Written omni:scenePartition to %d cameras", num_envs)
 
     def _setup_xform_bindings_ovstage(self) -> None:
-        """Setup OVRTX bindings for scene objects to sync with Newton physics (ovstage path)."""
-        try:
-            from isaaclab_newton.physics import NewtonManager
-        except ImportError:
-            logger.debug("NewtonManager not available, skipping object bindings")
+        """Setup OVRTX bindings for rigid transforms published by the active physics backend."""
+        sim = SimulationContext.instance()
+        if sim is None:
+            logger.info("No active simulation context, will not set up OVRTX object bindings")
             return
 
-        if SimulationContext.instance() is None:
-            logger.info("No active simulation context, will not set up ovrtx object bindings for newton")
+        scene_data_provider = sim.get_scene_data_provider()
+        if scene_data_provider is None:
+            logger.debug("Scene data provider not available, skipping object bindings")
             return
 
-        newton_model = NewtonManager.get_model()
-        if newton_model is None:
-            logger.debug("Newton model not available, skipping object bindings")
-            return
-
-        all_body_paths = getattr(newton_model, "body_label", None)
-        if all_body_paths is None:
-            logger.info("Newton model has no body_label, skipping object bindings")
+        scene_data_backend = scene_data_provider.backend
+        all_body_paths = scene_data_backend.transform_paths
+        if not all_body_paths:
+            logger.info("Physics backend publishes no rigid-body paths, skipping object bindings")
             return
 
         object_paths = []
-        newton_indices = []
+        physics_indices = []
         for idx, path in enumerate(all_body_paths):
             if "/World/envs/" in path and self._camera_rel_path not in path and "GroundPlane" not in path:
                 object_paths.append(path)
-                newton_indices.append(idx)
+                physics_indices.append(idx)
 
         if len(object_paths) == 0:
             logger.info("No dynamic objects found for binding")
@@ -2010,6 +2008,11 @@ class OVRTXRenderer(BaseRenderer):
         self._object_paths_list = self._stage_paths.create_path_list_from_strings(object_paths)
         self._object_xform_query = self._stage.query_from_path_list(self._object_paths_list)
 
+        if self._object_xform_query is None:
+            raise RuntimeError("Failed to create OVRTX object bindings")
+
+        # Physics scene-data backends publish world poses. Reset the inherited environment and
+        # asset transforms so the authored matrix is interpreted in the same space.
         self._stage.write_attribute(
             self._object_xform_query,
             "omni:resetXformStack",
@@ -2018,10 +2021,8 @@ class OVRTXRenderer(BaseRenderer):
             is_array=False,
         ).wait()
 
-        if self._object_xform_query is None:
-            raise RuntimeError("Failed to create OVRTX object bindings")
-
-        self._object_newton_indices = wp.array(newton_indices, dtype=wp.int32, device=self._device)
+        self._object_physics_indices = wp.array(physics_indices, dtype=wp.int32, device=self._device)
+        self._object_scene_data_backend = scene_data_backend
         self._object_scales = self._create_object_scale_array(object_paths)
 
     def _setup_deformable_bindings_ovstage(self, num_envs: int) -> None:
@@ -2213,27 +2214,24 @@ class OVRTXRenderer(BaseRenderer):
             raise RuntimeError("Failed to create OVRTX particle point bindings")
 
     def _update_transforms_ovstage(self) -> None:
-        if self._object_xform_query is None or self._object_newton_indices is None or self._object_scales is None:
+        if (
+            self._object_xform_query is None
+            or self._object_physics_indices is None
+            or self._object_scales is None
+            or self._object_scene_data_backend is None
+        ):
             return
 
-        # If self._object_newton_indices is not None, then Newton's the current physics backend
-
-        from isaaclab_newton.physics import NewtonManager
-
-        newton_state = NewtonManager.get_state()
-        if newton_state is None:
-            raise RuntimeError("Newton state should not be None")
-
-        body_q = getattr(newton_state, "body_q", None)
+        body_q = self._object_scene_data_backend.transforms.transforms
         if body_q is None:
             return
 
-        num_objects = len(self._object_newton_indices)
+        num_objects = len(self._object_physics_indices)
         object_transforms = wp.empty(num_objects, dtype=wp.mat44d, device=self._device)
         wp.launch(
-            kernel=sync_newton_transforms_kernel,
+            kernel=sync_physics_transforms_kernel,
             dim=num_objects,
-            inputs=[object_transforms, self._object_newton_indices, body_q, self._object_scales],
+            inputs=[object_transforms, self._object_physics_indices, body_q, self._object_scales],
             device=self._device,
         )
         # The tensor is handed over zero-copy, so ovstage reads ``object_transforms`` in place and
@@ -2461,7 +2459,8 @@ class OVRTXRenderer(BaseRenderer):
         _safe_destroy_path_list(self._cable_paths_list, "cable paths")
         self._cable_paths_list = None
 
-        self._object_newton_indices = None
+        self._object_physics_indices = None
+        self._object_scene_data_backend = None
         self._object_scales = None
         self._object_scales_by_path = {}
         self._deformable_particle_offsets = []

--- a/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
+++ b/source/isaaclab_ov/isaaclab_ov/renderers/ovrtx_renderer_kernels.py
@@ -176,20 +176,20 @@ def generate_random_colors_from_ids_kernel(
 
 
 @wp.kernel
-def sync_newton_transforms_kernel(
+def sync_physics_transforms_kernel(
     ovrtx_transforms: wp.array(dtype=wp.mat44d),  # type: ignore
-    newton_body_indices: wp.array(dtype=wp.int32),  # type: ignore
-    newton_body_q: wp.array(dtype=wp.transformf),  # type: ignore
+    physics_body_indices: wp.array(dtype=wp.int32),  # type: ignore
+    physics_body_q: wp.array(dtype=wp.transformf),  # type: ignore
     object_scales: wp.array(dtype=wp.vec3f),  # type: ignore
 ):
-    """Sync Newton physics body transforms to OVRTX 4x4 column-major matrices.
+    """Sync physics body transforms to OVRTX 4x4 column-major matrices.
 
-    A Newton ``transformf`` holds only translation and rotation, so the authored USD scale is
-    reapplied here to keep it from being overwritten with unit scale.
+    Physics backends publish ``transformf`` values containing only translation and rotation, so
+    the authored USD scale is reapplied here to keep it from being overwritten with unit scale.
     """
     i = wp.tid()
-    body_idx = newton_body_indices[i]
-    transform = newton_body_q[body_idx]
+    body_idx = physics_body_indices[i]
+    transform = physics_body_q[body_idx]
     scale = object_scales[i]
     ovrtx_transforms[i] = wp.mat44d(
         wp.transpose(

--- a/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
+++ b/source/isaaclab_ov/test/physics/test_ovphysx_manager_lifecycle.py
@@ -72,41 +72,50 @@ def _fake_ovphysx_module(bootstrap):
 
 
 @pytest.mark.parametrize(
-    ("registered_names", "expected_paths"),
+    ("registered_names", "expected_paths", "schema_root"),
     [
-        (["physxSchema"], ["/schemas/OmniUsdPhysicsDeformableSchema/resources"]),
-        (["PhysxSchema", "OmniUsdPhysicsDeformableSchema"], []),
+        (["physxSchema"], ["/schemas/OmniUsdPhysicsDeformableSchema/resources"], "/schemas"),
+        (["PhysxSchema", "OmniUsdPhysicsDeformableSchema"], [], "/schemas"),
+        (["PhysxSchema", "OmniUsdPhysicsDeformableSchema"], [], None),
     ],
 )
 def test_schema_registration_skips_providers_already_supplied_by_host(
-    monkeypatch, manager_module, registered_names, expected_paths
+    monkeypatch, manager_module, registered_names, expected_paths, schema_root
 ):
     manager = manager_module.OvPhysxManager
     schema_paths = [
         Path("/schemas/PhysxSchema/resources"),
         Path("/schemas/OmniUsdPhysicsDeformableSchema/resources"),
     ]
-    registrations = []
+    host_registrations = []
+    ovstage_registrations = []
 
     fake_ovphysx = ModuleType("ovphysx")
     fake_ovphysx.codeless_schema_paths = lambda: schema_paths
+    if schema_root is not None:
+        fake_ovphysx.codeless_schema_root = lambda: Path(schema_root)
+
+    fake_ovstage = ModuleType("ovstage")
+    fake_ovstage.population = SimpleNamespace(register_usd_schemas=ovstage_registrations.append)
 
     class FakeRegistry:
         def GetAllPlugins(self):
             return [SimpleNamespace(name=name) for name in registered_names]
 
         def RegisterPlugins(self, paths):
-            registrations.append(list(paths))
+            host_registrations.append(list(paths))
 
     fake_pxr = ModuleType("pxr")
     fake_pxr.Plug = type("FakePlug", (), {"Registry": staticmethod(FakeRegistry)})
     monkeypatch.setitem(sys.modules, "ovphysx", fake_ovphysx)
+    monkeypatch.setitem(sys.modules, "ovstage", fake_ovstage)
     monkeypatch.setitem(sys.modules, "pxr", fake_pxr)
 
     manager._ensure_physx_schemas_registered()
     manager._ensure_physx_schemas_registered()
 
-    assert registrations == ([expected_paths] if expected_paths else [])
+    assert ovstage_registrations == ([schema_root] if schema_root is not None else [])
+    assert host_registrations == ([expected_paths] if expected_paths else [])
 
 
 def test_construct_physx_bootstraps_each_runtime_without_replacing_pxr(monkeypatch, manager_module):

--- a/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
+++ b/source/isaaclab_ov/test/test_ovrtx_deformable_bindings.py
@@ -597,7 +597,7 @@ def test_update_transforms_writes_caller_owned_buffer(monkeypatch: pytest.Monkey
     renderer, _ = _make_renderer_without_backend()
     buffer = object()
     renderer._object_xform_binding = _FakePointsBinding("omni:xform")
-    renderer._object_newton_indices = [0, 1]
+    renderer._object_physics_indices = [0, 1]
     renderer._object_scales = object()
     renderer._object_transform_buffer = buffer
 

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -10,6 +10,7 @@ import importlib.util
 import sys
 import types
 
+import numpy as np
 import pytest
 import torch
 import warp as wp
@@ -600,7 +601,7 @@ def _make_ovstage_renderer_with_backend(events: list[str]) -> OVRTXRenderer:
     renderer._particle_paths_list = "particle"
     renderer._cable_points_query = "cable"
     renderer._cable_paths_list = "cable"
-    renderer._object_newton_indices = object()
+    renderer._object_physics_indices = object()
     renderer._deformable_particle_offsets = [0]
     renderer._deformable_particle_counts = [1]
     renderer._particle_visual_offsets = [0]
@@ -612,6 +613,79 @@ def _make_ovstage_renderer_with_backend(events: list[str]) -> OVRTXRenderer:
     renderer._initialized_scene = True
     renderer._current_ordinal = 7
     return renderer
+
+
+def test_ovstage_object_transforms_use_active_scene_data_backend(monkeypatch: pytest.MonkeyPatch):
+    """OVStage publishes object poses from the active backend instead of requiring Newton state."""
+
+    class Completion:
+        def wait(self) -> None:
+            return
+
+    object_paths = ["/World/envs/env_0/Object", "/World/envs/env_1/Object"]
+    body_transforms = wp.array(
+        [
+            wp.transformf(wp.vec3f(1.0, 2.0, 3.0), wp.quat_identity()),
+            wp.transform_identity(),
+            wp.transform_identity(),
+            wp.transformf(wp.vec3f(4.0, 5.0, 6.0), wp.quat_identity()),
+        ],
+        dtype=wp.transformf,
+        device="cpu",
+    )
+    scene_data_backend = types.SimpleNamespace(
+        transform_paths=[
+            object_paths[0],
+            "/World/envs/env_0/Camera",
+            "/World/GroundPlane",
+            object_paths[1],
+        ],
+        transforms=types.SimpleNamespace(transforms=body_transforms),
+    )
+    sim = types.SimpleNamespace(get_scene_data_provider=lambda: types.SimpleNamespace(backend=scene_data_backend))
+    monkeypatch.setattr(ovrtx_renderer_module.SimulationContext, "instance", classmethod(lambda cls: sim))
+
+    writes: list[tuple[str, object]] = []
+
+    def write_attribute(query, attribute, **kwargs):
+        tensors = kwargs["tensors"]
+        if attribute == "omni:xform":
+            wp.synchronize()
+            tensors = np.array(ovrtx_renderer_module.ovstage.dltensor_to_numpy(tensors)).reshape(-1, 4, 4)
+        writes.append((attribute, tensors))
+        return Completion()
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._device = "cpu"
+    renderer._warp_device = types.SimpleNamespace(stream=types.SimpleNamespace(cuda_stream=None))
+    renderer._camera_rel_path = "Camera"
+    renderer._stage_paths = types.SimpleNamespace(create_path_list_from_strings=lambda paths: tuple(paths))
+    renderer._stage = types.SimpleNamespace(
+        query_from_path_list=lambda path_list: "object_query",
+        write_attribute=write_attribute,
+    )
+    renderer._current_ordinal = 7
+    renderer._object_xform_query = None
+    renderer._object_paths_list = None
+    renderer._object_physics_indices = None
+    renderer._object_scene_data_backend = None
+    renderer._object_scales_by_path = {object_paths[0]: (2.0, 3.0, 4.0)}
+
+    renderer._setup_xform_bindings_ovstage()
+    renderer._update_transforms_ovstage()
+
+    assert renderer._object_paths_list == tuple(object_paths)
+    assert renderer._object_scene_data_backend is scene_data_backend
+    assert np.array_equal(writes[0][1], np.ones(2, dtype=np.bool_))
+    assert writes[0][0] == "omni:resetXformStack"
+    assert writes[1][0] == "omni:xform"
+    expected = np.array(
+        [
+            [[2.0, 0.0, 0.0, 0.0], [0.0, 3.0, 0.0, 0.0], [0.0, 0.0, 4.0, 0.0], [1.0, 2.0, 3.0, 1.0]],
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [4.0, 5.0, 6.0, 1.0]],
+        ]
+    )
+    np.testing.assert_allclose(writes[1][1], expected)
 
 
 def test_ovrtx_close_releases_legacy_renderer_state():
@@ -673,7 +747,7 @@ def test_ovrtx_close_releases_ovstage_renderer_state():
     assert renderer._particle_paths_list is None
     assert renderer._cable_points_query is None
     assert renderer._cable_paths_list is None
-    assert renderer._object_newton_indices is None
+    assert renderer._object_physics_indices is None
     assert renderer._renderer is None
     assert renderer._ovstage_exit_stack is None
     assert renderer._stage is None

--- a/source/isaaclab_ov/test/test_runtime_imports.py
+++ b/source/isaaclab_ov/test/test_runtime_imports.py
@@ -6,8 +6,12 @@
 """Tests for optional OvPhysX runtime imports."""
 
 import importlib
+import importlib.metadata
+from pathlib import Path
+from types import ModuleType
 
 import pytest
+from isaaclab_ov import _runtime
 from isaaclab_ov._runtime import _OVPHYSX_INSTALL_MESSAGE, import_ovphysx
 
 
@@ -42,3 +46,32 @@ def test_import_ovphysx_preserves_nested_missing_dependency(monkeypatch):
 
     assert exc_info.value.name == "carb"
     assert "carb" in str(exc_info.value)
+
+
+def test_required_omniverseclient_version_reads_ovphysx_marker(tmp_path: Path):
+    """OvPhysX's full OVStage build marker resolves to the public OmniClient package version."""
+    marker_path = tmp_path / "plugins" / "ovstage-omniclient.version"
+    marker_path.parent.mkdir()
+    marker_path.write_text("2.74.0-release.7316+gl.ec99a64b\n", encoding="utf-8")
+
+    assert _runtime._required_omniverseclient_version(tmp_path) == "2.74.0"
+
+
+def test_required_omniverseclient_version_rejects_invalid_marker(tmp_path: Path):
+    """Malformed compatibility metadata fails before OvPhysX initializes native plugins."""
+    marker_path = tmp_path / "plugins" / "ovstage-omniclient.version"
+    marker_path.parent.mkdir()
+    marker_path.write_text("release-unknown\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Invalid OvPhysX OmniClient compatibility marker"):
+        _runtime._required_omniverseclient_version(tmp_path)
+
+
+def test_import_ovphysx_rejects_mismatched_omniverseclient(monkeypatch: pytest.MonkeyPatch):
+    """A mismatched OmniClient release reports the exact version OvPhysX requires."""
+    monkeypatch.setattr(importlib, "import_module", lambda module_name: ModuleType(module_name))
+    monkeypatch.setattr(_runtime, "_installed_ovphysx_omniverseclient_version", lambda: "2.74.0")
+    monkeypatch.setattr(importlib.metadata, "version", lambda distribution_name: "2.72.3")
+
+    with pytest.raises(RuntimeError, match=r"requires omniverseclient==2\.74\.0, but 2\.72\.3 is installed"):
+        import_ovphysx()

--- a/tools/resolve_ovphysx_omniclient.py
+++ b/tools/resolve_ovphysx_omniclient.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Print the OmniClient requirement embedded in the installed OvPhysX wheel."""
+
+from isaaclab_ov._runtime import _installed_ovphysx_omniverseclient_version
+
+
+def main() -> None:
+    """Print the exact pip requirement for OvPhysX's matched OmniClient release."""
+    version = _installed_ovphysx_omniverseclient_version()
+    if version is None:
+        raise RuntimeError("The installed OvPhysX wheel does not provide an OmniClient compatibility marker.")
+    print(f"omniverseclient=={version}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Fix the Isaac Lab integration boundaries exposed by testing the latest internal OV stack:

- Resolve the exact `omniverseclient` release embedded in the installed OvPhysX wheel and install it before importing OvPhysX in wheelhouse CI jobs.
- Reject manually assembled OvPhysX environments early with an actionable version-mismatch error instead of allowing native plugin initialization to fail later.
- Source OVRTX OVStage rigid transforms from the active `SceneDataBackend`, enabling OvPhysX as well as Newton while preserving authored scale and world-pose semantics.
- Register the OvPhysX codeless schema root with OVStage's separate population registry, preserving PhysX contact-report and articulation-tendon schemas when OvPhysX 0.6.1+ populates a stage.

The original internal run used `omniverseclient==2.72.3` with an OvPhysX wheel whose `ovstage-omniclient.version` requires `2.74.0-release.7316+gl.ec99a64b`. That mismatch caused 544 of 569 `isaaclab_ov` failures to share the same `ovphysx_create_instance()` startup error. Installing the marker-selected release removes that cascade.

The subsequent rendering run exposed 22 additional physics failures. The USD stage contained the required PhysX schemas, but OVStage population dropped them because its schema registry is independent of the host USD `Plug.Registry`. Registering `ovphysx.codeless_schema_root()` with `ovstage.population.register_usd_schemas()` fixes all 11 contact-reporter and all 11 fixed-tendon rendering cases.

Original run: https://github.com/NVIDIA-Omniverse/IsaacLab-Internal/actions/runs/33908292244

Baseline run: https://github.com/NVIDIA-Omniverse/IsaacLab-Internal/actions/runs/33908863254

The current public package pins remain unchanged; the dynamic OmniClient resolution is limited to internal wheelhouse overlays. Schema registration is feature-gated for compatibility with the currently pinned public OvPhysX/OVStage stack.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

Tested with:

- OVRTX `0.5.0.377615`
- OvPhysX `0.6.2`
- OVStage `0.2.0.377349`
- OmniClient `2.74.0`
- Newton `1.6.0rc1`
- NVIDIA RTX PRO 6000 Blackwell, driver `595.58.03`

Passing focused checks:

- `19 passed`: OvPhysX manager lifecycle and schema-registration tests.
- Contact module, split by device: CUDA `14 passed, 4 skipped`; CPU `15 passed, 4 skipped`.
- GPU tendon-focused articulation tests: `3 passed, 2 skipped`.
- Homogeneous-Kuka contact filtering and fixed-tendon target-write regressions: passed.
- `60 passed`: runtime-import, OVRTX renderer-contract, and deformable-binding focused tests from the first integration pass.
- `uv run isaaclab -f`.

Full rendering correctness after the schema fix:

| Path | Before | After | Physics failures after |
| --- | --- | --- | --- |
| OVRTX 0.5 legacy | 15 failed, 39 passed, 36 skipped | 4 failed, 50 passed, 36 skipped | 0 |
| OVRTX 0.5 + OVStage 0.2 | 41 failed, 3 passed, 32 skipped | 39 failed, 5 passed, 32 skipped | 0 |

All 22 physics-caused rendering failures are fixed. The remaining failures are image comparisons: four on the legacy path and 39 on the OVStage path. Nine image mismatches were previously masked by the physics initialization failures.

A separate CPU-only Shadow Hand tendon run now reaches an OvPhysX 0.6.2 native segmentation fault in `PhysX.step_sync`. The GPU path used by rendering passes; this appears to be an upstream OvPhysX CPU issue and is not hidden by this change.

## Screenshots

The investigation generated full golden/actual/diff galleries and JUnit XML as a local test artifact. They are intentionally not committed because they are diagnostic output rather than source assets.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
