### PR TITLE
Default surface-gripper tasks to CPU simulation

### DIFF
--- a/source/isaaclab_rl/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
+++ b/source/isaaclab_rl/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Fixed the zero and random agents overriding task-defined simulation devices when ``--device`` was omitted.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -67,7 +67,12 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
     # override with CLI arguments and reject unsupported configurations before
     # launching Kit or initializing a native physics backend.
     env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
-    env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+    if getattr(args_cli, "device_explicit", False):
+        env_cfg.sim.device = args_cli.device
+    else:
+        # Keep task-specific requirements (for example CPU-only surface grippers) and pass the
+        # resolved default through to AppLauncher.
+        args_cli.device = env_cfg.sim.device
     if args_cli.disable_fabric:
         env_cfg.sim.use_fabric = False
     try:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -67,12 +67,10 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
     # override with CLI arguments and reject unsupported configurations before
     # launching Kit or initializing a native physics backend.
     env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
-    if getattr(args_cli, "device_explicit", False):
+    if args_cli.device is not None:
         env_cfg.sim.device = args_cli.device
-    else:
-        # Keep task-specific requirements (for example CPU-only surface grippers) and pass the
-        # resolved default through to AppLauncher.
-        args_cli.device = env_cfg.sim.device
+    # Pass the resolved task device through to AppLauncher.
+    args_cli.device = env_cfg.sim.device
     if args_cli.disable_fabric:
         env_cfg.sim.use_fabric = False
     try:
@@ -254,8 +252,8 @@ def _parse_args(argv: list[str] | None, policy: PolicyName) -> argparse.Namespac
     )
     # append AppLauncher cli args
     add_launcher_args(parser)
-    # Keep checkpoint-free agents on the kitless default path.
-    parser.set_defaults(visualizer=["newton_gl"])
+    # Let task configs select the simulation device and keep checkpoint-free agents on the kitless default path.
+    parser.set_defaults(device=None, visualizer=["newton_gl"])
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     sys.argv = [sys.argv[0]] + hydra_args
     return args_cli

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -237,6 +237,73 @@ def test_simple_agents_default_to_newton_visualizer(
     assert args.visualizer == ["newton_gl"]
 
 
+def test_simple_agents_preserve_task_device_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checkpoint-free agents should not replace a task-required device with the CLI default."""
+
+    class _ExpectedStop(Exception):
+        pass
+
+    class _Cfg:
+        scene = SimpleNamespace(num_envs=1)
+        sim = SimpleNamespace(device="cpu", use_fabric=True)
+
+        def validate(self) -> None:
+            pass
+
+    args = SimpleNamespace(
+        num_envs=None,
+        device="cuda:0",
+        disable_fabric=False,
+        task="Cpu-Task",
+    )
+
+    def launch_simulation(cfg, launcher_args):
+        assert cfg.sim.device == "cpu"
+        assert launcher_args.device == "cpu"
+        raise _ExpectedStop
+
+    monkeypatch.setattr(_simple_agents, "_parse_args", lambda argv, policy: args)
+    monkeypatch.setattr(_simple_agents, "resolve_task_config", lambda task, agent: (_Cfg(), None))
+    monkeypatch.setattr(_simple_agents, "launch_simulation", launch_simulation)
+
+    with pytest.raises(_ExpectedStop):
+        _simple_agents.run([], policy="zero")
+
+
+def test_simple_agents_apply_explicit_device_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checkpoint-free agents should continue to honor an explicit CLI device."""
+
+    class _ExpectedStop(Exception):
+        pass
+
+    class _Cfg:
+        scene = SimpleNamespace(num_envs=1)
+        sim = SimpleNamespace(device="cpu", use_fabric=True)
+
+        def validate(self) -> None:
+            pass
+
+    args = SimpleNamespace(
+        num_envs=None,
+        device="cuda:1",
+        device_explicit=True,
+        disable_fabric=False,
+        task="Cpu-Task",
+    )
+
+    def launch_simulation(cfg, launcher_args):
+        assert cfg.sim.device == "cuda:1"
+        assert launcher_args.device == "cuda:1"
+        raise _ExpectedStop
+
+    monkeypatch.setattr(_simple_agents, "_parse_args", lambda argv, policy: args)
+    monkeypatch.setattr(_simple_agents, "resolve_task_config", lambda task, agent: (_Cfg(), None))
+    monkeypatch.setattr(_simple_agents, "launch_simulation", launch_simulation)
+
+    with pytest.raises(_ExpectedStop):
+        _simple_agents.run([], policy="random")
+
+
 def test_zero_agent_rejects_invalid_config_before_launch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Unsupported task presets fail cleanly before a simulator backend is initialized."""
 

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -234,7 +234,21 @@ def test_simple_agents_default_to_newton_visualizer(
 
     args = _simple_agents._parse_args([], policy)
 
+    assert args.device is None
     assert args.visualizer == ["newton_gl"]
+
+
+@pytest.mark.parametrize("policy", ["zero", "random"])
+def test_simple_agents_accept_explicit_device(
+    policy: _simple_agents.PolicyName,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Checkpoint-free agents should retain an explicit CLI device."""
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+
+    args = _simple_agents._parse_args(["--device", "cuda:1"], policy)
+
+    assert args.device == "cuda:1"
 
 
 def test_simple_agents_preserve_task_device_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -252,7 +266,7 @@ def test_simple_agents_preserve_task_device_default(monkeypatch: pytest.MonkeyPa
 
     args = SimpleNamespace(
         num_envs=None,
-        device="cuda:0",
+        device=None,
         disable_fabric=False,
         task="Cpu-Task",
     )
@@ -286,7 +300,6 @@ def test_simple_agents_apply_explicit_device_override(monkeypatch: pytest.Monkey
     args = SimpleNamespace(
         num_envs=None,
         device="cuda:1",
-        device_explicit=True,
         disable_fabric=False,
         task="Cpu-Task",
     )

--- a/source/isaaclab_tasks/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
+++ b/source/isaaclab_tasks/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed surface-gripper stack tasks to select CPU simulation by default and reject unsupported GPU overrides before
+  simulator initialization.

--- a/source/isaaclab_tasks/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
+++ b/source/isaaclab_tasks/changelog.d/kellyg-fix-galbot-surface-gripper-device.rst
@@ -2,4 +2,5 @@ Fixed
 ^^^^^
 
 * Fixed surface-gripper stack tasks to select CPU simulation by default and reject unsupported GPU overrides before
-  simulator initialization.
+  simulator initialization. Task-defined simulation devices are now preserved by :func:`parse_env_cfg` when no
+  explicit device override is provided.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/galbot/stack_joint_pos_env_cfg.py
@@ -26,6 +26,7 @@ from isaaclab_tasks.contrib.stack.mdp import franka_stack_events
 from isaaclab_tasks.contrib.stack.stack_env_cfg import (
     ObservationsCfg,
     StackEnvCfg,
+    raise_if_surface_gripper_on_gpu,
     raise_if_surface_gripper_on_newton,
 )
 
@@ -348,10 +349,14 @@ class GalbotRightArmCubeStackEnvCfg(GalbotLeftArmCubeStackEnvCfg):
     def validate_config(self):
         # The right-arm suction cup uses a PhysX-only surface gripper.
         raise_if_surface_gripper_on_newton(self)
+        raise_if_surface_gripper_on_gpu(self)
 
     def __post_init__(self):
         # post init of parent
         super().__post_init__()
+
+        # Surface grippers currently require CPU simulation.
+        self.sim.device = "cpu"
 
         # Move to area below right hand (invert y-axis)
         left, right = self.events.randomize_cube_positions.params["pose_range"]["y"]

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/ur10_gripper/stack_joint_pos_env_cfg.py
@@ -20,6 +20,7 @@ from isaaclab_tasks.contrib.stack import mdp
 from isaaclab_tasks.contrib.stack.mdp import franka_stack_events
 from isaaclab_tasks.contrib.stack.stack_env_cfg import (
     StackEnvCfg,
+    raise_if_surface_gripper_on_gpu,
     raise_if_surface_gripper_on_newton,
 )
 
@@ -88,6 +89,7 @@ class UR10CubeStackEnvCfg(StackEnvCfg):
     def validate_config(self):
         # Surface grippers used by these suction robots are PhysX-only.
         raise_if_surface_gripper_on_newton(self)
+        raise_if_surface_gripper_on_gpu(self)
 
     def __post_init__(self):
         # post init of parent
@@ -152,7 +154,7 @@ class UR10LongSuctionCubeStackEnvCfg(UR10CubeStackEnvCfg):
         super().__post_init__()
 
         # Suction grippers currently require CPU simulation
-        self.device = "cpu"
+        self.sim.device = "cpu"
 
         # Set events
         self.events = EventCfgLongSuction()
@@ -192,7 +194,7 @@ class UR10ShortSuctionCubeStackEnvCfg(UR10CubeStackEnvCfg):
         super().__post_init__()
 
         # Suction grippers currently require CPU simulation
-        self.device = "cpu"
+        self.sim.device = "cpu"
 
         # Set UR10 as robot
         self.scene.robot = UR10_SHORT_SUCTION_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -342,6 +342,20 @@ def raise_if_surface_gripper_on_newton(env_cfg) -> None:
         )
 
 
+def raise_if_surface_gripper_on_gpu(env_cfg) -> None:
+    """Reject GPU simulation for scenes that configure a surface gripper.
+
+    Args:
+        env_cfg: The resolved environment config to inspect.
+    """
+    if getattr(env_cfg.scene, "surface_gripper", None) is None:
+        return
+    if env_cfg.sim.device != "cpu":
+        raise ValueError(
+            "Surface grippers are only supported on the CPU simulation device. Re-run this task with --device cpu."
+        )
+
+
 @configclass
 class StackEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the stacking environment."""

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -146,7 +146,7 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
 
 def parse_env_cfg(
     task_name: str,
-    device: str = "cuda:0",
+    device: str | None = None,
     num_envs: int | None = None,
     use_fabric: bool | None = None,
     overrides: Sequence[str] = (),
@@ -155,7 +155,7 @@ def parse_env_cfg(
 
     Args:
         task_name: The name of the environment.
-        device: The device to run the simulation on. Defaults to "cuda:0".
+        device: The device to run the simulation on. Defaults to None, in which case it is left unchanged.
         num_envs: Number of environments to create. Defaults to None, in which case it is left unchanged.
         use_fabric: Whether to enable/disable fabric interface. If false, all read/write operations go through USD.
             This slows down the simulation but allows seeing the changes in the USD through the USD stage.
@@ -190,7 +190,8 @@ def parse_env_cfg(
         raise RuntimeError(f"Configuration for the task: '{task_name}' is not a class. Please provide a class.")
 
     # simulation device
-    cfg.sim.device = device
+    if device is not None:
+        cfg.sim.device = device
     # disable fabric to read/write through USD
     if use_fabric is not None:
         cfg.sim.use_fabric = use_fabric

--- a/source/isaaclab_tasks/test/contrib/stack/test_surface_gripper_task_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/stack/test_surface_gripper_task_cfg.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+_SURFACE_GRIPPER_TASKS = [
+    "IsaacContrib-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow",
+    "IsaacContrib-Stack-Cube-UR10-Long-Suction-IK-Rel",
+    "IsaacContrib-Stack-Cube-UR10-Short-Suction-IK-Rel",
+]
+
+
+@pytest.mark.parametrize("task_name", _SURFACE_GRIPPER_TASKS)
+def test_surface_gripper_tasks_default_to_cpu(task_name: str) -> None:
+    """Surface-gripper tasks should select their only supported simulation device."""
+    env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
+
+    assert env_cfg.sim.device == "cpu"
+    env_cfg.validate()
+
+
+@pytest.mark.parametrize("task_name", _SURFACE_GRIPPER_TASKS)
+def test_surface_gripper_tasks_reject_gpu_override(task_name: str) -> None:
+    """An explicit unsupported GPU device should fail during config validation."""
+    env_cfg = load_cfg_from_registry(task_name, "env_cfg_entry_point")
+    env_cfg.sim.device = "cuda:0"
+
+    with pytest.raises(ValueError, match="only supported on the CPU simulation device"):
+        env_cfg.validate()

--- a/source/isaaclab_tasks/test/core/test_parse_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_parse_cfg.py
@@ -21,3 +21,18 @@ def test_parse_env_cfg_accepts_list_overrides():
     """A properly wrapped override list should apply without error."""
     env_cfg = parse_env_cfg("Isaac-Cartpole", overrides=["physics=isaacsim_physx"])
     assert env_cfg is not None
+
+
+def test_parse_env_cfg_preserves_task_device_when_omitted():
+    """An omitted device should preserve a task-specific simulation requirement."""
+    env_cfg = parse_env_cfg("IsaacContrib-Stack-Cube-Galbot-Right-Arm-Suction-RmpFlow")
+
+    assert env_cfg.sim.device == "cpu"
+    env_cfg.validate()
+
+
+def test_parse_env_cfg_applies_explicit_device_override():
+    """An explicit device should continue to override the registered task default."""
+    env_cfg = parse_env_cfg("Isaac-Cartpole", device="cpu")
+
+    assert env_cfg.sim.device == "cpu"


### PR DESCRIPTION
# Description

Fixes NVBug 6684415.

The three contrib stack tasks that configure a PhysX `SurfaceGripper` now select CPU simulation by default, and config validation rejects an explicit unsupported GPU override before simulator initialization. The zero and random agent entrypoints now preserve a task-defined simulation device unless the user explicitly passes `--device`, allowing `AppLauncher` to start these tasks on CPU automatically.

The public `parse_env_cfg` helper also preserves the registered task device when its `device` argument is omitted, while continuing to apply explicit device overrides. This also corrects the two UR10 suction configs, which previously assigned `self.device` instead of `self.sim.device`.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Testing

- `uv run --isolated --frozen --extra test --extra teleop python -m pytest source/isaaclab_rl/test/test_entrypoints.py source/isaaclab_tasks/test/core/test_parse_cfg.py source/isaaclab_tasks/test/contrib/stack/test_surface_gripper_task_cfg.py -q` (`44 passed, 2 skipped`)
- `uv run --frozen isaaclab -f`
- `uv run --frozen python tools/changelog/cli.py check develop`
- Verified the task-config regression test fails against the reported 3.0 commit because all three affected tasks resolved to `cuda:0`.
- Verified the `parse_env_cfg` regression against the first PR revision: the omitted device resolved back to `cuda:0` and failed CPU-only validation.

The full Isaac Sim smoke test was attempted in a fresh environment but stopped at the interactive Omniverse EULA prompt before Kit startup.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have confirmed that no documentation or environment-browser selector change is required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
