### PR TITLE
[CI] Use latest Isaac Sim 6.1 release image

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -9,7 +9,7 @@
 # (frozen at 6.1.0-alpha.2). Both images use Isaac Sim's NGC org, which is current and
 # which the CI credential can reach.
 isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
-# Isaac Sim 6.1.0-alpha.50 (b86cf6ce) includes Kit 110.3.0-360924's fix for NVBug 6566677.
-isaacsim_image_tag: latest-develop@sha256:b6222dffc0182e82f49d656d08dabdfb6a279e368a478cbd38080bbe959bb2ba
+# Test the release/3.0.0 branch against the latest Isaac Sim 6.1 release image.
+isaacsim_image_tag: latest-release-6-1
 isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""


### PR DESCRIPTION
# Description

Update the shared CI configuration on `release/3.0.0` to use the `latest-release-6-1` Isaac Sim image instead of the pinned `latest-develop` image. This keeps release-branch testing on the Isaac Sim 6.1 release line.

No dependencies are added.

## Type of change

- CI configuration

## Release backport

- [ ] Backport this pull request to the active release branch after it merges into `develop` (not applicable; this PR targets `release/3.0.0` directly)

## Screenshots

Not applicable.

## Validation

- `uv run python` YAML/config assertion: passed
- `git diff --check`: passed
- `uv run isaaclab -f`: all formatting, lint, YAML, and repository hygiene hooks passed except the changelog-fragment hook. That hook reports pre-existing divergence between `release/3.0.0` and the repository's default beta branch; this PR changes no source package or changelog fragment.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] Relevant formatting, lint, and YAML checks pass
- [x] My changes generate no new warnings
- [x] Documentation changes are not required for this CI-only update
- [x] New tests are not required for this configuration-only update
- [x] Changelog fragments are not required because no source package is changed
- [x] My name already exists in `CONTRIBUTORS.md`
