### PR TITLE
[Backport release/3.0.0] Fix pretrained checkpoint lookup for domain presets (#7594)

### DIFF
--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -16,36 +16,36 @@
             ["Isaac-Ant", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/ant.jpg", true],
             ["Isaac-Cartpole-Direct", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
             ["Isaac-Cartpole", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cartpole.jpg", true],
-            ["Isaac-Cartpole-Camera-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "tasks/classic/cartpole.jpg"],
-            ["Isaac-Cartpole-Camera", "rl_games,rsl_rl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,resnet18,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl,theia_tiny", {"rl_games_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rl_games_feature_cfg_entry_point": ["resnet18", "theia_tiny"], "rsl_rl_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rsl_rl_feature_cfg_entry_point": ["resnet18", "theia_tiny"]}, "tasks/classic/cartpole.jpg"],
+            ["Isaac-Cartpole-Camera-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "tasks/classic/cartpole.jpg", false, {"*": ["rgb"], "rl_games": ["depth"]}],
+            ["Isaac-Cartpole-Camera", "rl_games,rsl_rl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,resnet18,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl,theia_tiny", {"rl_games_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rl_games_feature_cfg_entry_point": ["resnet18", "theia_tiny"], "rsl_rl_cfg_entry_point": ["albedo", "depth", "rgb", "semantic_segmentation", "simple_shading_constant_diffuse", "simple_shading_diffuse_mdl", "simple_shading_full_mdl"], "rsl_rl_feature_cfg_entry_point": ["resnet18", "theia_tiny"]}, "tasks/classic/cartpole.jpg", false, {"*": ["rgb"]}],
             ["Isaac-Fourbar-Pole-Swingup", "rsl_rl", "newton_kamino", "", "", {}, "tasks/classic/fourbar_pole.jpg"],
             ["Isaac-Humanoid-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/humanoid.jpg", true],
             ["Isaac-Humanoid", "rl_games,rsl_rl,skrl,sb3", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/humanoid.jpg", true],
-            ["Isaac-Lift-Cable-Franka", "rsl_rl", "newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "tasks/manipulation/franka_lift_cable.jpg"],
-            ["Isaac-Lift-Cable-Franka-Camera", "rsl_rl", "newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "tasks/manipulation/franka_lift_cable.jpg"],
-            ["Isaac-Lift-Cloth-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "tasks/manipulation/franka_lift_cloth.jpg"],
-            ["Isaac-Lift-Cloth-Franka-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "tasks/manipulation/franka_lift_cloth.jpg"],
-            ["Isaac-Lift-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes"],
-            ["Isaac-Lift-KukaAllegro", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "tasks/manipulation/kuka_allegro_lift.jpg"],
-            ["Isaac-Lift-KukaAllegro-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo128,albedo256,albedo64,cube,depth128,depth256,depth64,duo_camera,raycaster_depth128,raycaster_depth256,raycaster_depth64,rgb128,rgb256,rgb64,semantic_segmentation128,semantic_segmentation256,semantic_segmentation64,shapes,simple_shading_constant_diffuse128,simple_shading_constant_diffuse256,simple_shading_constant_diffuse64,simple_shading_diffuse_mdl128,simple_shading_diffuse_mdl256,simple_shading_diffuse_mdl64,simple_shading_full_mdl128,simple_shading_full_mdl256,simple_shading_full_mdl64,single_camera", {}, "tasks/manipulation/kuka_allegro_lift.jpg"],
-            ["Isaac-Lift-Soft-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "newton/franka-mjwarp-vbd-coupling.png"],
-            ["Isaac-Lift-Soft-Franka-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "newton/franka-mjwarp-vbd-coupling.png"],
+            ["Isaac-Lift-Cable-Franka", "rsl_rl", "newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "tasks/manipulation/franka_lift_cable.jpg", false, {"*": ["joint"]}],
+            ["Isaac-Lift-Cable-Franka-Camera", "rsl_rl", "newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "tasks/manipulation/franka_lift_cable.jpg", false, {"*": ["joint"]}],
+            ["Isaac-Lift-Cloth-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "tasks/manipulation/franka_lift_cloth.jpg", false, {"*": ["joint"]}],
+            ["Isaac-Lift-Cloth-Franka-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "tasks/manipulation/franka_lift_cloth.jpg", false, {"*": ["joint"]}],
+            ["Isaac-Lift-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "", false, {"*": ["shapes"]}],
+            ["Isaac-Lift-KukaAllegro", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "tasks/manipulation/kuka_allegro_lift.jpg", false, {"*": ["shapes"]}],
+            ["Isaac-Lift-KukaAllegro-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo128,albedo256,albedo64,cube,depth128,depth256,depth64,duo_camera,raycaster_depth128,raycaster_depth256,raycaster_depth64,rgb128,rgb256,rgb64,semantic_segmentation128,semantic_segmentation256,semantic_segmentation64,shapes,simple_shading_constant_diffuse128,simple_shading_constant_diffuse256,simple_shading_constant_diffuse64,simple_shading_diffuse_mdl128,simple_shading_diffuse_mdl256,simple_shading_diffuse_mdl64,simple_shading_full_mdl128,simple_shading_full_mdl256,simple_shading_full_mdl64,single_camera", {}, "tasks/manipulation/kuka_allegro_lift.jpg", false, {"*": ["rgb64", "shapes", "single_camera"]}],
+            ["Isaac-Lift-Soft-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "", "ik,joint", {}, "newton/franka-mjwarp-vbd-coupling.png", false, {"*": ["joint"]}],
+            ["Isaac-Lift-Soft-Franka-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp_vbd_proxy", "isaacsim_rtx,newton_renderer,ovrtx", "ik,joint", {}, "newton/franka-mjwarp-vbd-coupling.png", false, {"*": ["joint"]}],
             ["Isaac-Open-Drawer-Franka-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/franka_open_drawer.jpg"],
             ["Isaac-Open-Drawer-Franka", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/franka_open_drawer.jpg"],
-            ["Isaac-Pendulum-MARL-Direct", "rl_games,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cart_double_pendulum.jpg", false, {"skrl": "MAPPO"}],
-            ["Isaac-Reach-Franka", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "diffik,diffik_abs,joint_pos,newton_ik", {}, "tasks/manipulation/franka_reach.jpg", true],
+            ["Isaac-Pendulum-MARL-Direct", "rl_games,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/classic/cart_double_pendulum.jpg", false, {}, {"skrl": "MAPPO"}],
+            ["Isaac-Reach-Franka", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "diffik,diffik_abs,joint_pos,newton_ik", {}, "tasks/manipulation/franka_reach.jpg", true, {"*": ["joint_pos"]}],
             ["Isaac-Reach-Franka-OSC", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "diffik_abs", {}, "tasks/manipulation/franka_reach.jpg"],
             ["Isaac-Reach-UR10", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/ur10_reach.jpg", true],
             ["Isaac-Reorient-Cube-Allegro-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/allegro_cube.jpg", true],
-            ["Isaac-Reorient-Cube-Allegro", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "randomized,reset_only", {}, "tasks/manipulation/allegro_cube.jpg"],
+            ["Isaac-Reorient-Cube-Allegro", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "randomized,reset_only", {}, "tasks/manipulation/allegro_cube.jpg", false, {"*": ["reset_only"]}],
             ["Isaac-Reorient-Cube-Shadow-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/shadow_cube.jpg"],
             ["Isaac-Reorient-Cube-Shadow", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "asymmetric,randomized"],
-            ["Isaac-Reorient-Cube-Shadow-Camera-Direct", "rl_games,rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,full,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "tasks/manipulation/shadow_cube.jpg"],
-            ["Isaac-Reorient-Cube-Shadow-Camera", "rl_games,rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,full,randomized,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl"],
-            ["Isaac-Reorient-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes"],
-            ["Isaac-Reorient-KukaAllegro", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "tasks/manipulation/kuka_allegro_reorient.jpg"],
-            ["Isaac-Reorient-KukaAllegro-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo128,albedo256,albedo64,cube,depth128,depth256,depth64,duo_camera,raycaster_depth128,raycaster_depth256,raycaster_depth64,rgb128,rgb256,rgb64,semantic_segmentation128,semantic_segmentation256,semantic_segmentation64,shapes,simple_shading_constant_diffuse128,simple_shading_constant_diffuse256,simple_shading_constant_diffuse64,simple_shading_diffuse_mdl128,simple_shading_diffuse_mdl256,simple_shading_diffuse_mdl64,simple_shading_full_mdl128,simple_shading_full_mdl256,simple_shading_full_mdl64,single_camera", {}, "tasks/manipulation/kuka_allegro_reorient.jpg"],
-            ["Isaac-Shadow-Handover-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/shadow_hand_over.jpg", false, {"skrl": "MAPPO"}],
+            ["Isaac-Reorient-Cube-Shadow-Camera-Direct", "rl_games,rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,full,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "tasks/manipulation/shadow_cube.jpg", false, {"*": ["full"]}],
+            ["Isaac-Reorient-Cube-Shadow-Camera", "rl_games,rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo,depth,full,randomized,rgb,semantic_segmentation,simple_shading_constant_diffuse,simple_shading_diffuse_mdl,simple_shading_full_mdl", {}, "", false, {"*": ["full"]}],
+            ["Isaac-Reorient-Franka", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "", false, {"*": ["shapes"]}],
+            ["Isaac-Reorient-KukaAllegro", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "cube,shapes", {}, "tasks/manipulation/kuka_allegro_reorient.jpg", false, {"*": ["shapes"]}],
+            ["Isaac-Reorient-KukaAllegro-Camera", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "isaacsim_rtx,newton_renderer,ovrtx", "albedo128,albedo256,albedo64,cube,depth128,depth256,depth64,duo_camera,raycaster_depth128,raycaster_depth256,raycaster_depth64,rgb128,rgb256,rgb64,semantic_segmentation128,semantic_segmentation256,semantic_segmentation64,shapes,simple_shading_constant_diffuse128,simple_shading_constant_diffuse256,simple_shading_constant_diffuse64,simple_shading_diffuse_mdl128,simple_shading_diffuse_mdl256,simple_shading_diffuse_mdl64,simple_shading_full_mdl128,simple_shading_full_mdl256,simple_shading_full_mdl64,single_camera", {}, "tasks/manipulation/kuka_allegro_reorient.jpg", false, {"*": ["rgb64", "shapes", "single_camera"]}],
+            ["Isaac-Shadow-Handover-Direct", "rl_games,rsl_rl,skrl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "", {}, "tasks/manipulation/shadow_hand_over.jpg", false, {}, {"skrl": "MAPPO"}],
             ["Isaac-Shadow-Handover", "rsl_rl", "isaacsim_physx,newton_mjwarp,ovphysx", "", "randomized"],
             ["Isaac-Velocity-Flat-AnymalD", "rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "tasks/locomotion/anymal_d_flat.jpg", true],
             ["Isaac-Velocity-Flat-Cassie", "rsl_rl,skrl", "isaacsim_physx,newton_kamino,newton_mjwarp,ovphysx", "", "", {}, "", true],
@@ -154,6 +154,7 @@
     const splitValues = (value) => value ? value.split(",") : [];
     const tasks = taskRows.map(([
         task, rl, physics, renderer, presets, agentPresetCompatibility = {}, previewImage = "", supportsWarpFrontend = false,
+        pretrainedCheckpointPresetCompatibility = {},
         defaultAlgorithms = {},
     ]) => ({
         task,
@@ -165,6 +166,7 @@
         agentPresetCompatibility,
         previewImage,
         supportsWarpFrontend,
+        pretrainedCheckpointPresetCompatibility,
         defaultAlgorithms,
     }));
 
@@ -292,7 +294,14 @@
             modeButton.setAttribute("aria-pressed", String(isActive));
         }
         nonRlNote.hidden = supportsRl;
-        const supportsPretrainedCheckpoint = supportsRl && state.scope === "core";
+        const task = selectedTask();
+        const selectedPreset = fields.presets.value;
+        const compatiblePresets = [
+            ...(task.pretrainedCheckpointPresetCompatibility["*"] || []),
+            ...(task.pretrainedCheckpointPresetCompatibility[fields.rl.value] || []),
+        ];
+        const supportsPretrainedCheckpoint = supportsRl && state.scope === "core"
+            && (!selectedPreset || compatiblePresets.includes(selectedPreset));
         fields.checkpoint.disabled = !supportsPretrainedCheckpoint;
         if (!supportsPretrainedCheckpoint) {
             fields.checkpoint.checked = false;
@@ -675,6 +684,7 @@
     });
     for (const field of [fields.rl, fields.physics, fields.renderer, fields.presets, fields.checkpoint]) {
         field.addEventListener("change", () => {
+            updateModeControls();
             commandOutput.textContent = currentCommand();
             updatePreview();
         });

--- a/scripts/tools/test/test_train_and_publish_checkpoints.py
+++ b/scripts/tools/test/test_train_and_publish_checkpoints.py
@@ -57,6 +57,7 @@ def test_job_commands_use_uv_run_isaaclab() -> None:
         task_name="Isaac-Test",
         physics_backend="physx",
         render_backend="none",
+        preset_names=("depth",),
         physics_selector="isaacsim_physx",
     )
     args = Namespace(max_iterations=None, num_envs=None)
@@ -66,8 +67,33 @@ def test_job_commands_use_uv_run_isaaclab() -> None:
 
     assert train_command[:4] == ["uv", "run", "isaaclab", "train"]
     assert play_command[:4] == ["uv", "run", "isaaclab", "play"]
-    assert train_command[-1] == "physics=isaacsim_physx"
-    assert play_command[-1] == "physics=isaacsim_physx"
+    assert train_command[-2:] == ["physics=isaacsim_physx", "presets=depth"]
+    assert play_command[-2:] == ["physics=isaacsim_physx", "presets=depth"]
+
+
+def test_build_core_jobs_includes_declared_checkpoint_presets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Core jobs must include preset-specific checkpoints declared by the task."""
+    task_spec = SimpleNamespace(
+        id="Isaac-Test",
+        kwargs={
+            "env_cfg_entry_point": "isaaclab_tasks.core.test:TestEnvCfg",
+            "rl_games_cfg_entry_point": "isaaclab_tasks.core.test:TestAgentCfg",
+            "rsl_rl_cfg_entry_point": "isaaclab_tasks.core.test:TestAgentCfg",
+            "pretrained_checkpoint_preset_compatibility": {"rl_games": ("depth",)},
+        },
+    )
+    monkeypatch.setattr("scripts.tools.train_and_publish_checkpoints.gym.registry", {task_spec.id: task_spec})
+    monkeypatch.setattr("scripts.tools.train_and_publish_checkpoints.parse_env_cfg", lambda _: object())
+    monkeypatch.setattr("scripts.tools.train_and_publish_checkpoints.enumerate_task_presets", lambda _: {})
+    monkeypatch.setattr(
+        "scripts.tools.train_and_publish_checkpoints.get_pretrained_checkpoint_backend_names",
+        lambda _: ("physx", "rtx"),
+    )
+    args = Namespace(physics_backends="physx", render_backends="rtx")
+
+    jobs = _build_core_jobs(args)
+
+    assert [(job.workflow, job.preset_names) for job in jobs] == [("rsl_rl", ()), ("rl_games", ("depth",))]
 
 
 def test_select_physics_variants_uses_concrete_isaac_sim_physx() -> None:
@@ -130,8 +156,9 @@ def test_publish_uses_collected_checkpoint_without_training_logs(
         task_name="Isaac-Test",
         physics_backend="newtonmjwarp",
         render_backend="none",
+        preset_names=("depth",),
     )
-    collected_path = tmp_path / "rsl_rl" / "Isaac-Test_newtonmjwarp_none_rsl_rl.pt"
+    collected_path = tmp_path / "rsl_rl" / "Isaac-Test_depth_newtonmjwarp_none_rsl_rl.pt"
     collected_path.parent.mkdir()
     collected_path.touch()
     args = Namespace(
@@ -143,6 +170,6 @@ def test_publish_uses_collected_checkpoint_without_training_logs(
 
     assert publish_pretrained_checkpoint(job, args)
     assert (
-        f"Publishing {collected_path} -> omniverse://checkpoints/rsl_rl/Isaac-Test_newtonmjwarp_none_rsl_rl.pt"
+        f"Publishing {collected_path} -> omniverse://checkpoints/rsl_rl/Isaac-Test_depth_newtonmjwarp_none_rsl_rl.pt"
         in capsys.readouterr().out
     )

--- a/scripts/tools/train_and_publish_checkpoints.py
+++ b/scripts/tools/train_and_publish_checkpoints.py
@@ -17,7 +17,7 @@ checkpoints are collected into one subdirectory per RL library:
     └── skrl/
 
 Each checkpoint is named
-``<task_name>_<physics_backend>_<render_backend>_<rl_library><extension>``.
+``<task_name>[_<preset_names>]_<physics_backend>_<render_backend>_<rl_library><extension>``.
 State-only tasks use ``none`` as the render backend because their policies do
 not depend on rendering. This workflow targets core tasks only; other
 registered tasks do not receive published checkpoints from this matrix. The
@@ -106,12 +106,13 @@ _CORE_WORKFLOWS = ("rl_games", "rsl_rl", "skrl")
 
 @dataclass(frozen=True)
 class CheckpointJob:
-    """One workflow, task, physics, and renderer training combination."""
+    """One workflow, task, preset, physics, and renderer training combination."""
 
     workflow: str
     task_name: str
     physics_backend: str | None = None
     render_backend: str | None = None
+    preset_names: tuple[str, ...] = ()
     physics_selector: str | None = None
     render_selector: str | None = None
     agent: str | None = None
@@ -122,7 +123,8 @@ class CheckpointJob:
         """Return the stable human-readable job identifier."""
         if self.physics_backend is None:
             return f"{self.workflow}:{self.task_name}"
-        return f"{self.workflow}:{self.task_name}:{self.physics_backend}:{self.render_backend}"
+        parts = [self.workflow, self.task_name, *self.preset_names, self.physics_backend, self.render_backend]
+        return ":".join(parts)
 
     @property
     def experiment_name(self) -> str:
@@ -134,18 +136,21 @@ class CheckpointJob:
             self.task_name,
             self.physics_backend,
             self.render_backend,
+            preset_names=self.preset_names,
         )
         extension = os.path.splitext(filename)[1]
         return filename.removesuffix(extension)
 
     @property
     def preset_args(self) -> list[str]:
-        """Return typed preset selectors for this job."""
+        """Return preset selectors for this job."""
         args = []
         if self.physics_selector is not None:
             args.append(f"physics={self.physics_selector}")
         if self.render_selector is not None:
             args.append(f"renderer={self.render_selector}")
+        if self.preset_names:
+            args.append(f"presets={','.join(self.preset_names)}")
         return args
 
 
@@ -158,10 +163,7 @@ def _create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "jobs",
         nargs="*",
-        help=(
-            "Job patterns. Legacy jobs use workflow:task. Core matrix patterns "
-            "also match workflow:task:physics:renderer."
-        ),
+        help="Job patterns. Legacy jobs use workflow:task. Core matrix patterns match the displayed job IDs.",
     )
     parser.add_argument("-t", "--train", action="store_true", help="Run full training and collect checkpoints.")
     parser.add_argument("--smoke", action="store_true", help="Run one-iteration backend smoke training.")
@@ -335,7 +337,14 @@ def _build_core_jobs(args: argparse.Namespace) -> list[CheckpointJob]:
         physics_variants = preset_map.get(PresetTarget.PHYSICS, [])
         render_variants = preset_map.get(PresetTarget.RENDERER, [])
         env_cfg = parse_env_cfg(task_spec.id)
-        workflow, agent, algorithm = _select_workflow(task_spec, env_cfg)
+        preferred_workflow = _select_workflow(task_spec, env_cfg)
+        checkpoint_compatibility = task_spec.kwargs.get("pretrained_checkpoint_preset_compatibility", {})
+        workflow_selections = [preferred_workflow]
+        workflow_selections.extend(
+            (workflow, None, None)
+            for workflow in checkpoint_compatibility
+            if workflow != preferred_workflow[0] and f"{workflow}_cfg_entry_point" in task_spec.kwargs
+        )
         default_physics = None
         if not physics_variants:
             default_physics, _ = get_pretrained_checkpoint_backend_names(env_cfg)
@@ -347,21 +356,26 @@ def _build_core_jobs(args: argparse.Namespace) -> list[CheckpointJob]:
             physics_backends,
         )
         render_selections = _select_render_variants(render_variants, render_backends)
-        for _physics_family, physics_selector in physics_selections:
-            physics_backend = _resolve_physics_backend(task_spec.id, physics_selector, default_physics)
-            for render_backend, render_selector in render_selections:
-                jobs.append(
-                    CheckpointJob(
-                        workflow=workflow,
-                        task_name=task_spec.id,
-                        physics_backend=physics_backend,
-                        render_backend=render_backend,
-                        physics_selector=physics_selector,
-                        render_selector=render_selector,
-                        agent=agent,
-                        algorithm=algorithm,
-                    )
-                )
+        for workflow, agent, algorithm in workflow_selections:
+            checkpoint_presets = [()] if workflow == preferred_workflow[0] else []
+            checkpoint_presets.extend((preset_name,) for preset_name in checkpoint_compatibility.get(workflow, ()))
+            for _physics_family, physics_selector in physics_selections:
+                physics_backend = _resolve_physics_backend(task_spec.id, physics_selector, default_physics)
+                for render_backend, render_selector in render_selections:
+                    for preset_names in checkpoint_presets:
+                        jobs.append(
+                            CheckpointJob(
+                                workflow=workflow,
+                                task_name=task_spec.id,
+                                physics_backend=physics_backend,
+                                render_backend=render_backend,
+                                preset_names=preset_names,
+                                physics_selector=physics_selector,
+                                render_selector=render_selector,
+                                agent=agent,
+                                algorithm=algorithm,
+                            )
+                        )
     return jobs
 
 
@@ -470,6 +484,7 @@ def _has_training_job_completed(job: CheckpointJob) -> bool:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if run_path is None or not os.path.isfile(os.path.join(run_path, _TRAINING_COMPLETE_FILENAME)):
         return False
@@ -478,6 +493,7 @@ def _has_training_job_completed(job: CheckpointJob) -> bool:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
 
 
@@ -488,6 +504,7 @@ def _mark_training_job_completed(job: CheckpointJob) -> None:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if run_path is None:
         raise RuntimeError(f"Unable to determine the latest run for {job.job_id}")
@@ -513,6 +530,7 @@ def train_job(job: CheckpointJob, args: argparse.Namespace, smoke: bool = False)
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     ):
         print(f"Training did not produce a checkpoint for {job.job_id}", file=sys.stderr)
         return False
@@ -532,6 +550,7 @@ def collect_pretrained_checkpoint(job: CheckpointJob, output_dir: str, dry_run: 
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if source_path is None or not os.path.isfile(source_path):
         print(f"No completed checkpoint to collect for {job.job_id}")
@@ -550,6 +569,7 @@ def review_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) -
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     ):
         print(f"Skipping review of {job.job_id}; it has not been trained")
         return False
@@ -558,6 +578,7 @@ def review_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) -
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     ):
         print(f"Skipping review of {job.job_id}; training is incomplete")
         return False
@@ -567,6 +588,7 @@ def review_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) -
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if not args.force_review and review and review.get("reviewed"):
         print(f"Review already complete for {job.job_id}")
@@ -577,6 +599,7 @@ def review_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) -
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if checkpoint_path is None:
         print(f"Skipping review of {job.job_id}; no checkpoint was found")
@@ -600,6 +623,7 @@ def review_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) -
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     if review_path is None:
         raise RuntimeError(f"Unable to determine review path for {job.job_id}")
@@ -623,6 +647,7 @@ def publish_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) 
             job.task_name,
             job.physics_backend,
             job.render_backend,
+            preset_names=job.preset_names,
         )
         if not review or review.get("result") != "accepted":
             print(f"Skipping publish of {job.job_id}; it does not have an accepted review")
@@ -634,6 +659,7 @@ def publish_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) 
             job.task_name,
             job.physics_backend,
             job.render_backend,
+            preset_names=job.preset_names,
         )
     else:
         filename = get_pretrained_checkpoint_filename(
@@ -641,6 +667,7 @@ def publish_pretrained_checkpoint(job: CheckpointJob, args: argparse.Namespace) 
             job.task_name,
             job.physics_backend,
             job.render_backend,
+            preset_names=job.preset_names,
         )
         publish_path = posixpath.join(args.publish_root.rstrip("/"), job.workflow, filename)
     print(f"Publishing {local_path} -> {publish_path}")
@@ -664,6 +691,7 @@ def _summary_row(job: CheckpointJob, output_dir: str) -> list[str | bool]:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     has_finished = (
         _has_training_job_completed(job)
@@ -676,10 +704,12 @@ def _summary_row(job: CheckpointJob, output_dir: str) -> list[str | bool]:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     return [
         job.workflow,
         job.task_name,
+        ",".join(job.preset_names),
         job.physics_backend or "",
         job.render_backend or "",
         job.physics_selector or "",
@@ -698,6 +728,7 @@ def _get_collected_checkpoint_path(job: CheckpointJob, output_dir: str) -> str:
         job.task_name,
         job.physics_backend,
         job.render_backend,
+        preset_names=job.preset_names,
     )
     path_parts = [output_dir, job.workflow]
     if job.physics_backend is None:
@@ -733,6 +764,7 @@ def main(argv: list[str] | None = None) -> int:
             [
                 "Workflow",
                 "Task",
+                "Presets",
                 "Physics",
                 "Renderer",
                 "Physics selector",

--- a/source/isaaclab_rl/changelog.d/mustafa-pretrained-checkpoint-presets.rst
+++ b/source/isaaclab_rl/changelog.d/mustafa-pretrained-checkpoint-presets.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed published checkpoint lookup ignoring non-default domain presets, which could fetch an
+  incompatible policy or miss an available preset-specific checkpoint. Preset-specific checkpoints
+  can now also be trained, collected, reviewed, and published through the checkpoint management tool.

--- a/source/isaaclab_rl/isaaclab_rl/utils/pretrained_checkpoint.py
+++ b/source/isaaclab_rl/isaaclab_rl/utils/pretrained_checkpoint.py
@@ -12,6 +12,8 @@ import glob
 import json
 import os
 import posixpath
+import sys
+from collections.abc import Sequence
 
 from isaaclab.envs import DirectMARLEnvCfg, DirectRLEnvCfg, ManagerBasedRLEnvCfg
 from isaaclab.physics import PhysicsCfg
@@ -73,11 +75,13 @@ def get_pretrained_checkpoint_filename(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str:
     """Return the published checkpoint filename.
 
     Backend-aware checkpoints use
-    ``<task_name>_<physics_backend>_<render_backend>_<rl_library><extension>``.
+    ``<task_name>[_<preset_names>]_<physics_backend>_<render_backend>_<rl_library><extension>``.
     Omitting both backend names returns the legacy workflow-specific filename.
 
     Args:
@@ -86,6 +90,7 @@ def get_pretrained_checkpoint_filename(
         physics_backend: Physics backend name, such as ``"physx"``,
             ``"newtonmjwarp"``, or ``"newtonmjwarpvbdproxy"`` for a coupled solver.
         render_backend: Render backend name, such as ``"rtx"``, ``"newton"``, or ``"none"``.
+        preset_names: Non-default domain presets that affect policy compatibility.
 
     Returns:
         The checkpoint filename.
@@ -95,7 +100,10 @@ def get_pretrained_checkpoint_filename(
     """
     if workflow not in WORKFLOW_PRETRAINED_CHECKPOINT_EXTENSIONS:
         raise ValueError(f"Unsupported workflow: {workflow!r}")
+    preset_names = _normalize_pretrained_checkpoint_preset_names(preset_names)
     if physics_backend is None and render_backend is None:
+        if preset_names:
+            raise ValueError("preset_names require backend-aware checkpoint naming")
         return WORKFLOW_PRETRAINED_CHECKPOINT_FILENAMES[workflow]
     if physics_backend is None or render_backend is None:
         raise ValueError("physics_backend and render_backend must be provided together")
@@ -103,9 +111,57 @@ def get_pretrained_checkpoint_filename(
         raise ValueError(f"Unsupported physics backend: {physics_backend!r}")
     if render_backend not in {"newton", "none", "rtx"}:
         raise ValueError(f"Unsupported render backend: {render_backend!r}")
+    preset_suffix = "" if not preset_names else f"_{'_'.join(preset_names)}"
     return (
-        f"{task_name}_{physics_backend}_{render_backend}_{workflow}"
+        f"{task_name}{preset_suffix}_{physics_backend}_{render_backend}_{workflow}"
         f"{WORKFLOW_PRETRAINED_CHECKPOINT_EXTENSIONS[workflow]}"
+    )
+
+
+def get_pretrained_checkpoint_preset_names(task_name: str, overrides: Sequence[str] | None = None) -> tuple[str, ...]:
+    """Return non-default domain presets selected for a checkpoint.
+
+    Preset aliases whose value is the preset's ``default`` are omitted so existing
+    unsuffixed checkpoints remain compatible. Typed physics and renderer selectors
+    are also omitted because they already have dedicated checkpoint fields.
+
+    Args:
+        task_name: Registered task name.
+        overrides: Hydra-style overrides. Defaults to :data:`sys.argv`.
+
+    Returns:
+        Selected non-default domain preset names in canonical order.
+    """
+    from isaaclab_tasks.utils.hydra import collect_presets
+    from isaaclab_tasks.utils.preset_target import PresetTarget
+
+    selected_names = []
+    for override in sys.argv[1:] if overrides is None else overrides:
+        if "=" not in override:
+            continue
+        key, value = override.split("=", 1)
+        if key.lstrip("-") == PresetTarget.DOMAIN.value:
+            selected_names.extend(name.strip() for name in value.split(",") if name.strip())
+
+    if not selected_names:
+        return ()
+
+    preset_fields = collect_presets(load_cfg_from_registry(task_name, "env_cfg_entry_point"))
+    typed_targets = tuple(target for target in PresetTarget if target.base_classes)
+    typed_names = {
+        name
+        for fields in preset_fields.values()
+        for name, value in fields.items()
+        if any(target.matches(value) for target in typed_targets)
+    }
+    non_default_domain_names = {
+        name
+        for fields in preset_fields.values()
+        for name, value in fields.items()
+        if name != "default" and name not in typed_names and not _preset_value_matches_default(value, fields)
+    }
+    return _normalize_pretrained_checkpoint_preset_names(
+        name for name in selected_names if name in non_default_domain_names
     )
 
 
@@ -145,9 +201,13 @@ def get_log_root_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str:
     """Return the absolute log root for a workflow, task, and backend combination."""
-    experiment_name = _get_pretrained_checkpoint_stem(workflow, task_name, physics_backend, render_backend)
+    experiment_name = _get_pretrained_checkpoint_stem(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     return os.path.abspath(os.path.join("logs", workflow, experiment_name))
 
 
@@ -156,9 +216,11 @@ def get_latest_job_run_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str | None:
     """Return the local log path of the most recent matching run."""
-    log_root_path = get_log_root_path(workflow, task_name, physics_backend, render_backend)
+    log_root_path = get_log_root_path(workflow, task_name, physics_backend, render_backend, preset_names=preset_names)
     return _get_latest_file_or_directory(log_root_path)
 
 
@@ -167,13 +229,17 @@ def get_pretrained_checkpoint_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str | None:
     """Return the trained checkpoint path from the latest local run."""
-    path = get_latest_job_run_path(workflow, task_name, physics_backend, render_backend)
+    path = get_latest_job_run_path(workflow, task_name, physics_backend, render_backend, preset_names=preset_names)
     if not path:
         return None
 
-    checkpoint_stem = _get_pretrained_checkpoint_stem(workflow, task_name, physics_backend, render_backend)
+    checkpoint_stem = _get_pretrained_checkpoint_stem(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     if workflow == "rl_games":
         preferred_path = os.path.join(path, "nn", f"{checkpoint_stem}.pth")
         if os.path.isfile(preferred_path):
@@ -197,9 +263,13 @@ def get_pretrained_checkpoint_publish_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str:
     """Return the path where a checkpoint is published."""
-    filename = get_pretrained_checkpoint_filename(workflow, task_name, physics_backend, render_backend)
+    filename = get_pretrained_checkpoint_filename(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     if physics_backend is None:
         return posixpath.join(PRETRAINED_CHECKPOINT_PATH, workflow, task_name, filename)
     return posixpath.join(PRETRAINED_CHECKPOINT_PATH, workflow, filename)
@@ -210,9 +280,13 @@ def get_published_pretrained_checkpoint_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str:
     """Return the path from which a published checkpoint is fetched."""
-    filename = get_pretrained_checkpoint_filename(workflow, task_name, physics_backend, render_backend)
+    filename = get_pretrained_checkpoint_filename(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     path_parts = [ISAACLAB_NUCLEUS_DIR, "PretrainedCheckpoints", workflow]
     if physics_backend is None:
         path_parts.append(task_name)
@@ -224,6 +298,8 @@ def get_published_pretrained_checkpoint(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] | None = None,
 ) -> str | None:
     """Gets the path for the pre-trained checkpoint.
 
@@ -237,12 +313,23 @@ def get_published_pretrained_checkpoint(
             to use the legacy checkpoint layout.
         render_backend: Render backend name. Omit with :paramref:`physics_backend`
             to use the legacy checkpoint layout.
+        preset_names: Non-default domain presets that affect policy compatibility.
+            For backend-aware checkpoints, defaults to resolving ``presets=`` selectors
+            from :data:`sys.argv`. Legacy checkpoints do not use preset-qualified names.
 
     Returns:
         The path.
     """
-    filename = get_pretrained_checkpoint_filename(workflow, task_name, physics_backend, render_backend)
-    ov_path = get_published_pretrained_checkpoint_path(workflow, task_name, physics_backend, render_backend)
+    if preset_names is None and physics_backend is not None and render_backend is not None:
+        preset_names = get_pretrained_checkpoint_preset_names(task_name)
+    elif preset_names is None:
+        preset_names = ()
+    filename = get_pretrained_checkpoint_filename(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
+    ov_path = get_published_pretrained_checkpoint_path(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     download_dir = os.path.join(".pretrained_checkpoints", workflow)
     if physics_backend is None:
         download_dir = os.path.join(download_dir, task_name)
@@ -265,9 +352,13 @@ def has_pretrained_checkpoint_job_run(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> bool:
     """Return whether an experiment exists for the workflow, task, and backends."""
-    return os.path.exists(get_log_root_path(workflow, task_name, physics_backend, render_backend))
+    return os.path.exists(
+        get_log_root_path(workflow, task_name, physics_backend, render_backend, preset_names=preset_names)
+    )
 
 
 def has_pretrained_checkpoint_job_finished(
@@ -275,9 +366,13 @@ def has_pretrained_checkpoint_job_finished(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> bool:
     """Return whether an experiment has a checkpoint result."""
-    local_path = get_pretrained_checkpoint_path(workflow, task_name, physics_backend, render_backend)
+    local_path = get_pretrained_checkpoint_path(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     return local_path is not None and os.path.exists(local_path)
 
 
@@ -286,9 +381,11 @@ def get_pretrained_checkpoint_review_path(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str | None:
     """Return the review JSON path for a workflow, task, and backends."""
-    run_path = get_latest_job_run_path(workflow, task_name, physics_backend, render_backend)
+    run_path = get_latest_job_run_path(workflow, task_name, physics_backend, render_backend, preset_names=preset_names)
     if not run_path:
         return None
     return os.path.join(run_path, "pretrained_checkpoint_review.json")
@@ -299,9 +396,13 @@ def get_pretrained_checkpoint_review(
     task_name: str,
     physics_backend: str | None = None,
     render_backend: str | None = None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> dict | None:
     """Return the review JSON data for a workflow, task, and backends."""
-    review_path = get_pretrained_checkpoint_review_path(workflow, task_name, physics_backend, render_backend)
+    review_path = get_pretrained_checkpoint_review_path(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     if not review_path:
         return None
 
@@ -387,12 +488,34 @@ def _get_pretrained_checkpoint_stem(
     task_name: str,
     physics_backend: str | None,
     render_backend: str | None,
+    *,
+    preset_names: Sequence[str] = (),
 ) -> str:
     """Return the checkpoint filename without its workflow extension."""
     if physics_backend is None and render_backend is None:
         return task_name
-    filename = get_pretrained_checkpoint_filename(workflow, task_name, physics_backend, render_backend)
+    filename = get_pretrained_checkpoint_filename(
+        workflow, task_name, physics_backend, render_backend, preset_names=preset_names
+    )
     return filename.removesuffix(WORKFLOW_PRETRAINED_CHECKPOINT_EXTENSIONS[workflow])
+
+
+def _normalize_pretrained_checkpoint_preset_names(preset_names: Sequence[str]) -> tuple[str, ...]:
+    """Return unique, validated checkpoint preset names in canonical order."""
+    normalized = tuple(sorted(set(preset_names)))
+    invalid = [name for name in normalized if not name or not name.replace("_", "").isalnum()]
+    if invalid:
+        raise ValueError(f"Invalid checkpoint preset names: {invalid}")
+    return normalized
+
+
+def _preset_value_matches_default(value, fields: dict) -> bool:
+    """Return whether a preset value is structurally equivalent to its default."""
+    default = fields.get("default")
+    try:
+        return bool(value == default)
+    except (RuntimeError, TypeError, ValueError):
+        return value is default
 
 
 def _get_latest_file_or_directory(path: str, pattern: str = "*") -> str | None:

--- a/source/isaaclab_rl/test/test_pretrained_checkpoint.py
+++ b/source/isaaclab_rl/test/test_pretrained_checkpoint.py
@@ -47,9 +47,33 @@ def test_get_pretrained_checkpoint_filename_includes_backends():
     assert filename == "Isaac-Cartpole_newtonmjwarp_rtx_rsl_rl.pt"
 
 
-def test_get_pretrained_checkpoint_filename_preserves_legacy_layout():
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        (("presets=depth",), ("depth",)),
+        (("presets=rgb",), ()),
+        (("physics=newton_mjwarp", "renderer=newton_renderer"), ()),
+    ],
+)
+def test_get_pretrained_checkpoint_preset_names_uses_non_default_domain_presets(overrides, expected):
+    """Test that default aliases and typed backends do not duplicate checkpoint identity fields."""
+    preset_names = pretrained_checkpoint.get_pretrained_checkpoint_preset_names(
+        "Isaac-Cartpole-Camera-Direct", overrides
+    )
+
+    assert preset_names == expected
+
+
+def test_get_pretrained_checkpoint_filename_preserves_legacy_layout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Test that callers omitting both backends retain the legacy filename."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["play.py", "presets=depth"])
+    cached_path = Path(".pretrained_checkpoints/rl_games/Isaac-Cartpole/checkpoint.pth")
+    cached_path.parent.mkdir(parents=True)
+    cached_path.touch()
+
     assert pretrained_checkpoint.get_pretrained_checkpoint_filename("rl_games", "Isaac-Cartpole") == "checkpoint.pth"
+    assert pretrained_checkpoint.get_published_pretrained_checkpoint("rl_games", "Isaac-Cartpole") == str(cached_path)
 
 
 def test_get_log_root_path_preserves_legacy_task_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -149,6 +173,7 @@ def test_get_published_pretrained_checkpoint_downloads_to_flat_cache(
     """Test that backend-aware downloads use the workflow cache directory."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(pretrained_checkpoint, "ISAACLAB_NUCLEUS_DIR", "omniverse://IsaacLab")
+    monkeypatch.setattr("sys.argv", ["play.py", "presets=depth"])
     retrieved = {}
 
     def _retrieve_file_path(remote_path: str, download_dir: str) -> str:
@@ -162,15 +187,16 @@ def test_get_published_pretrained_checkpoint_downloads_to_flat_cache(
     monkeypatch.setattr(pretrained_checkpoint, "retrieve_file_path", _retrieve_file_path)
 
     path = pretrained_checkpoint.get_published_pretrained_checkpoint(
-        "rsl_rl",
-        "Isaac-Cartpole",
-        "physx",
-        "none",
+        "rl_games",
+        "Isaac-Cartpole-Camera-Direct",
+        "newtonmjwarp",
+        "newton",
     )
 
-    expected_download_dir = str(Path(".pretrained_checkpoints") / "rsl_rl")
-    assert path == str(Path(expected_download_dir) / "Isaac-Cartpole_physx_none_rsl_rl.pt")
+    expected_download_dir = str(Path(".pretrained_checkpoints") / "rl_games")
+    filename = "Isaac-Cartpole-Camera-Direct_depth_newtonmjwarp_newton_rl_games.pth"
+    assert path == str(Path(expected_download_dir) / filename)
     assert retrieved == {
-        "remote_path": "omniverse://IsaacLab/PretrainedCheckpoints/rsl_rl/Isaac-Cartpole_physx_none_rsl_rl.pt",
+        "remote_path": f"omniverse://IsaacLab/PretrainedCheckpoints/rl_games/{filename}",
         "download_dir": expected_download_dir,
     }

--- a/source/isaaclab_tasks/changelog.d/mustafa-pretrained-checkpoint-presets.skip
+++ b/source/isaaclab_tasks/changelog.d/mustafa-pretrained-checkpoint-presets.skip
@@ -1,0 +1,1 @@
+Declared preset-specific checkpoint availability for the environment browser.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/__init__.py
@@ -53,6 +53,7 @@ gym.register(
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:CartpoleCameraDirectPPORunnerCfg",
         "default_agent": "rsl_rl",
         "skrl_cfg_entry_point": f"{agents.__name__}:skrl_direct_camera_ppo_cfg.yaml",
+        "pretrained_checkpoint_preset_compatibility": {"rl_games": ("depth",)},
     },
 )
 

--- a/tools/environ_docs.py
+++ b/tools/environ_docs.py
@@ -125,6 +125,7 @@ class EnvironmentDocRow:
     presets: dict[PresetTarget, list[str]] | None
     agent_preset_compatibility: dict[str, tuple[str, ...]] = field(default_factory=dict)
     supports_warp_frontend: bool = False
+    pretrained_checkpoint_preset_compatibility: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
 
 def _supports_warp_frontend(task_name: str, workflow: str, presets: dict[PresetTarget, list[str]] | None) -> bool:
@@ -286,6 +287,27 @@ def _domain_presets_for_docs(preset_map: dict[PresetTarget, list[str]]) -> list[
             continue
         domain_names.append(name)
     return domain_names
+
+
+def _default_domain_presets(task_name: str) -> tuple[str, ...]:
+    """Return domain preset aliases that resolve to the task's default config."""
+    from isaaclab_tasks.utils.hydra import collect_presets
+    from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+    fields_by_path = collect_presets(load_cfg_from_registry(task_name, "env_cfg_entry_point"))
+    typed_targets = tuple(target for target in PresetTarget if target.base_classes)
+    aliases: dict[str, bool] = {}
+    for fields in fields_by_path.values():
+        default = fields.get("default")
+        for name, value in fields.items():
+            if name == "default" or any(target.matches(value) for target in typed_targets):
+                continue
+            try:
+                matches_default = bool(value == default)
+            except (RuntimeError, TypeError, ValueError):
+                matches_default = value is default
+            aliases[name] = aliases.get(name, True) and matches_default
+    return tuple(sorted(name for name, matches_default in aliases.items() if matches_default))
 
 
 def _selector_names_for_docs(
@@ -581,6 +603,20 @@ def collect_environment_doc_rows(
             preset_map[PresetTarget.PHYSICS] = _physics_names_for_docs(spec.id, preset_map)
             preset_map = _apply_preset_exclusions(spec.id, preset_map)
         agents = apply_rl_library_overrides(spec.id, parse_rl_libraries_from_kwargs(spec.kwargs))
+        visible_domain_presets = set(_selector_names_for_docs(preset_map)[PresetTarget.DOMAIN])
+        default_checkpoint_presets = ()
+        if spec.id.startswith("Isaac-"):
+            with contextlib.suppress(Exception):
+                default_checkpoint_presets = tuple(
+                    name for name in _default_domain_presets(spec.id) if name in visible_domain_presets
+                )
+        checkpoint_preset_compatibility = {
+            library: tuple(preset for preset in presets if preset in visible_domain_presets)
+            for library, presets in spec.kwargs.get("pretrained_checkpoint_preset_compatibility", {}).items()
+            if library in agents
+        }
+        if default_checkpoint_presets:
+            checkpoint_preset_compatibility["*"] = default_checkpoint_presets
 
         workflow = get_workflow(spec.entry_point)
         rows.append(
@@ -595,6 +631,7 @@ def collect_environment_doc_rows(
                     if agent in spec.kwargs
                 },
                 supports_warp_frontend=_supports_warp_frontend(spec.id, workflow, preset_map),
+                pretrained_checkpoint_preset_compatibility=checkpoint_preset_compatibility,
             )
         )
 
@@ -680,14 +717,24 @@ def render_environment_browser_task_rows(
             if aliases:
                 preview_image = max(aliases, key=lambda item: len(item[0]))[1]
         default_algorithms = {"skrl": "MAPPO"} if "MAPPO" in row.rl_libraries.get("skrl", []) else {}
-        if row.agent_preset_compatibility or preview_image or row.supports_warp_frontend or default_algorithms:
-            rendered_values += f", {json.dumps(row.agent_preset_compatibility, sort_keys=True)}"
-        if preview_image or row.supports_warp_frontend or default_algorithms:
-            rendered_values += f", {json.dumps(preview_image)}"
-        if row.supports_warp_frontend or default_algorithms:
-            rendered_values += f", {json.dumps(row.supports_warp_frontend)}"
-        if default_algorithms:
-            rendered_values += f", {json.dumps(default_algorithms, sort_keys=True)}"
+        optional_values = [
+            row.agent_preset_compatibility,
+            preview_image,
+            row.supports_warp_frontend,
+            row.pretrained_checkpoint_preset_compatibility,
+            default_algorithms,
+        ]
+        optional_defaults = [{}, "", False, {}, {}]
+        last_value = next(
+            (
+                index
+                for index in reversed(range(len(optional_values)))
+                if optional_values[index] != optional_defaults[index]
+            ),
+            -1,
+        )
+        for value in optional_values[: last_value + 1]:
+            rendered_values += f", {json.dumps(value, sort_keys=True)}"
         lines.append(f"            [{rendered_values}],")
     lines.append("        ];")
     return "\n".join(lines)

--- a/tools/test/test_environ_docs.py
+++ b/tools/test/test_environ_docs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import gymnasium as gym
 import pytest
 from gymnasium.envs.registration import EnvSpec
 
@@ -292,6 +293,16 @@ def test_collect_environment_doc_rows_includes_registered_agent_preset_compatibi
     }
 
 
+def test_collect_environment_doc_rows_includes_checkpoint_preset_compatibility():
+    """Checkpoint preset availability must be carried into generated browser rows."""
+    row = collect_environment_doc_rows([gym.spec("Isaac-Cartpole-Camera-Direct")])[0]
+
+    assert row.pretrained_checkpoint_preset_compatibility == {
+        "*": ("rgb",),
+        "rl_games": ("depth",),
+    }
+
+
 def test_collect_environment_doc_rows_excludes_deprecated_task_aliases():
     specs = [
         EnvSpec(
@@ -423,6 +434,7 @@ def test_environment_browser_rows_include_concrete_core_and_contributed_selector
                 "rsl_rl_feature_cfg_entry_point": ("resnet18", "theia_tiny"),
             },
             supports_warp_frontend=True,
+            pretrained_checkpoint_preset_compatibility={"*": ("rgb",), "rsl_rl": ("depth",)},
         ),
         EnvironmentDocRow(
             task_name="IsaacContrib-Cartpole",
@@ -458,6 +470,8 @@ def test_environment_browser_rows_include_concrete_core_and_contributed_selector
     assert '"ovphysx"' in updated
     assert '"tasks/classic/cartpole.jpg"' in updated
     assert '"tasks/classic/cartpole.jpg", true' in updated
+    assert '"*": ["rgb"]' in updated
+    assert '"rsl_rl": ["depth"]' in updated
     assert updated.index('"Isaac-Cartpole"') < updated.index('"IsaacContrib-Cartpole"')
     assert "const preserved = true;" in updated
 
@@ -475,7 +489,7 @@ def test_environment_browser_rows_include_mappo_as_the_skrl_default():
 
     rendered = render_environment_browser_task_rows(rows)
 
-    assert '["Isaac-Multi-Agent-Direct", "skrl", "", "", "", {}, "", false, {"skrl": "MAPPO"}]' in rendered
+    assert '["Isaac-Multi-Agent-Direct", "skrl", "", "", "", {}, "", false, {}, {"skrl": "MAPPO"}]' in rendered
 
 
 def test_collect_environment_browser_preview_images_preserves_generated_assignments():


### PR DESCRIPTION
# Description

Backports #7594 to `release/3.0.0`.

Published checkpoint lookup included the task, physics backend, renderer backend, and RL library, but ignored domain presets. This backport adds non-default domain presets to canonical checkpoint filenames, preserves unsuffixed names for aliases of the default preset, declares the published Cartpole depth checkpoint, and disables the environment-browser pretrained option for undeclared preset selections.

The merged commit cherry-picked cleanly onto the latest `release/3.0.0`. No new dependencies.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

This PR already targets `release/3.0.0`.

## Screenshots

Not applicable; the UI change disables the existing pretrained-checkpoint checkbox for unsupported preset selections.

## Validation

- All repository pre-commit hooks passed, including Ruff, formatting, RST validation, changelog coverage, and Git LFS checks.
- The source PR's Linux CI passed, including the package tests, tools tests, documentation build, installation tests, and pre-commit checks.
- Simulator-dependent tests could not be rerun locally because this branch's uv lockfile supports Linux x86_64/aarch64 and Windows AMD64, but not macOS.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the repository pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] The original author's name already exists in `CONTRIBUTORS.md`
