### PR TITLE
Log VideoRecorder cubric warning once per recorder

### DIFF
--- a/source/isaaclab/changelog.d/video-recorder-cubric-warn-once.rst
+++ b/source/isaaclab/changelog.d/video-recorder-cubric-warn-once.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the :class:`~isaaclab.envs.utils.video_recorder.VideoRecorder` Kit/Newton cubric
+  warning being logged on every captured frame, which flooded the terminal during
+  ``--video`` runs (roughly one line per frame for the whole clip). The warned-about
+  condition is fixed configuration state, so the message is now emitted once per
+  recorder, matching the existing once-only behavior of the frame-capture error path.

--- a/source/isaaclab/isaaclab/envs/utils/video_recorder.py
+++ b/source/isaaclab/isaaclab/envs/utils/video_recorder.py
@@ -84,6 +84,10 @@ class VideoRecorder:
         # Set to True after the first unrecoverable frame-capture error so that
         # subsequent steps do not propagate the exception or repeat the log message.
         self._frame_error_logged: bool = False
+        # Set to True after the Kit/Newton cubric warning is emitted. The condition it
+        # reports is fixed configuration state, so warning once per recorder is enough;
+        # without this the message repeats on every captured frame.
+        self._cubric_warning_logged: bool = False
 
     def step(self) -> None:
         """Advance the recorder by one env step."""
@@ -186,9 +190,10 @@ class VideoRecorder:
         # Kit Replicator requires cubric to propagate Newton Fabric transforms to RTX's
         # scene delegate. Without cubric, frames will be black. Log a warning but allow
         # the capture to proceed — users with cubric available will get correct frames.
-        if viz_type == "kit":
+        if viz_type == "kit" and not self._cubric_warning_logged:
             physics_backend = getattr(getattr(sim, "physics_manager", None), "video_capture_backend", lambda: None)()
             if physics_backend == "newton_gl":
+                self._cubric_warning_logged = True
                 logger.warning(
                     "[VideoRecorder] source='visualizer:kit' with Newton physics requires cubric "
                     "to propagate Fabric transforms to RTX. Frames may be black if cubric is "

--- a/source/isaaclab/test/envs/test_video_recorder.py
+++ b/source/isaaclab/test/envs/test_video_recorder.py
@@ -245,6 +245,9 @@ def test_kit_visualizer_newton_physics_logs_warning(caplog):
 
     With cubric the capture succeeds; without it frames may be black.  Either way
     the recorder warns and does not hard-fail.
+
+    The warned-about condition is fixed configuration state, so the message is emitted
+    once per recorder rather than once per captured frame.
     """
     import logging
 
@@ -254,11 +257,13 @@ def test_kit_visualizer_newton_physics_logs_warning(caplog):
 
     recorder = VideoRecorder(_cfg(source="visualizer:kit"), env)
     with caplog.at_level(logging.WARNING, logger="isaaclab.envs.utils.video_recorder"):
-        recorder._get_frame()
+        for _ in range(5):
+            recorder._get_frame()
 
-    assert any("source='visualizer:newton'" in r.message for r in caplog.records)
-    # The recorder attempts capture rather than short-circuiting.
-    assert kit_viz.render_calls == 1
+    cubric_warnings = [r for r in caplog.records if "source='visualizer:newton'" in r.message]
+    assert len(cubric_warnings) == 1
+    # Capture is still attempted on every frame rather than short-circuiting.
+    assert kit_viz.render_calls == 5
 
 
 def test_visualizer_newton_alias_resolves_newton_gl():


### PR DESCRIPTION
# Description

`VideoRecorder` logs the Kit/Newton "requires cubric" warning from
`_frame_from_visualizer()`, which `_get_frame()` calls on **every** captured frame. The
warning has no once-only guard, so it repeats once per frame for the entire clip and
buries all other console output.

Observed on `release/3.0.0` with Isaac Sim 6.1.0rc26 on Windows — roughly 120 identical
lines in 12 seconds before the run was interrupted; a full `--video_length 200` run emits
~200 copies:

```
uv run isaaclab play --rl_library rl_games --task Isaac-Cartpole-Camera-Direct \
  --checkpoint pretrained --video --video_length 200 --visualizer kit,newton_gl,rerun,viser
```

```
[Warning] [isaaclab.envs.utils.video_recorder] [VideoRecorder] source='visualizer:kit' with Newton physics requires cubric to propagate Fabric transforms to RTX. Frames may be black if cubric is unavailable. Use source='visualizer:newton' for guaranteed capture.
... x ~120, one per captured frame ...
```

The condition being reported — `viz_type == "kit"` and
`physics_manager.video_capture_backend() == "newton_gl"` — is fixed configuration state
that cannot change between frames, so re-logging it per frame carries no new information.

This change adds a `self._cubric_warning_logged` flag and gates the warning on it,
mirroring the once-only `self._frame_error_logged` guard that the same class already uses
for its frame-capture error path.

Behavior is otherwise unchanged: the warning text is byte-identical, it still fires on the
first frame, capture is still attempted on every frame, and the flag is per-recorder so a
second recorder stream still warns.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — console output only; before/after line counts are given above.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format` <!-- verified green by the `pre-commit` CI check on this PR -->
- [x] I have made corresponding changes to the documentation <!-- none required, see note below -->
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Test coverage

Extended the existing `test_kit_visualizer_newton_physics_logs_warning` rather than adding
a new case: it now drives five captures and asserts exactly one warning while all five
frames are still captured. The test fails on the current code (5 warnings) and passes with
this change (1 warning).


### Documentation

No documentation change is required. `docs/source/features/record_video.rst` already
describes this case as "a warning is logged" (singular), which this change makes accurate
rather than contradicting. No public API, signature, or cfg field is touched.
