### PR TITLE
Resolve check_instanceable asset input through retrieve_file_path

### DIFF
--- a/scripts/tools/check_instanceable.py
+++ b/scripts/tools/check_instanceable.py
@@ -6,14 +6,16 @@
 """
 This script uses the cloner API to check if asset has been instanced properly.
 
+An asset path may be a local file or a Nucleus/HTTPS URL; remote assets are downloaded before use.
+
 Usage with different inputs (replace `<Asset-Path>` and `<Asset-Path-Instanced>` with the path to the
 original asset and the instanced asset respectively):
 
 ```bash
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
 ```
 
 Output from the above commands:
@@ -42,7 +44,6 @@ Output from the above commands:
 
 import argparse
 import contextlib
-import os
 
 from isaaclab.app import AppLauncher
 
@@ -73,7 +74,7 @@ from isaacsim.core.cloner import GridCloner
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.utils import Timer
-from isaaclab.utils.assets import check_file_path
+from isaaclab.utils.assets import check_file_path, retrieve_file_path
 
 
 def main():
@@ -99,8 +100,10 @@ def main():
     # Spawn things into stage
     sim_utils.create_prim("/World/Light", "DistantLight")
 
-    # Everything under the namespace "/World/envs/env_0" will be cloned
-    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=os.path.abspath(args_cli.input))
+    # Everything under the namespace "/World/envs/env_0" will be cloned.
+    # Resolve through retrieve_file_path so Nucleus/HTTPS inputs are downloaded first; applying
+    # os.path.abspath() to a URL would prepend the working directory and corrupt it.
+    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=retrieve_file_path(args_cli.input))
     # Clone the scene
     num_clones = args_cli.num_clones
 


### PR DESCRIPTION
# Description

`scripts/tools/check_instanceable.py` accepts a Nucleus/HTTPS asset URL at validation and then
corrupts it before use, so no remote asset can be loaded.

- Line 82 — `check_file_path(args_cli.input)` returns `2` ("exists on the Nucleus Server"), so
  validation passes.
- Line 103 — `os.path.abspath(args_cli.input)` was applied unconditionally. On Windows this
  prepends the working directory and flips separators, turning the URL into a nonsense local path.

The script therefore contradicted itself: it validated remote paths as supported, then handled them
as if they were local. Because Isaac Lab robot assets live on the asset server (for example
`ANT_CFG` in `isaaclab_assets/robots/ant.py:22` points at
`{ISAAC_NUCLEUS_DIR}/Robots/IsaacSim/Ant/ant_instanceable.usd`), the tool could not profile the
assets it exists to profile without a manual download first.

Repro before this change:

```bash
uv run python scripts/tools/check_instanceable.py \
  https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.1/Isaac/Robots/IsaacSim/Ant/ant_instanceable.usd \
  -n 4096 --physics
```

```
FileNotFoundError: Unable to open the usd file at path:
C:\Users\horde\IsaacLab\https:\omniverse-content-production.s3-us-west-2.amazonaws.com\Assets\Isaac\6.1\Isaac\Robots\IsaacSim\Ant\ant_instanceable.usd
```

The input is now resolved through `retrieve_file_path()` from `isaaclab.utils.assets`, which is
purpose-built for this local-or-remote case: it returns `os.path.abspath(path)` for a local file
(**identical to the previous behavior**, so local inputs are unaffected) and downloads a Nucleus
file — along with its USD references, payloads and MDL textures — before returning a usable local
path. Existing precedent for the same pattern: `scripts/reinforcement_learning/leapp/rl_games/export.py:205`
and `.../sb3/export.py:248`.

The existing `check_file_path()` guard is deliberately left in place so the `ValueError: Invalid file
path: ...` message for a genuinely missing asset is preserved rather than becoming a
`FileNotFoundError`.

`import os` is removed because that call site was its only remaining use.

This PR also corrects the module docstring, which told users to run the script from
`source/tools/check_instanceable.py` — a directory that does not exist in the repository. All four
documented example commands failed if copy-pasted.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — command-line tool; the before/after traceback is shown above.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation <!-- module docstring corrected -->
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- see note -->
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package <!-- N/A, see note -->
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Notes on tests and changelog

**Tests.** No unit test is added. `check_instanceable.py` calls `AppLauncher` at module scope
(lines 61-62), so the module cannot be imported in a unit test without launching Isaac Sim — which
is why the script has no existing test. The change delegates to `retrieve_file_path()`, which is
already covered in `source/isaaclab/test/utils/test_assets.py`, including remote-URL handling
(`test_retrieve_file_path_serializes_cold_cache_population`). Happy to add an end-to-end test if a
maintainer prefers one.

**Changelog.** No fragment is included: `tools/changelog/cli.py` scopes fragment requirements to
packages under `source/`, and this change touches only `scripts/`.
