### PR TITLE
Fix DR Legs Kamino P-ADMM divergence

### DIFF
--- a/source/isaaclab_tasks/changelog.d/antoiner-fix-drlegs-padmm-divergence.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-fix-drlegs-padmm-divergence.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Stabilized the DR Legs Kamino P-ADMM preset under bounded random joint targets.

--- a/source/isaaclab_tasks/changelog.d/antoiner-fix-drlegs-padmm-divergence.rst
+++ b/source/isaaclab_tasks/changelog.d/antoiner-fix-drlegs-padmm-divergence.rst
@@ -1,4 +1,5 @@
 Fixed
 ^^^^^
 
-* Stabilized the DR Legs Kamino P-ADMM preset under bounded random joint targets.
+* Stabilized the DR Legs Kamino P-ADMM preset by disabling its driven-joint effort limit; PhysX retained
+  the 3.1 N m limit.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -59,7 +59,7 @@ def _kamino_newton_cfg() -> NewtonCfg:
                 primal_tolerance=1.0e-5,
                 dual_tolerance=1.0e-5,
                 compl_tolerance=1.0e-5,
-                rho_0=0.02,
+                rho_0=2.0,
             ),
         ),
         use_cuda_graph=True,

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/dr_legs/hold_pose_env_cfg.py
@@ -8,11 +8,13 @@
 The robot must keep its pelvis upright at a target height.
 """
 
+import math
+
 from isaaclab_newton.physics import KaminoPADMMCfg, KaminoPADMMSolverCfg, NewtonCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
-from isaaclab.assets import AssetBaseCfg
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
@@ -27,7 +29,7 @@ from isaaclab.utils.configclass import configclass
 from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.contrib.dr_legs.mdp as mdp
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils import PresetCfg, preset
 
 from isaaclab_assets.robots.dr_legs import DR_LEGS_ACTUATED_JOINTS, DR_LEGS_IMPLICIT_PD_CFG
 
@@ -59,7 +61,7 @@ def _kamino_newton_cfg() -> NewtonCfg:
                 primal_tolerance=1.0e-5,
                 dual_tolerance=1.0e-5,
                 compl_tolerance=1.0e-5,
-                rho_0=2.0,
+                rho_0=0.02,
             ),
         ),
         use_cuda_graph=True,
@@ -77,6 +79,19 @@ class DrLegsPhysicsCfg(PresetCfg):
     physx: PhysxAutoCfg = PhysxAutoCfg(isaacsim_physx=isaacsim_physx)
 
 
+def _dr_legs_robot_cfg() -> ArticulationCfg:
+    """Return the task-local DR Legs articulation configuration."""
+    cfg = DR_LEGS_IMPLICIT_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    # Work around Newton issue #4173: finite implicit-PD effort rows can destabilize closed-loop P-ADMM.
+    cfg.actuators["driven_joints"].joint_effort_limit = preset(
+        default=math.inf,
+        newton_kamino=math.inf,
+        isaacsim_physx=3.1,
+        physx=3.1,
+    )
+    return cfg
+
+
 ##
 # Scene definition
 ##
@@ -89,7 +104,7 @@ class HoldPoseSceneCfg(InteractiveSceneCfg):
         spawn=sim_utils.GroundPlaneCfg(size=(100.0, 100.0), physics_material=_PHYSICS_MATERIAL),
     )
 
-    robot = DR_LEGS_IMPLICIT_PD_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+    robot = _dr_legs_robot_cfg()
 
     dome_light = AssetBaseCfg(
         prim_path="/World/DomeLight",

--- a/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
+++ b/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
@@ -21,18 +21,13 @@ simulation_app = app_launcher.app
 
 import math
 
-import gymnasium as gym
 import pytest
-import torch
-
-import isaaclab.sim as sim_utils
-from isaaclab.sim import SimulationContext
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
 
 # Local imports should be imported last
-from env_test_utils import _check_valid_tensor, _run_environments, setup_environment  # isort: skip
+from env_test_utils import _run_environments, setup_environment  # isort: skip
 
 
 _SKIPPED_TASKS = {
@@ -89,36 +84,6 @@ def test_dr_legs_driven_joint_effort_limit_matches_physics_backend(
     env_cfg = parse_env_cfg("IsaacContrib-DrLegs-Walk", overrides=overrides)
     actual_effort_limit = env_cfg.scene.robot.actuators["driven_joints"].joint_effort_limit
     assert actual_effort_limit == expected_effort_limit
-
-
-def test_dr_legs_walk_seed_zero_remains_finite():
-    """Keep DR Legs state finite under the random actions that exposed P-ADMM divergence."""
-    sim_utils.create_new_stage()
-    env = None
-    try:
-        env_cfg = parse_env_cfg("IsaacContrib-DrLegs-Walk", device="cuda", num_envs=2)
-        env_cfg.seed = 0
-        env = gym.make("IsaacContrib-DrLegs-Walk", cfg=env_cfg)
-        env.unwrapped.sim._app_control_on_stop_handle = None  # type: ignore
-
-        action_space = gym.vector.utils.batch_space(env.unwrapped.single_action_space, 2)
-        action_space.seed(0)
-        obs, _ = env.reset(seed=0)
-        assert _check_valid_tensor(obs)
-
-        with torch.inference_mode():
-            for _ in range(5):
-                actions = torch.as_tensor(action_space.sample(), device=env.unwrapped.device, dtype=torch.float32)
-                transition = env.step(actions)
-                assert all(_check_valid_tensor(data) for data in transition[:-1])
-                joint_velocity = env.unwrapped.scene["robot"].data.joint_vel
-                joint_velocity = joint_velocity.torch if hasattr(joint_velocity, "torch") else joint_velocity
-                max_joint_velocity = torch.max(torch.abs(joint_velocity)).item()
-                assert max_joint_velocity < 100.0, f"Joint velocity diverged to {max_joint_velocity} rad/s"
-    finally:
-        if env is not None:
-            env.close()
-        SimulationContext.clear_instance()
 
 
 @pytest.mark.parametrize("task_name", _contrib_environment_params())

--- a/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
+++ b/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
@@ -19,12 +19,18 @@ simulation_app = app_launcher.app
 
 """Rest everything follows."""
 
+import gymnasium as gym
 import pytest
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.sim import SimulationContext
 
 import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import parse_env_cfg
 
 # Local imports should be imported last
-from env_test_utils import _run_environments, setup_environment  # isort: skip
+from env_test_utils import _check_valid_tensor, _run_environments, setup_environment  # isort: skip
 
 
 _SKIPPED_TASKS = {
@@ -32,11 +38,6 @@ _SKIPPED_TASKS = {
     "IsaacContrib-AutoMate-Disassembly-Direct": "Requires CUDA support outside the standard environment test runner.",
 }
 _SKIPPED_TASK_SUBSTRINGS = {
-    # Under random actions the Kamino P-ADMM solver intermittently diverges and the whole robot state
-    # (root pose, joint state) turns NaN mid-episode, so the run fails nondeterministically (about 1 in 12
-    # seeds locally; the sibling HoldPose task stays finite). The termination terms cannot catch a NaN state.
-    # Re-enable once the solver instability is resolved upstream.
-    "DrLegs-Walk": "Kamino solver intermittently produces NaN robot state under random actions.",
     "RmpFlow": "Uses SingleArticulation, which requires an update.",
     "Skillgen": "Requires cuRobo-specific coverage.",
     "Suction": "Requires CPU simulation.",
@@ -68,6 +69,36 @@ def _contrib_environment_params() -> list:
             marks = (*marks, pytest.mark.skip(reason=skip_reason))
         params.append(pytest.param(task_name, id=task_name, marks=marks))
     return params
+
+
+def test_dr_legs_walk_seed_zero_remains_finite():
+    """Keep DR Legs state finite under the random actions that exposed P-ADMM divergence."""
+    sim_utils.create_new_stage()
+    env = None
+    try:
+        env_cfg = parse_env_cfg("IsaacContrib-DrLegs-Walk", device="cuda", num_envs=2)
+        env_cfg.seed = 0
+        env = gym.make("IsaacContrib-DrLegs-Walk", cfg=env_cfg)
+        env.unwrapped.sim._app_control_on_stop_handle = None  # type: ignore
+
+        action_space = gym.vector.utils.batch_space(env.unwrapped.single_action_space, 2)
+        action_space.seed(0)
+        obs, _ = env.reset(seed=0)
+        assert _check_valid_tensor(obs)
+
+        with torch.inference_mode():
+            for _ in range(5):
+                actions = torch.as_tensor(action_space.sample(), device=env.unwrapped.device, dtype=torch.float32)
+                transition = env.step(actions)
+                assert all(_check_valid_tensor(data) for data in transition[:-1])
+                joint_velocity = env.unwrapped.scene["robot"].data.joint_vel
+                joint_velocity = joint_velocity.torch if hasattr(joint_velocity, "torch") else joint_velocity
+                max_joint_velocity = torch.max(torch.abs(joint_velocity)).item()
+                assert max_joint_velocity < 100.0, f"Joint velocity diverged to {max_joint_velocity} rad/s"
+    finally:
+        if env is not None:
+            env.close()
+        SimulationContext.clear_instance()
 
 
 @pytest.mark.parametrize("task_name", _contrib_environment_params())

--- a/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
+++ b/source/isaaclab_tasks/test/contrib/test_contrib_environments.py
@@ -19,6 +19,8 @@ simulation_app = app_launcher.app
 
 """Rest everything follows."""
 
+import math
+
 import gymnasium as gym
 import pytest
 import torch
@@ -69,6 +71,24 @@ def _contrib_environment_params() -> list:
             marks = (*marks, pytest.mark.skip(reason=skip_reason))
         params.append(pytest.param(task_name, id=task_name, marks=marks))
     return params
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_effort_limit"),
+    [
+        ((), math.inf),
+        (("physics=newton_kamino",), math.inf),
+        (("physics=isaacsim_physx",), 3.1),
+        (("physics=physx",), 3.1),
+    ],
+)
+def test_dr_legs_driven_joint_effort_limit_matches_physics_backend(
+    overrides: tuple[str, ...], expected_effort_limit: float
+):
+    """Disable the unstable effort constraint only for the Kamino backend."""
+    env_cfg = parse_env_cfg("IsaacContrib-DrLegs-Walk", overrides=overrides)
+    actual_effort_limit = env_cfg.scene.robot.actuators["driven_joints"].joint_effort_limit
+    assert actual_effort_limit == expected_effort_limit
 
 
 def test_dr_legs_walk_seed_zero_remains_finite():


### PR DESCRIPTION
# Description

Stabilize the DR Legs Kamino P-ADMM preset under bounded random joint targets by disabling the
driven-joint solver effort limit only for Newton/Kamino. The PhysX presets retain the authored
3.1 N m limit, and the Kamino penalty parameter is restored to its original ``rho_0=0.02``.

Re-enable ``IsaacContrib-DrLegs-Walk`` in the contributed-environment smoke suite and add coverage
proving that the nested effort-limit preset resolves to ``inf`` for Newton/default and ``3.1`` for
both PhysX aliases.

The finite effort limit adds solver-side constraint rows; the failure is in their interaction with
the closed-loop Kamino P-ADMM solve, rather than ordinary controller-side torque clipping. This is a
temporary Isaac Lab workaround for https://github.com/newton-physics/newton/issues/4173. Its explicit
tradeoff is that Newton no longer enforces the robot's 3.1 N m driven-joint torque cap until the
upstream constraint instability is fixed. PhysX behavior is unchanged.

Fixes #7625

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Testing

- ``uv run isaaclab -f``
- ``uv run python tools/changelog/cli.py check develop``
- Effort-limit preset regression: failed for both Newton/default variants before the fix; all four
  Newton and PhysX variants pass after the fix
- ``test_contrib_environments[IsaacContrib-DrLegs-Walk]`` (CUDA): passed in 12/12 fresh 20-step runs
- Final focused CUDA run: 5/5 tests passed together

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (not applicable; no public API or workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
