### PR TITLE
Use default ground planes in MPM demos

### DIFF
--- a/scripts/demos/mpm/newton_mpm_granular.py
+++ b/scripts/demos/mpm/newton_mpm_granular.py
@@ -146,7 +146,7 @@ def create_scene_cfg():
 
         ground = AssetBaseCfg(
             prim_path="/World/Ground",
-            spawn=sim_utils.GroundPlaneCfg(size=(12.0, 12.0), color=(0.30, 0.30, 0.30)),
+            spawn=sim_utils.GroundPlaneCfg(),
         )
 
         dome_light = AssetBaseCfg(

--- a/scripts/demos/mpm/newton_mpm_twoway_coupling.py
+++ b/scripts/demos/mpm/newton_mpm_twoway_coupling.py
@@ -230,7 +230,7 @@ def create_scene_cfg():
 
         ground = AssetBaseCfg(
             prim_path="/World/Ground",
-            spawn=sim_utils.GroundPlaneCfg(size=(12.0, 12.0), color=(0.30, 0.30, 0.30)),
+            spawn=sim_utils.GroundPlaneCfg(),
             init_state=AssetBaseCfg.InitialStateCfg(pos=(0.0, 0.0, -wall_t)),
         )
         dome_light = AssetBaseCfg(

--- a/scripts/demos/mpm/snowball_smash.py
+++ b/scripts/demos/mpm/snowball_smash.py
@@ -279,7 +279,7 @@ def create_scene_cfg():
         # the MPM model view.
         ground = AssetBaseCfg(
             prim_path="/World/Ground",
-            spawn=sim_utils.GroundPlaneCfg(size=(12.0, 12.0), color=(0.32, 0.34, 0.38)),
+            spawn=sim_utils.GroundPlaneCfg(),
         )
 
         # The co-located hidden kinematic slab belongs only to the MPM entry.


### PR DESCRIPTION
# Description

Use the default `GroundPlaneCfg` appearance in the granular, two-way coupling, and snowball MPM demos. This removes per-demo size and color overrides and keeps the examples aligned with the standard Isaac Lab ground plane.

No new dependencies.

## Type of change

- Documentation/example cleanup (non-breaking)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this intentionally adopts the standard ground-plane appearance.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) on all changed files
- [x] Documentation changes are not required
- [x] My changes generate no new warnings
- [x] Tests are not required for configuration-only demo cleanup
- [x] Changelog fragments are not required because no source package is changed
- [x] My name already exists in `CONTRIBUTORS.md`