### PR TITLE
Avoid continuous rendering between video captures

### DIFF
--- a/source/isaaclab/changelog.d/fix-headless-video-idle-rendering.rst
+++ b/source/isaaclab/changelog.d/fix-headless-video-idle-rendering.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Fixed ``--video`` training continuously updating PhysX Fabric and the capture-only Kit visualizer
+  between recording windows. Physics transforms are now synchronized on demand before each captured frame.

--- a/source/isaaclab/isaaclab/envs/utils/video_recorder.py
+++ b/source/isaaclab/isaaclab/envs/utils/video_recorder.py
@@ -196,6 +196,8 @@ class VideoRecorder:
                 )
 
         viz = candidates[0]
+        if not sim.is_rendering:
+            sim.forward()
         if sub == "streaming_view":
             if not hasattr(viz, "render_tiled_rgb_array"):
                 raise RuntimeError(

--- a/source/isaaclab/isaaclab/sensors/camera/camera.py
+++ b/source/isaaclab/isaaclab/sensors/camera/camera.py
@@ -198,6 +198,7 @@ class Camera(SensorBase):
 
             settings = get_settings_manager()
             settings.set_bool("/isaaclab/render/rtx_sensors", True)
+            settings.set_bool("/physics/fabricUpdateTransformations", True)
             if require_hdr_output:
                 settings.set_bool("/rtx/rtpt/gaussian/skipTonemapping/enabled", False)
         elif renderer_type == "ovrtx" and require_hdr_output:

--- a/source/isaaclab/isaaclab/sim/simulation_context.py
+++ b/source/isaaclab/isaaclab/sim/simulation_context.py
@@ -210,6 +210,9 @@ class SimulationContext:
         # cameras rather than inheriting a stale True from a previously torn-down simulation. RTX
         # cameras created for this instance re-set it to True before it is read.
         self.set_setting("/isaaclab/render/rtx_sensors", False)
+        # Preserve rendering initialization, then avoid continuous Fabric synchronization when
+        # the only visualizer is used for on-demand headless capture.
+        self.set_setting("/physics/fabricUpdateTransformations", self.is_rendering)
         # Set by camera sensors, which draw visual-only geometry regardless of renderer backend.
         self._visual_shapes_required = False
         self._pending_camera_view: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
@@ -341,7 +344,7 @@ class SimulationContext:
         return (
             self._has_gui
             or self.get_setting("/isaaclab/render/rtx_sensors")
-            or bool(self.resolve_visualizer_types())
+            or self._has_continuous_visualizers()
             or self._xr_enabled
         )
 
@@ -514,6 +517,31 @@ class SimulationContext:
         if not isinstance(visualizer_cfgs, list):
             visualizer_cfgs = [visualizer_cfgs]
         return [cfg.visualizer_type for cfg in visualizer_cfgs if getattr(cfg, "visualizer_type", None)]
+
+    def _has_continuous_visualizers(self) -> bool:
+        """Return whether the resolved visualizers require per-step updates."""
+        visualizer_types = self.resolve_visualizer_types()
+        if not visualizer_types:
+            return False
+
+        visualizer_cfgs = self.cfg.visualizer_cfgs
+        if visualizer_cfgs is None:
+            visualizer_cfgs = []
+        elif not isinstance(visualizer_cfgs, list):
+            visualizer_cfgs = [visualizer_cfgs]
+
+        if self._is_cli_visualizer_explicit():
+            for visualizer_type in visualizer_types:
+                matching_cfgs = [
+                    cfg for cfg in visualizer_cfgs if getattr(cfg, "visualizer_type", None) == visualizer_type
+                ]
+                if not matching_cfgs or any(not getattr(cfg, "headless", False) for cfg in matching_cfgs):
+                    return True
+            return False
+
+        return any(
+            getattr(cfg, "visualizer_type", None) and not getattr(cfg, "headless", False) for cfg in visualizer_cfgs
+        )
 
     def _resolve_visualizer_cfgs(self) -> list[Any]:
         """Resolve final visualizer configs from cfg and optional CLI override.

--- a/source/isaaclab/test/envs/test_video_recorder.py
+++ b/source/isaaclab/test/envs/test_video_recorder.py
@@ -229,6 +229,31 @@ def test_visualizer_source_auto_picks_first_with_render_rgb_array():
     assert viz.render_calls == 1
 
 
+def test_visualizer_source_refreshes_physics_before_on_demand_capture():
+    """On-demand capture reads a frame after physics transforms are synchronized."""
+    synchronized = False
+
+    class _FreshFrameViz(_FakeViz):
+        def render_rgb_array(self) -> np.ndarray:
+            return np.full_like(self._frame, 255 if synchronized else 0)
+
+    viz = _FreshFrameViz("kit")
+    env = _make_env(visualizers=[viz])
+    env.sim.is_rendering = False
+
+    def synchronize_physics() -> None:
+        nonlocal synchronized
+        synchronized = True
+
+    env.sim.forward.side_effect = synchronize_physics
+    recorder = VideoRecorder(_cfg(source="visualizer:kit"), env)
+
+    frame = recorder._get_frame()
+
+    assert frame is not None
+    assert np.all(frame == 255)
+
+
 def test_visualizer_source_auto_no_visualizer_logs_and_returns_none(caplog):
     """source='visualizer' with no visualizers logs an error once and returns None instead of raising."""
     import logging

--- a/source/isaaclab/test/sensors/test_camera.py
+++ b/source/isaaclab/test/sensors/test_camera.py
@@ -106,10 +106,12 @@ def test_camera_init(setup_sim_camera):
     """Test camera initialization."""
     # Create camera configuration
     sim, camera_cfg, dt = setup_sim_camera
+    sim.set_setting("/physics/fabricUpdateTransformations", False)
     # Create camera
     camera = Camera(camera_cfg)
     # Check simulation parameter is set correctly
     assert sim.get_setting("/isaaclab/render/rtx_sensors")
+    assert sim.get_setting("/physics/fabricUpdateTransformations")
     # Play sim
     sim.reset()
     # Check if camera is initialized

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -925,6 +925,19 @@ def test_is_rendering_true_when_only_cfg_visualizer_is_set():
     assert ctx.is_rendering is True
 
 
+def test_is_rendering_false_when_only_cfg_visualizer_is_headless():
+    """A capture-only headless visualizer must not trigger continuous rendering."""
+    cfg_visualizer = type("CfgVisualizer", (), {"visualizer_type": "kit", "headless": True})()
+    settings = {
+        "/isaaclab/render/rtx_sensors": False,
+        "/isaaclab/visualizer/types": "",
+        "/isaaclab/visualizer/explicit": False,
+        "/isaaclab/visualizer/disable_all": False,
+    }
+    ctx = _make_context_with_settings(settings, visualizer_cfgs=[cfg_visualizer])
+    assert ctx.is_rendering is False
+
+
 def test_is_rendering_false_when_cli_disable_all_even_with_cfg_visualizer():
     cfg_visualizer = type("CfgVisualizer", (), {"visualizer_type": "newton_gl"})()
     settings = {

--- a/source/isaaclab_tasks/changelog.d/fix-video-idle-rendering-overhead.skip
+++ b/source/isaaclab_tasks/changelog.d/fix-video-idle-rendering-overhead.skip
@@ -1,0 +1,1 @@
+Test-only coverage for simultaneous headless Kit video recorders.

--- a/source/isaaclab_tasks/test/core/test_video_recording.py
+++ b/source/isaaclab_tasks/test/core/test_video_recording.py
@@ -189,6 +189,39 @@ def test_kit_physx_records_moving_clip():
         _assert_clip_has_content(os.path.join(output_dir, "kit_0000.mp4"), "kit-physx")
 
 
+def test_multiple_headless_kit_recorders_simultaneous(monkeypatch):
+    """Multiple capture-only Kit recorders can share one visualizer."""
+    from isaaclab_visualizers.kit import KitVisualizerCfg
+
+    captured_clips: dict[str, list[np.ndarray]] = {}
+
+    class _FrameCaptureClip:
+        def __init__(self, frames: list[np.ndarray], fps: int):
+            self.frames = [frame.copy() for frame in frames]
+            self.fps = fps
+
+        def write_videofile(self, path: str, **_kwargs) -> None:
+            captured_clips[os.path.basename(path)] = self.frames
+
+    monkeypatch.setattr("isaaclab.envs.utils.video_recorder.ImageSequenceClip", _FrameCaptureClip)
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        env_cfg = _cartpole_cfg(num_envs=1)
+        env_cfg.sim.visualizer_cfgs = [KitVisualizerCfg(headless=True, window_width=320, window_height=240)]
+        env_cfg.video_recorders = [
+            _recorder_cfg(output_dir, "visualizer:kit", prefix="first"),
+            _recorder_cfg(output_dir, "visualizer:kit", prefix="second"),
+        ]
+        _run_cartpole(env_cfg)
+
+    assert set(captured_clips) == {"first_0000.mp4", "second_0000.mp4"}
+    for frames in captured_clips.values():
+        stack = np.stack(frames).astype(np.float32)
+        assert len(frames) == _CLIP
+        assert max(np.count_nonzero(frame) / frame.size for frame in stack) >= _MIN_NONZERO_RATIO
+        assert stack.std(axis=0).mean() >= _MIN_MOTION_STD
+
+
 def test_kit_newton_logs_warning_on_capture(caplog):
     """source='visualizer:kit' + Newton → logs a warning and capture proceeds.
 


### PR DESCRIPTION
# Description

`--video` enabled a headless Kit visualizer and continuous PhysX Fabric transform updates for the full training run, even though frames are only needed during capture windows. This caused a substantial FPS drop between recordings.

This change treats headless visualizers as on-demand rather than continuous renderers, disables continuous Fabric synchronization after PhysX initialization, and synchronizes transforms immediately before each visualizer frame capture. RTX camera sensors explicitly retain continuous Fabric updates.

### RTX 5090 benchmark

`Isaac-Humanoid-Direct`, PhysX, 4,096 environments, RSL-RL, 16 iterations. Idle results exclude iterations 0 and 10, which contain the two scheduled 32-frame capture windows.

| Configuration | Mean idle FPS | Difference |
| --- | ---: | ---: |
| Plain headless | 360,635 | — |
| Offscreen RTX enabled, no video recorder | 326,336 | -9.5% vs. plain headless |
| Periodic `--video` with this fix | 315,966 | -3.2% vs. offscreen RTX control |

The unfixed periodic-video run reproduced approximately 214,300 FPS between captures, about 34% below its plain-headless control. With this fix, most of that avoidable idle-window regression is removed. Capture iterations still drop as expected; the fixed periodic run measured 76,127 and 135,151 FPS during its two capture iterations, with 289,675 FPS overall including both captures.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this is a performance fix. A frame probe on the RTX 5090 verified that all 20 captured frames were non-black and changed over time (`temporal_std=72.21`, mean consecutive delta `12.46`).

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (not applicable; no public API or user workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Validation

- `uv run --frozen --extra test --extra rerun python -m pytest source/isaaclab/test/sim/test_simulation_context_visualizers.py source/isaaclab/test/envs/test_video_recorder.py -q` — 74 passed
- `uv run --frozen isaaclab -f` — all hooks passed
- `source/isaaclab/test/sensors/test_camera.py::test_camera_init` — passed on RTX 5090
