### PR TITLE
[Docs] Use uv pip for Python package installation

### DIFF
--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -721,12 +721,12 @@ Install the CUDA-enabled PyTorch build appropriate for your system architecture:
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (x86_64)
       :sync: linux-x86_64
 
-      .. isaaclab-torch-install:: cu128 pip
+      .. isaaclab-torch-install:: cu128
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows (x86_64)
       :sync: windows-x86_64
 
-      .. isaaclab-torch-install:: cu128 pip
+      .. isaaclab-torch-install:: cu128
 
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (aarch64)
       :sync: linux-aarch64
@@ -741,7 +741,7 @@ Install the CUDA-enabled PyTorch build appropriate for your system architecture:
             sudo apt install python3.12-dev libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev \
                libxinerama-dev libxrandr-dev
 
-      .. isaaclab-torch-install:: cu130 pip
+      .. isaaclab-torch-install:: cu130
 
       .. note::
 


### PR DESCRIPTION
# Description

Updates the CUDA-enabled PyTorch commands in the Isaac Lab Python package installation workflow to use `uv pip`, matching the uv-based environment setup. The managed conda workflow continues to render `python -m pip`.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run --isolated --extra dev -- sphinx-build -W --keep-going -j auto docs <temporary-output-directory>` — passed without warnings.
- Verified the rendered Python-package commands use `uv pip` for Linux x86_64, Windows x86_64, and Linux aarch64.
- `uv run isaaclab -f` — all applicable formatting and documentation hooks passed. The repository-wide changelog hook reports unrelated existing `develop` discrepancies in packages untouched by this docs-only change.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the applicable pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] No source package was changed, so no changelog fragment is required
- [x] My name already exists in `CONTRIBUTORS.md`