### PR TITLE
[Docs] Improve environment browser cards

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,13 +325,7 @@ html_last_updated_fmt = ""  # to reveal the build date in the pages meta
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [
-    "source/_static/css",
-    "source/_static/how-to",
-    "source/_static/visualizers",
-    "source/_static/tasks/previews",
-    "source/_static/benchmarks",
-]
+html_static_path = ["source/_static"]
 html_css_files = ["custom.css", "environment-browser.css"]
 html_js_files = ["environment-browser.js"]
 

--- a/docs/source/_static/css/environment-browser.css
+++ b/docs/source/_static/css/environment-browser.css
@@ -410,61 +410,138 @@ html[data-theme="dark"] .environment-browser {
 
 .environment-task-list {
     display: grid;
-    max-height: 31rem;
-    overflow-y: auto;
-    border: 1px solid var(--environment-border);
-    border-radius: 8px;
+    grid-template-columns: repeat(auto-fill, minmax(12.5rem, 1fr));
+    gap: 0.75rem;
 }
 
-.environment-task-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 1rem;
-    width: 100%;
-    min-height: 3.4rem;
-    padding: 0.65rem 0.85rem;
-    border: 0;
-    border-bottom: 1px solid var(--environment-border);
-    border-radius: 0;
+.environment-task-card {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--environment-border);
+    border-radius: 8px;
     color: var(--pst-color-text-base);
     background: var(--pst-color-background);
+}
+
+.environment-task-card:hover,
+.environment-task-card:has(.environment-task-card-select:focus-visible) {
+    border-color: var(--pst-color-primary);
+    box-shadow: 0 6px 16px color-mix(in srgb, var(--pst-color-shadow) 18%, transparent);
+}
+
+.environment-task-card.is-selected {
+    border-color: var(--pst-color-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--pst-color-primary) 35%, transparent);
+}
+
+.environment-task-card-select {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    align-content: start;
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
     text-align: left;
 }
 
-.environment-task-row:last-child {
-    border-bottom: 0;
+.environment-task-card-select > img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    border-bottom: 1px solid var(--environment-border);
+    object-fit: cover;
 }
 
-.environment-task-row:hover,
-.environment-task-row:focus-visible,
-.environment-task-row.is-selected {
-    background: color-mix(in srgb, var(--pst-color-primary) 9%, var(--pst-color-background));
-}
-
-.environment-task-row.is-selected {
-    box-shadow: inset 3px 0 var(--pst-color-primary);
+.environment-task-card-content {
+    display: grid;
+    align-content: start;
+    min-width: 0;
+    padding: 0.55rem 0.6rem 0.35rem;
 }
 
 .environment-task-name {
+    display: block;
     min-width: 0;
     overflow-wrap: anywhere;
     font-family: var(--pst-font-family-monospace);
+    font-size: 0.8rem;
     font-weight: 650;
 }
 
-.environment-task-meta {
-    display: inline-flex;
-    gap: 0.45rem;
-    color: var(--environment-muted);
-    font-size: 0.78rem;
-    white-space: nowrap;
+.environment-task-symbols {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    padding: 0 0.6rem 0.6rem;
 }
 
-.environment-task-meta span {
-    padding: 0.15rem 0.4rem;
+.environment-task-symbols:empty {
+    display: none;
+}
+
+.environment-task-symbol {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.18rem 0.45rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-family: var(--pst-font-family-monospace);
+    font-size: 0.64rem;
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+.environment-task-symbol i {
+    font-size: 0.6rem;
+}
+
+.environment-task-symbol-physics {
+    border-color: color-mix(in srgb, var(--environment-physics) 35%, transparent);
+    color: var(--environment-physics);
+    background: color-mix(in srgb, var(--environment-physics) 8%, transparent);
+}
+
+.environment-task-symbol-renderer {
+    border-color: color-mix(in srgb, var(--environment-renderer) 35%, transparent);
+    color: var(--environment-renderer);
+    background: color-mix(in srgb, var(--environment-renderer) 8%, transparent);
+}
+
+.environment-task-symbol-rl {
+    border-color: color-mix(in srgb, var(--environment-preset) 35%, transparent);
+    color: var(--environment-preset);
+    background: color-mix(in srgb, var(--environment-preset) 8%, transparent);
+}
+
+.environment-task-variants {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0 0.6rem 0.45rem;
+}
+
+.environment-task-variants button {
+    padding: 0.12rem 0.45rem;
     border: 1px solid var(--environment-border);
-    border-radius: 4px;
+    border-radius: 999px;
+    color: var(--environment-muted);
+    background: color-mix(in srgb, var(--pst-color-surface) 65%, transparent);
+    font-size: 0.68rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.environment-task-variants button.is-selected {
+    color: #1f3300;
+    border-color: #76b900;
+    background: #76b900;
 }
 
 .environment-empty-state {
@@ -745,13 +822,8 @@ html[data-theme="dark"] .environment-browser {
         width: 100%;
     }
 
-    .environment-task-row {
+    .environment-task-list {
         grid-template-columns: 1fr;
-        gap: 0.35rem;
-    }
-
-    .environment-task-meta {
-        white-space: normal;
     }
 
     .environment-benchmark-panel {

--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -187,12 +187,13 @@
     const copyButton = builder.querySelector("[data-copy-command]");
     const copyStatus = builder.querySelector("[data-copy-status]");
     const modeButtons = [...builder.querySelectorAll("[data-command-mode]")];
-    const scopeButtons = [...builder.querySelectorAll("[data-task-scope]")];
+    const scopeButtons = [...document.querySelectorAll("[data-task-scope]")];
     const taskList = taskBrowser.querySelector("[data-task-list]");
     const taskSearch = taskBrowser.querySelector("[data-task-search]");
     const taskCategory = taskBrowser.querySelector("[data-task-category]");
     const taskCount = taskBrowser.querySelector("[data-task-count]");
     const taskEmpty = taskBrowser.querySelector("[data-task-empty]");
+    const taskCardRefreshers = new WeakMap();
     const state = {
         mode: "train",
         scope: "core",
@@ -210,6 +211,89 @@
             return "manipulation";
         }
         return "classic";
+    };
+
+    // Direct/camera variants of the same task are folded into a single card; this only strips
+    // exact trailing suffixes, so unrelated tasks that merely contain "Camera"/"Direct" elsewhere
+    // in their name are never merged.
+    const variantOrder = ["manager", "direct", "camera", "direct-camera"];
+    const variantLabels = {manager: "Manager", direct: "Direct", camera: "Camera", "direct-camera": "Direct-Camera"};
+    const variantOf = (task) => {
+        if (task.endsWith("-Camera-Direct")) {
+            return "direct-camera";
+        }
+        if (task.endsWith("-Direct")) {
+            return "direct";
+        }
+        if (task.endsWith("-Camera")) {
+            return "camera";
+        }
+        return "manager";
+    };
+    const baseTaskName = (task) => task
+        .replace(/-Camera-Direct$/, "")
+        .replace(/-Direct$/, "")
+        .replace(/-Camera$/, "");
+
+    const groupTasks = (taskList) => {
+        const groups = new Map();
+        for (const task of taskList) {
+            const base = baseTaskName(task.task);
+            if (!groups.has(base)) {
+                groups.set(base, []);
+            }
+            groups.get(base).push(task);
+        }
+        for (const variants of groups.values()) {
+            variants.sort((left, right) => (
+                variantOrder.indexOf(variantOf(left.task)) - variantOrder.indexOf(variantOf(right.task))
+            ));
+        }
+        return groups;
+    };
+
+    // Keep capability labels compact on the cards while retaining the full names in tooltips and
+    // accessible labels.
+    const capabilitySymbolSets = [
+        ["physics", [
+            ["isaacsim_physx", "physx", "Isaac Sim PhysX"],
+            ["newton_kamino", "kamino", "Newton Kamino"],
+            ["newton_mjwarp", "mjwarp", "Newton MJWarp"],
+            ["newton_mjwarp_vbd_proxy", "mjwarp vbd", "Newton MJWarp VBD proxy"],
+            ["ovphysx", "ovphysx", "OV PhysX"],
+        ]],
+        ["renderer", [
+            ["isaacsim_rtx", "rtx", "Isaac Sim RTX"],
+            ["newton_renderer", "renderer", "Newton renderer"],
+            ["ovrtx", "ovrtx", "OV RTX"],
+        ]],
+        ["rl", [
+            ["rl_games", "rl_games", "RL Games"],
+            ["rsl_rl", "rsl_rl", "RSL-RL"],
+            ["skrl", "skrl", "skrl"],
+            ["sb3", "sb3", "Stable-Baselines3"],
+            ["rlinf", "rlinf", "RLinf"],
+        ]],
+    ];
+
+    const buildCapabilitySymbols = (task) => {
+        const values = {physics: task.physics, renderer: task.renderer, rl: task.rl};
+        const icons = {physics: "fa-gears", renderer: "fa-eye", rl: "fa-chart-line"};
+        return capabilitySymbolSets.flatMap(([type, symbols]) => symbols
+            .filter(([value]) => values[type].includes(value))
+            .map(([, shortLabel, fullLabel]) => {
+                const symbol = document.createElement("span");
+                symbol.className = `environment-task-symbol environment-task-symbol-${type}`;
+                symbol.title = fullLabel;
+                symbol.setAttribute("aria-label", fullLabel);
+                const icon = document.createElement("i");
+                icon.className = `fa-solid ${icons[type]}`;
+                icon.setAttribute("aria-hidden", "true");
+                const label = document.createElement("span");
+                label.textContent = shortLabel;
+                symbol.replaceChildren(icon, label);
+                return symbol;
+            }));
     };
 
     const preferredValue = (values, preferred) => preferred.find((value) => values.includes(value)) || values[0] || "";
@@ -415,6 +499,9 @@
         updateModeControls();
         commandOutput.textContent = currentCommand();
         updatePreview();
+        for (const card of taskList.querySelectorAll(".environment-task-card")) {
+            taskCardRefreshers.get(card)?.();
+        }
         for (const row of taskList.querySelectorAll("[data-task-name]")) {
             const isSelected = row.dataset.taskName === state.task;
             row.classList.toggle("is-selected", isSelected);
@@ -422,44 +509,100 @@
         }
     };
 
+    const createTaskCard = (variants) => {
+        const card = document.createElement("div");
+        card.className = "environment-task-card";
+
+        const selectButton = document.createElement("button");
+        selectButton.type = "button";
+        selectButton.className = "environment-task-card-select";
+
+        const image = document.createElement("img");
+        image.alt = "";
+        image.loading = "lazy";
+
+        const content = document.createElement("span");
+        content.className = "environment-task-card-content";
+        const nameEl = document.createElement("span");
+        nameEl.className = "environment-task-name";
+        const symbolsEl = document.createElement("span");
+        symbolsEl.className = "environment-task-symbols";
+        content.append(nameEl);
+        selectButton.append(image, content);
+
+        const variantsRow = document.createElement("div");
+        variantsRow.className = "environment-task-variants";
+        variantsRow.setAttribute("role", "group");
+        variantsRow.setAttribute("aria-label", "Task variant");
+        for (const variantTask of variants) {
+            const variantButton = document.createElement("button");
+            variantButton.type = "button";
+            variantButton.textContent = variantLabels[variantOf(variantTask.task)];
+            variantButton.dataset.taskName = variantTask.task;
+            variantButton.addEventListener("click", (event) => {
+                event.stopPropagation();
+                state.task = variantTask.task;
+                refreshCard();
+                updateSelection();
+            });
+            variantsRow.append(variantButton);
+        }
+
+        const refreshCard = () => {
+            const activeTask = variants.find((task) => task.task === state.task) || variants[0];
+            const isSelected = variants.includes(activeTask) && activeTask.task === state.task;
+            const previewImageName = previewImageFor(activeTask).split("/").pop();
+            image.src = new URL(`../../_images/${previewImageName}`, window.location.href).href;
+            image.alt = "";
+            selectButton.dataset.taskName = activeTask.task;
+            selectButton.setAttribute("aria-pressed", String(isSelected));
+            nameEl.textContent = activeTask.task;
+            symbolsEl.replaceChildren(...buildCapabilitySymbols(activeTask));
+            card.classList.toggle("is-selected", isSelected);
+            for (const button of variantsRow.querySelectorAll("[data-task-name]")) {
+                const isActiveVariant = button.dataset.taskName === state.task;
+                button.classList.toggle("is-selected", isActiveVariant);
+                button.setAttribute("aria-pressed", String(isActiveVariant));
+            }
+        };
+
+        selectButton.addEventListener("click", () => {
+            state.task = selectButton.dataset.taskName;
+            updateSelection();
+        });
+
+        taskCardRefreshers.set(card, refreshCard);
+        refreshCard();
+        card.append(selectButton, variantsRow, symbolsEl);
+        return card;
+    };
+
     const renderTasks = () => {
         const query = taskSearch.value.trim().toLowerCase();
         const category = taskCategory.value;
-        const visibleTasks = tasksForScope().filter((task) => {
-            const matchesQuery = task.task.toLowerCase().includes(query);
+        const matchesFilter = (task) => {
+            const searchableValues = [
+                task.task,
+                ...(task.physics.length ? task.physics : ["Default"]),
+                ...(task.renderer.length ? task.renderer : ["Default"]),
+                ...(task.rl.length ? task.rl : ["Not supported"]),
+            ];
+            const matchesQuery = searchableValues.some((value) => value.toLowerCase().includes(query));
             const matchesCategory = category === "all"
                 || categoryFor(task.task) === category;
             return matchesQuery && matchesCategory;
-        });
-        taskList.replaceChildren(...visibleTasks.map((task) => {
-            const button = document.createElement("button");
-            button.type = "button";
-            button.className = "environment-task-row";
-            button.dataset.taskName = task.task;
-            const isSelected = task.task === state.task;
-            button.classList.toggle("is-selected", isSelected);
-            button.setAttribute("aria-pressed", String(isSelected));
-            button.innerHTML = `<span class="environment-task-name"></span><span class="environment-task-meta"></span>`;
-            button.querySelector(".environment-task-name").textContent = task.task;
-            const meta = button.querySelector(".environment-task-meta");
-            const workflow = task.task.includes("Direct") ? "Direct" : "Manager based";
-            const rlSupport = task.rl.length
-                ? `${task.rl.length} RL ${task.rl.length === 1 ? "library" : "libraries"}`
-                : "RL not supported";
-            meta.replaceChildren(...[workflow, rlSupport].map((label) => {
-                const badge = document.createElement("span");
-                badge.textContent = label;
-                return badge;
-            }));
-            button.addEventListener("click", () => {
-                state.task = task.task;
-                updateSelection();
-            });
-            return button;
-        }));
-        taskCount.textContent = `${visibleTasks.length} ${visibleTasks.length === 1 ? "task" : "tasks"}`;
-        taskEmpty.hidden = visibleTasks.length !== 0;
-        taskList.hidden = visibleTasks.length === 0;
+        };
+        const groups = groupTasks(tasksForScope());
+        const visibleGroups = [...groups.values()].filter((variants) => variants.some(matchesFilter));
+
+        taskList.replaceChildren(...visibleGroups.map((variants) => createTaskCard(variants)));
+        const matchingTaskCount = visibleGroups.reduce(
+            (total, variants) => total + variants.filter(matchesFilter).length,
+            0,
+        );
+        taskCount.textContent = `${matchingTaskCount} ${matchingTaskCount === 1 ? "task" : "tasks"}`;
+        taskEmpty.hidden = visibleGroups.length !== 0;
+        taskList.hidden = visibleGroups.length === 0;
     };
 
     const initializeTasks = () => {
@@ -716,7 +859,7 @@
             }
             state.scope = scope;
             for (const scopeButton of scopeButtons) {
-                const isActive = scopeButton === button;
+                const isActive = scopeButton.dataset.taskScope === scope;
                 scopeButton.classList.toggle("is-active", isActive);
                 scopeButton.setAttribute("aria-pressed", String(isActive));
             }

--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -187,7 +187,7 @@
     const copyButton = builder.querySelector("[data-copy-command]");
     const copyStatus = builder.querySelector("[data-copy-status]");
     const modeButtons = [...builder.querySelectorAll("[data-command-mode]")];
-    const scopeButtons = [...document.querySelectorAll("[data-task-scope]")];
+    const scopeButtons = [...taskBrowser.querySelectorAll("[data-task-scope]")];
     const taskList = taskBrowser.querySelector("[data-task-list]");
     const taskSearch = taskBrowser.querySelector("[data-task-search]");
     const taskCategory = taskBrowser.querySelector("[data-task-category]");
@@ -335,7 +335,6 @@
             [/Reorient-Franka/, "tasks/manipulation/franka_lift.jpg"],
             [/Reorient-KukaAllegro/, "tasks/manipulation/kuka_allegro_reorient.jpg"],
             [/Shadow-Handover/, "tasks/manipulation/shadow_hand_over.jpg"],
-            [/Keyboard-SO101/, "tasks/manipulation/so101_keyboard.jpg"],
             [/AnymalB/, "tasks/locomotion/anymal_b_flat.jpg"],
             [/AnymalC/, "tasks/locomotion/anymal_c_flat.jpg"],
             [/AnymalD/, "tasks/locomotion/anymal_d_flat.jpg"],
@@ -551,8 +550,7 @@
         const refreshCard = () => {
             const activeTask = variants.find((task) => task.task === state.task) || variants[0];
             const isSelected = variants.includes(activeTask) && activeTask.task === state.task;
-            const previewImageName = previewImageFor(activeTask).split("/").pop();
-            image.src = new URL(`../../_images/${previewImageName}`, window.location.href).href;
+            image.src = new URL(`../../_static/${previewImageFor(activeTask)}`, window.location.href).href;
             image.alt = "";
             selectButton.dataset.taskName = activeTask.task;
             selectButton.setAttribute("aria-pressed", String(isSelected));
@@ -593,13 +591,12 @@
             return matchesQuery && matchesCategory;
         };
         const groups = groupTasks(tasksForScope());
-        const visibleGroups = [...groups.values()].filter((variants) => variants.some(matchesFilter));
+        const visibleGroups = [...groups.values()]
+            .map((variants) => variants.filter(matchesFilter))
+            .filter((variants) => variants.length > 0);
 
-        taskList.replaceChildren(...visibleGroups.map((variants) => createTaskCard(variants)));
-        const matchingTaskCount = visibleGroups.reduce(
-            (total, variants) => total + variants.filter(matchesFilter).length,
-            0,
-        );
+        taskList.replaceChildren(...visibleGroups.map(createTaskCard));
+        const matchingTaskCount = visibleGroups.reduce((total, variants) => total + variants.length, 0);
         taskCount.textContent = `${matchingTaskCount} ${matchingTaskCount === 1 ? "task" : "tasks"}`;
         taskEmpty.hidden = visibleGroups.length !== 0;
         taskList.hidden = visibleGroups.length === 0;
@@ -859,7 +856,7 @@
             }
             state.scope = scope;
             for (const scopeButton of scopeButtons) {
-                const isActive = scopeButton.dataset.taskScope === scope;
+                const isActive = scopeButton === button;
                 scopeButton.classList.toggle("is-active", isActive);
                 scopeButton.setAttribute("aria-pressed", String(isActive));
             }

--- a/docs/source/setup/environments.rst
+++ b/docs/source/setup/environments.rst
@@ -135,8 +135,8 @@ Available Tasks
      <div class="environment-task-toolbar">
        <label class="environment-task-search">
          <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-         <span class="visually-hidden">Search tasks</span>
-         <input type="search" data-task-search placeholder="Search tasks" autocomplete="off">
+         <span class="visually-hidden">Search tasks and capabilities</span>
+         <input type="search" data-task-search placeholder="Search tasks or capabilities" autocomplete="off">
        </label>
        <label class="environment-task-filter">
          <span class="visually-hidden">Task category</span>
@@ -147,6 +147,11 @@ Available Tasks
            <option value="locomotion">Locomotion</option>
          </select>
        </label>
+       <div class="environment-scope-switch" role="group" aria-label="Task collection">
+         <button type="button" class="is-active" data-task-scope="core" aria-pressed="true">Core</button>
+         <button type="button" data-task-scope="contrib" aria-pressed="false">Contrib</button>
+         <button type="button" data-task-scope="warp" aria-pressed="false">Warp</button>
+       </div>
        <span class="environment-task-count" data-task-count></span>
      </div>
      <div class="environment-task-list" data-task-list></div>

--- a/docs/source/setup/environments.rst
+++ b/docs/source/setup/environments.rst
@@ -31,11 +31,6 @@ Command Builder
            <span>--task</span>
            <select data-environment-field="task" aria-label="Task"></select>
          </label>
-         <div class="environment-scope-switch" role="group" aria-label="Task collection">
-           <button type="button" class="is-active" data-task-scope="core" aria-pressed="true">Core</button>
-           <button type="button" data-task-scope="contrib" aria-pressed="false">Contrib</button>
-           <button type="button" data-task-scope="warp" aria-pressed="false">Warp</button>
-         </div>
        </div>
        <div class="environment-command-row environment-command-row-options">
          <label class="environment-selector environment-selector-physics">


### PR DESCRIPTION
# Description

Improve the environment browser by presenting related task variants as visual cards and making task capabilities easier to discover.

This change:

- groups manager-based, direct, camera, and direct-camera variants into one card
- adds preview images and physics, renderer, and RL capability badges
- supports searching by task name or capability
- moves the Core, Contrib, and Warp scope selector alongside the task filters
- updates responsive styling for the new card layout

No additional dependencies are required.

## Type of change

- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not included; the rendered documentation preview shows the updated card layout.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the formatting and pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (no source packages are touched)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
