### PR TITLE
Cache marker scene-partition tokens instead of rebuilding them each f…

### DIFF
--- a/source/isaaclab/changelog.d/cache-marker-scene-partition.skip
+++ b/source/isaaclab/changelog.d/cache-marker-scene-partition.skip
@@ -1,0 +1,2 @@
+Internal: added regression coverage for marker scene-partition token caching in
+``isaaclab_visualizers``; no library behavior changed in this package.

--- a/source/isaaclab/test/markers/test_visualization_markers.py
+++ b/source/isaaclab/test/markers/test_visualization_markers.py
@@ -204,6 +204,68 @@ def test_environment_ids_author_point_instance_scene_partitions(sim):
     assert list(primvar.Get()) == ["env_1", "env_0"]
 
 
+def test_unchanged_environment_ids_do_not_rebuild_scene_partitions(sim, monkeypatch):
+    """Unchanged environment IDs should not rebuild partition tokens on every call.
+
+    Marker ownership is static in most tasks, but ``visualize`` runs every frame. Rebuilding the
+    token array anyway costs a device synchronization and one string per marker per frame.
+    """
+    from pxr import Sdf, UsdGeom, Vt
+
+    sim._has_offscreen_render = True
+    stage = sim_utils.get_current_stage()
+    for env_id in range(2):
+        env_prim = stage.DefinePrim(f"/World/envs/env_{env_id}", "Xform")
+        env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(f"env_{env_id}")
+
+    config = VisualizationMarkersCfg(
+        prim_path="/World/Visuals/cached_partition_marker",
+        markers={"test": sim_utils.SphereCfg(radius=0.1)},
+    )
+    test_marker = VisualizationMarkers(config)
+    translations = torch.tensor([[0.0, 0.0, 0.0], [0.2, 0.0, 0.0]], device=sim.device)
+    environment_ids = torch.tensor([1, 0], device=sim.device)
+    test_marker.visualize(translations=translations, environment_ids=environment_ids)
+
+    rebuilt_token_arrays = []
+    original_token_array = Vt.TokenArray
+
+    def _counting_token_array(*args, **kwargs):
+        rebuilt_token_arrays.append(args)
+        return original_token_array(*args, **kwargs)
+
+    monkeypatch.setattr(Vt, "TokenArray", _counting_token_array)
+    # Markers move every frame while their environment ownership stays fixed.
+    test_marker.visualize(translations=translations + 0.1, environment_ids=environment_ids)
+
+    assert rebuilt_token_arrays == []
+    primvar = UsdGeom.PrimvarsAPI(stage.GetPrimAtPath(test_marker.prim_path)).GetPrimvar("omni:scenePartition")
+    assert list(primvar.Get()) == ["env_1", "env_0"]
+
+
+def test_changed_environment_ids_reauthor_scene_partitions(sim):
+    """New environment IDs should still update the authored partition tokens."""
+    from pxr import Sdf, UsdGeom
+
+    sim._has_offscreen_render = True
+    stage = sim_utils.get_current_stage()
+    for env_id in range(2):
+        env_prim = stage.DefinePrim(f"/World/envs/env_{env_id}", "Xform")
+        env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set(f"env_{env_id}")
+
+    config = VisualizationMarkersCfg(
+        prim_path="/World/Visuals/updated_partition_marker",
+        markers={"test": sim_utils.SphereCfg(radius=0.1)},
+    )
+    test_marker = VisualizationMarkers(config)
+    translations = torch.tensor([[0.0, 0.0, 0.0], [0.2, 0.0, 0.0]], device=sim.device)
+    test_marker.visualize(translations=translations, environment_ids=torch.tensor([1, 0], device=sim.device))
+    test_marker.visualize(translations=translations, environment_ids=torch.tensor([0, 1], device=sim.device))
+
+    primvar = UsdGeom.PrimvarsAPI(stage.GetPrimAtPath(test_marker.prim_path)).GetPrimvar("omni:scenePartition")
+    assert list(primvar.Get()) == ["env_0", "env_1"]
+
+
 def test_environment_ids_require_active_scene_partitions(sim):
     """Environment IDs should not partition markers when renderer stage preparation is inactive."""
     from pxr import UsdGeom

--- a/source/isaaclab_visualizers/changelog.d/cache-marker-scene-partition.rst
+++ b/source/isaaclab_visualizers/changelog.d/cache-marker-scene-partition.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab_visualizers.kit.kit_visualization_markers.KitVisualizationMarkers`
+  rebuilding its scene-partition tokens on every frame. Marker ownership is now cached and the
+  ``primvars:omni:scenePartition`` primvar is only re-authored when the environment IDs change,
+  removing a per-frame device synchronization and one token string per marker. This noticeably
+  improves throughput for camera tasks at high environment counts.

--- a/source/isaaclab_visualizers/changelog.d/cache-marker-scene-partition.rst
+++ b/source/isaaclab_visualizers/changelog.d/cache-marker-scene-partition.rst
@@ -4,5 +4,6 @@ Fixed
 * Fixed :class:`~isaaclab_visualizers.kit.kit_visualization_markers.KitVisualizationMarkers`
   rebuilding its scene-partition tokens on every frame. Marker ownership is now cached and the
   ``primvars:omni:scenePartition`` primvar is only re-authored when the environment IDs change,
-  removing a per-frame device synchronization and one token string per marker. This noticeably
-  improves throughput for camera tasks at high environment counts.
+  avoiding a device-to-host copy and one token string per marker on unchanged frames. A device
+  synchronization from comparing the cached and incoming environment IDs still occurs every call.
+  This noticeably improves throughput for camera tasks at high environment counts.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualization_markers.py
@@ -41,6 +41,13 @@ class KitVisualizationMarkers:
     .. _UsdGeom.PointInstancer: https://graphics.pixar.com/usd/dev/api/class_usd_geom_point_instancer.html
     """
 
+    # Marker ownership is static in most tasks, but ``visualize`` runs every frame. These memoize
+    # the resolved partition tokens, the tensor they came from, and the tokens currently authored,
+    # so unchanged environment IDs cost neither a device synchronization nor a USD write.
+    _environment_ids_source: torch.Tensor | None = None
+    _authored_environment_ids: tuple[int, ...] | None = None
+    _scene_partitioning_active: bool = False
+
     def __init__(self, cfg: VisualizationMarkersCfg, visible: bool = True):
         """Initialize the USD point instancer and register marker prototypes.
 
@@ -146,11 +153,14 @@ class KitVisualizationMarkers:
                 # changes and explicit marker indices are not provided.
                 self._instancer_manager.GetProtoIndicesAttr().Set([0] * num_markers)
         if environment_ids is not None:
-            self._environment_ids = tuple(int(env_id) for env_id in environment_ids.detach().cpu().tolist())
+            if not self._matches_cached_environment_ids(environment_ids):
+                self._environment_ids_source = environment_ids.detach().clone()
+                self._environment_ids = tuple(int(env_id) for env_id in self._environment_ids_source.cpu().tolist())
             if num_markers == 0:
                 num_markers = len(self._environment_ids)
         elif num_markers != 0 and num_markers != previous_count:
             self._environment_ids = None
+            self._environment_ids_source = None
         if num_markers != 0:
             self._count = num_markers
         self._sync_scene_partition_primvar()
@@ -164,12 +174,20 @@ class KitVisualizationMarkers:
         """
         from pxr import Sdf, UsdGeom, Vt  # noqa: PLC0415
 
+        target_ids = self._environment_ids if self._scene_partitioning_is_active() else None
+        # The tuple is rebuilt only when marker ownership changes, so identity is enough to tell
+        # that the authored tokens are still current. Skipping the write keeps the renderer from
+        # rebuilding its partition data on frames where nothing moved between environments.
+        if target_ids is self._authored_environment_ids:
+            return
+
         primvars_api = UsdGeom.PrimvarsAPI(self._instancer_manager.GetPrim())
         # PrimvarsAPI adds the ``primvars:`` namespace, matching the env-root attribute.
         primvar = primvars_api.GetPrimvar("omni:scenePartition")
-        if self._environment_ids is None or not self._scene_partitioning_is_active():
+        if target_ids is None:
             if primvar:
                 primvar.GetAttr().Clear()
+            self._authored_environment_ids = None
             return
 
         if not primvar:
@@ -184,7 +202,19 @@ class KitVisualizationMarkers:
             raise RuntimeError(
                 f"Expected '{primvar.GetAttr().GetPath()}' to have type TokenArray. Received: {primvar.GetTypeName()}."
             )
-        primvar.Set(Vt.TokenArray([f"env_{env_id}" for env_id in self._environment_ids]))
+        primvar.Set(Vt.TokenArray([f"env_{env_id}" for env_id in target_ids]))
+        self._authored_environment_ids = target_ids
+
+    def _matches_cached_environment_ids(self, environment_ids: torch.Tensor) -> bool:
+        """Return whether ``environment_ids`` still describes the cached marker ownership."""
+        cached = self._environment_ids_source
+        return (
+            cached is not None
+            and cached.shape == environment_ids.shape
+            and cached.dtype == environment_ids.dtype
+            and cached.device == environment_ids.device
+            and bool(torch.equal(cached, environment_ids))
+        )
 
     def _scene_partitioning_is_active(self) -> bool:
         """Return whether renderer stage preparation authored environment partitions.
@@ -192,11 +222,16 @@ class KitVisualizationMarkers:
         Renderer preparation always starts with ``env_0``, so its root is the
         canonical stage-level signal regardless of which environments own markers.
         """
+        # Markers can be created before the renderer prepares the stage, so a negative result is
+        # re-checked. Partitions are never withdrawn from a stage, so a positive one is cached.
+        if self._scene_partitioning_active:
+            return True
         env_prim = self.stage.GetPrimAtPath("/World/envs/env_0")
         if not env_prim.IsValid():
             return False
         attr = env_prim.GetAttribute("primvars:omni:scenePartition")
-        return attr.IsValid() and attr.Get() is not None
+        self._scene_partitioning_active = attr.IsValid() and attr.Get() is not None
+        return self._scene_partitioning_active
 
     def _add_markers_prototypes(self, markers_cfg: dict[str, sim_utils.SpawnerCfg]) -> None:
         """Add marker prototypes to the scene and register them with the point instancer."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualization_markers.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualization_markers.py
@@ -43,7 +43,8 @@ class KitVisualizationMarkers:
 
     # Marker ownership is static in most tasks, but ``visualize`` runs every frame. These memoize
     # the resolved partition tokens, the tensor they came from, and the tokens currently authored,
-    # so unchanged environment IDs cost neither a device synchronization nor a USD write.
+    # so unchanged environment IDs skip the device-to-host copy, token rebuild, and USD write. The
+    # cached-vs-incoming tensor comparison itself still synchronizes the device every call.
     _environment_ids_source: torch.Tensor | None = None
     _authored_environment_ids: tuple[int, ...] | None = None
     _scene_partitioning_active: bool = False


### PR DESCRIPTION
# Description

KitVisualizationMarkers.visualize() re-resolved and re-authored the primvars:omni:scenePartition token array on every call. Marker ownership is static in most tasks, but visualize() runs every frame — and ObjectUniformPoseCommand._update_metrics() calls it independently of debug_vis. At 4096 envs, every frame paid a device synchronization, a 4096-entry tuple rebuild, and 4096 token strings for a value that never changed. Isaac-Lift-KukaAllegro-Camera has two such instancers (SuccessMarkers, ObservationPointCloud).

This caches the resolved tokens, the tensor they came from, and the tokens currently authored, so the primvar is rebuilt only when the environment IDs change. The partition-active probe caches its positive result; a negative one is still re-checked, since markers can be created before the renderer prepares the stage.


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Benchmark Results

Measured on `Isaac-Lift-KukaAllegro-Camera` (4096 envs, `duo_camera` preset, single L40 GPU), 200-step `isaaclab benchmark runtime` run before vs. after this commit on top of `develop` (25fad3eac7f):

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| Mean Total FPS | 3773.4 | 4270.6 | **+13.2%** |
| Mean Iteration Time | 1085.5 ms | 959.1 ms | -11.6% |
| Max Total FPS | 4284.9 | 4703.1 | +9.8% |
| GPU Utilization | 28.6% | 37.3% | +8.7 pts |
| Scene Creation Time | 295.9 s | 282.0 s | -4.7% |

Single run per side, but well outside the ~150-180 FPS std-dev band reported within each run. Confirms the throughput improvement claimed above for this task's SuccessMarkers/ObservationPointCloud instancers.

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

