### PR TITLE
Resolve check_instanceable asset input through retrieve_file_path

### DIFF
--- a/scripts/tools/check_instanceable.py
+++ b/scripts/tools/check_instanceable.py
@@ -6,14 +6,16 @@
 """
 This script uses the cloner API to check if asset has been instanced properly.
 
+An asset path may be a local file or a Nucleus/HTTPS URL; remote assets are downloaded before use.
+
 Usage with different inputs (replace `<Asset-Path>` and `<Asset-Path-Instanced>` with the path to the
 original asset and the instanced asset respectively):
 
 ```bash
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
 ```
 
 Output from the above commands:
@@ -42,7 +44,6 @@ Output from the above commands:
 
 import argparse
 import contextlib
-import os
 
 from isaaclab.app import AppLauncher
 
@@ -73,7 +74,7 @@ from isaacsim.core.cloner import GridCloner
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.utils import Timer
-from isaaclab.utils.assets import check_file_path
+from isaaclab.utils.assets import check_file_path, retrieve_file_path
 
 
 def main():
@@ -99,8 +100,10 @@ def main():
     # Spawn things into stage
     sim_utils.create_prim("/World/Light", "DistantLight")
 
-    # Everything under the namespace "/World/envs/env_0" will be cloned
-    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=os.path.abspath(args_cli.input))
+    # Everything under the namespace "/World/envs/env_0" will be cloned.
+    # Resolve through retrieve_file_path so Nucleus/HTTPS inputs are downloaded first; applying
+    # os.path.abspath() to a URL would prepend the working directory and corrupt it.
+    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=retrieve_file_path(args_cli.input))
     # Clone the scene
     num_clones = args_cli.num_clones
 


### PR DESCRIPTION
# Description

Port of #7635 to `develop`. The original commit and Krishna Lakhi's authorship are preserved.

`scripts/tools/check_instanceable.py` accepts a Nucleus/HTTPS asset URL during validation, but then unconditionally applies `os.path.abspath()` before use. On Windows this prepends the working directory and changes separators, corrupting the URL into an unusable local path.

The input is now resolved through `retrieve_file_path()` from `isaaclab.utils.assets`, which supports both local and remote paths. Local inputs keep the prior absolute-path behavior, while remote assets and their USD/MDL dependencies are downloaded before the script opens them. The module docstring's example commands are also corrected from the nonexistent `source/tools/` path to `scripts/tools/`.

The active-release counterpart is #7635.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

Already represented by #7635 for `release/3.0.0`.

## Screenshots

N/A — command-line tool.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

### Validation

- `uv run --extra test python -m pytest -q source/isaaclab/test/utils/test_assets.py::test_retrieve_file_path_serializes_cold_cache_population` — passed
- `uv run python -m py_compile scripts/tools/check_instanceable.py` — passed
- `uv run isaaclab -f` — passed

No new test is added because this script launches `AppLauncher` at module scope and cannot be imported as a unit without starting Isaac Sim. The delegated remote-path behavior is covered by the existing `retrieve_file_path()` unit test above. No changelog fragment is required because this change touches only `scripts/`, not a source package.
