### PR TITLE
[PERF] Increase VBD iterations and narrow stiffness range in deformables demo

### DIFF
--- a/scripts/demos/deformables.py
+++ b/scripts/demos/deformables.py
@@ -195,7 +195,7 @@ def design_scene() -> tuple[dict, list[list[float]]]:
             obj_cfg.physics_material.tri_ke = random.uniform(5e3, 5e4)
             obj_cfg.physics_material.tri_ka = random.uniform(5e3, 5e4)
         else:
-            youngs_modulus = random.uniform(5e5, 1e8)
+            youngs_modulus = random.uniform(5e5, 1e7)
             poissons_ratio = random.uniform(0.25, 0.45)
             if args_cli.physics == "newton_vbd":
                 obj_cfg.physics_material.k_mu = youngs_modulus / (2.0 * (1.0 + poissons_ratio))
@@ -265,7 +265,7 @@ def main():
     with launch_simulation(cfg=PhysicsCfg(), launcher_args=args_cli) as physics_cfg:
         # tune the CLI-selected backend for this demo
         if args_cli.physics == "newton_vbd":
-            physics_cfg.solver_cfg.iterations = 5
+            physics_cfg.solver_cfg.iterations = 20
             physics_cfg.solver_cfg.particle_enable_self_contact = True
             physics_cfg.solver_cfg.particle_self_contact_radius = 0.0001
             physics_cfg.solver_cfg.particle_self_contact_margin = 0.1

--- a/scripts/demos/deformables.py
+++ b/scripts/demos/deformables.py
@@ -270,6 +270,7 @@ def main():
             physics_cfg.solver_cfg.particle_self_contact_radius = 0.0001
             physics_cfg.solver_cfg.particle_self_contact_margin = 0.1
             physics_cfg.num_substeps = 4
+            physics_cfg.collision_decimation = 1
             physics_cfg.soft_contact_cfg = NewtonSoftContactCfg(
                 soft_contact_ke=1.0e5,
                 soft_contact_kd=1.0e0,


### PR DESCRIPTION
# Description

Deformable objects in the Newton VBD deformables demo passed through the ground plane, and cloth sheets were occasionally launched several metres into the air. Two causes:

- Collision ran once per 10 ms tick with no continuous collision detection, while objects dropped from up to 3.5 m cross the 18 mm contact detection band within a single tick. The plane was missed during the crossing tick and the penalty force resolved on the next one, ejecting the object.
- Young's modulus was sampled up to 1e8 Pa, far stiffer than the contact penalty can resist, so the elastic response overwhelmed the ground contact and vertices ended up below the plane.

This sets `collision_decimation` to 1 so the collision pipeline re-runs on every solver substep, caps the sampled Young's modulus at 1e7 Pa, and raises the VBD iteration count to 20. Only affects `--physics newton_vbd`; the PhysX paths are unchanged.

Measured over 6 s with two seeds, the stiffness and iteration changes alone still left 5 objects stranded in the air (one cloth at 3.27 m, another at 0.53 m, a volume deformable at 1.43 m). With `collision_decimation = 1` every object settles on the plane and worst-case penetration drops from 51 mm to 29 mm.

Fixes nvbugs 6201420

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] My changes generate no new warnings
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
