### PR TITLE
Mute repetitive USD out-of-scope material-binding diagnostic

### DIFF
--- a/source/isaaclab/changelog.d/mtrepte-mute-usd-out-of-scope-binding-warnings.rst
+++ b/source/isaaclab/changelog.d/mtrepte-mute-usd-out-of-scope-binding-warnings.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Muted the repetitive ``refers to a path outside the scope of the reference ... Ignoring``
+  USD diagnostic that several shipped assets with out-of-scope material-binding relationships
+  (for example a MuJoCo-converter payload split, or Isaac Sim's own "_instanceable.usd"
+  wrapper convention) log once per affected prim during PhysX scene cooking. The dropped
+  relationship duplicates a correctly-scoped binding established elsewhere on the same prim
+  in every case audited so far, so this is a stopgap until a future ``ovstage`` release
+  filters this diagnostic class by default.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1379,6 +1379,19 @@ class AppLauncher:
             logging.getLogger().setLevel(logging.INFO)
         settings = get_settings_manager()
 
+        # Temporary: several shipped USD assets author a material-binding relationship that
+        # falls outside the scope of the reference or instanceable arc that composes it (for
+        # example a MuJoCo-converter payload split, or Isaac Sim's own "_instanceable.usd"
+        # wrapper convention). When PhysX's material-binding walk resolves that relationship
+        # during scene cooking, USD logs a "refers to a path outside the scope of the
+        # reference ... Ignoring" diagnostic per affected prim -- in every case audited so far
+        # a functional no-op, since the dropped relationship duplicates a correctly-scoped
+        # binding established elsewhere on the same prim, but noisy enough to bury real
+        # warnings for assets with many collision-geometry parts (NVBugs 6629400 and the
+        # [Isaac-Sim 6.0 rc59] AllegroHand ovphysx report). A future ``ovstage`` release is
+        # expected to filter this diagnostic class by default; mute it globally until then.
+        settings.set_bool("/persistent/app/usd/muteUsdDiagnostics", True)
+
         # Publish whether Kit has an interactive GUI (local window, livestream, or XR).
         # SimulationContext and renderers consume this setting during their initialization.
         settings.set_bool("/isaaclab/has_gui", not self._headless or self._livestream >= 1 or self._xr)


### PR DESCRIPTION
# Description

Several shipped assets author a material-binding relationship (`material:binding` or
`material:binding:physics`) as an absolute path that falls outside the scope of the
reference or instanceable arc that composes it — for example a MuJoCo-converter payload
split, or Isaac Sim's own `_instanceable.usd` wrapper convention. When PhysX's
material-binding walk resolves that relationship during scene cooking, USD's composition
engine drops it and logs a `refers to a path outside the scope of the reference ...
Ignoring` diagnostic, once per affected prim. For assets with many collision-geometry
parts this can be dozens to hundreds of lines per run, burying real warnings.

In every case audited so far, the dropped relationship duplicates a correctly-scoped
binding already established elsewhere on the same composed prim, so dropping it is a
functional no-op — reproduced and confirmed with a full RSL-RL training run for each
asset (training completes normally, physics behavior unaffected).

We looked at filtering the console output directly (an OS-level file-descriptor redirect,
and carb's `ILogging.add_logger` callback) — both failed to intercept these lines at all,
consistent with USD's default `Tf` diagnostic delegate writing straight to the terminal
device. We also tried removing the out-of-scope opinion from the loaded stage itself
before anything queries it, but the affected relationships in these assets often live on
prims that are themselves marked `instanceable`, so the opinion lives inside a shared USD
instance prototype; authoring onto a prototype through the `Usd` API is unsupported and
crashed in testing.

Instead, this sets the existing Kit setting `/persistent/app/usd/muteUsdDiagnostics` to
`true` during `AppLauncher` startup, muting USD diagnostics globally. This is a stopgap:
a newer `ovstage` release (`0.2.0.377349`, confirmed in local testing) already flips this
setting by default, muting this diagnostic class without any Isaac Lab change. Our
`ovphysx` extra is currently pinned to `0.5.11`, which hard-requires the older
`ovstage==0.1.1.355824`, so we can't yet pick up the newer `ovstage` through the normal
dependency graph. Once an `ovphysx` release compatible with the newer `ovstage` ships,
this Isaac Lab workaround should be removed.

Fixes the warning spam reported against FrankaEmika/ShadowHandNewton/H2plus (NVBugs
6629400) and the [Isaac-Sim 6.0 rc59] AllegroHand ovphysx report.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced both tracked reports against `develop` tip: `Isaac-Reach-Franka-OSC` (with a
  locally mirrored, intentionally-unfixed copy of the Franka asset — 71 occurrences of the
  diagnostic per 2-iteration RSL-RL training run) and `Isaac-Reorient-Cube-Allegro-Direct`
  (54 occurrences with the shipped asset, `physics=isaacsim_physx`).
- With this change, both commands produce 0 occurrences of the diagnostic; training
  completes normally in both cases.
- Verified with the real, unmodified remote Franka asset (no local override) that nothing
  else regresses.
- `source/isaaclab/test/app/test_app_launcher_argv.py`: 17 passed.
- `uv run isaaclab -f`.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there