### PR TITLE
Log VideoRecorder cubric warning once per recorder

### DIFF
--- a/source/isaaclab/changelog.d/video-recorder-cubric-warn-once.rst
+++ b/source/isaaclab/changelog.d/video-recorder-cubric-warn-once.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the :class:`~isaaclab.envs.utils.video_recorder.VideoRecorder` Kit/Newton cubric
+  warning being logged on every captured frame, which flooded the terminal during
+  ``--video`` runs (roughly one line per frame for the whole clip). The warned-about
+  condition is fixed configuration state, so the message is now emitted once per
+  recorder, matching the existing once-only behavior of the frame-capture error path.

--- a/source/isaaclab/isaaclab/envs/utils/video_recorder.py
+++ b/source/isaaclab/isaaclab/envs/utils/video_recorder.py
@@ -84,6 +84,10 @@ class VideoRecorder:
         # Set to True after the first unrecoverable frame-capture error so that
         # subsequent steps do not propagate the exception or repeat the log message.
         self._frame_error_logged: bool = False
+        # Set to True after the Kit/Newton cubric warning is emitted. The condition it
+        # reports is fixed configuration state, so warning once per recorder is enough;
+        # without this the message repeats on every captured frame.
+        self._cubric_warning_logged: bool = False
 
     def step(self) -> None:
         """Advance the recorder by one env step."""
@@ -186,9 +190,10 @@ class VideoRecorder:
         # Kit Replicator requires cubric to propagate Newton Fabric transforms to RTX's
         # scene delegate. Without cubric, frames will be black. Log a warning but allow
         # the capture to proceed — users with cubric available will get correct frames.
-        if viz_type == "kit":
+        if viz_type == "kit" and not self._cubric_warning_logged:
             physics_backend = getattr(getattr(sim, "physics_manager", None), "video_capture_backend", lambda: None)()
             if physics_backend == "newton_gl":
+                self._cubric_warning_logged = True
                 logger.warning(
                     "[VideoRecorder] source='visualizer:kit' with Newton physics requires cubric "
                     "to propagate Fabric transforms to RTX. Frames may be black if cubric is "

--- a/source/isaaclab/test/envs/test_video_recorder.py
+++ b/source/isaaclab/test/envs/test_video_recorder.py
@@ -259,11 +259,13 @@ def test_kit_visualizer_newton_physics_logs_warning(caplog):
     with caplog.at_level(logging.WARNING, logger="isaaclab.envs.utils.video_recorder"):
         for _ in range(5):
             recorder._get_frame()
+        second_recorder = VideoRecorder(_cfg(source="visualizer:kit"), env)
+        second_recorder._get_frame()
 
     cubric_warnings = [r for r in caplog.records if "source='visualizer:newton'" in r.message]
-    assert len(cubric_warnings) == 1
+    assert len(cubric_warnings) == 2
     # Capture is still attempted on every frame rather than short-circuiting.
-    assert kit_viz.render_calls == 5
+    assert kit_viz.render_calls == 6
 
 
 def test_visualizer_newton_alias_resolves_newton_gl():

--- a/source/isaaclab/test/envs/test_video_recorder.py
+++ b/source/isaaclab/test/envs/test_video_recorder.py
@@ -245,6 +245,9 @@ def test_kit_visualizer_newton_physics_logs_warning(caplog):
 
     With cubric the capture succeeds; without it frames may be black.  Either way
     the recorder warns and does not hard-fail.
+
+    The warned-about condition is fixed configuration state, so the message is emitted
+    once per recorder rather than once per captured frame.
     """
     import logging
 
@@ -254,11 +257,13 @@ def test_kit_visualizer_newton_physics_logs_warning(caplog):
 
     recorder = VideoRecorder(_cfg(source="visualizer:kit"), env)
     with caplog.at_level(logging.WARNING, logger="isaaclab.envs.utils.video_recorder"):
-        recorder._get_frame()
+        for _ in range(5):
+            recorder._get_frame()
 
-    assert any("source='visualizer:newton'" in r.message for r in caplog.records)
-    # The recorder attempts capture rather than short-circuiting.
-    assert kit_viz.render_calls == 1
+    cubric_warnings = [r for r in caplog.records if "source='visualizer:newton'" in r.message]
+    assert len(cubric_warnings) == 1
+    # Capture is still attempted on every frame rather than short-circuiting.
+    assert kit_viz.render_calls == 5
 
 
 def test_visualizer_newton_alias_resolves_newton_gl():


### PR DESCRIPTION
# Description

Forward-ports #7633 from `release/3.0.0` to `develop`.

`VideoRecorder` logs the Kit/Newton "requires cubric" warning from `_frame_from_visualizer()`, which is called on every captured frame. Because the condition is fixed recorder configuration state, repeating the warning once per frame floods the terminal without adding information.

This change adds a per-recorder guard so the warning is emitted on the first applicable capture only. Frame capture continues on every frame, the warning text is unchanged, and each independent recorder still emits its own warning.

The original commit by @klakhi is preserved. The test also covers a second recorder instance, addressing the review feedback on #7633.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

Existing release PR: #7633

## Screenshots

N/A — console-output behavior only.

## Validation

- Regression test on unmodified `upstream/develop`: failed as expected with 6 warnings instead of 2.
- `PYTHONPATH=source/isaaclab:source/isaaclab_visualizers uv run --no-project --with pytest --with numpy --with torch --with gymnasium --with lazy-loader --with warp-lang --with 'moviepy<2' python -m pytest source/isaaclab/test/envs/test_video_recorder.py -q` — 33 passed.
- Changelog fragment gate — passed against the current `upstream/develop`.
- `uv run --no-project --with-editable ./source/isaaclab --with pre-commit isaaclab -f` — passed all hooks.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation (none required; no public API or documented behavior changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] The original contributor already exists in `CONTRIBUTORS.md`
