### PR TITLE
[Backport] PR #7643 to release/3.0.0

### DIFF
--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -703,12 +703,12 @@ Install the CUDA-enabled PyTorch build appropriate for your system architecture:
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (x86_64)
       :sync: linux-x86_64
 
-      .. isaaclab-torch-install:: cu128 pip
+      .. isaaclab-torch-install:: cu128
 
    .. tab-item:: :icon:`fa-brands fa-windows` Windows (x86_64)
       :sync: windows-x86_64
 
-      .. isaaclab-torch-install:: cu128 pip
+      .. isaaclab-torch-install:: cu128
 
    .. tab-item:: :icon:`fa-brands fa-linux` Linux (aarch64)
       :sync: linux-aarch64
@@ -723,7 +723,7 @@ Install the CUDA-enabled PyTorch build appropriate for your system architecture:
             sudo apt install python3.12-dev libgl1-mesa-dev libx11-dev libxcursor-dev libxi-dev \
                libxinerama-dev libxrandr-dev
 
-      .. isaaclab-torch-install:: cu130 pip
+      .. isaaclab-torch-install:: cu130
 
       .. note::
 


### PR DESCRIPTION
# Description

Backports #7643 to `release/3.0.0`.

This is a conflict-free, exact-patch cherry-pick of merged commit `4db018695a97cc127a1b664827bdbca1a5d0ae7c`. It updates the CUDA-enabled PyTorch commands in the uv-based Python package installation workflow to use `uv pip`. The managed conda workflow remains unchanged.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Validation

- `.github/scripts/backport.py validate-candidate --exact_patch` passed against the current `release/3.0.0` tip.
- Rendered the installation page and verified `uv pip install` for Linux x86_64, Windows x86_64, and Linux aarch64.
- `uv run isaaclab -f` equivalent passed all formatting, RST, changelog, and Git LFS hooks.
- The locked documentation environment does not support this macOS arm64 host, so the warning-as-error Linux documentation build is deferred to PR CI. A no-project fallback rendered the affected page; its repository-wide build reported existing missing-dependency warnings unrelated to this exact docs-only patch.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the applicable pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the affected page
- [x] Tests are not applicable to this exact docs-only backport
- [x] No source package was changed, so no changelog fragment is required
- [x] My name already exists in `CONTRIBUTORS.md`
