### PR TITLE
[Forward port] PR #7635 to develop

### DIFF
--- a/scripts/tools/check_instanceable.py
+++ b/scripts/tools/check_instanceable.py
@@ -6,14 +6,16 @@
 """
 This script uses the cloner API to check if asset has been instanced properly.
 
+An asset path may be a local file or a Nucleus/HTTPS URL; remote assets are downloaded before use.
+
 Usage with different inputs (replace `<Asset-Path>` and `<Asset-Path-Instanced>` with the path to the
 original asset and the instanced asset respectively):
 
 ```bash
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
-uv run python source/tools/check_instanceable.py <Asset-Path> -n 4096
-uv run python source/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096 --physics
+uv run python scripts/tools/check_instanceable.py <Asset-Path> -n 4096
+uv run python scripts/tools/check_instanceable.py <Asset-Path-Instanced> -n 4096
 ```
 
 Output from the above commands:
@@ -42,7 +44,6 @@ Output from the above commands:
 
 import argparse
 import contextlib
-import os
 
 from isaaclab.app import AppLauncher
 
@@ -73,7 +74,7 @@ from isaacsim.core.cloner import GridCloner
 import isaaclab.sim as sim_utils
 from isaaclab.sim import SimulationCfg, SimulationContext
 from isaaclab.utils import Timer
-from isaaclab.utils.assets import check_file_path
+from isaaclab.utils.assets import check_file_path, retrieve_file_path
 
 
 def main():
@@ -99,8 +100,10 @@ def main():
     # Spawn things into stage
     sim_utils.create_prim("/World/Light", "DistantLight")
 
-    # Everything under the namespace "/World/envs/env_0" will be cloned
-    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=os.path.abspath(args_cli.input))
+    # Everything under the namespace "/World/envs/env_0" will be cloned.
+    # Resolve through retrieve_file_path so Nucleus/HTTPS inputs are downloaded first; applying
+    # os.path.abspath() to a URL would prepend the working directory and corrupt it.
+    sim_utils.create_prim("/World/envs/env_0/Asset", "Xform", usd_path=retrieve_file_path(args_cli.input))
     # Clone the scene
     num_clones = args_cli.num_clones
 


### PR DESCRIPTION
# Description

Forward-ports #7635 from `release/3.0.0` to `develop`.

This is a conflict-free, exact-patch cherry-pick of source commit `a91f81af891dc58443d1d75cd66f12bab79e98e4`. It fixes `scripts/tools/check_instanceable.py` so validated Nucleus/HTTPS asset URLs are resolved with `retrieve_file_path()` rather than corrupted by `os.path.abspath()`. It also corrects the script paths in the module usage examples.

Local asset behavior remains unchanged, and no new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

The corresponding change is already proposed against `release/3.0.0` in #7635, so no additional release backport is needed.

## Validation

- `.github/scripts/backport.py validate-candidate --exact_patch` passed against the current `develop` tip.
- `uv run --no-project python -m compileall -q scripts/tools/check_instanceable.py` passed.
- `uv run isaaclab -f` equivalent passed all formatting, RST, changelog, and Git LFS hooks.
- The source PR's full docs, pre-commit, changelog, broken-link, wheel, and license CI checks are green.
- The locked documentation environment does not support this macOS arm64 host, so the warning-as-error documentation build is deferred to this PR's Linux CI.

## Screenshots

Not applicable; this changes a command-line tool.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the applicable pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The script launches Isaac Sim at module scope; the delegated `retrieve_file_path()` behavior is already covered in `source/isaaclab/test/utils/test_assets.py`
- [x] Only `scripts/` changed, so no source-package changelog fragment is required
- [x] The original author's name already exists in `CONTRIBUTORS.md`
