### PR TITLE
Fix/so101 teleop success tolerance

### DIFF
--- a/source/isaaclab_tasks/changelog.d/so101-teleop-success-tolerance.rst
+++ b/source/isaaclab_tasks/changelog.d/so101-teleop-success-tolerance.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Fixed the SO-101 joint-teleop cube-stack task often failing to auto-reset after a completed
+  stack. The success termination accepted the gripper as open only within 0.2 rad of
+  ``SO101_GRIPPER_OPEN``, which is the top 0.2 rad of the jaw's 1.92 rad range, so a leader arm
+  whose calibrated full-open reading fell short never triggered success. The tolerance is now
+  0.5 rad, which still requires more opening than releasing a cube needs.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_teleop_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_teleop_env_cfg.py
@@ -32,6 +32,9 @@ _SO101_JOINTS = _SO101_ARM_JOINTS + ["gripper"]
 # plugin (or any pusher emitting the same schema) advertises.
 _SO101_LEADER_COLLECTION_ID = "so101_leader"
 
+# Tolerance [rad] below ``SO101_GRIPPER_OPEN`` that still counts as releasing the cube.
+_SUCCESS_GRIPPER_ATOL = 0.5
+
 
 def _build_so101_joint_teleop_pipeline():
     """Build an IsaacTeleop joint-space pipeline driven by the SO-101 leader arm.
@@ -159,14 +162,15 @@ class SO101CubeStackEnvCfg(stack_joint_pos_env_cfg.SO101CubeStackEnvCfg):
             xr_cfg=self.xr,
         )
 
-        # Relax the gripper-open check in the success termination. The default atol=0.0001 rad
-        # (100 µrad) is reachable when the gripper target is set to exactly SO101_GRIPPER_OPEN
-        # via an affine mapping (as in the IK-Abs env). In joint teleop the leader arm's raw
-        # encoder angle is mirrored 1:1, so the follower gripper may not reach the exact open
-        # value within 100 µrad due to calibration offsets or soft-limit ceilings. Using
-        # gripper_threshold (0.2 rad) as the tolerance matches the threshold already used by
-        # observations to classify the gripper as open vs. closed.
+        # Widen the gripper-open check in the success termination. In joint teleop the follower jaw
+        # mirrors the leader's raw encoder 1:1 and is capped by its own joint limit (1.7453 rad), so
+        # a 0.2 rad tolerance accepts only the top 0.2 rad of a 1.92 rad range and a leader whose
+        # calibrated full-open reading falls short never trips success. 0.5 rad still demands more
+        # opening than freeing a cube needs: the jaw opens by ``2 * L * sin(q / 2)``, so a 0.0477 m
+        # cube is released by q >= 1.245 for any lever arm ``L >= 0.043 m`` (the jaw spans ~0.093 m).
+        # Deliberately not ``gripper_threshold``, which ``object_grasped`` uses to annotate the
+        # grasp subtasks for every SO-101 stack env.
         self.terminations.success = DoneTerm(
             func=mdp.cubes_stacked,
-            params={"atol": self.gripper_threshold, "rtol": 0.0},
+            params={"atol": _SUCCESS_GRIPPER_ATOL, "rtol": 0.0},
         )

--- a/source/isaaclab_tasks/test/contrib/stack/test_so101_teleop_success.py
+++ b/source/isaaclab_tasks/test/contrib/stack/test_so101_teleop_success.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sim-free unit tests for the SO-101 joint-teleop success termination.
+
+The joint-teleop pipeline mirrors the leader arm's raw gripper encoder angle onto the follower 1:1,
+so the follower jaw stops wherever the operator's leader jaw does. These tests pin the gripper-open
+window that :func:`~isaaclab_tasks.contrib.stack.mdp.cubes_stacked` accepts, using the success term
+as the environment actually wires it, so a tolerance that is too tight to reach in practice cannot
+be reintroduced silently.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from isaaclab_tasks.contrib.stack.config.so101.stack_joint_teleop_env_cfg import SO101CubeStackEnvCfg
+
+# Resting center-to-center distance of two stacked cubes [m], measured in sim.
+_STACK_DZ = 0.0477
+
+
+def _proxy(tensor: torch.Tensor) -> SimpleNamespace:
+    """Wrap a tensor in the ``.torch`` accessor the MDP terms read."""
+    return SimpleNamespace(torch=tensor)
+
+
+class _Scene:
+    """Minimal scene mapping. Deliberately has no ``surface_grippers`` attribute."""
+
+    def __init__(self, entities: dict):
+        self._entities = entities
+
+    def __getitem__(self, key: str):
+        return self._entities[key]
+
+
+class _Robot:
+    def __init__(self, gripper_pos: float):
+        self.data = SimpleNamespace(joint_pos=_proxy(torch.tensor([[gripper_pos]])))
+
+    def find_joints(self, names):
+        return [0], names
+
+
+def _make_env(gripper_pos: float, stacked: bool = True) -> SimpleNamespace:
+    """Build a fake env holding one stack of three cubes and a gripper at ``gripper_pos`` [rad]."""
+    # cube_1 bottom, cube_2 middle, cube_3 top, sharing an xy column.
+    heights = [0.0, _STACK_DZ, 2 * _STACK_DZ]
+    if not stacked:
+        # Swap the top two so the required bottom-to-top order no longer holds.
+        heights = [0.0, 2 * _STACK_DZ, _STACK_DZ]
+    cubes = {
+        f"cube_{i + 1}": SimpleNamespace(data=SimpleNamespace(root_pos_w=_proxy(torch.tensor([[0.3, 0.0, z]]))))
+        for i, z in enumerate(heights)
+    }
+    return SimpleNamespace(
+        scene=_Scene({"robot": _Robot(gripper_pos), **cubes}),
+        cfg=SimpleNamespace(gripper_joint_names=["gripper"], gripper_open_val=1.745),
+        device="cpu",
+    )
+
+
+def _success(gripper_pos: float, stacked: bool = True) -> bool:
+    """Evaluate the success term exactly as the joint-teleop env configures it."""
+    term = SO101CubeStackEnvCfg().terminations.success
+    return bool(term.func(_make_env(gripper_pos, stacked=stacked), **term.params)[0])
+
+
+@pytest.mark.parametrize("gripper_pos", [1.745, 1.5, 1.3])
+def test_success_fires_once_the_gripper_is_open_enough(gripper_pos):
+    """A completed stack terminates without opening the jaw to the very top of its range.
+
+    1.3 rad fails under the previous 0.2 rad tolerance, which is the regression this guards.
+    """
+    assert _success(gripper_pos)
+
+
+@pytest.mark.parametrize("gripper_pos", [0.0, 0.5, 1.2])
+def test_success_does_not_fire_while_the_gripper_is_still_closing(gripper_pos):
+    """The window still has a lower bound, so success cannot fire while the cube is held."""
+    assert not _success(gripper_pos)
+
+
+def test_success_requires_the_documented_stack_order():
+    """Cubes out of the bottom-to-top cube_1, cube_2, cube_3 order never count as stacked."""
+    assert not _success(1.745, stacked=False)


### PR DESCRIPTION
# Description

  The SO-101 joint-teleop cube-stack task did not auto-reset after the operator
  completed a stack and opened the gripper, so the session had to be reset manually.
  
  In joint teleop the leader arm's raw gripper encoder angle is mirrored onto the
  follower 1:1 (identity `JointStateRetargeter`: `scale=1.0`, `offset=0.0`,
  `sign=+1.0`), so the follower jaw lands wherever the operator's leader jaw does.
  The `success` termination accepted the gripper as open only within `atol=0.2` rad
  of `SO101_GRIPPER_OPEN` (1.745 rad), and the jaw's own joint limit is 1.7453 rad.
  That means success required the jaw to land in `[1.545, 1.745]`, the top 0.2 rad
  of a 1.92 rad range. A leader arm whose calibrated full-open reading falls short
  of 1.545 therefore never trips success, no matter how far the operator opens it,
  and the environment never resets.

  This widens the tolerance for that task's success term to 0.5 rad, so the accepted
  window becomes `q >= 1.245` rad (71.3 deg instead of 88.5 deg of the 100 deg jaw
  range).
 
  0.5 rad still demands more opening than releasing a cube requires. The jaw opening
  follows `2 * L * sin(q / 2)` for jaw lever arm `L`, so a 0.0477 m cube is freed by
  `q >= 1.245` for any `L >= 0.043 m`, and the moving jaw spans about 0.093 m. So the
  check cannot start firing while the operator is still gripping the cube.
 
  `gripper_threshold` is deliberately left at 0.2. `object_grasped` reads it to
  annotate the `grasp_1` / `grasp_2` subtask signals for every SO-101 stack env, so
  changing it would alter demo and mimic annotations well beyond this task. 

  Scope: `stack_joint_teleop_env_cfg:SO101CubeStackEnvCfg` is referenced only by the
  `IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0` registration, and nothing imports
  or subclasses it. The joint-position and IK-Abs SO-101 envs are unchanged.

Fixes # (issue)

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there