### PR TITLE
Use decord2 on supported architectures

### DIFF
--- a/docs/source/overview/imitation-learning/humanoids_imitation.rst
+++ b/docs/source/overview/imitation-learning/humanoids_imitation.rst
@@ -649,7 +649,10 @@ Then, from the **Isaac-GR00T** directory, install GR00T N1.5 and its dependencie
    uv pip install wheel
    MAX_JOBS=4 uv pip install --no-build-isolation flash-attn==2.7.1.post4
    MAX_JOBS=4 uv pip install --no-build-isolation 'git+https://github.com/facebookresearch/pytorch3d.git@v0.7.9'
-   uv pip install diffusers decord zmq
+   uv pip install diffusers decord2 zmq
+
+The ``decord2`` distribution retains the ``decord`` Python import used by GR00T and provides
+pre-built wheels for both x86_64 and aarch64 systems, including DGX Spark.
 
 .. note::
 


### PR DESCRIPTION
# Description

Updates the GR00T installation instructions to use `decord2`, which retains the `decord` import API and provides current platform wheels, including aarch64 wheels needed by DGX Spark.

Tracks NVBug 6698023.

## Type of change

- Bug fix
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- `uv run --isolated --extra test -- make -C docs current-docs`
- `uv run isaaclab -f`
- Installed `decord2==3.4.0` and verified the `decord`, `VideoReader`, and bridge APIs inside Isaac Sim 6.0.1.
- The original DGX Spark/aarch64 host was unavailable, so architecture-specific runtime validation remains for CI or the reporter.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the pre-commit checks.
- [x] I have made the corresponding documentation change.
- [x] My changes generate no new warnings.
- [x] I have run targeted validation for the fix.
- [x] Changelog fragment is not applicable to this docs-only change.
- [x] The contributor already appears in repository revision history.
