### PR TITLE
Default SO-101 cube-stacking tasks to PhysX and document the selector

### DIFF
--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -464,7 +464,8 @@ on launch -- no headset connection is needed (see :ref:`isaac-teleop-standalone`
          uv run --extra teleop,isaacsim isaaclab teleop run \
              --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
              --num_envs 1 \
-             --visualizer kit
+             --visualizer kit \
+             physics=isaacsim_physx
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
@@ -473,7 +474,8 @@ on launch -- no headset connection is needed (see :ref:`isaac-teleop-standalone`
          ./isaaclab.sh -p scripts/environments/teleoperation/teleop_se3_agent.py \
              --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
              --num_envs 1 \
-             --visualizer kit
+             --visualizer kit \
+             physics=isaacsim_physx
 
 **With a headset (immersive XR view)**
 
@@ -491,7 +493,8 @@ only controls whether the scene is rendered to the headset. Follow the connectio
          uv run --extra teleop,isaacsim isaaclab teleop run \
              --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
              --num_envs 1 \
-             --visualizer kit --xr
+             --visualizer kit --xr \
+             physics=isaacsim_physx
 
    .. tab-item:: isaaclab.sh / isaaclab.bat
 
@@ -500,7 +503,8 @@ only controls whether the scene is rendered to the headset. Follow the connectio
          ./isaaclab.sh -p scripts/environments/teleoperation/teleop_se3_agent.py \
              --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
              --num_envs 1 \
-             --visualizer kit --xr
+             --visualizer kit --xr \
+             physics=isaacsim_physx
 
 Start the plugin
 ^^^^^^^^^^^^^^^^
@@ -689,7 +693,7 @@ These environments use the Isaac Teleop XR pipeline with motion controllers or h
      - Right
      - **Arm:** right controller grip pose drives end-effector.
        **Gripper:** right trigger.
-   * - ``IsaacContrib-Stack-Cube-SO101-IK-Abs-v0``
+   * - ``IsaacContrib-Stack-Cube-SO101-IK-Abs-v0`` with ``physics=isaacsim_physx``
      - Controllers
      - Right
      - **Arm:** right controller grip pose drives the end-effector via absolute IK
@@ -899,7 +903,7 @@ for the run command and pipeline.
    * - Task ID
      - Device
      - Operator Interaction
-   * - ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0``
+   * - ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0`` with ``physics=isaacsim_physx``
      - SO-101 leader arm
      - **Arm + gripper:** the leader arm's six joint angles (five arm DOF + gripper) are mirrored
        onto the follower via ``JointStateRetargeter`` (``mode="joint"``).

--- a/source/isaaclab_tasks/changelog.d/so101-stack-default-physx.rst
+++ b/source/isaaclab_tasks/changelog.d/so101-stack-default-physx.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Defaulted the SO-101 cube-stacking tasks to the PhysX backend, so the gripper no longer
+  penetrates the cubes and grasps hold. ``IsaacContrib-Stack-Cube-SO101-v0``,
+  ``IsaacContrib-Stack-Cube-SO101-IK-Abs-v0``, and
+  ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0`` previously resolved to Newton MJWarp, whose
+  gripper contact response is still being tuned for this robot. Pass ``physics=newton_mjwarp``
+  to select the previous backend.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_ik_abs_env_cfg.py
@@ -227,7 +227,7 @@ class SO101CubeStackEnvCfg(stack_joint_pos_env_cfg.SO101CubeStackEnvCfg):
                     "Robot": "robot",
                     "Sensor": "sensors",
                     "Physics": preset(
-                        default="physics",
+                        default="physx",
                         isaacsim_physx="physx",
                         physx="physx",
                         newton_mjwarp="physics",

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/config/so101/stack_joint_pos_env_cfg.py
@@ -68,7 +68,7 @@ class SO101CubeStackEnvCfg(StackEnvCfg):
         self.scene.replicate_physics = True
         self.sim.physics.newton_mjwarp.solver_cfg.nconmax = 600
         self.sim.physics = preset(
-            default=self.sim.physics.newton_mjwarp,
+            default=self.sim.physics.isaacsim_physx,
             isaacsim_physx=self.sim.physics.isaacsim_physx,
             physx=self.sim.physics.physx,
             newton_mjwarp=self.sim.physics.newton_mjwarp,
@@ -95,7 +95,7 @@ class SO101CubeStackEnvCfg(StackEnvCfg):
                     "Robot": "robot",
                     "Sensor": "sensors",
                     "Physics": preset(
-                        default="physics",
+                        default="physx",
                         isaacsim_physx="physx",
                         physx="physx",
                         newton_mjwarp="physics",


### PR DESCRIPTION
# Description

  SQA reported that the SO-101 gripper visibly penetrates the cubes in the stacking
  environments and grasps do not hold.
 
  **Root cause.** The base stack `PhysicsCfg` defaults to `isaacsim_physx` 
  (`contrib/stack/stack_env_cfg.py:323`), but the SO-101 subclass overrode that default to
  Newton MJWarp in `stack_joint_pos_env_cfg.py:71`. MJWarp gripper contact response for this
  robot is still being tuned. Because `-IK-Abs-v0` and `-Joint-Teleop-v0` both subclass the
  joint-position config, all three SO-101 stacking tasks inherited the Newton default.

  This also made the repository self-inconsistent: `tools/environ_docs.py` already lists all
  three tasks in `_NEWTON_MJWARP_EXCLUSIONS`, so the generated environment browser advertises
  them as PhysX-only while the runtime was selecting Newton.

  **Changes**

  1. Flipped the physics preset default back to `isaacsim_physx`
     (`stack_joint_pos_env_cfg.py`).
  2. Flipped the two USD payload variant defaults from `"physics"` (the Newton variant) to
     `"physx"`, in `stack_joint_pos_env_cfg.py` and `stack_ik_abs_env_cfg.py`. These must move
     together with the solver default, otherwise PhysX would run against the Newton USD variant.
  3. Made the selector explicit in `docs/source/features/isaac_teleop.rst`: appended
     `physics=isaacsim_physx` to the four SO-101 Joint-Teleop launch commands and tagged the two
     environment-reference rows, matching the existing `Isaac-Reach-Franka` convention. This is
     now belt-and-braces rather than load-bearing, but it keeps the documented commands explicit
     about the backend they rely on.

  Newton remains selectable with `physics=newton_mjwarp` for anyone working on the MJWarp path.
  No environment-browser regeneration is needed, since the generated rows are derived from the
  declared preset fields minus `_NEWTON_MJWARP_EXCLUSIONS` and do not encode which one is default.
 
  **Verification.** Resolved all three registered task configs and confirmed
  `cfg.sim.physics` is now `PhysxCfg` and the `Physics` USD variant resolves to `physx`:
  
  ```
  IsaacContrib-Stack-Cube-SO101-v0              -> PhysxCfg   variants default='physx'
  IsaacContrib-Stack-Cube-SO101-IK-Abs-v0       -> PhysxCfg   variants default='physx'
  IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 -> PhysxCfg   variants default='physx'
  ```

Fixes # (issue)

## Type of change

- Bug Fix

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there