### PR TITLE
Use decord2 on supported architectures

### DIFF
--- a/docs/source/overview/imitation-learning/humanoids_imitation.rst
+++ b/docs/source/overview/imitation-learning/humanoids_imitation.rst
@@ -649,7 +649,10 @@ Then, from the **Isaac-GR00T** directory, install GR00T N1.5 and its dependencie
    uv pip install wheel
    MAX_JOBS=4 uv pip install --no-build-isolation flash-attn==2.7.1.post4
    MAX_JOBS=4 uv pip install --no-build-isolation 'git+https://github.com/facebookresearch/pytorch3d.git@v0.7.9'
-   uv pip install diffusers decord zmq
+   uv pip install diffusers decord2 zmq
+
+The ``decord2`` distribution retains the ``decord`` Python import used by GR00T and provides
+pre-built wheels for both x86_64 and aarch64 systems, including DGX Spark.
 
 .. note::
 


### PR DESCRIPTION
# Description

Forward-ports #7662, which was merged into `release/3.0.0`, to `develop`.

Updates the GR00T installation instructions to use `decord2`, which retains the `decord` import API and provides current platform wheels, including aarch64 wheels needed by DGX Spark.

Tracks NVBug 6698023.

## Type of change

- Bug fix
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

Not applicable: this change is already present in `release/3.0.0` through #7662.

## Validation

- `uv run --no-project --with pre-commit python -m pre_commit run --all-files`
- `git diff --check upstream/develop...HEAD`
- Verified the stable patch ID matches #7662 exactly.
- The required project-managed docs command cannot resolve on this Apple Silicon macOS host because the `develop` lockfile supports only Linux and Windows. A no-project Sphinx fallback parsed all 226 documentation pages, including the changed page, but `-W` failed on unrelated autodoc imports for Linux-only modules. The identical patch passed `uv run --isolated --extra test -- make -C docs current-docs` in #7662.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run all pre-commit hooks successfully.
- [x] I have made the corresponding documentation change.
- [ ] My changes generate no new warnings. Full verification is deferred to CI on a supported host; the identical patch passed in #7662.
- [x] Targeted validation is complete; tests are not applicable to this docs-only change.
- [x] Changelog fragment is not applicable to this docs-only change.
- [x] The original author already appears in repository revision history.
