### PR TITLE
Fix deferred CUDA checks before Kit GPU filtering

### DIFF
--- a/source/isaaclab/changelog.d/preloaded-torch-cuda-init.rst
+++ b/source/isaaclab/changelog.d/preloaded-torch-cuda-init.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Initialized an already-imported PyTorch CUDA runtime before Kit startup so deferred capability checks do not retain
+  stale device indices when Kit filters the GPUs available to its Vulkan backend.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -328,6 +328,13 @@ class AppLauncher:
         # Integrate env-vars and input keyword args into simulation app config
         self._config_resolution(launcher_args)
 
+        # PyTorch may already have been imported while constructing simulation configs. Drain
+        # its deferred CUDA capability checks before Kit changes the set of CUDA devices that
+        # correspond to Vulkan-capable GPUs. Otherwise a queued check for a device that Kit
+        # filters out fails during the post-Kit ``set_device`` call (for example, device=1 with
+        # two CUDA GPUs but only GPU 0 attached to the display).
+        self._initialize_preloaded_torch_cuda()
+
         # Create SimulationApp, passing the resolved self._config to it for initialization
         self._create_app()
         self._set_deferred_cuda_device()
@@ -1148,6 +1155,21 @@ class AppLauncher:
         self.device = device
 
         logger.info("Using device: %s", device)
+
+    def _initialize_preloaded_torch_cuda(self) -> None:
+        """Initialize CUDA before Kit when another import has already loaded PyTorch.
+
+        Importing PyTorch schedules capability checks for every CUDA device it can see. Kit may
+        subsequently restrict CUDA to the GPUs that its Vulkan backend can use, leaving those
+        queued checks with stale device indices. Do not import PyTorch here: when it has not
+        already been loaded, the normal post-Kit initialization path remains preferable.
+        """
+        if self._deferred_cuda_device_id is None:
+            return
+
+        torch = sys.modules.get("torch")
+        if torch is not None and not torch.cuda.is_initialized():
+            torch.cuda.init()
 
     def _set_deferred_cuda_device(self) -> None:
         """Set the current CUDA device after Kit startup."""

--- a/source/isaaclab/test/app/test_kwarg_launch.py
+++ b/source/isaaclab/test/app/test_kwarg_launch.py
@@ -5,6 +5,8 @@
 
 import argparse
 import logging
+import sys
+from types import SimpleNamespace
 
 import pytest
 from isaaclab_newton.physics import NewtonCfg, VBDSolverCfg
@@ -214,6 +216,35 @@ def test_deferred_cuda_device_synchronizes_torch_and_warp(monkeypatch: pytest.Mo
     launcher._set_deferred_cuda_device()
 
     assert devices == [2]
+
+
+def test_preloaded_torch_cuda_is_initialized_before_kit(monkeypatch: pytest.MonkeyPatch):
+    """Drain PyTorch's queued CUDA checks before Kit can change visible device indices."""
+    init_calls = []
+    torch = SimpleNamespace(
+        cuda=SimpleNamespace(
+            is_initialized=lambda: False,
+            init=lambda: init_calls.append(True),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    launcher = AppLauncher.__new__(AppLauncher)
+    launcher._deferred_cuda_device_id = 0
+
+    launcher._initialize_preloaded_torch_cuda()
+
+    assert init_calls == [True]
+
+
+def test_cuda_initialization_remains_deferred_when_torch_is_not_loaded(monkeypatch: pytest.MonkeyPatch):
+    """Do not import PyTorch solely to initialize CUDA before Kit."""
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    launcher = AppLauncher.__new__(AppLauncher)
+    launcher._deferred_cuda_device_id = 0
+
+    launcher._initialize_preloaded_torch_cuda()
+
+    assert "torch" not in sys.modules
 
 
 def test_limit_cpu_threads_forwarded_to_simulation_app(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
# Description

Initialize CUDA before Kit startup when PyTorch has already been imported and a CUDA simulation device was selected.

Importing PyTorch queues capability checks for every CUDA device visible at import time. On heterogeneous multi-GPU systems, Kit can subsequently filter the CUDA devices to those usable by its Vulkan backend. The queued checks then retain stale indices and fail during the post-Kit `torch.cuda.set_device` call with `device >= 0 && device < num_gpus`.

The launcher does not import PyTorch solely for this workaround. If PyTorch has not already been loaded, CUDA initialization remains deferred until after Kit startup as before.

Reproduction hardware:

- Ubuntu 24.04 ARM64
- NVIDIA RTX PRO 6000 Blackwell attached to the display as GPU 0
- NVIDIA GB300 compute GPU as GPU 1
- Driver 610.43.03
- Isaac Sim 6.0.1

Previously failing command:

```bash
./isaaclab.sh -p scripts/demos/arms.py --device=cuda:0 --visualizer kit
```

The command now reaches setup completion and runs the visualized simulation with both GPUs visible. Restricting visibility to GPU 0 also continues to work.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable. The failure was a deferred CUDA initialization traceback; the fixed command was validated interactively through the Kit visualizer.

## Validation

- `3 passed, 47 deselected` for the focused AppLauncher CUDA tests
- GB300-only SKRL headless training completed one iteration and saved a checkpoint
- The previously failing Kit arms demo ran successfully with both GPUs visible
- Full `./isaaclab.sh --format` pre-commit suite passed

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation via a changelog fragment
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`