### PR TITLE
[Docker] Rebuild the kit-less image as a single stage

### DIFF
--- a/.github/workflows/kitless-docker.yml
+++ b/.github/workflows/kitless-docker.yml
@@ -49,6 +49,7 @@ jobs:
           ^docker/docker-compose\.yaml$ :: Kit-less Compose definition
           ^docker/test/test_container_profiles\.py$ :: Kit-less profile tests
           ^docker/test/test_dockerfile_nonroot\.py$ :: Dockerfile contract tests
+          ^docker/test/test_image_invariants\.py$ :: Built-image invariant tests
           ^docker/utils/container_interface\.py$ :: Container profile implementation
           ^docker/utils/volume_mounts\.py$ :: Container volume helper
           ^isaaclab\.sh$ :: Install CLI wrapper
@@ -104,6 +105,12 @@ jobs:
         fetch-depth: 1
         lfs: true
 
+    # The GPU runners have no uv on PATH; the invariant check below needs it.
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
     # Mirrors the per-commit tag scheme of build.yaml's config job so the
     # ECR tags stay in the same family as the other CI images.
     - name: Compute image tag
@@ -137,6 +144,7 @@ jobs:
         isaacsim-version: "24.04"
         dockerfile-path: docker/Dockerfile.kitless
         cache-tag: cache-kitless
+        verify-test-path: docker/test/test_image_invariants.py
         # Validation below docker-runs the image in this same job, and the
         # ECR login only exists while the action runs, so the action itself
         # must pull on a deps-cache hit.

--- a/docker/Dockerfile.kitless
+++ b/docker/Dockerfile.kitless
@@ -3,118 +3,32 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Kit-less image for GPU-accelerated training without Isaac Sim or Kit:
-# Newton physics, OVRTX rendering, and every core RL framework.
+# Kit-less image: Newton physics, OVRTX rendering and the RL frameworks, without Isaac Sim or Kit.
 ARG BASE_IMAGE_ARG=ubuntu:24.04
 
 FROM ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff AS uv
 
-FROM ${BASE_IMAGE_ARG} AS builder
+FROM ${BASE_IMAGE_ARG}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG ISAACLAB_PATH_ARG=/workspace/isaaclab
-# Deliberately outside ISAACLAB_PATH: CI bind-mounts the checkout over that path, which would
-# otherwise hide the interpreter and leave ``python`` resolving to nothing.
-ARG VENV_PATH_ARG=/opt/isaaclab-venv
-ENV ISAACLAB_PATH=${ISAACLAB_PATH_ARG}
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LANG=C.UTF-8
-ENV VIRTUAL_ENV=${VENV_PATH_ARG}
-ENV UV_PROJECT_ENVIRONMENT=${VENV_PATH_ARG}
-ENV PATH=${VENV_PATH_ARG}/bin:/usr/local/bin:${PATH}
-# The project pins ``python-preference = "only-managed"``, which makes ``uv sync`` download its own
-# CPython, delete the venv and rebuild it against the download. That interpreter is not copied into
-# the runtime stage, leaving bin/python a dangling symlink. Pin uv to the system interpreter, whose
-# libpython3.12 the runtime stage installs.
-ENV UV_PYTHON=/usr/bin/python3.12
-ENV UV_PYTHON_PREFERENCE=only-system
-ENV UV_NO_CACHE=1
-ENV PIP_RETRIES=12
-ENV UV_HTTP_RETRIES=12
-
-# Native build tools remain confined to this stage.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      build-essential \
-      ca-certificates \
-      cmake \
-      git \
-      libglib2.0-0 \
-      python3 \
-      python3-dev \
- && rm -rf /var/lib/apt/lists/*
-
-# Copy uv from its official versioned image instead of executing a mutable
-# installer URL during the build.
-COPY --from=uv /uv /uvx /usr/local/bin/
-
-WORKDIR ${ISAACLAB_PATH}
-
-# Copy the install inputs before the rest of the runtime tree so dependency
-# installation remains cached when only scripts or application code changes.
-COPY pyproject.toml uv.lock VERSION LICENSE LICENSE-mimic README.md ./
-COPY source/ source/
-COPY isaaclab.sh ./
-
-# Installed from uv.lock rather than via ``isaaclab.sh --install``: only the lock applies
-# ``[tool.uv] override-dependencies``, which pins ``packaging>=20,<27`` against ovphysx's
-# ``packaging<24``. The pip-style path ignores that table and needs a duplicated overrides file
-# instead, which the lock makes unnecessary. ``all`` is exactly rl+visualizer+ov and excludes the
-# ``isaacsim`` extra; ``importers`` is the two standalone wheels. UV_PYTHON above pins the venv to
-# python3.12, matching the runtime stage's libpython3.12; isaaclab.sh resolves VIRTUAL_ENV first.
-# ``--no-managed-python`` is not usable here -- uv rejects it alongside a python-preference.
-# OVRTX caches shaders, textures and derived data inside its own site-packages, and a
-# volume-mounted run executes as the runner's uid rather than the image's, so those paths must be
-# writable by a uid the image cannot know. Widened here rather than bind-mounted: the write targets
-# sit alongside shipped content such as ``cache/shadercache``, which a mount would hide.
-# ``--frozen`` is load-bearing: without it uv re-resolves whenever it judges the lock stale, which
-# would silently defeat the point of installing from it. ``--inexact`` keeps the seeded pip, which
-# is not a lock entry. ``uv sync`` reuses the venv only because UV_PYTHON pins the same interpreter
-# it was created with; otherwise it deletes and rebuilds it.
-RUN uv venv --seed "${VIRTUAL_ENV}" \
- && uv sync --frozen --inexact --extra all --extra importers --extra test \
- && chmod +x "${ISAACLAB_PATH}/isaaclab.sh" \
- && chmod -R a+rwX "${VIRTUAL_ENV}"/lib/python3.*/site-packages/ovrtx \
- && python -c "import importlib.metadata as m; \
-      names = {d.metadata['Name'].lower() for d in m.distributions()}; \
-      assert 'isaacsim' not in names; \
-      assert 'isaacsim-asset-isolated' in names; \
-      assert 'ovphysx' in names; \
-      assert 'ovrtx' in names; \
-      assert 'viser' in names; \
-      assert 'rerun-sdk' in names" \
- && test ! -e "${ISAACLAB_PATH}/_isaac_sim"
-
-# isaaclab.utils.assets parses apps/isaaclab.python.kit at import time to
-# resolve the Nucleus asset root, so apps/ is required even without Kit.
-COPY apps/ apps/
-COPY scripts/ scripts/
-COPY docs/licenses/ docs/licenses/
-COPY docker/docker-compose.yaml docker/docker-compose.yaml
-COPY docker/utils/volume_mounts.py docker/utils/volume_mounts.py
-
-
-FROM ${BASE_IMAGE_ARG} AS runtime
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-ARG ISAACLAB_PATH_ARG=/workspace/isaaclab
-ENV ISAACLAB_PATH=${ISAACLAB_PATH_ARG}
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LANG=C.UTF-8
-# Build arg like Dockerfile.base, so the image home and the Compose mounts
-# derived from DOCKER_USER_HOME cannot drift apart.
 ARG DOCKER_USER_HOME_ARG=/home/isaaclab
+# Outside ISAACLAB_PATH: CI bind-mounts the checkout over that path and would hide the interpreter.
 ARG VENV_PATH_ARG=/opt/isaaclab-venv
+ENV ISAACLAB_PATH=${ISAACLAB_PATH_ARG}
 ENV DOCKER_USER_HOME=${DOCKER_USER_HOME_ARG}
 ENV HOME=${DOCKER_USER_HOME}
 ENV VIRTUAL_ENV=${VENV_PATH_ARG}
 ENV PATH=${VENV_PATH_ARG}/bin:/usr/local/bin:${PATH}
-# ENV does not cross stages and this is the only multi-stage image, so the builder's uv settings
-# are repeated here. uv reads UV_PROJECT_ENVIRONMENT, never VIRTUAL_ENV. UV_PYTHON overrides
-# pyproject's ``python-preference = "only-managed"``, which would fetch a CPython and replace this
-# venv. UV_NO_SYNC stops ``uv run`` rebuilding the editable packages into a mounted ``source/``.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+
+# uv reads UV_PROJECT_ENVIRONMENT, never VIRTUAL_ENV. UV_PYTHON overrides pyproject's
+# ``python-preference = "only-managed"``, which would fetch a CPython and rebuild the venv.
+# UV_NO_SYNC stops ``uv run`` rebuilding the editable packages into a bind-mounted ``source/``,
+# which docker-compose.yaml does for this image; without it a container uid that cannot write the
+# host checkout fails with ``egg-info: Permission denied``.
 ENV UV_PROJECT_ENVIRONMENT=${VENV_PATH_ARG}
 ENV UV_PYTHON=/usr/bin/python3.12
 ENV UV_PYTHON_PREFERENCE=only-system
@@ -124,15 +38,12 @@ ENV PYTHONUNBUFFERED=1
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
 
-# ``git-lfs`` is required because CI checks out with ``lfs: true`` and bind-mounts that tree in.
-# Any ``git`` call then invokes the LFS filter, and without the binary it fails with "the remote
-# end hung up unexpectedly" -- which surfaced as every kit-less case failing before it allocated a
-# single byte of GPU memory. Dockerfile.base does not need this: the Isaac Sim base already has it.
-#
-# Libraries ovrtx loads at init. GLVND splits these: libgl1 gives libGL.so.1,
-# but libOpenGL.so.0 and libEGL.so.1 need libopengl0 and libegl1. libxrender1 is
-# for the Newton GL viewer: pyglet's xlib backend resolves libXrender.so.1 via
-# ctypes at import time and nothing else in this list pulls it in transitively.
+# --- System packages ---
+# Runtime libraries only. On x86_64 every wheel the lock resolves is prebuilt, so no toolchain
+# ships; the arm64 exceptions are installed conditionally below.
+# git-lfs: CI checks out with ``lfs: true``, and without it every ``git`` call fails the LFS filter.
+# GLVND splits the GL stack: libgl1 gives libGL.so.1, libopengl0/libegl1 the other two.
+# libxrender1: pyglet's xlib backend resolves it via ctypes for the Newton GL viewer.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
@@ -149,22 +60,77 @@ RUN apt-get update \
       libxext6 \
       libxrender1 \
       python3 \
- && rm -rf /var/lib/apt/lists/* \
- && if getent passwd ubuntu >/dev/null; then userdel -r ubuntu; fi \
+ && rm -rf /var/lib/apt/lists/*
+
+# arm64-only build deps, as in Dockerfile.base: psutil and pyopengl-accelerate publish no
+# aarch64 wheels, so uv builds them from sdist there.
+RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends build-essential python3-dev && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# --- Runtime user ---
+# ubuntu:24.04 ships its own uid/gid 1000, which useradd would collide with. ${HOME}/.cache is
+# pre-created because BuildKit makes a missing cache-mount parent root-owned inside a 750 home.
+RUN if getent passwd ubuntu >/dev/null; then userdel -r ubuntu; fi \
  && if getent group ubuntu >/dev/null; then groupdel ubuntu; fi \
  && groupadd --gid 1000 isaaclab \
  && useradd --uid 1000 --gid 1000 --home-dir "${HOME}" --create-home --shell /bin/bash isaaclab \
- && mkdir -p "${HOME}" \
+ && mkdir -p "${HOME}/.cache" "${VIRTUAL_ENV}" "${ISAACLAB_PATH}" \
  && chown -R isaaclab:isaaclab "${HOME}" \
+ && chown isaaclab:isaaclab "${VIRTUAL_ENV}" "${ISAACLAB_PATH}" \
  && chmod 750 "${HOME}"
 
-COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
-COPY --from=builder /usr/local/bin/uvx /usr/local/bin/uvx
-COPY --from=builder --chown=isaaclab:isaaclab ${VENV_PATH_ARG} ${VENV_PATH_ARG}
-COPY --from=builder --chown=isaaclab:isaaclab ${ISAACLAB_PATH} ${ISAACLAB_PATH}
+COPY --from=uv /uv /uvx /usr/local/bin/
 
-# A fresh named volume inherits ownership from the image directory at its mount
-# path, so pre-create and chown them; derived from Compose to avoid duplication.
+WORKDIR ${ISAACLAB_PATH}
+
+# --- Dependencies ---
+# Install inputs first, so the sync layer survives a change to anything copied below it.
+COPY --chown=isaaclab:isaaclab pyproject.toml uv.lock VERSION LICENSE LICENSE-mimic README.md ./
+COPY --chown=isaaclab:isaaclab source/ source/
+COPY --chown=isaaclab:isaaclab isaaclab.sh ./
+
+# From the lock, not ``isaaclab.sh --install``: only the lock applies ``[tool.uv]
+# override-dependencies``, which pins ``packaging`` above ovphysx's ``<24``.
+# ``--frozen`` stops uv re-resolving a lock it judges stale; ``--inexact`` keeps the seeded pip.
+# Cache mount as in Dockerfile.base and Dockerfile.curobo, but under ${HOME}: this image sets
+# HOME globally, so uv caches there rather than in root's home, and an unmatched mount bakes the
+# whole cache into the layer. UV_CACHE_DIR pins it so the two cannot drift.
+# ovrtx writes shader caches inside its own site-packages, which a volume-mounted run reaches as
+# the runner's uid rather than the image's.
+RUN --mount=type=cache,target=/home/isaaclab/.cache/uv \
+    export UV_HTTP_RETRIES=12 UV_CACHE_DIR=/home/isaaclab/.cache/uv \
+ && uv venv --seed "${VIRTUAL_ENV}" \
+ && uv sync --frozen --inexact --extra all --extra importers --extra test \
+ && chmod +x "${ISAACLAB_PATH}/isaaclab.sh" \
+ && chmod -R a+rwX "${VIRTUAL_ENV}"/lib/python3.*/site-packages/ovrtx \
+ && python -c "import importlib.metadata as m; \
+      names = {d.metadata['Name'].lower() for d in m.distributions()}; \
+      assert 'isaacsim' not in names; \
+      assert 'isaacsim-asset-isolated' in names; \
+      assert 'ovphysx' in names; \
+      assert 'ovrtx' in names; \
+      assert 'viser' in names; \
+      assert 'rerun-sdk' in names" \
+ && test ! -e "${ISAACLAB_PATH}/_isaac_sim" \
+ && chown -R isaaclab:isaaclab "${VIRTUAL_ENV}" "${ISAACLAB_PATH}"
+
+# The sync needed the system interpreter as the venv base; from here on uv commands such as
+# ``uv pip install`` target the venv, not the externally-managed system Python.
+ENV UV_PYTHON=${VENV_PATH_ARG}/bin/python
+
+# apps/ is required even without Kit: isaaclab.utils.assets parses isaaclab.python.kit on import.
+COPY --chown=isaaclab:isaaclab apps/ apps/
+COPY --chown=isaaclab:isaaclab scripts/ scripts/
+COPY --chown=isaaclab:isaaclab docs/licenses/ docs/licenses/
+COPY --chown=isaaclab:isaaclab docker/docker-compose.yaml docker/docker-compose.yaml
+COPY --chown=isaaclab:isaaclab docker/utils/volume_mounts.py docker/utils/volume_mounts.py
+
+# --- Named-volume mount points ---
+# A fresh volume inherits ownership from the image directory at its mount path; the list comes
+# from Compose so it cannot drift.
 RUN set -o pipefail \
  && export DOCKER_ISAACLAB_PATH="${ISAACLAB_PATH}" \
            DOCKER_USER_HOME="${HOME}" \

--- a/docker/test/test_dockerfile_nonroot.py
+++ b/docker/test/test_dockerfile_nonroot.py
@@ -147,12 +147,12 @@ def test_kitless_dockerfile_installs_newton_rl_ov_and_visualizers_without_isaac_
     # so a venv beneath it is masked and isaaclab.sh execs a missing interpreter (exit 127).
     assert "ARG VENV_PATH_ARG=/opt/isaaclab-venv" in dockerfile_text
     assert "ENV VIRTUAL_ENV=${VENV_PATH_ARG}" in dockerfile_text
-    # ``uv sync`` honours the project's ``only-managed`` preference and would rebuild the venv
-    # against a downloaded interpreter the runtime stage never receives, leaving bin/python
-    # dangling. The image must pin uv to the system interpreter.
+    # ``uv sync`` honours the project's ``only-managed`` preference and would download its own
+    # interpreter and rebuild the venv against it rather than reuse the shipped one. The image
+    # must pin uv to the system interpreter, whose libpython3.12 it installs.
     assert "ENV UV_PYTHON=/usr/bin/python3.12" in dockerfile_text
     assert "ENV UV_PYTHON_PREFERENCE=only-system" in dockerfile_text
-    assert "COPY isaaclab.sh ./" in dockerfile_text
+    assert "COPY --chown=isaaclab:isaaclab isaaclab.sh ./" in dockerfile_text
     assert "'isaacsim' not in names" in dockerfile_text
     assert "'isaacsim-asset-isolated' in names" in dockerfile_text
     assert "'ovphysx' in names" in dockerfile_text
@@ -164,9 +164,9 @@ def test_kitless_dockerfile_installs_newton_rl_ov_and_visualizers_without_isaac_
     # volume_mounts.py parses docker-compose.yaml at runtime, so both must reach the image -
     # either named individually or via a whole-tree copy.
     for required in ("docker/docker-compose.yaml", "docker/utils/volume_mounts.py"):
-        assert f"COPY {required} {required}" in dockerfile_text or "COPY . ." in dockerfile_text, (
-            f"{required} must be copied into the kit-less image"
-        )
+        assert (
+            f"COPY --chown=isaaclab:isaaclab {required} {required}" in dockerfile_text or "COPY . ." in dockerfile_text
+        ), f"{required} must be copied into the kit-less image"
 
 
 def test_container_test_runner_only_links_an_actual_isaac_sim_runtime():

--- a/docker/test/test_image_invariants.py
+++ b/docker/test/test_image_invariants.py
@@ -52,3 +52,21 @@ def test_no_prebundled_package_lost_its_entry_point():
     """
     broken = _in_image('find / -path "*pip_prebundle*" -xtype l -name "__init__.py" 2>/dev/null || true').strip()
     assert not broken, "prebundled packages lost their entry point:\n" + broken
+
+
+def test_uv_run_resolves_the_shipped_environment():
+    """``uv run`` must use the venv the image ships, not build a second one.
+
+    uv reads the project environment from ``UV_PROJECT_ENVIRONMENT`` and ignores ``VIRTUAL_ENV``,
+    so an image setting only the latter has ``uv run`` create ``${ISAACLAB_PATH}/.venv`` and
+    reinstall the whole lock. On a bind-mounted source tree that write fails outright
+    (nvbugs 6732972, ``could not create '<package>.egg-info': Permission denied``).
+    """
+    virtual_env = _in_image('printf %s "$VIRTUAL_ENV"').strip()
+    assert virtual_env, "image does not set VIRTUAL_ENV"
+
+    prefix = _in_image('uv run python -c "import sys; print(sys.prefix)"').strip()
+    assert prefix == virtual_env, f"uv run resolved {prefix}, not the image environment {virtual_env}"
+
+    stray = _in_image('ls -d "${ISAACLAB_PATH}/.venv" 2>/dev/null || true').strip()
+    assert not stray, f"uv run built a second environment at {stray}"

--- a/source/isaaclab/changelog.d/jichuanh-kitless-single-stage.rst
+++ b/source/isaaclab/changelog.d/jichuanh-kitless-single-stage.rst
@@ -1,0 +1,11 @@
+Changed
+^^^^^^^
+
+* Rebuilt the kit-less Docker image as a single stage. Every wheel the lock resolves for x86_64
+  is prebuilt, so the image no longer installs a C toolchain there; ``psutil`` and
+  ``pyopengl-accelerate`` have no aarch64 wheels, so the build dependencies they need are
+  installed on arm64 only.
+* Switched the kit-less image's dependency install to a uv cache mount, matching the Isaac Sim
+  images, so a rebuild reuses downloaded wheels instead of re-fetching them.
+* Pointed ``uv`` at the shipped environment for runtime commands in the kit-less image, so
+  ``uv pip install`` no longer resolves to the externally managed system interpreter.


### PR DESCRIPTION
## Summary

The kit-less image drops from 159 to 114 Dockerfile lines and stops installing a C toolchain
it never uses on x86_64, while a `uv run` invariant runs against the built image for the first
time. Cold build 109 s, image unchanged at 15.46 GB.

# Description

Stacked on #7628 — that PR carries the four runtime `uv` settings for NVBug 6732972 and should
merge first. Until it does, this PR's diff shows its commits too.

## 1. Single stage

`Dockerfile.kitless` was the repo's only image whose final stage was not the stage that ran the
install, which is why `ENV` had to be declared twice and why nvbugs 6732972 was possible at all.
Merging the stages removes that class of bug rather than patching it.

The builder stage existed to keep a compiler out of the runtime. Measured: 0 of 222 installed
distributions are locally built on x86_64, so `build-essential`, `cmake` and `python3-dev` were
339 MB of unused toolchain. `psutil==5.9.8` and `pyopengl-accelerate==3.1.10` publish no aarch64
wheels, so those build deps are restored for arm64 only, as `Dockerfile.base` already does.

## 2. uv cache mount

Kit-less was the only image without one; base and cuRobo have used `--mount=type=cache` since
#7405. The mount targets `${HOME}/.cache/uv` rather than root's, because this image sets `HOME`
for the whole build — an unmatched target silently bakes the cache into the layer.

## 3. Built-image invariant

`kitless-docker.yml` never passed `verify-test-path`, so `docker/test/test_image_invariants.py`
had never run against this image. It now does, with a new assertion that `uv run` resolves the
shipped environment. Verified to fail on an image with `UV_PROJECT_ENVIRONMENT` removed and pass
on the fixed one.

## 4. Validation

Measured on an RTX PRO 6000 (Blackwell), amd64:

| Check | Result |
|---|---|
| Cold `--no-cache` build | 109 s, 15.46 GB |
| OVRTX renderer, `--gpus all` | initialises |
| Warp / Newton on CUDA | warp 1.17.0, newton 1.6.0rc1 |
| `uv run` with `source/` bind-mounted read-only | resolves `/opt/isaaclab-venv`, no stray `.venv` |
| `docker/test` | 46 passed, 2 skipped |
| `uv run isaaclab -f` | clean |

**arm64 is not verified.** PR CI builds amd64 only; the aarch64 path is exercised by
`publish-images.yaml` after merge. The conditional is confirmed inert on amd64.

A two-phase `uv sync` (deps, then workspace) was measured and rejected: it made a source-edit
rebuild 6.9× slower (468 s vs 68 s) and the image 14.9 GB larger, because the second sync
rewrites the venv in a later layer.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
