### PR TITLE
fix(newton): split flat-builder site injection per environment

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-flat-builder-per-env-sites.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-flat-builder-per-env-sites.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_newton.physics.NewtonManager._cl_inject_sites_fallback` (the
+  non-replicated/flat-builder path, used when ``replicate_physics=False``) collapsing every
+  environment's matched site index into a single one-element outer list instead of one sublist
+  per environment. This raised ``IndexError`` in any consumer indexing ``per_world[env_index]``
+  for ``env_index > 0`` (e.g. :meth:`~isaaclab_newton.sensors.ray_caster.NewtonRaycastSensor._resolve_site_indices`)
+  as soon as a scene had more than one environment with ``replicate_physics=False``.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -1414,7 +1414,13 @@ class NewtonManager(PhysicsManager):
         Populates :attr:`_cl_site_index_map` with the unified per-world structure:
 
         - Global sites (``body_pattern is None``): ``(shape_idx, None)``
-        - Local and world sites: ``(None, [[idx, ...]])`` — one sublist for the single world.
+        - Local sites: ``(None, [[idx, ...], ...])`` — one sublist per environment, keyed off the
+          ``env_<N>`` path segment of the matched body label. The flat builder holds every
+          environment's bodies in a single (non-replicated) model, so a body-pattern match spans
+          all environments at once and must be split back into per-environment sites; consumers
+          such as :meth:`NewtonRaycastSensor._resolve_site_indices` index this list by environment.
+        - World sites (``per_world=True``): ``(None, [[idx]])`` — one shared site, same for every
+          environment.
         """
         builder = cls._builder
         body_labels = list(builder.body_label)
@@ -1436,14 +1442,24 @@ class NewtonManager(PhysicsManager):
                         f"in the flat builder. Available body labels: {body_labels}."
                     ) from e
 
-                site_indices: list[int] = []
-                for body_idx in matched_indices:
-                    site_label = f"{builder.body_label[body_idx]}/{label}"
+                # group matches by their env_<N> path segment: the flat builder concatenates every
+                # environment's bodies into one model, so a per-env pattern like
+                # ".*/env_[^/]+/Robot/base" matches once per environment here.
+                sites_by_env: dict[int, list[int]] = {}
+                for body_idx, body_name in zip(matched_indices, matched_names):
+                    site_label = f"{body_name}/{label}"
                     site_idx = builder.add_site(body=body_idx, xform=xform, label=site_label)
-                    site_indices.append(site_idx)
+                    env_match = re.search(r"/env_(\d+)(?:/|$)", body_name)
+                    if env_match is None:
+                        raise ValueError(
+                            f"Site '{label}' with body_pattern '{body_pattern}' matched body '{body_name}', "
+                            "which has no 'env_<N>' path segment. The flat (non-replicated) builder needs "
+                            "each match tied to an environment index to build a per-environment site map."
+                        )
+                    sites_by_env.setdefault(int(env_match.group(1)), []).append(site_idx)
 
-                # Single world (no replication): one-element outer list
-                cls._cl_site_index_map[label] = (None, [site_indices])
+                num_envs = max(sites_by_env) + 1
+                cls._cl_site_index_map[label] = (None, [sites_by_env.get(i, []) for i in range(num_envs)])
 
         cls._cl_pending_sites.clear()
 


### PR DESCRIPTION
# Description

`_cl_inject_sites_fallback` — the non-replicated/flat-builder path in `isaaclab_newton`'s
`NewtonManager`, used whenever a scene is built with `replicate_physics=False` — packed every
environment's matched site index into a single one-element outer list instead of one sublist per
environment. Any consumer indexing `per_world[env_index]` for `env_index > 0` (e.g.
`NewtonRaycastSensor._resolve_site_indices`) hit an `IndexError` as soon as a scene had more than
one environment with `replicate_physics=False`.

The fix groups matches by their `env_<N>` path segment instead, so the site map has one sublist
per environment, matching the convention already used by the replicated builder path.

Fixes # (issue)
<!-- N/A, found and fixed during development; no linked GitHub issue. -->

**Test plan:** Reproduced against a custom multi-environment task with `replicate_physics=False`
and a robot-attached ray-caster sensor; confirmed the `IndexError` before the fix and clean
initialization after. Not covered by an automated CI test yet.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — backend indexing fix, no visual output.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
