### PR TITLE
fix(newton): resolve environment-vs-world index in the FK/reset-mask kernels

### DIFF
--- a/source/isaaclab_newton/changelog.d/fix-newton-flat-builder-reset-masks.rst
+++ b/source/isaaclab_newton/changelog.d/fix-newton-flat-builder-reset-masks.rst
@@ -1,0 +1,10 @@
+Fixed
+^^^^^
+
+* Fixed :meth:`~isaaclab_newton.physics.NewtonManager.invalidate_fk` and
+  :meth:`~isaaclab_newton.physics.NewtonManager.invalidate_body_state` conflating the environment
+  index with the world index in their reset-mask kernels. This is correct for the replicated
+  builder (one world per environment) but wrote out of bounds for the flat (non-replicated)
+  builder used when ``replicate_physics=False``, where every environment shares world 0 — causing
+  an "illegal memory access" CUDA error on every ``env.reset()`` call for any non-replicated scene
+  with more than one environment.

--- a/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
+++ b/source/isaaclab_newton/isaaclab_newton/physics/newton_manager.py
@@ -276,12 +276,21 @@ class _ParticleVisualPrim:
 def _or_reset_masks_from_mask(
     env_mask: wp.array(dtype=wp.bool),
     articulation_ids: wp.array2d(dtype=int),
+    is_flat_builder: int,
     world_mask: wp.array(dtype=wp.bool),
     fk_mask: wp.array(dtype=wp.bool),
 ):
-    """OR env_mask into world_mask and set corresponding articulation bits in fk_mask."""
+    """OR env_mask into world_mask and set corresponding articulation bits in fk_mask.
+
+    ``articulation_ids`` maps ``(world, arti)`` to a model articulation index. The replicated
+    builder gives one world per environment (``world == env_id``, any ``arti`` count); the flat
+    (non-replicated) builder collapses every environment into a single world 0, with the
+    environment index carried by ``arti`` instead. ``is_flat_builder`` (``world_count == 1``,
+    resolved once at launch time) selects which axis is the environment index into ``env_mask``.
+    """
     world, arti = wp.tid()
-    if env_mask[world]:
+    env_id = wp.where(is_flat_builder, arti, world)
+    if env_mask[env_id]:
         world_mask[world] = True
         fk_mask[articulation_ids[world, arti]] = True
 
@@ -290,14 +299,20 @@ def _or_reset_masks_from_mask(
 def _scatter_reset_masks_from_ids(
     env_ids: wp.array(dtype=Any),
     articulation_ids: wp.array2d(dtype=int),
+    is_flat_builder: int,
     world_mask: wp.array(dtype=wp.bool),
     fk_mask: wp.array(dtype=wp.bool),
 ):
-    """Scatter-set world_mask and fk_mask from sparse env_ids."""
+    """Scatter-set world_mask and fk_mask from sparse env_ids.
+
+    See :func:`_or_reset_masks_from_mask` for the flat-vs-replicated ``(world, arti)`` convention
+    that ``is_flat_builder`` resolves.
+    """
     i, arti = wp.tid()
-    world = wp.int32(env_ids[i])
-    world_mask[world] = True
+    env_id = wp.int32(env_ids[i])
+    world = wp.where(is_flat_builder, 0, env_id)
     fk_mask[articulation_ids[world, arti]] = True
+    world_mask[world] = True
 
 
 _SCATTER_RESET_MASKS_FROM_IDS_DISPATCHER = IndexKernelDispatcher(_scatter_reset_masks_from_ids, ("env_ids",))
@@ -309,17 +324,29 @@ def _scatter_reset_masks_from_ids_kernel(env_ids: wp.array | torch.Tensor) -> wp
 
 
 @wp.kernel(enable_backward=False)
-def _or_world_reset_mask_from_mask(env_mask: wp.array(dtype=wp.bool), world_mask: wp.array(dtype=wp.bool)):
-    """Mark masked worlds for solver reset without requesting FK."""
-    world = wp.tid()
-    if env_mask[world]:
-        world_mask[world] = True
+def _or_world_reset_mask_from_mask(
+    env_mask: wp.array(dtype=wp.bool), is_flat_builder: int, world_mask: wp.array(dtype=wp.bool)
+):
+    """Mark masked worlds for solver reset without requesting FK.
+
+    In the flat (non-replicated) builder every environment shares world 0, so any dirtied
+    environment marks that single world; see :func:`_or_reset_masks_from_mask`.
+    """
+    env_id = wp.tid()
+    if env_mask[env_id]:
+        world_mask[wp.where(is_flat_builder, 0, env_id)] = True
 
 
 @wp.kernel(enable_backward=False)
-def _scatter_world_reset_mask_from_ids(env_ids: wp.array(dtype=wp.int32), world_mask: wp.array(dtype=wp.bool)):
-    """Mark selected worlds for solver reset without requesting FK."""
-    world_mask[env_ids[wp.tid()]] = True
+def _scatter_world_reset_mask_from_ids(
+    env_ids: wp.array(dtype=wp.int32), is_flat_builder: int, world_mask: wp.array(dtype=wp.bool)
+):
+    """Mark selected worlds for solver reset without requesting FK.
+
+    See :func:`_or_world_reset_mask_from_mask` for the flat-builder collapse to world 0.
+    """
+    env_id = env_ids[wp.tid()]
+    world_mask[wp.where(is_flat_builder, 0, env_id)] = True
 
 
 class NewtonSceneDataBackend(SceneDataBackend):
@@ -1480,18 +1507,20 @@ class NewtonManager(PhysicsManager):
             return
 
         if articulation_ids is not None and env_mask is not None:
+            is_flat_builder = int(articulation_ids.shape[0] == 1 and articulation_ids.shape[1] > 1)
             wp.launch(
                 _or_reset_masks_from_mask,
                 dim=articulation_ids.shape,
-                inputs=[env_mask, articulation_ids],
+                inputs=[env_mask, articulation_ids, is_flat_builder],
                 outputs=[NewtonManager._world_reset_mask, NewtonManager._fk_reset_mask],
                 device=PhysicsManager._device,
             )
         elif articulation_ids is not None and env_ids is not None:
+            is_flat_builder = int(articulation_ids.shape[0] == 1 and articulation_ids.shape[1] > 1)
             wp.launch(
                 _scatter_reset_masks_from_ids_kernel(env_ids),
                 dim=(env_ids.shape[0], articulation_ids.shape[1]),
-                inputs=[env_ids, articulation_ids],
+                inputs=[env_ids, articulation_ids, is_flat_builder],
                 outputs=[NewtonManager._world_reset_mask, NewtonManager._fk_reset_mask],
                 device=PhysicsManager._device,
             )
@@ -1515,11 +1544,12 @@ class NewtonManager(PhysicsManager):
         cls._mark_transforms_dirty()
         if cls._world_reset_mask is None:
             return
+        is_flat_builder = int(cls._world_reset_mask.shape[0] == 1 and (cls._num_envs or 0) > 1)
         if env_mask is not None:
             wp.launch(
                 _or_world_reset_mask_from_mask,
                 dim=env_mask.shape[0],
-                inputs=[env_mask],
+                inputs=[env_mask, is_flat_builder],
                 outputs=[NewtonManager._world_reset_mask],
                 device=PhysicsManager._device,
             )
@@ -1527,7 +1557,7 @@ class NewtonManager(PhysicsManager):
             wp.launch(
                 _scatter_world_reset_mask_from_ids,
                 dim=env_ids.shape[0],
-                inputs=[env_ids],
+                inputs=[env_ids, is_flat_builder],
                 outputs=[NewtonManager._world_reset_mask],
                 device=PhysicsManager._device,
             )


### PR DESCRIPTION
# Description

`NewtonManager.invalidate_fk` and `invalidate_body_state` (in `isaaclab_newton`) mark environments
as needing FK recomputation and solver reset by writing `world_mask`/`fk_mask` through four Warp
kernels (`_or_reset_masks_from_mask`, `_scatter_reset_masks_from_ids`,
`_or_world_reset_mask_from_mask`, `_scatter_world_reset_mask_from_ids`) that all conflated the
environment index with the world index.

That is correct for the replicated builder (`world_count == num_envs`, one world per environment)
but wrong for the flat (non-replicated) builder used when `replicate_physics=False`, where every
environment shares a single world 0 and the environment index is carried by the articulation
("arti") axis instead. Treating an environment index as a world index there wrote out of bounds
into `world_mask` (sized `world_count == 1`), producing an "illegal memory access" CUDA error on
every `env.reset()` call for any non-replicated scene with more than one environment.

The fix resolves the builder convention once at launch time (`world_count == 1`) and passes it
into each kernel so it indexes the correct axis.

This is the third bug in the same family (environment-index-vs-world-index confusion in Newton's
flat/non-replicated builder), alongside #7672 and #7673.

**Reproduction / verification:** reproduced against a custom multi-environment task with
`replicate_physics=False`: `env.reset()` crashed with a CUDA illegal-memory-access error before the
fix, confirmed synchronously with `CUDA_LAUNCH_BLOCKING=1`, which pinpointed the crash to
`_scatter_reset_masks_from_ids`. After the fix, the same task runs a full episode and records video
with no errors.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — backend kernel fix, no visual output.

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
