### PR TITLE
Fix Franka Reach teleoperation stability and collisions

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-franka-reach-teleop-startup.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-franka-reach-teleop-startup.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed unexpected Franka Reach motion before teleoperation input by configuring backend-native gravity control
+  for the differential and Newton IK presets.
+* Fixed Franka Reach links intersecting the table on PhysX by enabling the Menagerie asset's convex link colliders.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/franka/ik_abs_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/reach/config/franka/ik_abs_env_cfg.py
@@ -8,6 +8,7 @@
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.reach.config.franka import franka_reach_env_cfg
+from isaaclab_tasks.utils import resolve_presets
 
 
 @configclass
@@ -16,9 +17,4 @@ class FrankaReachEnvCfg(franka_reach_env_cfg.FrankaReachEnvCfg):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        self.sim.physics = self.sim.physics.isaacsim_physx
-        self.scene.robot.spawn.rigid_props.disable_gravity = (
-            self.scene.robot.spawn.rigid_props.disable_gravity.diffik_abs
-        )
-        self.rewards.action_magnitude.weight = self.rewards.action_magnitude.weight.diffik_abs
-        self.actions.arm_action = self.actions.arm_action.diffik_abs
+        resolve_presets(self, selected=("diffik_abs", "isaacsim_physx"))

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -11,6 +11,8 @@ from isaaclab_newton.envs.mdp.actions.newton_ik_actions_cfg import NewtonInverse
 from isaaclab_newton.ik.newton_ik_objectives_cfg import NewtonIKJointLimitObjectiveCfg, NewtonIKPoseObjectiveCfg
 from isaaclab_newton.ik.newton_ik_solver_cfg import NewtonIKSolverCfg
 from isaaclab_newton.physics import NewtonCfg
+from isaaclab_newton.sim.schemas import MujocoRigidBodyCfg
+from isaaclab_physx.sim.schemas import PhysxRigidBodyCfg
 
 import isaaclab.envs.mdp as mdp
 from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
@@ -19,6 +21,7 @@ from isaaclab.devices.gamepad import Se3GamepadCfg
 from isaaclab.devices.keyboard import Se3KeyboardCfg
 from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
+from isaaclab.sim.schemas import UsdPhysicsCollisionCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_tasks.core.reach.reach_env_cfg import ReachEnvCfg
@@ -100,7 +103,25 @@ class FrankaReachEnvCfg(ReachEnvCfg):
 
         # switch robot to franka
         self.scene.robot = FRANKA_PANDA_MENAGERIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
-        self.scene.robot.spawn.rigid_props.disable_gravity = preset(default=False, diffik_abs=True)
+        # IK targets need backend-native gravity control to hold steady between commands.
+        self.scene.robot.spawn.rigid_props = [
+            PhysxRigidBodyCfg(
+                disable_gravity=preset(default=False, diffik=True, diffik_abs=True, newton_ik=True),
+                max_depenetration_velocity=5.0,
+            ),
+            MujocoRigidBodyCfg(gravcomp=preset(default=None, diffik=1.0, diffik_abs=1.0, newton_ik=1.0)),
+        ]
+        # The Menagerie asset ships its designated convex link-collision meshes disabled.
+        physx_collision_props = {"/Geometry/.*_c.*": [UsdPhysicsCollisionCfg(collision_enabled=True)]}
+        self.scene.robot.spawn.make_uninstanceable = preset(
+            default=False, isaacsim_physx=True, physx=True, ovphysx=True
+        )
+        self.scene.robot.spawn.collision_props = preset(
+            default=None,
+            isaacsim_physx=physx_collision_props,
+            physx=physx_collision_props,
+            ovphysx=physx_collision_props,
+        )
         # override rewards
         self.rewards.end_effector_position_tracking.params["asset_cfg"].body_names = ["panda_hand"]
         self.rewards.end_effector_orientation_tracking.params["asset_cfg"].body_names = ["panda_hand"]

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_osc_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_osc_env_cfg.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from isaaclab_newton.sim.schemas import MujocoRigidBodyCfg
+from isaaclab_physx.sim.schemas import PhysxRigidBodyCfg
+
 from isaaclab.actuators import IdealPDActuatorCfg
 from isaaclab.controllers.operational_space_cfg import OperationalSpaceControllerCfg
 from isaaclab.envs.mdp.actions.actions_cfg import OperationalSpaceControllerActionCfg
@@ -25,7 +28,11 @@ class FrankaReachEnvCfg(franka_reach_env_cfg.FrankaReachEnvCfg):
             stiffness=0.0,
             damping=0.0,
         )
-        self.scene.robot.spawn.rigid_props.disable_gravity = True
+        for rigid_props in self.scene.robot.spawn.rigid_props:
+            if isinstance(rigid_props, PhysxRigidBodyCfg):
+                rigid_props.disable_gravity = True
+            elif isinstance(rigid_props, MujocoRigidBodyCfg):
+                rigid_props.gravcomp = 1.0
 
         # If closed-loop contact force control is desired, contact sensors should be enabled for the robot
         # self.scene.robot.spawn.activate_contact_sensors = True

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -144,6 +144,16 @@ def test_reach_ik_presets_configure_gravity_control(action_preset, physics_prese
     assert mujoco_props.gravcomp == gravcomp
 
 
+def test_reach_osc_configures_backend_native_gravity_control():
+    cfg = _load_reach_env_cfg("Isaac-Reach-Franka-OSC")
+    rigid_props = cfg.scene.robot.spawn.rigid_props
+
+    physx_props = next(props for props in rigid_props if isinstance(props, PhysxRigidBodyCfg))
+    mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
+    assert physx_props.disable_gravity
+    assert mujoco_props.gravcomp == pytest.approx(1.0)
+
+
 def test_reach_franka_enables_link_collision_meshes_for_physx():
     cfg = _load_env_cfg("isaacsim_physx")
     collision_props = cfg.scene.robot.spawn.collision_props

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -13,7 +13,6 @@ from isaaclab_newton.sim.schemas import MujocoRigidBodyCfg
 from isaaclab_physx.sim.schemas import PhysxRigidBodyCfg
 
 import isaaclab.envs.mdp as mdp
-from isaaclab.sim.schemas import UsdPhysicsCollisionCfg
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils.hydra import resolve_presets
@@ -121,56 +120,23 @@ def test_reach_relative_ik_presets_configure_six_dof_native_teleop_devices(actio
     assert all(not device_cfg.gripper_term for device_cfg in cfg.teleop_devices.devices.values())
 
 
-@pytest.mark.parametrize(
-    ("action_preset", "physics_preset", "disable_gravity", "gravcomp"),
-    [
-        ("joint_pos", "isaacsim_physx", False, None),
-        ("joint_pos", "newton_mjwarp", False, None),
-        ("diffik", "isaacsim_physx", True, 1.0),
-        ("diffik", "newton_mjwarp", True, 1.0),
-        ("diffik_abs", "isaacsim_physx", True, 1.0),
-        ("diffik_abs", "newton_mjwarp", True, 1.0),
-        ("newton_ik", "newton_mjwarp", True, 1.0),
-    ],
-)
-def test_reach_ik_presets_configure_gravity_control(action_preset, physics_preset, disable_gravity, gravcomp):
-    cfg = _load_env_cfg(action_preset, physics_preset)
+def test_reach_diffik_physx_configures_teleop_physics():
+    cfg = _load_env_cfg("diffik", "isaacsim_physx")
     rigid_props = cfg.scene.robot.spawn.rigid_props
 
     physx_props = next(props for props in rigid_props if isinstance(props, PhysxRigidBodyCfg))
-    mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
-    assert physx_props.disable_gravity is disable_gravity
-    assert physx_props.max_depenetration_velocity == pytest.approx(5.0)
-    assert mujoco_props.gravcomp == gravcomp
-
-
-def test_reach_osc_configures_backend_native_gravity_control():
-    cfg = _load_reach_env_cfg("Isaac-Reach-Franka-OSC")
-    rigid_props = cfg.scene.robot.spawn.rigid_props
-
-    physx_props = next(props for props in rigid_props if isinstance(props, PhysxRigidBodyCfg))
-    mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
     assert physx_props.disable_gravity
-    assert mujoco_props.gravcomp == pytest.approx(1.0)
-
-
-def test_reach_franka_enables_link_collision_meshes_for_physx():
-    cfg = _load_env_cfg("isaacsim_physx")
-    collision_props = cfg.scene.robot.spawn.collision_props
-
+    assert physx_props.max_depenetration_velocity == pytest.approx(5.0)
     assert cfg.scene.robot.spawn.make_uninstanceable
-    assert set(collision_props) == {"/Geometry/.*_c.*"}
-    assert len(collision_props["/Geometry/.*_c.*"]) == 1
-    link_collision_props = collision_props["/Geometry/.*_c.*"][0]
-    assert isinstance(link_collision_props, UsdPhysicsCollisionCfg)
-    assert link_collision_props.collision_enabled
+    assert cfg.scene.robot.spawn.collision_props["/Geometry/.*_c.*"][0].collision_enabled
 
 
-def test_reach_franka_keeps_instancing_for_newton():
-    cfg = _load_env_cfg("newton_mjwarp")
+def test_reach_newton_ik_configures_gravity_compensation():
+    cfg = _load_env_cfg("newton_ik", "newton_mjwarp")
+    rigid_props = cfg.scene.robot.spawn.rigid_props
 
-    assert not cfg.scene.robot.spawn.make_uninstanceable
-    assert cfg.scene.robot.spawn.collision_props is None
+    mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
+    assert mujoco_props.gravcomp == pytest.approx(1.0)
 
 
 def test_reach_newton_ik_uses_native_se3_command_convention():

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -9,8 +9,11 @@ import pytest
 import torch
 from gymnasium.envs.registration import registry
 from isaaclab_newton.ik.newton_ik_objectives_cfg import NewtonIKPoseObjectiveCfg
+from isaaclab_newton.sim.schemas import MujocoRigidBodyCfg
+from isaaclab_physx.sim.schemas import PhysxRigidBodyCfg
 
 import isaaclab.envs.mdp as mdp
+from isaaclab.sim.schemas import UsdPhysicsCollisionCfg
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils.hydra import resolve_presets
@@ -33,6 +36,9 @@ def _without_controller_dependent_cfg(cfg):
     cfg_dict = cfg.to_dict()
     cfg_dict.pop("actions")
     cfg_dict.pop("teleop_devices")
+    for rigid_props in cfg_dict["scene"]["robot"]["spawn"]["rigid_props"]:
+        rigid_props.pop("disable_gravity", None)
+        rigid_props.pop("gravcomp", None)
     return cfg_dict
 
 
@@ -113,6 +119,48 @@ def test_reach_relative_ik_presets_configure_six_dof_native_teleop_devices(actio
     cfg.validate()
     assert set(cfg.teleop_devices.devices) == {"keyboard", "gamepad", "spacemouse"}
     assert all(not device_cfg.gripper_term for device_cfg in cfg.teleop_devices.devices.values())
+
+
+@pytest.mark.parametrize(
+    ("action_preset", "physics_preset", "disable_gravity", "gravcomp"),
+    [
+        ("joint_pos", "isaacsim_physx", False, None),
+        ("joint_pos", "newton_mjwarp", False, None),
+        ("diffik", "isaacsim_physx", True, 1.0),
+        ("diffik", "newton_mjwarp", True, 1.0),
+        ("diffik_abs", "isaacsim_physx", True, 1.0),
+        ("diffik_abs", "newton_mjwarp", True, 1.0),
+        ("newton_ik", "newton_mjwarp", True, 1.0),
+    ],
+)
+def test_reach_ik_presets_configure_gravity_control(action_preset, physics_preset, disable_gravity, gravcomp):
+    cfg = _load_env_cfg(action_preset, physics_preset)
+    rigid_props = cfg.scene.robot.spawn.rigid_props
+
+    physx_props = next(props for props in rigid_props if isinstance(props, PhysxRigidBodyCfg))
+    mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
+    assert physx_props.disable_gravity is disable_gravity
+    assert physx_props.max_depenetration_velocity == pytest.approx(5.0)
+    assert mujoco_props.gravcomp == gravcomp
+
+
+def test_reach_franka_enables_link_collision_meshes_for_physx():
+    cfg = _load_env_cfg("isaacsim_physx")
+    collision_props = cfg.scene.robot.spawn.collision_props
+
+    assert cfg.scene.robot.spawn.make_uninstanceable
+    assert set(collision_props) == {"/Geometry/.*_c.*"}
+    assert len(collision_props["/Geometry/.*_c.*"]) == 1
+    link_collision_props = collision_props["/Geometry/.*_c.*"][0]
+    assert isinstance(link_collision_props, UsdPhysicsCollisionCfg)
+    assert link_collision_props.collision_enabled
+
+
+def test_reach_franka_keeps_instancing_for_newton():
+    cfg = _load_env_cfg("newton_mjwarp")
+
+    assert not cfg.scene.robot.spawn.make_uninstanceable
+    assert cfg.scene.robot.spawn.collision_props is None
 
 
 def test_reach_newton_ik_uses_native_se3_command_convention():


### PR DESCRIPTION
# Description

Resolves NVBug 6740415 and NVBug 6740433.

Relative IK uses the current end-effector pose as the next target. After the Reach controller consolidation, gravity remained enabled for the relative DiffIK and Newton IK presets, so zero SpaceMouse input let the arm fall between control updates and continuously re-anchored the target to the falling pose.

This change:

- configures `physxRigidBody:disableGravity` for the IK action presets on PhysX;
- configures `mjc:gravcomp=1.0` for the same presets on Newton MJWarp;
- enables the Menagerie asset's designated convex `*_c` link colliders for the PhysX family, making its instance proxies editable before applying the task-scoped override;
- keeps gravity and the instanced asset path unchanged for the default joint-position/Newton configuration; and
- updates the deprecated absolute-DiffIK alias to use the shared preset resolver.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

The exact commit applies cleanly with `git cherry-pick --no-commit` on the current `origin/release/3.0.0` tip.

## Screenshots

Not applicable. QA should replay the attached NVBug recordings and the reported SpaceMouse command.

## Validation

- `uv run --frozen python -m pytest source/isaaclab_tasks/test/core/test_reach_franka_presets.py -q` — 32 passed.
- `uv run --frozen isaaclab zero_agent --task Isaac-Reach-Franka --num_envs 1 --max_steps 100 physics=newton_mjwarp presets=newton_ik` — passed.
- Zero-action probes over 100 environment steps:
  - Newton IK hand translation fell from about 0.876 m before the fix to less than 0.000001 m.
  - DiffIK hand translation fell from about 0.938 m before the fix to about 0.000002 m.
- The PhysX collision override enabled all 11 previously disabled convex link meshes while retaining the existing hand collider; a sustained downward-action contact probe stopped at the table surface.
- `uv run --frozen isaaclab -f` — passed.
- `uv run --frozen python tools/changelog/cli.py check develop` — passed.
- The Isaac Sim PhysX runtime is not installed in this worktree, so QA/CI should replay the exact reported PhysX SpaceMouse command.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
