### PR TITLE
[Docs] Fix demo card media paths

### DIFF
--- a/docs/source/setup/demos.rst
+++ b/docs/source/setup/demos.rst
@@ -50,7 +50,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn different robot arms and apply random joint-position commands.">
-         <img src="../../_static/arms.jpg" alt="Robot arms in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/arms.jpg" alt="Robot arms in Isaac Lab" loading="lazy">
          <span>Arms</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -58,7 +58,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn a collection of biped robots.">
-         <img src="../../_static/bipeds.jpg" alt="Biped robots in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/bipeds.jpg" alt="Biped robots in Isaac Lab" loading="lazy">
          <span>Bipeds</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -66,7 +66,7 @@ Command Builder
                data-demo-physics="newton_vbd"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Simulate a pile of colliding cables with Newton VBD.">
-         <img src="../../_static/cables.jpg" alt="Cable pile simulated with Newton VBD" loading="lazy">
+         <img src="../../_static/demos/cables.jpg" alt="Cable pile simulated with Newton VBD" loading="lazy">
          <span>Cables</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -77,7 +77,7 @@ Command Builder
                data-demo-visualizers-newton-vbd="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-visualizers-ovphysx="none" data-demo-extras="tetrahedralization"
                data-demo-description="Drop deformable primitive shapes from a height.">
-         <img src="../../_static/deformables.jpg" alt="Deformable objects in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/deformables.jpg" alt="Deformable objects in Isaac Lab" loading="lazy">
          <span>Deformable Objects</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -86,14 +86,14 @@ Command Builder
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-args="--device cuda:0"
                data-demo-description="Fill a Utah teapot with MPM water particles and pour them into a bowl.">
-         <img src="../../_static/teapot_fill.jpg" alt="Utah teapot pouring simulated water" loading="lazy">
+         <img src="../../_static/demos/teapot_fill.jpg" alt="Utah teapot pouring simulated water" loading="lazy">
          <span>Teapot Fill</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
                data-demo-name="H1 Locomotion" data-demo-path="scripts/demos/h1_locomotion.py"
                data-demo-physics="isaacsim_physx" data-demo-visualizers="kit"
                data-demo-description="Interactively control a trained H1 rough-terrain locomotion policy with the keyboard.">
-         <img src="../../_static/h1_locomotion.jpg" alt="H1 locomotion in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/h1_locomotion.jpg" alt="H1 locomotion in Isaac Lab" loading="lazy">
          <span>H1 Locomotion</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -101,7 +101,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn dexterous hands and command them to open and close.">
-         <img src="../../_static/hands.jpg" alt="Dexterous hands in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/hands.jpg" alt="Dexterous hands in Isaac Lab" loading="lazy">
          <span>Dexterous Hands</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -109,7 +109,7 @@ Command Builder
                data-demo-physics="isaacsim_physx"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Create reusable visualization markers.">
-         <img src="../../_static/markers.jpg" alt="Visualization markers in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/markers.jpg" alt="Visualization markers in Isaac Lab" loading="lazy">
          <span>Markers</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -117,7 +117,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn varying assets in separate environments of one interactive scene.">
-         <img src="../../_static/multi_asset.jpg" alt="Multiple assets in one simulation" loading="lazy">
+         <img src="../../_static/demos/multi_asset.jpg" alt="Multiple assets in one simulation" loading="lazy">
          <span>Multi-Asset Scene</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -125,7 +125,7 @@ Command Builder
                data-demo-physics="isaacsim_physx"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Compose several task scenes into one heterogeneous cloned simulation.">
-         <img src="../../_static/heterogeneous_scene.jpg" alt="Heterogeneous task scenes in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/heterogeneous_scene.jpg" alt="Heterogeneous task scenes in Isaac Lab" loading="lazy">
          <span>Heterogeneous Scene</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -133,14 +133,14 @@ Command Builder
                data-demo-physics="isaacsim_physx"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Demonstrate bin packing with a rigid-object collection.">
-         <img src="../../_static/bin_packing.jpg" alt="Randomized objects in bins" loading="lazy">
+         <img src="../../_static/demos/bin_packing.jpg" alt="Randomized objects in bins" loading="lazy">
          <span>Bin Packing</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
                data-demo-name="Pick and Place" data-demo-path="scripts/demos/pick_and_place.py"
                data-demo-physics="isaacsim_physx" data-demo-visualizers="kit"
                data-demo-description="Interactively pick up a cube with a parallel robot and place it on a target.">
-         <img src="../../_static/pick_and_place.jpg" alt="Interactive pick and place demo" loading="lazy">
+         <img src="../../_static/demos/pick_and_place.jpg" alt="Interactive pick and place demo" loading="lazy">
          <span>Pick and Place</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -150,7 +150,7 @@ Command Builder
                data-demo-extras="teleop"
                data-demo-args="--websocket_uri ws://localhost:10001 --pos_sensitivity 1.65"
                data-demo-description="Teleoperate a Franka Panda with Haply Inverse3 and VerseGrip hardware.">
-         <img src="../../_static/haply_teleop_franka.jpg" alt="Haply teleoperation with force feedback" loading="lazy">
+         <img src="../../_static/demos/haply_teleop_franka.jpg" alt="Haply teleoperation with force feedback" loading="lazy">
          <span>Haply Teleoperation</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -158,7 +158,7 @@ Command Builder
                data-demo-physics="isaacsim_physx"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Create and spawn procedurally generated terrain configurations.">
-         <img src="../../_static/procedural_terrain.jpg" alt="Procedurally generated terrain" loading="lazy">
+         <img src="../../_static/demos/procedural_terrain.jpg" alt="Procedurally generated terrain" loading="lazy">
          <span>Procedural Terrain</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -166,7 +166,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn a quadcopter in the default environment.">
-         <img src="../../_static/quadcopter.jpg" alt="Quadcopter in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/quadcopter.jpg" alt="Quadcopter in Isaac Lab" loading="lazy">
          <span>Quadcopter</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -174,7 +174,7 @@ Command Builder
                data-demo-physics="isaacsim_physx,newton_mjwarp"
                data-demo-visualizers="none,kit,newton_gl,newton_rtx,rerun,viser"
                data-demo-description="Spawn quadruped robots and hold standing poses with position commands.">
-         <img src="../../_static/quadrupeds.jpg" alt="Quadruped robots in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/quadrupeds.jpg" alt="Quadruped robots in Isaac Lab" loading="lazy">
          <span>Quadrupeds</span>
        </button>
        <button type="button" class="demo-card" aria-pressed="false"
@@ -185,7 +185,7 @@ Command Builder
                data-demo-visualizers-newton-mjwarp="none,newton_gl,newton_rtx,rerun,viser"
                data-demo-args="--num_envs 16 --asset_type objects"
                data-demo-description="Cast rays against multiple meshes with Warp kernels.">
-         <img src="../../_static/multi-mesh-raycast.jpg" alt="Multi-mesh ray casting in Isaac Lab" loading="lazy">
+         <img src="../../_static/demos/multi-mesh-raycast.jpg" alt="Multi-mesh ray casting in Isaac Lab" loading="lazy">
          <span>Multi-Mesh Ray Caster</span>
        </button>
      </div>

--- a/source/isaaclab/test/app/test_standalone_scripts.py
+++ b/source/isaaclab/test/app/test_standalone_scripts.py
@@ -116,7 +116,8 @@ def test_script_scope_rejects_empty_selection():
 
 def test_demo_browser_documents_options_for_each_demo():
     """Every demo card must expose its supported launch options to the command builder."""
-    demos_page = (script_cases.ROOT / "docs/source/setup/demos.rst").read_text(encoding="utf-8")
+    docs_source = script_cases.ROOT / "docs/source"
+    demos_page = (docs_source / "setup/demos.rst").read_text(encoding="utf-8")
     cards = re.findall(r'(?s)<button[^>]+data-demo-path="[^"]+"[^>]*>', demos_page)
     documented_entries = {}
     for card in cards:
@@ -134,6 +135,10 @@ def test_demo_browser_documents_options_for_each_demo():
         if spec.relative_path.startswith("scripts/demos/") and spec.relative_path in referenced_paths
     }
     assert demo_specs.keys() == referenced_paths
+    image_paths = re.findall(r'<img src="../../([^"]+)"', demos_page)
+    assert image_paths
+    missing_images = [path for path in image_paths if not (docs_source / path).is_file()]
+    assert not missing_images, f"demo browser references missing images: {missing_images}"
     for path, spec in demo_specs.items():
         entry = documented_entries[path]
         expected_physics = {backend for _, backend in spec.physics_backends}


### PR DESCRIPTION
# Description

Fix all 17 demo-card image paths to include the `demos/` static asset subdirectory. The deployed page requested files such as `_static/arms.jpg`, which return 404, while the assets are published under `_static/demos/`.

Extend the existing demo-browser contract test to verify that every raw HTML image target exists. This prevents stale local Sphinx output from masking broken deployed URLs again.

No new dependencies are introduced.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable. This is a path-only correction; all 17 generated image URLs were verified against the built documentation output.

## Validation

- Regression test failed with the original paths and passed with the fix
- `uv run python -m pytest source/isaaclab/test/app/test_standalone_scripts.py --no-header -q` (44 passed, 386 skipped)
- `uv run --isolated --extra dev -- make -C docs current-docs` (warning-free)
- Verified all 17 generated demo-card image URLs resolve to files in the documentation build
- `uv run isaaclab -f` (all hooks passed)

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks applicable to this change
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added a test that proves the fix is effective
- [x] I have added a changelog fragment for the touched package
- [x] My name already exists in `CONTRIBUTORS.md`