### PR TITLE
Pin ovrtx-cache-warm to exact rendering node IDs

### DIFF
--- a/.github/test-subsets/postmerge-rendering.toml
+++ b/.github/test-subsets/postmerge-rendering.toml
@@ -23,3 +23,17 @@ rendering-correctness-kitless-ovstage = [
   "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[ovstage-newton-ovrtx_renderer-static]",
   "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[ovstage-ovphysx-ovrtx_renderer-static]",
 ]
+
+# Nodes the shader-cache warmer runs: the RTX-renderer subset of the lists above,
+# which are the only ones that compile PSO blobs. isaacsim_rtx fills kit/ and ovrtx
+# fills kitless/; the newton_renderer nodes drive the Warp rasterizer and populate
+# neither tree. Exact node IDs rather than a -k expression so a parametrize-ID
+# rename fails collection instead of silently selecting nothing.
+ovrtx-cache-warm = [
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole.py::test_rendering_cartpole[newton-isaacsim_rtx_renderer-static]",
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole.py::test_rendering_cartpole[physx-isaacsim_rtx_renderer-static]",
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[legacy-newton-ovrtx_renderer-static]",
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[legacy-ovphysx-ovrtx_renderer-static]",
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[ovstage-newton-ovrtx_renderer-static]",
+  "source/isaaclab_tasks/test/core/test_rendering_cartpole_kitless.py::test_rendering_cartpole_kitless[ovstage-ovphysx-ovrtx_renderer-static]",
+]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1020,9 +1020,11 @@ jobs:
           test_rendering_cartpole_kitless.py
         # Only the two RTX paths compile PSO blobs: isaacsim_rtx fills kit/ and
         # ovrtx fills kitless/. newton_warp would exercise the Warp rasterizer,
-        # which populates neither tree.
-        test-k-expr: >-
-          (isaacsim_rtx or ovrtx) and (rgb or depth)
+        # which populates neither tree. The nodes are pinned by exact ID rather
+        # than a -k expression, so a parametrize-ID rename fails collection here
+        # instead of quietly leaving the warmer with nothing to run.
+        test-node-ids-file: .github/test-subsets/postmerge-rendering.toml
+        test-node-ids-key: ovrtx-cache-warm
         ovrtx-shader-cache: ${{ env.PUBLISHES_OVRTX_CACHE == 'true' && 'save' || 'restore' }}
         container-name: isaac-lab-ovrtx-cache-warm
         omni-github-test-type: ovrtx-cache-warm


### PR DESCRIPTION
# Description

The `ovrtx-cache-warm` job selects its tests with `test-k-expr: (isaacsim_rtx or ovrtx) and (rgb or depth)`. That expression matches **zero** of the 33 collected items, so the job deselects everything and the shader-cache save step runs with nothing to publish:

```
collected 11 items / 11 deselected / 0 selected   (test_rendering_cartpole.py)
collected 22 items / 22 deselected / 0 selected   (test_rendering_cartpole_kitless.py)
```

## How #7114 made the AOV labels stale

`pytest -k` matches against parametrize IDs, and #7114 ("[Test] Group rendering correctness AOVs") changed what those IDs are made of.

Before #7114, `_make_sensor_data_type_params()` emitted one node per data type, and the data type was the last segment of the ID. After #7114, `group_rendering_params()` merges every AOV that can be captured from a single environment into one node, and the ID's last segment becomes the *capture group* name (`static`, `temporal`) rather than any individual data type:

| | Before #7114 | After #7114 |
| --- | --- | --- |
| kit | `physx-isaacsim_rtx-rgb`<br>`physx-isaacsim_rtx-depth`<br>`physx-isaacsim_rtx-albedo`<br>… | `physx-isaacsim_rtx_renderer-static` |
| kitless | `legacy-ovphysx-ovrtx-rgb`<br>`legacy-ovphysx-ovrtx-depth`<br>… | `legacy-ovphysx-ovrtx_renderer-static` |

`rgb` and `depth` still run — they are two of the AOVs captured inside the `-static` node — but they are no longer *named* in any node ID. So the `(rgb or depth)` half of the expression, which selected 4 kit + 8 kitless nodes under the old scheme, now selects nothing. The `(isaacsim_rtx or ovrtx)` half still matches fine; only the AOV half went stale.

The timeline is why this was never caught: #7114 merged 2026-08-21 and the cache-warm job was added in #6905 on 2026-09-03, so the expression was written against an ID scheme that had already been replaced two weeks earlier. The job has deselected everything for its entire life.

Only this one expression was affected — the other `test-k-expr` values in the workflows (`legacy`, `ovstage`, `not ovphysx`, `test_environments and not (Soft or Cloth or Cable)`) match on segments #7114 did not touch.

## Impact

* The warmer compiles no PSO blobs, so the `kit/` and `kitless/` shader-cache trees are never populated and the rendering-correctness jobs that restore them keep compiling shaders cold.
* Nothing bad is *published*: the save steps in `.github/actions/ovrtx-shader-cache/action.yml` are gated on non-zero file counts, so an empty tree is never written back.
* `verify.sh` does emit `::error::` for the empty trees, but the job is `continue-on-error: true`, so the failure never surfaced.

## Fix

Pin the warmer to the RTX-renderer subset of the existing post-merge node lists (2 kit + 4 kitless nodes) via the `test-node-ids-file`/`test-node-ids-key` mechanism the sibling `rendering-correctness-kitless-*` jobs already use, and drop `test-k-expr`.

The mechanism change is deliberate rather than repairing the expression to `(isaacsim_rtx or ovrtx) and static`. A `-k` expression that matches nothing is indistinguishable from one that legitimately matches nothing in a given file, so `tools/conftest.py` treats "0 selected with a k-expr" as a pass by design — which is exactly why this went unnoticed for the life of the job. An unknown node ID is passed to pytest as an explicit target and fails collection outright, so the next parametrize-ID rename cannot silently empty this job again.

Verified by generating the parametrize IDs from `rendering_test_utils` at both `7b504e34df^` and `develop`, confirming the before/after IDs above, that the pre-fix 11/22 deselected counts reproduce exactly, and that all six configured node IDs resolve.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works <!-- CI-only change; no source package is touched -->
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package <!-- none touched: CI configuration only -->
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
