### PR TITLE
[CI] Add on-demand hosted documentation previews

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,10 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 Docker and GPU tests run on demand. Push the commits you want tested, then
 comment `run-ci` on the pull request.
 
+To host a documentation preview, comment `publish-doc`. The bot replies with
+the link after deployment. The preview updates after successful docs builds and
+is removed when the PR closes or the `docs-preview` label is removed.
+
 - [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
 - [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
 - [ ] I have made corresponding changes to the documentation

--- a/.github/scripts/docs_preview.py
+++ b/.github/scripts/docs_preview.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reconcile static docs artifacts using trusted GitHub API metadata, then notify PRs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlencode
+
+_MARKER = "<!-- isaaclab-docs-preview -->"
+_LABEL = "docs-preview"
+_MAX_SITE_BYTES = 950 * 1024 * 1024
+
+
+def _api(endpoint: str, method: str = "GET", **body):
+    command = ["gh", "api", f"repos/{os.environ['GH_REPO']}/{endpoint}", "--method", method]
+    if body:
+        command += ["--input", "-"]
+    result = subprocess.run(
+        command, input=json.dumps(body) if body else None, text=True, capture_output=True, check=True
+    )
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def _pages(endpoint: str, key: str | None = None, **query):
+    page = 1
+    while True:
+        result = _api(f"{endpoint}?{urlencode(dict(query, per_page=100, page=page))}")
+        items = result[key] if key else result
+        yield from items
+        if len(items) < 100:
+            return
+        page += 1
+
+
+def _extract(archive: Path, destination: Path, prefix: str = "") -> None:
+    """Extract regular files within one artifact subtree, rejecting unsafe archive entries."""
+    with zipfile.ZipFile(archive) as bundle:
+        entries = bundle.infolist()
+        if sum(entry.file_size for entry in entries) > _MAX_SITE_BYTES:
+            raise ValueError("Docs artifact exceeds the site size budget")
+        for entry in entries:
+            path = PurePosixPath(entry.filename)
+            mode = stat.S_IFMT(entry.external_attr >> 16)
+            if (
+                path.is_absolute()
+                or ".." in path.parts
+                or "\\" in entry.filename
+                or any(part.lower().startswith(".git") for part in path.parts)
+                or mode not in (0, stat.S_IFREG, stat.S_IFDIR)
+            ):
+                raise ValueError(f"Unsafe docs artifact entry: {entry.filename!r}")
+        for entry in entries:
+            if entry.is_dir() or not entry.filename.startswith(prefix):
+                continue
+            relative = entry.filename[len(prefix) :]
+            if not relative:
+                continue
+            target = destination / relative
+            if not target.resolve().is_relative_to(destination.resolve()):
+                raise ValueError(f"Docs artifact entry escapes its destination: {entry.filename!r}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with bundle.open(entry) as source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+    if not (destination / "index.html").is_file():
+        raise ValueError("Docs artifact has no index.html")
+
+
+def _download(artifact: dict, destination: Path, prefix: str = "") -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        archive = Path(temporary) / "docs.zip"
+        with archive.open("wb") as output:
+            subprocess.run(
+                ["gh", "api", f"repos/{os.environ['GH_REPO']}/actions/artifacts/{artifact['id']}/zip"],
+                stdout=output,
+                check=True,
+            )
+        _extract(archive, destination, prefix)
+
+
+def _artifact(run: dict, name: str) -> dict | None:
+    return next(
+        (
+            item
+            for item in _pages(f"actions/runs/{run['id']}/artifacts", "artifacts")
+            if item["name"] == name and not item["expired"]
+        ),
+        None,
+    )
+
+
+def _revision(run: dict) -> list[int]:
+    return [run["id"], run["run_attempt"]]
+
+
+def _matches_pr(run: dict, pr: dict) -> bool:
+    # Fork workflow runs can have an empty pull_requests array. In that case,
+    # authenticate the source through the API's repository, branch, and commit.
+    associations = run.get("pull_requests", [])
+    return (
+        run["event"] == "pull_request"
+        and run["conclusion"] == "success"
+        and run["head_sha"] == pr["head"]["sha"]
+        and run["head_branch"] == pr["head"]["ref"]
+        and run["head_repository"]["id"] == pr["head"]["repo"]["id"]
+        and (not associations or any(item["number"] == pr["number"] for item in associations))
+    )
+
+
+def _save(root: Path, state: dict) -> None:
+    (root / "state.json").write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def _request(event: dict) -> None:
+    """Authorize the same requesters as run-ci, persist opt-in, and wake the publisher."""
+    if os.environ.get("REPO_NAME") != os.environ["GH_REPO"]:
+        raise PermissionError("Preview publishing is not enabled for this repository")
+    if not event["issue"].get("pull_request") or event["comment"]["body"] != "publish-doc":
+        raise ValueError("Expected a publish-doc comment on a pull request")
+    number = event["issue"]["number"]
+    pr = _api(f"pulls/{number}")
+    if pr["state"] != "open":
+        raise ValueError(f"PR #{number} is not open")
+    author = event["comment"]["user"]["login"]
+    if author.casefold() != pr["user"]["login"].casefold():
+        permission = _api(f"collaborators/{author}/permission")["permission"]
+        if permission not in ("admin", "write"):
+            raise PermissionError("Only the PR author or a user with write access can request a preview")
+
+    if not any(label["name"] == _LABEL for label in _pages("labels")):
+        try:
+            _api("labels", "POST", name=_LABEL, color="0e8a16", description="Host docs while this PR is open")
+        except subprocess.CalledProcessError:
+            # Another PR command may have created the shared label concurrently.
+            _api(f"labels/{_LABEL}")
+    _api(f"issues/{number}/labels", "POST", labels=[_LABEL])
+    # GITHUB_TOKEN label changes do not trigger workflows. Explicit dispatch is
+    # supported and the persistent label also survives a replaced pending run.
+    _api("actions/workflows/docs-publish.yaml/dispatches", "POST", ref=_api("")["default_branch"])
+    print(f"Requested docs preview for PR #{number}; awaiting a successful current-head Docs artifact and publication")
+
+
+def _prepare(root: Path, state: dict) -> None:
+    before = json.dumps(state, sort_keys=True)
+    public = root / "public"
+    public.mkdir(exist_ok=True)
+    repository = _api("")
+    # Only successful runs of the known workflow on the default branch can
+    # replace release docs. PR artifacts never control the site's root.
+    for run in _pages(
+        "actions/workflows/docs.yaml/runs", "workflow_runs", branch=repository["default_branch"], status="success"
+    ):
+        if run["event"] not in ("schedule", "workflow_dispatch") or run["head_repository"]["id"] != repository["id"]:
+            continue
+        if _revision(run) <= state.get("release", [0, 0]):
+            break
+        artifact = _artifact(run, "docs-release-html")
+        if artifact is None:
+            continue
+        with tempfile.TemporaryDirectory() as temporary:
+            release = Path(temporary) / "release"
+            _download(artifact, release)
+            if (release / "pr-preview").exists():
+                raise ValueError("Release artifact uses the reserved pr-preview directory")
+            for child in public.iterdir():
+                if child.name != "pr-preview":
+                    if child.is_dir():
+                        shutil.rmtree(child)
+                    else:
+                        child.unlink()
+            shutil.copytree(release, public, dirs_exist_ok=True)
+        state["release"] = _revision(run)
+        break
+    if not (public / "index.html").is_file():
+        raise RuntimeError("Run the Docs workflow on the default branch once to seed release docs before publishing")
+
+    previews = state.setdefault("previews", {})
+    open_prs = {
+        str(pr["number"]): pr
+        for pr in _pages("pulls", state="open")
+        if any(label["name"] == _LABEL for label in pr["labels"])
+    }
+    for number, preview in previews.items():
+        if number not in open_prs and preview["active"]:
+            shutil.rmtree(public / "pr-preview" / number)
+            preview["active"] = False
+
+    for number, pr in open_prs.items():
+        if not pr["head"]["repo"]:
+            continue
+        previous = previews.get(number, {})
+        for run in _pages(
+            "actions/workflows/docs.yaml/runs",
+            "workflow_runs",
+            event="pull_request",
+            status="success",
+            head_sha=pr["head"]["sha"],
+        ):
+            if not _matches_pr(run, pr):
+                continue
+            if previous.get("active") and previous["sha"] == pr["head"]["sha"] and _revision(run) <= previous["run"]:
+                break
+            artifact = _artifact(run, "docs-html")
+            if artifact is None:
+                continue
+            with tempfile.TemporaryDirectory() as temporary:
+                preview = Path(temporary) / "preview"
+                try:
+                    _download(artifact, preview, "current/")
+                except (OSError, ValueError, zipfile.BadZipFile, subprocess.CalledProcessError) as error:
+                    print(f"Rejected docs artifact for PR #{number}: {error}")
+                    break
+                target = public / "pr-preview" / number
+                if target.exists():
+                    shutil.rmtree(target)
+                shutil.copytree(preview, target)
+            previews[number] = {"active": True, "sha": pr["head"]["sha"], "run": _revision(run)}
+            break
+
+    if sum(path.stat().st_size for path in public.rglob("*") if path.is_file()) > _MAX_SITE_BYTES:
+        raise ValueError("Combined docs exceed the GitHub Pages size budget; the existing deployment is unchanged")
+    _save(root, state)
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        output.write(f"changed={str(before != json.dumps(state, sort_keys=True)).lower()}\n")
+
+
+def _notify(root: Path, state: dict) -> None:
+    url = _api("pages")["html_url"].rstrip("/")
+    failed = []
+    for number, preview in state.get("previews", {}).items():
+        signature = [preview["active"], *preview["run"], url]
+        if preview.get("notified") == signature:
+            continue
+        active = preview["active"]
+        link = f"{url}/pr-preview/{number}/"
+        body = (
+            f"{_MARKER}\n[View documentation preview]({link})\n\n"
+            f"Built from `{preview['sha']}`. Updated after successful docs builds; removed when this PR closes."
+            if active
+            else f"{_MARKER}\nDocumentation preview expired: the PR was closed or its `{_LABEL}` label was removed."
+        )
+        try:
+            comment = next(
+                (
+                    item
+                    for item in _pages(f"issues/{number}/comments")
+                    if item["user"]["login"] == "github-actions[bot]" and item["body"].startswith(_MARKER)
+                ),
+                None,
+            )
+            if comment:
+                if comment["body"] != body:
+                    _api(f"issues/comments/{comment['id']}", "PATCH", body=body)
+            elif active:
+                _api(f"issues/{number}/comments", "POST", body=body)
+            _api(
+                f"statuses/{preview['sha']}",
+                "POST",
+                state="success",
+                context=f"Docs preview / PR #{number}",
+                description="Documentation preview ready" if active else "Preview expired (closed or opted out)",
+                target_url=link if active else url,
+            )
+            preview["notified"] = signature
+        except subprocess.CalledProcessError:
+            failed.append(number)
+    _save(root, state)
+    if failed:
+        raise RuntimeError(f"Could not notify PRs {', '.join(failed)}; will retry on the next publisher run")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("request", "prepare", "notify"))
+    parser.add_argument("path", type=Path, help="Event JSON for request; publication state directory otherwise")
+    args = parser.parse_args()
+    if args.operation == "request":
+        _request(json.loads(args.path.read_text()))
+    else:
+        state_file = args.path / "state.json"
+        state = json.loads(state_file.read_text()) if state_file.exists() else {}
+        {"prepare": _prepare, "notify": _notify}[args.operation](args.path, state)

--- a/.github/scripts/test_docs_preview.py
+++ b/.github/scripts/test_docs_preview.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Exercise publishing against an in-memory GitHub API and real artifact ZIP files."""
+
+from __future__ import annotations
+
+import copy
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+import docs_preview as publisher
+
+
+class TestDocsPreview(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.state = {}
+        self.runs = []
+        self.prs = []
+        self.artifacts = {}
+        self.comments = {}
+        self.statuses = []
+        self.labels = [{"name": "docs-preview"}]
+        self.permissions = {}
+        self.writes = []
+        self.fail_comments = False
+        self.enterContext(
+            patch.dict(
+                os.environ,
+                GITHUB_OUTPUT=str(self.root / "output"),
+                GH_REPO="example/IsaacLab",
+                REPO_NAME="example/IsaacLab",
+            )
+        )
+        self.enterContext(patch.object(publisher, "_api", self.api))
+        self.enterContext(patch.object(publisher, "_download", self.download))
+
+    def api(self, endpoint, method="GET", **body):
+        parsed = urlsplit(endpoint)
+        query = parse_qs(parsed.query)
+        route = parsed.path
+        if method != "GET":
+            self.writes.append((route, body))
+        if route == "":
+            return {"default_branch": "main", "id": 1}
+        if route == "pages":
+            return {"html_url": "https://example.github.io/IsaacLab/"}
+        if route == "pulls":
+            return self.prs
+        if route.startswith("pulls/"):
+            return next(pr for pr in self.prs if pr["number"] == int(route.split("/")[1]))
+        if route == "labels":
+            if method == "POST":
+                self.labels.append(body)
+            return self.labels
+        if route.startswith("collaborators/"):
+            return {"permission": self.permissions.get(route.split("/")[1], "read")}
+        if route == "actions/workflows/docs-publish.yaml/dispatches":
+            return None
+        if route == "actions/workflows/docs.yaml/runs":
+            runs = [run for run in self.runs if run["conclusion"] == "success"]
+            if "branch" in query:
+                runs = [run for run in runs if run["head_branch"] == query["branch"][0]]
+            if "head_sha" in query:
+                runs = [run for run in runs if run["head_sha"] == query["head_sha"][0]]
+            return {"workflow_runs": sorted(runs, key=lambda run: run["id"], reverse=True)}
+        if route.endswith("/artifacts"):
+            run_id = int(route.split("/")[2])
+            return {"artifacts": [self.artifacts[run_id]] if run_id in self.artifacts else []}
+        if route.startswith("statuses/"):
+            self.statuses.append(body)
+            return {}
+        if route.startswith("issues/"):
+            if route.endswith("/labels"):
+                pr = next(pr for pr in self.prs if pr["number"] == int(route.split("/")[1]))
+                pr["labels"] = [{"name": label} for label in body["labels"]]
+                return pr["labels"]
+            if self.fail_comments and method != "GET":
+                raise subprocess.CalledProcessError(1, "gh")
+            if route.startswith("issues/comments/"):
+                for comments in self.comments.values():
+                    for comment in comments:
+                        if comment["id"] == int(route.split("/")[-1]):
+                            comment["body"] = body["body"]
+                            return comment
+            number = route.split("/")[1]
+            comments = self.comments.setdefault(number, [])
+            if method == "POST":
+                comments.append({"id": int(number), "user": {"login": "github-actions[bot]"}, **body})
+                return comments[-1]
+            return comments
+        raise AssertionError(f"Unexpected API request: {method} {endpoint}")
+
+    def download(self, artifact, destination, prefix=""):
+        publisher._extract(self.root / f"{artifact['id']}.zip", destination, prefix)
+
+    def build(self, run_id, pr=None, files=None):
+        run = {
+            "id": run_id,
+            "run_attempt": 1,
+            "event": "pull_request" if pr else "schedule",
+            "conclusion": "success",
+            "head_sha": pr["head"]["sha"] if pr else "release-sha",
+            "head_branch": pr["head"]["ref"] if pr else "main",
+            "head_repository": pr["head"]["repo"] if pr else {"id": 1},
+            # Exercise the fork case where GitHub omits this association.
+            "pull_requests": [],
+        }
+        self.runs.append(run)
+        self.artifacts[run_id] = {
+            "id": run_id,
+            "name": "docs-html" if pr else "docs-release-html",
+            "expired": False,
+        }
+        with zipfile.ZipFile(self.root / f"{run_id}.zip", "w") as archive:
+            for name, content in (files or {"index.html": str(run_id)}).items():
+                archive.writestr(f"current/{name}" if pr else name, content)
+        return run
+
+    def pr(self, number, sha="initial-sha", requested=True):
+        pr = {
+            "number": number,
+            "state": "open",
+            "user": {"login": "contributor"},
+            "labels": [{"name": "docs-preview"}] if requested else [],
+            "head": {"sha": sha, "ref": f"feature-{number}", "repo": {"id": 2}},
+        }
+        self.prs.append(pr)
+        return pr
+
+    def request_event(self, author="contributor"):
+        return {
+            "issue": {"number": 10, "pull_request": {"url": "https://api.github.com/example/pulls/10"}},
+            "comment": {"body": "publish-doc", "user": {"login": author}},
+        }
+
+    def test_command_opts_in_only_requested_pr_and_label_removal_cleans_up(self):
+        self.build(1)
+        first, second = self.pr(10, requested=False), self.pr(20, requested=False)
+        self.build(2, first)
+        self.build(3, second)
+        publisher._prepare(self.root, self.state)
+        self.assertFalse((self.root / "public/pr-preview").exists())
+        self.labels.clear()
+        publisher._request(self.request_event("Contributor"))
+        self.assertEqual(self.writes[-1], ("actions/workflows/docs-publish.yaml/dispatches", {"ref": "main"}))
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertTrue((self.root / "public/pr-preview/10/index.html").is_file())
+        self.assertFalse((self.root / "public/pr-preview/20").exists())
+        first["labels"].clear()
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertFalse((self.root / "public/pr-preview/10").exists())
+        self.assertIn("label was removed", self.comments["10"][0]["body"])
+
+    def test_command_authorization_matches_run_ci_and_rejects_closed_prs(self):
+        pr = self.pr(10, requested=False)
+        with self.assertRaises(PermissionError):
+            publisher._request(self.request_event("reader"))
+        self.assertEqual(self.writes, [])
+        for permission in ("write", "admin"):
+            self.permissions["maintainer"] = permission
+            publisher._request(self.request_event("maintainer"))
+            self.assertEqual(self.writes[-1][0], "actions/workflows/docs-publish.yaml/dispatches")
+        self.writes.clear()
+        pr["state"] = "closed"
+        with self.assertRaisesRegex(ValueError, "not open"):
+            publisher._request(self.request_event())
+        self.assertEqual(self.writes, [])
+        with patch.dict(os.environ, REPO_NAME="other/repository"), self.assertRaises(PermissionError):
+            publisher._request(self.request_event())
+        self.assertEqual(self.writes, [])
+
+    def test_request_survives_dispatch_failure_and_waits_for_successful_build(self):
+        self.build(1)
+        pr = self.pr(10, requested=False)
+
+        def dispatch_fails(endpoint, method="GET", **body):
+            if endpoint.endswith("/dispatches"):
+                raise subprocess.CalledProcessError(1, "gh")
+            return self.api(endpoint, method, **body)
+
+        with patch.object(publisher, "_api", dispatch_fails), self.assertRaises(subprocess.CalledProcessError):
+            publisher._request(self.request_event())
+        publisher._prepare(self.root, self.state)
+        self.assertFalse((self.root / "public/pr-preview/10").exists())
+        self.build(2, pr)
+        publisher._prepare(self.root, self.state)
+        self.assertTrue((self.root / "public/pr-preview/10/index.html").is_file())
+
+    def test_reconciles_multiple_prs_and_preserves_them_during_nightly_build(self):
+        self.build(1)
+        first, second = self.pr(10), self.pr(20)
+        self.build(2, first, {"index.html": "old", "removed.html": "old"})
+        self.build(3, second)
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertEqual(len(self.comments["10"]), 1)
+        self.assertIn("/pr-preview/10/", self.comments["10"][0]["body"])
+
+        self.build(4, files={"index.html": "new release"})
+        first["head"]["sha"] = "new-sha"
+        self.build(5, first)
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        public = self.root / "public"
+        self.assertEqual((public / "index.html").read_text(), "new release")
+        self.assertEqual((public / "pr-preview/10/index.html").read_text(), "5")
+        self.assertFalse((public / "pr-preview/10/removed.html").exists())
+        self.assertEqual((public / "pr-preview/20/index.html").read_text(), "3")
+        self.assertEqual(len(self.comments["10"]), 1)
+        self.assertIn("new-sha", self.comments["10"][0]["body"])
+
+        count = len(self.statuses)
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertEqual(len(self.statuses), count)
+        self.assertTrue((self.root / "output").read_text().endswith("changed=false\n"))
+
+    def test_close_and_reopen_updates_existing_comment(self):
+        self.build(1)
+        pr = self.pr(10)
+        self.build(2, pr)
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.prs.clear()
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertFalse((self.root / "public/pr-preview/10").exists())
+        self.assertIn("expired", self.comments["10"][0]["body"])
+        self.assertEqual(self.statuses[-1]["target_url"], "https://example.github.io/IsaacLab")
+
+        self.prs.append(pr)
+        publisher._prepare(self.root, self.state)
+        publisher._notify(self.root, self.state)
+        self.assertTrue((self.root / "public/pr-preview/10/index.html").is_file())
+        self.assertEqual(len(self.comments["10"]), 1)
+        self.assertIn("View documentation preview", self.comments["10"][0]["body"])
+
+    def test_stale_failed_unrelated_and_expired_builds_do_not_replace_preview(self):
+        self.build(1)
+        pr = self.pr(10)
+        self.build(2, pr)
+        publisher._prepare(self.root, self.state)
+        pr["head"]["sha"] = "latest-sha"
+        self.build(3, pr)["conclusion"] = "failure"
+        self.build(4, pr)["head_repository"] = {"id": 999}
+        self.build(5, pr)["pull_requests"] = [{"number": 99}]
+        self.build(6, pr)
+        self.artifacts[6]["expired"] = True
+        publisher._prepare(self.root, self.state)
+        self.assertEqual((self.root / "public/pr-preview/10/index.html").read_text(), "2")
+        self.assertEqual(self.state["previews"]["10"]["sha"], "initial-sha")
+
+    def test_rejected_artifact_keeps_last_good_preview_and_allows_cleanup(self):
+        self.build(1)
+        first, second = self.pr(10), self.pr(20)
+        self.build(2, first)
+        self.build(3, second)
+        publisher._prepare(self.root, self.state)
+        self.prs.remove(second)
+        first["head"]["sha"] = "malformed-sha"
+        self.build(4, first, {"../../escaped": "bad"})
+        publisher._prepare(self.root, self.state)
+        self.assertEqual((self.root / "public/pr-preview/10/index.html").read_text(), "2")
+        self.assertFalse((self.root / "public/pr-preview/20").exists())
+
+    def test_force_push_back_to_older_commit_and_rerun_refresh_the_preview(self):
+        self.build(1)
+        pr = self.pr(10)
+        old = self.build(2, pr)
+        pr["head"]["sha"] = "new-sha"
+        self.build(3, pr)
+        publisher._prepare(self.root, self.state)
+        pr["head"]["sha"] = "initial-sha"
+        publisher._prepare(self.root, self.state)
+        self.assertEqual((self.root / "public/pr-preview/10/index.html").read_text(), "2")
+        old["run_attempt"] = 2
+        with zipfile.ZipFile(self.root / "2.zip", "w") as archive:
+            archive.writestr("current/index.html", "rerun")
+        publisher._prepare(self.root, self.state)
+        self.assertEqual((self.root / "public/pr-preview/10/index.html").read_text(), "rerun")
+
+    def test_notifications_retry_without_editing_user_comments(self):
+        self.build(1)
+        self.build(2, self.pr(10))
+        publisher._prepare(self.root, self.state)
+        spoof = {"id": 100, "user": {"login": "contributor"}, "body": publisher._MARKER}
+        self.comments["10"] = [copy.deepcopy(spoof)]
+        self.fail_comments = True
+        with self.assertRaisesRegex(RuntimeError, "retry"):
+            publisher._notify(self.root, self.state)
+        self.assertNotIn("notified", self.state["previews"]["10"])
+        self.fail_comments = False
+        publisher._notify(self.root, self.state)
+        self.assertEqual(self.comments["10"][0], spoof)
+        self.assertEqual(len(self.comments["10"]), 2)
+
+    def test_requires_release_seed_and_enforces_combined_size_limit(self):
+        with self.assertRaisesRegex(RuntimeError, "seed release"):
+            publisher._prepare(self.root, self.state)
+        self.build(1, files={"index.html": "1234"})
+        self.build(2, self.pr(10), {"index.html": "5678"})
+        with patch.object(publisher, "_MAX_SITE_BYTES", 6), self.assertRaisesRegex(ValueError, "Combined docs"):
+            publisher._prepare(self.root, self.state)
+        self.assertFalse((self.root / "state.json").exists())
+
+    def test_artifact_paths_links_and_missing_index_are_rejected(self):
+        archive = self.root / "unsafe.zip"
+        symlink = zipfile.ZipInfo("current/link")
+        symlink.external_attr = (stat.S_IFLNK | 0o777) << 16
+        cases = ["../escape", "/absolute", "current//absolute", "current/../../escape", "current/.git/config", symlink]
+        for entry in cases:
+            with self.subTest(entry=entry):
+                with zipfile.ZipFile(archive, "w") as bundle:
+                    bundle.writestr(entry, "bad")
+                with self.assertRaises(ValueError):
+                    publisher._extract(archive, self.root / "extracted", "current/")
+        with zipfile.ZipFile(archive, "w") as bundle:
+            bundle.writestr("other/index.html", "not the preview")
+        with self.assertRaisesRegex(ValueError, "no index.html"):
+            publisher._extract(archive, self.root / "extracted", "current/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,77 @@
 # CI Workflows
 
-`schedule:` and `workflow_dispatch:` triggers fire **only from the default
-branch (`main`)**. A workflow YAML must live on `main` for its cron to
-register — the same file on other branches has no effect. `pull_request:`
-and `push:` triggers fire from the event branch's file and work normally
-on `develop`.
+Scheduled workflows run from the repository's default branch. `workflow_run`
+and `issue_comment` receivers must also exist there. `workflow_dispatch` must
+be enabled on the default branch but can target another branch. `pull_request:`
+and `push:` workflows use the event ref and work normally on `develop`.
+
+## Hosted documentation previews
+
+Comment exactly `publish-doc` on an open PR to request hosting. Like `run-ci`,
+the command accepts the PR author or a user with write/admin access. It adds the
+persistent `docs-preview` label and dispatches the publisher using `GITHUB_TOKEN`;
+no additional GitHub App token is needed. Only labeled PRs are hosted, keeping
+storage demand limited to requested previews. Removing the label frees that
+preview's space without closing the PR. Maintainers can also apply it directly.
+
+`Docs` builds a `docs-html` artifact for PRs and a `docs-release-html` artifact
+for nightly or manually dispatched release builds. `Publish Docs` combines the
+release site with previews at `/pr-preview/<PR number>/`, deploys to GitHub Pages,
+then creates or updates one bot comment and a commit status with the preview URL.
+Comments identify the built commit; a failed build leaves the last good preview
+available. Closing or merging a PR, or removing its label, removes its preview
+and expires its comment. If the current build is running or unavailable, the
+request waits for a successful Docs build. Rerun Docs if its artifact has expired.
+Reopening a PR restores a preview when a matching build artifact is available.
+
+The publisher runs after `Docs`, on command dispatch, PR closure or preview label
+changes, and hourly to recover missed events or notification failures. Every run
+reconciles all opted-in open PRs, and one
+concurrency group serializes the complete publication. This also handles GitHub
+replacing a pending run when several builds finish together. Unchanged sites
+are not redeployed. A PR closed during publication is removed by the next run.
+
+The automation-owned `docs-site` branch stores `public/` and a publication
+manifest. Only `public/` is uploaded to Pages. Release builds replace the release
+tree while preserving open previews; the manifest is saved only after deployment
+succeeds (or when no deployment was needed). Bot comment failures are retried.
+Removing a preview removes it from the hosted site; generated files remain in
+the branch's Git history and in build artifacts until their retention expires.
+
+### Repository setup and rollout
+
+1. Merge the Docs, Publish Docs, and Publish Docs Command workflows and
+   `.github/scripts/docs_preview.py` onto the default branch. `workflow_run` and
+   `issue_comment` require their receiving workflows there.
+2. Keep the existing `REPO_NAME` secret set to the publishing repository's
+   `owner/name`. Both release builds and the publisher use it; forks do not
+   publish unless explicitly configured.
+3. Keep GitHub Pages configured with **GitHub Actions** as its publishing source.
+   Allow the `github-pages` environment to deploy from the default branch and
+   the maintained PR base branches used by `pull_request_target` close events.
+   Environment approval requirements also apply to preview updates and cleanup.
+4. Allow `GITHUB_TOKEN` to write the `docs-site` branch, PR comments, commit
+   statuses, and Pages deployments. The command also needs Actions write
+   permission for explicit dispatch and PR write permission for labels.
+   Exempt the generated branch from rules
+   requiring PRs or signed commits. No personal access token is needed.
+5. Run **Docs** manually on the default branch once to seed the release site.
+   The publisher refuses to deploy a preview-only site before this succeeds,
+   leaving the existing hosted docs intact. Subsequent nightly builds use the
+   same publisher. **Publish Docs** can be run manually to retry publication.
+
+PR builds use a read-only token. The privileged publisher always checks out the
+default branch, looks up builds of the known Docs workflow through the GitHub
+API, and matches previews to the current PR source repository, branch, and SHA.
+It treats artifacts as static files, rejects path traversal and links, and never
+executes PR code. Fork builds still follow GitHub's contributor approval policy.
+Previews contain contributor-authored HTML and JavaScript and share the Pages
+origin with the release documentation. The combined site is capped at 950 MiB
+to stay below the [GitHub Pages 1 GB site limit](https://docs.github.com/en/pages/getting-started-with-github-pages/github-pages-limits).
+An oversized site fails before deployment and preserves the last published site.
+
+Run the publisher's tests without simulation dependencies:
+
+```bash
+uv run --no-project python -m unittest discover -s .github/scripts -p 'test_docs_preview.py' -v
+```

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,0 +1,116 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Publish Docs
+
+on:
+  workflow_run:
+    workflows: [Docs]
+    types: [completed]
+  pull_request_target:
+    types: [closed, labeled, unlabeled]
+  # Reconcile missed events, interrupted runs, and notification failures.
+  schedule:
+    - cron: '23 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Every run reconciles all open PRs, so replacing a pending run cannot lose an update.
+concurrency:
+  group: docs-pages-publisher
+  cancel-in-progress: false
+
+jobs:
+  select-repository:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.action == 'closed' ||
+      github.event.label.name == 'docs-preview'
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.repository.outputs.enabled }}
+    steps:
+      - id: repository
+        env:
+          REPO_NAME: ${{ secrets.REPO_NAME }}
+        if: github.repository == env.REPO_NAME
+        run: echo 'enabled=true' >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: select-repository
+    if: needs.select-repository.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: write
+      pages: write
+      id-token: write
+      pull-requests: write
+      statuses: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      # Never check out the triggering PR or execute anything from its artifacts.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+
+      - name: Set publication directory
+        run: echo "DOCS_STATE=$RUNNER_TEMP/docs-site" >> "$GITHUB_ENV"
+
+      - name: Restore published site
+        run: |
+          if git ls-remote --exit-code --heads origin docs-site; then
+            git fetch --depth=1 origin refs/heads/docs-site
+            git worktree add --detach "$DOCS_STATE" FETCH_HEAD
+          else
+            result=$?
+            if [ "$result" -ne 2 ]; then exit "$result"; fi
+            git worktree add --detach --no-checkout "$DOCS_STATE" HEAD
+            git -C "$DOCS_STATE" switch --orphan docs-site
+          fi
+
+      - name: Reconcile release docs and PR previews
+        id: prepare
+        run: uv run --no-project python .github/scripts/docs_preview.py prepare "$DOCS_STATE"
+
+      - name: Upload complete site
+        if: steps.prepare.outputs.changed == 'true'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ${{ env.DOCS_STATE }}/public
+
+      - name: Deploy GitHub Pages
+        if: steps.prepare.outputs.changed == 'true'
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Update PR comments and checks
+        run: uv run --no-project python .github/scripts/docs_preview.py notify "$DOCS_STATE"
+
+      # Persist successful deployments even if a comment was blocked (e.g. a locked PR).
+      # Notification acknowledgements are also saved and retried on the next run.
+      - name: Save published site
+        if: always() && steps.prepare.outcome == 'success' && (steps.deployment.outcome == 'success' || steps.prepare.outputs.changed == 'false')
+        working-directory: ${{ env.DOCS_STATE }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add --force --all public state.json
+          if ! git diff --cached --quiet; then
+            git commit -m 'Update hosted documentation and PR previews'
+            git push origin HEAD:refs/heads/docs-site
+          fi

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,9 @@
 
 name: Docs
 
+permissions:
+  contents: read
+
 on:
   # Pushes and PRs still build current-docs (build-latest-docs). The expensive
   # multi-version deploy is owned by the nightly cron on the repository default
@@ -30,6 +33,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  test-publisher:
+    name: Test Docs Publisher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+      - run: uv run --no-project python -m unittest discover -s .github/scripts -p 'test_docs_preview.py' -v
+
   doc-build-type:
     name: Detect Doc Build Type
     runs-on: ubuntu-latest
@@ -129,27 +142,10 @@ jobs:
         sed "s|url=\./[^\"]*/index.html|url=./$DOCS_DEFAULT_REF/index.html|" \
           _redirect/index.html > _build/index.html
 
-    - name: Upload GitHub Pages artifact
-      uses: actions/upload-pages-artifact@v4
+    # The trusted publisher combines this build with all open PR previews.
+    - name: Upload release docs artifact
+      uses: actions/upload-artifact@v7
       with:
+        name: docs-release-html
         path: ./docs/_build
-
-  deploy-docs:
-    name: Deploy Docs
-    runs-on: ubuntu-latest
-    needs: [doc-build-type, build-multi-docs]
-    # deploy only on "deploy" branches
-    if: needs.doc-build-type.outputs.trigger-deploy == 'true'
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-    - name: Deploy GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+        if-no-files-found: error

--- a/.github/workflows/publish-doc-command.yml
+++ b/.github/workflows/publish-doc-command.yml
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+name: Publish Docs Command
+run-name: Publish docs for PR #${{ github.event.issue.number }}
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+# Save each PR's opt-in before entering the shared publisher queue.
+concurrency:
+  group: publish-doc-command-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  request-preview:
+    if: github.event.issue.pull_request && github.event.comment.body == 'publish-doc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+      - name: Authorize and request preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REPO_NAME: ${{ secrets.REPO_NAME }}
+        run: uv run --no-project python .github/scripts/docs_preview.py request "$GITHUB_EVENT_PATH"


### PR DESCRIPTION
## Description

Reviewers currently have to download and unpack the docs artifact to review a PR. Commenting `publish-doc` now opts an open PR into a hosted GitHub Pages preview and produces a single updating bot comment with its URL. Requesters have the same authorization as `run-ci`: the PR author or a collaborator with write/admin access.

The command persists a `docs-preview` label and explicitly dispatches the publisher. Successful docs builds refresh opted-in previews; closing or merging a PR, or removing the label, removes the hosted preview and expires its comment. A shared publisher preserves release docs and previews across nightly updates, serializes deployment, and reconciles missed events. PR artifacts are validated as static files and never executed by the privileged publisher.

Hosting is opt-in because all open PRs would exceed GitHub Pages capacity. The combined site has a 950 MiB guard; exceeding it preserves the existing deployment. No project dependencies were added.

## Type of change

- New feature
- Documentation update

## Validation

- 11 focused tests passed, covering authorization, opt-in and cleanup, updates and retries, stale/fork build selection, unsafe artifacts, and the site size guard. Removed redundant command-text cases; no simulation/GPU tests are needed for this CI-only change.
- `actionlint` passed for all three docs workflows.
- `uv run isaaclab -f` passed.
- Full Sphinx build passed with warnings treated as errors, using the `dev` extra and a temporary IPv4-only inventory wrapper for this workstation's unreachable IPv6 routes. No repository configuration or warning suppression was needed.
- Executed the publisher's Git shell steps against a disposable local remote: initial branch creation, restore, preview removal, and unchanged saves passed.

## Rollout

The receiver workflows must also land on the repository's default branch before `publish-doc` can run. Retain the existing `REPO_NAME` secret, allow the generated `docs-site` branch and required token/environment permissions, and run Docs once on the default branch to seed the release site. See `.github/workflows/README.md` for the setup. Live Pages deployment and PR commenting have not been exercised locally.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] Read the contribution guidelines.
- [x] Ran the required formatting and pre-commit checks.
- [x] Updated contributor instructions and rollout documentation.
- [x] Added focused tests for the new behavior.
- [x] No source packages were changed; no package changelog fragment is required.
- [x] Antoine Richard is already listed in `CONTRIBUTORS.md`.
