### PR TITLE
[CI] Use public Isaac Sim 6.1 image on release/3.0.0

### DIFF
--- a/.github/workflows/config.yaml
+++ b/.github/workflows/config.yaml
@@ -5,11 +5,8 @@
 
 # Shared image config for CI workflows. Loaded by the `config` job in each
 # workflow via yq and exposed as job outputs (see e.g. .github/workflows/build.yaml).
-# The `nvidian/isaac-sim` mirror stopped receiving nightly develop builds on 2026-06-24
-# (frozen at 6.1.0-alpha.2). Both images use Isaac Sim's NGC org, which is current and
-# which the CI credential can reach.
-isaacsim_image_name: nvcr.io/0947644777160149/internal/isaac-sim
-# Test the release/3.0.0 branch against the latest Isaac Sim 6.1 release image.
-isaacsim_image_tag: latest-release-6-1
+# Test the release/3.0.0 branch against the public Isaac Sim 6.1 release image.
+isaacsim_image_name: nvcr.io/nvidia/isaac-sim
+isaacsim_image_tag: 6.1.0
 isaaclab_image_name: nvcr.io/0947644777160149/internal/isaac-lab
 ovphysx_wheelhouse_image: ""


### PR DESCRIPTION
## Description

- Point shared CI configuration on `release/3.0.0` at the public `nvcr.io/nvidia/isaac-sim:6.1.0` image.
- Replace the internal `latest-release-6-1` image name and moving tag with the public release image and fixed tag.
- Keep this PR limited to CI configuration on the release branch.

## Type of change

- CI configuration update

## Testing

- `docker manifest inspect nvcr.io/nvidia/isaac-sim:6.1.0` (public multi-platform manifest resolved)
- Parsed `.github/workflows/config.yaml` and verified the image resolves to `nvcr.io/nvidia/isaac-sim:6.1.0`.
- `ISAACLAB_CHANGELOG_BASE_REF=release/3.0.0 uv run isaaclab -f` (all hooks passed against current `upstream/release/3.0.0`)
- No package changelog is required for this CI-only change.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the applicable pre-commit checks
- [x] Documentation changes are not required
- [x] Tests are not required for this configuration-only change
- [x] A changelog fragment is not required for this CI-only change
- [x] My name already exists in `CONTRIBUTORS.md`
