### PR TITLE
fix(visualizers): pass native floats to Gf.Vec3d in the Kit renderer camera sync

### DIFF
--- a/source/isaaclab_visualizers/changelog.d/fix-kit-viewport-numpy-float32-vec3d.rst
+++ b/source/isaaclab_visualizers/changelog.d/fix-kit-viewport-numpy-float32-vec3d.rst
@@ -1,0 +1,11 @@
+Fixed
+^^^^^
+
+* Fixed :func:`~isaaclab_visualizers.kit.kit_visualizer.KitVisualizer._apply_viewer_origin_to_camera`
+  passing ``numpy.float32`` scalars (from a ``.detach().cpu().numpy()`` tensor) to
+  :func:`~isaaclab_physx.renderers.kit_viewport_utils.set_kit_renderer_camera_view`, which
+  constructs a ``pxr.Gf.Vec3d`` from them. pybind's ``Vec3d`` constructor only matches native
+  Python ``float``/``double`` overloads, so every asset-tracking camera update (``origin_type
+  ="asset"``) silently failed with a logged warning and the Kit renderer camera never moved,
+  leaving the recorded viewport stuck at its initial position instead of following the tracked
+  asset.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -1274,11 +1274,13 @@ class KitVisualizer(BaseVisualizer):
         origin = self._viewer_origin.detach().cpu().numpy()
         eye = np.array(self.cfg.eye, dtype=float) + origin
         target = np.array(self.cfg.lookat, dtype=float) + origin
-        self.set_camera_view(tuple(float(v) for v in eye), tuple(float(v) for v in target))
+        eye_f = tuple(float(v) for v in eye)
+        target_f = tuple(float(v) for v in target)
+        self.set_camera_view(eye_f, target_f)
         # Keep the Isaac RTX renderer camera in sync (no-op if isaaclab_physx is not installed).
         try:
             from isaaclab_physx.renderers.kit_viewport_utils import set_kit_renderer_camera_view  # noqa: PLC0415
 
-            set_kit_renderer_camera_view(eye=eye, target=target, camera_prim_path="/OmniverseKit_Persp")
+            set_kit_renderer_camera_view(eye=eye_f, target=target_f, camera_prim_path="/OmniverseKit_Persp")
         except (ImportError, ModuleNotFoundError):
             pass


### PR DESCRIPTION
# Description

`KitVisualizer._apply_viewer_origin_to_camera` (used whenever `KitVisualizerCfg.origin_type == "asset"`, i.e. an asset-tracking/follow camera) passed `numpy.float32` scalars straight from a detached torch tensor into `set_kit_renderer_camera_view`, which constructs `pxr.Gf.Vec3d(*eye)`. pybind's `Vec3d` constructor only matches native Python `float`/`double` overloads, so the call raised a `TypeError` on every single frame — caught and only logged as a warning (`[kit_viewport] Renderer camera update failed`). The practical effect: the Kit RTX renderer camera never moved, so any recorded video's viewport stayed stuck at its initial pose instead of following the tracked asset — frames looked static/wrong even though the simulation itself was running correctly.

`set_camera_view` (a couple of lines above the fix site) already cast to plain Python floats before use; the fix reuses those same casts for the renderer-camera call too.

Found while adding Newton MJWarp deployment support to a downstream task and trying to record a follow-camera video of a running policy.

Fixes # (issue)
N/A, found and fixed during development.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

N/A — backend camera-sync fix, not independently visual (the observable effect is a previously-static recorded viewport now following the tracked asset, which requires an asset-tracking video capture to demonstrate).

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there