### PR TITLE
Fix world_id/env_id conflation in NewtonSiteFrameView for the flat builder

### DIFF
--- a/source/isaaclab_newton/changelog.d/proth-frame-view-flat-builder-world-index.rst
+++ b/source/isaaclab_newton/changelog.d/proth-frame-view-flat-builder-world-index.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed an ``IndexError`` in ``NewtonSiteFrameView`` when a world-attached (body-less) site is
+  resolved per environment under the flat (non-replicated, ``replicate_physics=False``) builder.
+  ``NewtonManager._world_xforms`` has exactly one entry for the flat builder regardless of
+  environment count, so callers indexing it with an environment index greater than 0 (e.g. a
+  streaming/follow camera targeting a per-environment prim with no body ancestor) hit an
+  out-of-bounds index. Such callers now fall back to the single shared world.

--- a/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
+++ b/source/isaaclab_newton/isaaclab_newton/sim/views/newton_site_frame_view.py
@@ -440,9 +440,14 @@ class NewtonSiteFrameView(BaseFrameView):
                 if per_world:
                     if NewtonManager._world_xforms is None:
                         raise RuntimeError(f"FrameView '{self._prim_path}' needs Newton cloned-world transforms.")
-                    world_ids = range(len(NewtonManager._world_xforms)) if env_ids is None else env_ids
+                    num_worlds = len(NewtonManager._world_xforms)
+                    world_ids = range(num_worlds) if env_ids is None else env_ids
                     for world_id in world_ids:
-                        world_xform = NewtonManager._world_xforms[world_id]
+                        # The flat (non-replicated) builder has exactly one shared world
+                        # regardless of environment count, so env-indexed callers (env_ids
+                        # from a per-environment site spec) must fall back to that single
+                        # world instead of indexing world_id (an env index) out of bounds.
+                        world_xform = NewtonManager._world_xforms[world_id if num_worlds > 1 else 0]
                         site_bodies.append(WORLD_BODY_INDEX)
                         site_locals.append([float(v) for v in wp.transform_multiply(world_xform, xform)])
                         site_scales.append(scale)

--- a/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
+++ b/source/isaaclab_newton/test/sim/test_views_xform_prim_newton.py
@@ -257,3 +257,35 @@ def test_world_attached_set_world_roundtrip(device):
     torch.testing.assert_close(ret_pos.torch, wp.to_torch(new_pos), atol=1e-5, rtol=0)
     torch.testing.assert_close(ret_quat.torch, wp.to_torch(new_quat), atol=1e-5, rtol=0)
     ctx.__exit__(None, None, None)
+
+
+@pytest.mark.parametrize("device", test_devices())
+def test_world_attached_per_env_flat_builder(device):
+    """A world-attached frame resolved per environment does not crash under the flat
+    (non-replicated) builder.
+
+    The flat builder (``replicate_physics=False``) has exactly one shared Newton world
+    regardless of environment count, so a per-environment world-attached site (env_ids
+    from the cloner, not None) must not index ``NewtonManager._world_xforms`` — which has
+    length 1 — with an environment index greater than 0.
+    """
+    num_envs = 3
+    NEWTON_SIM_CFG.device = device
+    ctx = build_simulation_context(device=device, sim_cfg=NEWTON_SIM_CFG, add_ground_plane=True)
+    sim = ctx.__enter__()
+    sim._app_control_on_stop_handle = None
+    InteractiveScene(_SceneCfg(num_envs=num_envs, env_spacing=2.0, replicate_physics=False))
+
+    # a plain Xform sibling of the per-env Cube body: no RigidBodyAPI/ArticulationRootAPI
+    # ancestor, so it resolves through the per_world (body=-1) fallback, but it is still
+    # matched per environment via the cloner because it lives under the cloned env root.
+    for i in range(num_envs):
+        sim_utils.create_prim(f"/World/envs/env_{i}/WorldMarker", translation=WORLD_MARKER_POS)
+
+    sim.reset()
+    view = FrameView("/World/envs/env_[^/]+/WorldMarker", device=device)
+
+    pos = view.get_world_poses()[0].torch
+    expected = torch.tensor([list(WORLD_MARKER_POS)] * num_envs, device=device)
+    torch.testing.assert_close(pos, expected, atol=1e-5, rtol=0)
+    ctx.__exit__(None, None, None)


### PR DESCRIPTION
## Description

`NewtonSiteFrameView._initialize_from_specs` resolves world-attached (body-less)
sites by indexing `NewtonManager._world_xforms` directly with a per-environment
`env_id`. The flat (non-replicated, `replicate_physics=False`) builder has
exactly one shared Newton world regardless of environment count, so
`_world_xforms` has length 1 there — any `env_id` greater than 0 raises
`IndexError: list index out of range`.

This is hit whenever a per-environment site with no rigid-body/articulation-root
ancestor is resolved under the flat builder — for example a streaming/follow
camera (`streaming_cam_target_prim_path`) whose target pattern falls back to the
per-world site path because the target prim itself isn't a rigid body.

```
File ".../isaaclab_newton/sim/views/newton_site_frame_view.py", line 431, in _initialize_from_specs
    world_xform = NewtonManager._world_xforms[world_id]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
IndexError: list index out of range
```

The fix falls back to the single shared world when `_world_xforms` has only one
entry, matching the same "flat builder has fewer per-thing entries than
per-env" pattern already fixed for site injection (#7672) and articulation
bindings (#7673).

Fixes # (no tracked issue — found while wiring up a Newton follow-camera for a
downstream policy-recording script)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the `pre-commit` checks (`ruff check` / `ruff format`)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (verified failing without the fix, passing with it)
- [x] I have added a changelog fragment under `source/isaaclab_newton/changelog.d/`
- [x] I have added my name to `CONTRIBUTORS.md` (already present)