### PR TITLE
Minor Bug Fix to Mimic-Cosmos Eval

### DIFF
--- a/scripts/imitation_learning/robomimic/play.py
+++ b/scripts/imitation_learning/robomimic/play.py
@@ -54,7 +54,9 @@ args_cli, hydra_overrides = parser.parse_known_args()
 # renderer. ``resolve_task_config`` is safe to call before Kit is launched, and ``scan`` is the
 # same detection ``launch_simulation`` uses, so this matches how camera enabling is resolved
 # elsewhere now that the ``--enable_cameras`` flag is gone.
-env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "")
+# ``overrides`` must be passed explicitly: this script keeps its own flags in ``sys.argv`` rather
+# than stripping them, so letting Hydra fall back to reading ``sys.argv`` makes it reject them.
+env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "", overrides=hydra_overrides)
 app_launcher = AppLauncher(args_cli, enable_cameras=scan(env_cfg_for_scan, args_cli).has_kit_camera)
 simulation_app = app_launcher.app
 

--- a/scripts/imitation_learning/robomimic/robust_eval.py
+++ b/scripts/imitation_learning/robomimic/robust_eval.py
@@ -71,7 +71,9 @@ args_cli, hydra_overrides = parser.parse_known_args()
 # renderer. ``resolve_task_config`` is safe to call before Kit is launched, and ``scan`` is the
 # same detection ``launch_simulation`` uses, so this matches how camera enabling is resolved
 # elsewhere now that the ``--enable_cameras`` flag is gone.
-env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "")
+# ``overrides`` must be passed explicitly: this script keeps its own flags in ``sys.argv`` rather
+# than stripping them, so letting Hydra fall back to reading ``sys.argv`` makes it reject them.
+env_cfg_for_scan, _ = resolve_task_config(args_cli.task, "", overrides=hydra_overrides)
 app_launcher = AppLauncher(args_cli, enable_cameras=scan(env_cfg_for_scan, args_cli).has_kit_camera)
 simulation_app = app_launcher.app
 


### PR DESCRIPTION
# Description

Fix for bug 6683697.

Forward hydra_overrides to the pre-launch call, matching what the same scripts already do for the resolution inside main(). Genuine Hydra overrides now also reach the camera scan, so the detection runs against the same config the run ultimately uses.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`
