### PR TITLE
[Backport] PR #7678 to release/3.0.0

### DIFF
--- a/source/isaaclab_tasks/changelog.d/fix-agibot-shadow-visualizers.rst
+++ b/source/isaaclab_tasks/changelog.d/fix-agibot-shadow-visualizers.rst
@@ -1,0 +1,8 @@
+Fixed
+^^^^^
+
+* Added an early validation error when Agibot place tasks use Newton-backed visualizers, whose shadow-model importer
+  does not support the reversed gripper joints in the robot USD. Use ``--visualizer kit`` with Isaac Sim PhysX, or
+  ``--visualizer none`` for headless execution.
+* Reduced the default Agibot place environment count from 4096 to one and enabled physics replication to prevent
+  interactive tools from exhausting host memory. Use ``--num_envs`` to configure a larger batch when needed.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -9,6 +9,7 @@ from dataclasses import MISSING
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
+from isaaclab.app import get_settings_manager
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
 from isaaclab.devices.device_base import DevicesCfg
 from isaaclab.devices.keyboard import Se3KeyboardCfg
@@ -211,29 +212,55 @@ class PhysicsCfg(PresetCfg):
 # Robot USD assets whose gripper revolute joints are authored with reversed
 # body0/body1 ordering, which the Newton MJWarp USD parser rejects.
 _NEWTON_REVERSED_JOINT_ASSETS = ("Robots/Agibot/A2D/",)
+_NEWTON_MODEL_VISUALIZER_TYPES = {"newton", "newton_gl", "newton_rtx", "rerun", "viser"}
 
 
-def raise_if_reversed_joints_on_newton(env_cfg) -> None:
-    """Reject Newton physics for robots whose USD has reversed gripper joints.
+def _get_active_visualizer_types(env_cfg: ManagerBasedRLEnvCfg) -> set[str]:
+    """Return visualizer types selected by config or launcher settings."""
+    settings = get_settings_manager()
+    if settings.get("/isaaclab/visualizer/disable_all", False):
+        return set()
+
+    if settings.get("/isaaclab/visualizer/explicit", False):
+        value = settings.get("/isaaclab/visualizer/types", "")
+        return {item for chunk in str(value).split(",") for item in chunk.split() if item}
+
+    visualizer_cfgs = env_cfg.sim.visualizer_cfgs
+    if not isinstance(visualizer_cfgs, list):
+        visualizer_cfgs = [visualizer_cfgs]
+    return {cfg.visualizer_type for cfg in visualizer_cfgs if getattr(cfg, "visualizer_type", None)}
+
+
+def raise_if_reversed_joints_on_newton(env_cfg: ManagerBasedRLEnvCfg) -> None:
+    """Reject Newton import paths for robots whose USD has reversed gripper joints.
 
     The Newton MJWarp ``parse_usd`` importer requires each joint prim to define the parent
     body as ``physics:body0`` and the child as ``physics:body1``. Some robot assets (e.g. the
     Agibot A2D gripper support-link revolute joints) author these reversed; PhysX tolerates
-    this, but Newton raises ``Reversed joints are not supported`` deep in scene creation. This
-    raises an actionable error at config-validation time instead.
+    this, but Newton raises ``Reversed joints are not supported`` deep in scene creation.
+    Newton-backed visualizers also use this importer to build a shadow model when PhysX is
+    active. This raises an actionable error before either import path is initialized.
 
     Args:
         env_cfg: The resolved environment config to inspect.
     """
     robot_cfg = getattr(env_cfg.scene, "robot", None)
     usd_path = getattr(getattr(robot_cfg, "spawn", None), "usd_path", None)
-    if usd_path is None or not isinstance(env_cfg.sim.physics, NewtonCfg):
+    newton_model_visualizers = sorted(_get_active_visualizer_types(env_cfg) & _NEWTON_MODEL_VISUALIZER_TYPES)
+
+    if usd_path is None or not (isinstance(env_cfg.sim.physics, NewtonCfg) or newton_model_visualizers):
         return
     if any(marker in usd_path for marker in _NEWTON_REVERSED_JOINT_ASSETS):
+        visualizer_reason = (
+            f" The selected Newton-backed visualizer(s) {newton_model_visualizers} require the same importer."
+            if newton_model_visualizers
+            else ""
+        )
         raise ValueError(
             "This task's robot has gripper joints authored with reversed body0/body1 ordering, "
-            "which the Newton backend's USD parser does not support ('Reversed joints are not "
-            "supported'). Re-run this task with physics=isaacsim_physx (the default)."
+            "which Newton's USD importer does not support ('Reversed joints are not supported')."
+            f"{visualizer_reason} Use physics=isaacsim_physx with --visualizer kit, or use "
+            "--visualizer none for headless execution."
         )
 
 
@@ -242,7 +269,7 @@ class PlaceToy2BoxEnvCfg(ManagerBasedRLEnvCfg):
     """Configuration for the stacking environment."""
 
     # Scene settings
-    scene: ObjectTableSceneCfg = ObjectTableSceneCfg(num_envs=4096, env_spacing=3.0, replicate_physics=False)
+    scene: ObjectTableSceneCfg = ObjectTableSceneCfg(num_envs=1, env_spacing=3.0, replicate_physics=True)
     # Basic settings
     observations: ObservationsCfg = ObservationsCfg()
     actions: ActionsCfg = ActionsCfg()


### PR DESCRIPTION
Backports #7678 to `release/3.0.0`.

The source commit cherry-picked cleanly onto the current release tip, and the backport has the same stable patch ID as the original change.

| Field | Commit |
| --- | --- |
| Original change | `aec80b08220954fea4dd9a1514c428b239e77266` |
| Release base | `c4c934fbf3e134be8003edb5b9f27890afffb9bc` |
| Backport | `410106913` |

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this is a configuration validation and default-setting change.

## Validation

- [x] Stable patch ID matches #7678
- [x] Release-target changelog gate
- [x] Changed-file pre-commit hooks, including Git LFS pointer validation
- [x] Python syntax compilation
- [ ] Simulator-backed smoke validation was not rerun locally because the lockfile excludes macOS; #7678 passed its targeted Agibot configuration smoke validation and CI

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the repository pre-commit checks on the changed files
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new static-analysis warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (the source PR used focused configuration smoke validation)
- [x] I have added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] The original contributor's name already exists in `CONTRIBUTORS.md`
