### PR TITLE
[Workflow] Fix template generator dependency and AMP workflows

### DIFF
--- a/docs/source/developer-tools/template_generator.rst
+++ b/docs/source/developer-tools/template_generator.rst
@@ -70,9 +70,14 @@ installed Isaac Lab package:
 The command uses the dependencies from the active Isaac Lab environment. It
 does not invoke ``pip`` or install another set of template dependencies, so it
 also works in the pip-less virtual environments created by ``uv``.
-The generated ``pyproject.toml`` pins Isaac Lab and its optional extras to that
-environment's exact Isaac Lab version so ``uv sync`` cannot silently resolve an
-older release.
+When invoked from an installed wheel, the generated ``pyproject.toml`` pins
+Isaac Lab and its optional extras to that exact version so ``uv sync`` cannot
+silently resolve an older release. When invoked from a source checkout, it
+instead records editable paths to that checkout and its workspace packages.
+This lets development and release branches work before their version is
+published while preserving the code that generated the project.
+The source paths are relative to the generated project; regenerate the project
+or update ``[tool.uv.sources]`` if either directory moves.
 
 The short form is equivalent:
 
@@ -200,7 +205,9 @@ default is a headless task package and does not include these files.
 
 Run commands from the project root so ``uv`` can find the package and task entry
 point. Commit ``pyproject.toml`` and ``uv.lock`` to give collaborators the same
-dependency resolution.
+dependency resolution. For a project linked to a source checkout, collaborators
+must also place that checkout at the recorded relative path or update the source
+entries.
 
 Develop the generated task
 --------------------------

--- a/source/isaaclab_rl/changelog.d/fix-template-generator-regressions.skip
+++ b/source/isaaclab_rl/changelog.d/fix-template-generator-regressions.skip
@@ -1,0 +1,2 @@
+# No isaaclab_rl release note or version bump: this change only extends the package's template-generator tests.
+# The user-facing generator and generated-project changes live under tools/template.

--- a/source/isaaclab_rl/test/test_template_generator.py
+++ b/source/isaaclab_rl/test/test_template_generator.py
@@ -12,11 +12,13 @@ import pkgutil
 import subprocess
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import gymnasium as gym
 import pytest
 import tomllib
+import torch
 
 from isaaclab.utils import editor as editor_utils
 
@@ -203,12 +205,62 @@ def test_generator_registers_single_agent_rl_config_entry_points_for_all_librari
 
         if workflow_name == "manager-based":
             env_source = (task_dir / f"{env_filename}.py").read_text()
-            assert "class " + task_class + "Env(ManagerBasedRLEnv):" in env_source
+            env_cfg_source = (task_dir / f"{env_cfg_filename}.py").read_text()
             assert "self.amp_observation_space = spaces.Box" in env_source
-            assert 'extras["amp_obs"]' in env_source
             assert "def collect_reference_motions(" in env_source
+            assert "compute_final_obs = True" in env_cfg_source
 
         _unregister(task_id)
+
+
+def test_generated_manager_amp_environment_preserves_terminal_observations():
+    """AMP transitions must end with the terminal observation before same-step autoreset."""
+    env_source = generator.jinja_env.get_template("tasks/manager-based_single-agent/env").render(
+        task={"classname": "Test", "env_cfg_filename": "test_env_cfg"}
+    )
+    module = ast.parse(env_source)
+    env_class_node = next(node for node in module.body if isinstance(node, ast.ClassDef))
+
+    class FakeManagerBasedRLEnv:
+        def step(self, action):
+            return self.step_return
+
+    namespace = {
+        "ManagerBasedRLEnv": FakeManagerBasedRLEnv,
+        "torch": torch,
+    }
+    future_import = next(
+        node for node in module.body if isinstance(node, ast.ImportFrom) and node.module == "__future__"
+    )
+    exec(
+        compile(ast.Module(body=[future_import, env_class_node], type_ignores=[]), "<generated-env>", "exec"),
+        namespace,
+    )
+    env_class = namespace["TestEnv"]
+    env = object.__new__(env_class)
+    env.cfg = types.SimpleNamespace(num_amp_observations=2)
+    env.num_envs = 2
+    env.amp_observation_size = 4
+    env.amp_observation_buffer = torch.tensor([[[1.0, 10.0], [0.0, 9.0]], [[2.0, 20.0], [0.0, 19.0]]])
+    observations = {"policy": torch.tensor([[100.0, 1000.0], [4.0, 40.0]])}
+    extras = {"final_obs": {"policy": torch.tensor([[3.0, 30.0], [4.0, 40.0]])}}
+    env.step_return = (
+        observations,
+        torch.zeros(2),
+        torch.tensor([True, False]),
+        torch.tensor([False, False]),
+        extras,
+    )
+
+    _, _, _, _, returned_extras = env.step(torch.zeros((2, 1)))
+
+    torch.testing.assert_close(
+        returned_extras["amp_obs"], torch.tensor([[3.0, 30.0, 1.0, 10.0], [4.0, 40.0, 2.0, 20.0]])
+    )
+    torch.testing.assert_close(
+        env.amp_observation_buffer,
+        torch.tensor([[[100.0, 1000.0], [100.0, 1000.0]], [[4.0, 40.0], [2.0, 20.0]]]),
+    )
 
 
 @pytest.mark.parametrize("external", [False, True])

--- a/source/isaaclab_rl/test/test_template_generator.py
+++ b/source/isaaclab_rl/test/test_template_generator.py
@@ -187,10 +187,7 @@ def test_generator_registers_single_agent_rl_config_entry_points_for_all_librari
         env_filename = "env" if external else f"{task_folder}_env"
         env_cfg_filename = "env_cfg" if external else f"{task_folder}_env_cfg"
 
-        if workflow_name == "direct":
-            assert spec.entry_point == f"{module_name}.{env_filename}:{task_class}Env"
-        else:
-            assert spec.entry_point == "isaaclab.envs:ManagerBasedRLEnv"
+        assert spec.entry_point == f"{module_name}.{env_filename}:{task_class}Env"
 
         assert spec.kwargs["env_cfg_entry_point"] == f"{module_name}.{env_cfg_filename}:{task_class}EnvCfg"
         assert spec.kwargs["rl_games_cfg_entry_point"] == f"{agents_module}:rl_games_ppo_cfg.yaml"
@@ -203,6 +200,13 @@ def test_generator_registers_single_agent_rl_config_entry_points_for_all_librari
         assert spec.kwargs["skrl_cfg_entry_point"] == f"{agents_module}:skrl_ppo_cfg.yaml"
         assert spec.kwargs["sb3_cfg_entry_point"] == f"{agents_module}:sb3_ppo_cfg.yaml"
         assert "skrl_ppo_cfg_entry_point" not in spec.kwargs
+
+        if workflow_name == "manager-based":
+            env_source = (task_dir / f"{env_filename}.py").read_text()
+            assert "class " + task_class + "Env(ManagerBasedRLEnv):" in env_source
+            assert "self.amp_observation_space = spaces.Box" in env_source
+            assert 'extras["amp_obs"]' in env_source
+            assert "def collect_reference_motions(" in env_source
 
         _unregister(task_id)
 

--- a/tools/template/cli.py
+++ b/tools/template/cli.py
@@ -297,6 +297,7 @@ def main() -> None:
         "path": project_path,
         "name": project_name,
         "isaaclab_version": lab_module.__version__,
+        "isaaclab_source_path": ROOT_DIR if not is_lab_pip_installed else None,
         "task_name": task_name,
         "robot_name": robot_name,
         "include_ui_extension": include_ui_extension,

--- a/tools/template/generator.py
+++ b/tools/template/generator.py
@@ -4,11 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import glob
+import json
 import os
 import shutil
 import subprocess
+from typing import Any
 
 import jinja2
+import tomllib
 from common import MULTI_AGENT_ALGORITHMS, SINGLE_AGENT_ALGORITHMS, TASKS_DIR, TEMPLATE_DIR
 
 jinja_env = jinja2.Environment(
@@ -86,6 +89,11 @@ def _generate_task_per_workflow(task_dir: str, specification: dict) -> None:
         _write_file(
             os.path.join(task_dir, f"{task_spec['env_cfg_filename']}.py"), content=template.render(**specification)
         )
+        if task_spec["amp_selected"]:
+            template = jinja_env.get_template(f"tasks/manager-based_{task_spec['workflow']['type']}/env")
+            _write_file(
+                os.path.join(task_dir, f"{task_spec['env_filename']}.py"), content=template.render(**specification)
+            )
         shutil.copytree(
             os.path.join(TEMPLATE_DIR, "tasks", f"manager-based_{task_spec['workflow']['type']}", "mdp"),
             os.path.join(task_spec["family_dir"], "mdp"),
@@ -144,6 +152,9 @@ def _generate_tasks(specification: dict, task_dir: str) -> list[dict]:
             "env_cfg_filename": "env_cfg" if specification["external"] else f"{filename}_env_cfg",
             "env_filename": "env" if specification["external"] else f"{filename}_env",
             "id": task_id,
+            "amp_selected": any(
+                rl_library["name"] == "skrl" and "amp" in rl_library["algorithms"] for rl_library in task_rl_libraries
+            ),
         }
         print(f"  |    |-- Generating '{task['id']}' task...")
         for package_dir in (family_dir, os.path.join(family_dir, "config")):
@@ -166,10 +177,11 @@ def _external(specification: dict) -> None:
     name = specification["name"]
     project_dir = os.path.join(specification["path"], name)
     os.makedirs(project_dir, exist_ok=True)
+    specification = _prepare_external_dependencies(specification, project_dir)
     print("  |-- Copying repo files...")
     for filename in [".gitattributes", ".gitignore", ".pre-commit-config.yaml", "LICENSE"]:
         shutil.copyfile(os.path.join(TEMPLATE_DIR, "external", filename), os.path.join(project_dir, filename))
-    template = jinja_env.get_template("external/pyproject.toml")
+    template = jinja_env.get_template("external/pyproject.toml.jinja")
     _write_file(os.path.join(project_dir, "pyproject.toml"), content=template.render(**specification))
     print("  |-- Copying utility scripts...")
     scripts_dir = os.path.join(project_dir, "scripts")
@@ -225,6 +237,72 @@ def _external(specification: dict) -> None:
     print(f"Project '{name}' generated successfully in {project_dir} path.")
     print(f"See {project_dir}/README.md to get started!")
     print("-" * 80)
+
+
+def _prepare_external_dependencies(specification: dict, project_dir: str) -> dict:
+    """Resolve generated dependencies against a wheel or the active source checkout."""
+    specification = specification.copy()
+    source_path = specification.get("isaaclab_source_path")
+    if not source_path:
+        specification["isaaclab_dependency"] = "isaaclab"
+        specification["isaaclab_environments"] = []
+        specification["isaaclab_indexes"] = []
+        specification["isaaclab_overrides"] = []
+        specification["isaaclab_sources"] = []
+        return specification
+
+    source_root = os.path.realpath(source_path)
+    with open(os.path.join(source_root, "pyproject.toml"), "rb") as file:
+        source_config = tomllib.load(file)
+
+    uv_config = source_config["tool"]["uv"]
+    sources = []
+    for package_name, source in source_config["tool"]["uv"]["sources"].items():
+        if isinstance(source, dict) and "path" in source:
+            source = source.copy()
+            package_path = os.path.join(source_root, source["path"])
+            source["path"] = _project_source_path(package_path, project_dir)
+        sources.append({"name": package_name, "value": _format_toml_value(source)})
+    sources.append(
+        {
+            "name": source_config["project"]["name"],
+            "value": _format_toml_value(
+                {
+                    "path": _project_source_path(source_root, project_dir),
+                    "editable": True,
+                }
+            ),
+        }
+    )
+    specification["isaaclab_dependency"] = source_config["project"]["name"]
+    specification["isaaclab_environments"] = uv_config.get("environments", [])
+    specification["isaaclab_indexes"] = uv_config.get("index", [])
+    specification["isaaclab_overrides"] = uv_config.get("override-dependencies", [])
+    specification["isaaclab_sources"] = sorted(sources, key=lambda source: source["name"])
+    return specification
+
+
+def _project_source_path(source_path: str, project_dir: str) -> str:
+    """Return a portable source path, falling back to absolute paths across Windows drives."""
+    try:
+        path = os.path.relpath(source_path, project_dir)
+    except ValueError:
+        path = os.path.realpath(source_path)
+    return path.replace("\\", "/")
+
+
+def _format_toml_value(value: Any) -> str:
+    """Format the subset of TOML values used by ``tool.uv.sources``."""
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, list):
+        return "[" + ", ".join(_format_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        items = ", ".join(f"{key} = {_format_toml_value(item)}" for key, item in value.items())
+        return "{ " + items + " }"
+    raise TypeError(f"Unsupported TOML value: {value!r}")
 
 
 def get_algorithms_per_rl_library(single_agent: bool = True, multi_agent: bool = True):

--- a/tools/template/templates/external/README.md
+++ b/tools/template/templates/external/README.md
@@ -16,6 +16,11 @@ environment uses the Newton backend and does not install Isaac Sim:
 ```bash
 uv sync
 ```
+{% if isaaclab_sources %}
+
+This project was generated from an Isaac Lab source checkout. Its `pyproject.toml` uses editable relative paths to that
+checkout, so regenerate the project or update `[tool.uv.sources]` if either directory moves.
+{% endif %}
 
 Optional backends are available through extras. Pass the extra to each `uv run` command that needs it:
 

--- a/tools/template/templates/external/pyproject.toml.jinja
+++ b/tools/template/templates/external/pyproject.toml.jinja
@@ -16,17 +16,17 @@ license = { file = "LICENSE" }
 authors = [{ name = "Isaac Lab Project Developers" }]
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "isaaclab{% if rl_libraries %}[{% for rl_library in rl_libraries %}{% if not loop.first %},{% endif %}{{ rl_library.name | replace('_', '-') }}{% endfor %}]{% endif %}{% if isaaclab_version %}=={{ isaaclab_version }}{% endif %}",
+    "{{ isaaclab_dependency }}{% if rl_libraries %}[{% for rl_library in rl_libraries %}{% if not loop.first %},{% endif %}{{ rl_library.name | replace('_', '-') }}{% endfor %}]{% endif %}{% if not isaaclab_sources and isaaclab_version %}=={{ isaaclab_version }}{% endif %}",
 ]
 
 [project.entry-points."isaaclab.tasks"]
 "{{ name }}" = "{{ name }}.tasks"
 
 [project.optional-dependencies]
-isaacsim = ["isaaclab[isaacsim]{% if isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
-ov = ["isaaclab[ov]{% if isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
-ovphysx = ["isaaclab[ovphysx]{% if isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
-ovrtx = ["isaaclab[ovrtx]{% if isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
+isaacsim = ["{{ isaaclab_dependency }}[isaacsim]{% if not isaaclab_sources and isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
+ov = ["{{ isaaclab_dependency }}[ov]{% if not isaaclab_sources and isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
+ovphysx = ["{{ isaaclab_dependency }}[ovphysx]{% if not isaaclab_sources and isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
+ovrtx = ["{{ isaaclab_dependency }}[ovrtx]{% if not isaaclab_sources and isaaclab_version %}=={{ isaaclab_version }}{% endif %}"]
 
 [dependency-groups]
 dev = ["codespell>=2.4", "pre-commit>=4.2", "pytest>=8.3", "ruff>=0.11"]
@@ -34,6 +34,27 @@ dev = ["codespell>=2.4", "pre-commit>=4.2", "pytest>=8.3", "ruff>=0.11"]
 [tool.uv]
 index-strategy = "unsafe-best-match"
 prerelease = "allow"
+{% if isaaclab_environments %}
+environments = [
+{% for environment in isaaclab_environments %}
+    "{{ environment }}",
+{% endfor %}
+]
+{% endif %}
+{% if isaaclab_overrides %}
+override-dependencies = [
+{% for dependency in isaaclab_overrides %}
+    "{{ dependency }}",
+{% endfor %}
+]
+{% endif %}
+{% if isaaclab_sources %}
+
+[tool.uv.sources]
+{% for source in isaaclab_sources %}
+"{{ source.name }}" = {{ source.value }}
+{% endfor %}
+{% endif %}
 
 [tool.uv.build-backend]
 module-name = "{{ name }}"
@@ -91,6 +112,18 @@ markers = [
 [tool.codespell]
 skip = "*.usd,*.usda,*.usdc,*.json,*.onnx,*.pt,*.mp4,*.data,uv.lock,logs"
 
+{% if isaaclab_indexes %}
+{% for index in isaaclab_indexes %}
+[[tool.uv.index]]
+{% if index.name is defined %}
+name = "{{ index.name }}"
+{% endif %}
+url = "{{ index.url }}"
+explicit = {{ index.explicit | lower }}
+
+{% endfor %}
+{% else %}
 [[tool.uv.index]]
 url = "https://pypi.nvidia.com"
 explicit = false
+{% endif %}

--- a/tools/template/templates/tasks/__init__task
+++ b/tools/template/templates/tasks/__init__task
@@ -14,7 +14,7 @@ from . import agents
 
 gym.register(
     id="{{ task.id }}",
-{% if task.workflow.name == "direct" %}
+{% if task.workflow.name == "direct" or task.amp_selected %}
     entry_point=f"{__name__}.{{ task.env_filename }}:{{ task.classname }}Env",
 {% else %}
     entry_point="isaaclab.envs:ManagerBasedRLEnv",

--- a/tools/template/templates/tasks/manager-based_single-agent/env
+++ b/tools/template/templates/tasks/manager-based_single-agent/env
@@ -1,0 +1,47 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from gymnasium import spaces
+
+from isaaclab.envs import ManagerBasedRLEnv
+
+from .{{ task.env_cfg_filename }} import {{ task.classname }}EnvCfg
+
+
+class {{ task.classname }}Env(ManagerBasedRLEnv):
+    """Manager-based cart-pole environment with the interface required by skrl AMP."""
+
+    cfg: {{ task.classname }}EnvCfg
+
+    def __init__(self, cfg: {{ task.classname }}EnvCfg, render_mode: str | None = None, **kwargs):
+        super().__init__(cfg, render_mode, **kwargs)
+
+        observation_size = spaces.flatdim(self.single_observation_space["policy"])
+        self.amp_observation_size = self.cfg.num_amp_observations * observation_size
+        self.amp_observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(self.amp_observation_size,))
+        self.amp_observation_buffer = torch.zeros(
+            (self.num_envs, self.cfg.num_amp_observations, observation_size), device=self.device
+        )
+
+    def step(self, action: torch.Tensor):
+        observations, rewards, terminated, truncated, extras = super().step(action)
+
+        for index in reversed(range(self.cfg.num_amp_observations - 1)):
+            self.amp_observation_buffer[:, index + 1] = self.amp_observation_buffer[:, index]
+        policy_observations = observations["policy"].reshape(self.num_envs, -1)
+        self.amp_observation_buffer[:, 0] = policy_observations
+        reset_env_ids = (terminated | truncated).nonzero(as_tuple=False).squeeze(-1)
+        self.amp_observation_buffer[reset_env_ids] = policy_observations[reset_env_ids].unsqueeze(1)
+        extras["amp_obs"] = self.amp_observation_buffer.view(-1, self.amp_observation_size)
+        return observations, rewards, terminated, truncated, extras
+
+    def collect_reference_motions(self, num_samples: int, current_times: np.ndarray | None = None) -> torch.Tensor:
+        # This placeholder should be replaced with reference motions for the specific task.
+        # See the Humanoid-AMP task's implementation for a complete example.
+        return torch.zeros((num_samples, self.amp_observation_size), device=self.device)

--- a/tools/template/templates/tasks/manager-based_single-agent/env
+++ b/tools/template/templates/tasks/manager-based_single-agent/env
@@ -37,8 +37,14 @@ class {{ task.classname }}Env(ManagerBasedRLEnv):
         policy_observations = observations["policy"].reshape(self.num_envs, -1)
         self.amp_observation_buffer[:, 0] = policy_observations
         reset_env_ids = (terminated | truncated).nonzero(as_tuple=False).squeeze(-1)
-        self.amp_observation_buffer[reset_env_ids] = policy_observations[reset_env_ids].unsqueeze(1)
-        extras["amp_obs"] = self.amp_observation_buffer.view(-1, self.amp_observation_size)
+        if len(reset_env_ids) > 0:
+            final_policy_observations = extras["final_obs"]["policy"].reshape(self.num_envs, -1)
+            self.amp_observation_buffer[reset_env_ids, 0] = final_policy_observations[reset_env_ids]
+            amp_observations = self.amp_observation_buffer.view(-1, self.amp_observation_size).clone()
+            self.amp_observation_buffer[reset_env_ids] = policy_observations[reset_env_ids].unsqueeze(1)
+        else:
+            amp_observations = self.amp_observation_buffer.view(-1, self.amp_observation_size)
+        extras["amp_obs"] = amp_observations
         return observations, rewards, terminated, truncated, extras
 
     def collect_reference_motions(self, num_samples: int, current_times: np.ndarray | None = None) -> torch.Tensor:

--- a/tools/template/templates/tasks/manager-based_single-agent/env_cfg
+++ b/tools/template/templates/tasks/manager-based_single-agent/env_cfg
@@ -202,6 +202,11 @@ class {{ task.classname }}EnvCfg(ManagerBasedRLEnvCfg):
     # MDP settings
     rewards: RewardsCfg = RewardsCfg()
     terminations: TerminationsCfg = TerminationsCfg()
+{% if task.amp_selected %}
+
+    # AMP settings
+    num_amp_observations = 2
+{% endif %}
 
     # Post initialization
     def __post_init__(self) -> None:

--- a/tools/template/templates/tasks/manager-based_single-agent/env_cfg
+++ b/tools/template/templates/tasks/manager-based_single-agent/env_cfg
@@ -205,6 +205,7 @@ class {{ task.classname }}EnvCfg(ManagerBasedRLEnvCfg):
 {% if task.amp_selected %}
 
     # AMP settings
+    compute_final_obs = True
     num_amp_observations = 2
 {% endif %}
 

--- a/tools/template/test_cli.py
+++ b/tools/template/test_cli.py
@@ -127,6 +127,7 @@ def test_main_collects_canonical_external_project_choices():
     assert specification["robot_name"] == "so101"
     assert specification["include_ui_extension"] is False
     assert specification["isaaclab_version"] == "3.0.0"
+    assert specification["isaaclab_source_path"] == _MODULE.ROOT_DIR
 
 
 def test_generated_project_matches_canonical_uv_layout(tmp_path):
@@ -173,11 +174,53 @@ def test_generated_project_matches_canonical_uv_layout(tmp_path):
     assert (project_dir / "tests" / "test_registration.py").is_file()
     assert 'default="TestProject-"' in (project_dir / "scripts" / "list_envs.py").read_text()
     assert (task_dir / "env_cfg.py").is_file()
+    assert not (task_dir / "env.py").exists()
     assert (task_dir / "agents" / "rsl_rl_ppo_cfg.py").is_file()
     assert not (project_dir / "source").exists()
     assert not (project_dir / "config" / "extension.toml").exists()
     assert not (module_dir / "ui_extension_example.py").exists()
     assert "from .tasks import" not in (module_dir / "__init__.py").read_text()
+
+
+def test_generated_project_uses_active_source_checkout(tmp_path):
+    """Source-generated projects must use the checkout instead of requiring an unpublished wheel."""
+    specification = _external_specification(tmp_path)
+    specification["isaaclab_source_path"] = _MODULE.ROOT_DIR
+
+    with mock.patch.object(_GENERATOR, "_setup_git_repo"):
+        _GENERATOR.generate(specification)
+
+    project_dir = tmp_path / "test_project"
+    with (project_dir / "pyproject.toml").open("rb") as file:
+        project_config = tomllib.load(file)
+
+    assert project_config["project"]["dependencies"] == ["isaaclab-dev[rsl-rl]"]
+    assert project_config["project"]["optional-dependencies"] == {
+        "isaacsim": ["isaaclab-dev[isaacsim]"],
+        "ov": ["isaaclab-dev[ov]"],
+        "ovphysx": ["isaaclab-dev[ovphysx]"],
+        "ovrtx": ["isaaclab-dev[ovrtx]"],
+    }
+    sources = project_config["tool"]["uv"]["sources"]
+    expected_root = Path(_MODULE.ROOT_DIR)
+    assert (project_dir / sources["isaaclab-dev"]["path"]).resolve() == expected_root.resolve()
+    assert (project_dir / sources["isaaclab"]["path"]).resolve() == (expected_root / "source" / "isaaclab").resolve()
+    assert sources["isaaclab-dev"]["editable"] is True
+    assert sources["isaaclab"]["editable"] is True
+    with (expected_root / "pyproject.toml").open("rb") as file:
+        source_config = tomllib.load(file)
+    assert project_config["tool"]["uv"]["override-dependencies"] == source_config["tool"]["uv"]["override-dependencies"]
+    assert project_config["tool"]["uv"]["environments"] == source_config["tool"]["uv"]["environments"]
+    assert sources["torch"] == source_config["tool"]["uv"]["sources"]["torch"]
+    assert "uses editable relative paths" in (project_dir / "README.md").read_text()
+
+
+def test_source_path_falls_back_to_absolute_path_across_windows_drives(monkeypatch):
+    """A project on another Windows drive must still receive a valid source path."""
+    monkeypatch.setattr(_GENERATOR.os.path, "relpath", mock.Mock(side_effect=ValueError))
+    monkeypatch.setattr(_GENERATOR.os.path, "realpath", lambda path: path)
+
+    assert _GENERATOR._project_source_path(r"D:\IsaacLab", r"C:\projects\robot") == "D:/IsaacLab"
 
 
 def test_generated_project_can_opt_into_ui_extension(tmp_path):


### PR DESCRIPTION
# Description

Fix three failures in generated template projects:

- Generate the skrl AMP interface for manager-based tasks, including the AMP observation space, transition observations, and reference-motion hook.
- Resolve source-generated external projects against editable packages from the active checkout instead of pinning an unpublished aggregate wheel version.
- Preserve the checkout dependency overrides and index routing so all generated backend extras resolve consistently and the installed CLI cannot silently fall back to an older wheel.

The generated source paths are relative when possible and fall back to absolute paths for projects on another Windows drive. Installed-wheel generation retains the exact version pin.

No new dependencies are required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Validation

- `uv run --frozen python -m pytest --confcutdir=tools/template tools/template/test_cli.py -q` — 9 passed
- `uv run --frozen python -m pytest --confcutdir=source/isaaclab_rl source/isaaclab_rl/test/test_template_generator.py -q` — 29 passed
- Generated source project: `uv lock --offline` — resolved 309 packages
- Generated source project: `uv sync --dry-run` — selected all Isaac Lab packages from the active checkout
- `uv run --isolated --extra dev -- make -C docs current-docs` — passed without warnings
- `uv run --frozen isaaclab -f` — all formatting and lint hooks passed; the local changelog comparison still reports unrelated pre-existing `develop` fragment failures

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I added an `isaaclab_rl` `.skip` fragment because only that package test suite changed
- [x] My name already exists in `CONTRIBUTORS.md`