### PR TITLE
Ignore Kit's imgui.ini UI-state file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Omniverse
 **/*.dmp
 **/.thumbs
+# Kit's ImGui UI-state file, written to the process working directory by long
+# sessions with a GUI-backed visualizer (e.g. --visualizer kit).
+**/imgui.ini
 
 # No USD files allowed in the repo
 **/*.usd

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -458,6 +458,14 @@ Visualizer Overview
       - Direct access to the Isaac Sim USD stage for inspecting and editing prims at runtime
       - Full Isaac Sim GUI tooling (Property, Layers, and Stage panels)
 
+      .. note::
+
+         Kit's ImGui-based UI writes an ``imgui.ini`` file, recording window layout (panel
+         positions, docking, collapsed state), to the process working directory. If that is the
+         repository root, it shows up as an untracked file. ``imgui.ini`` is already listed in
+         ``.gitignore``; delete it or launch from outside the repository if you would rather it
+         not appear at all.
+
       **Core configuration:**
 
       .. code-block:: python


### PR DESCRIPTION
# Description

Long sessions using a GUI-backed visualizer (`--visualizer kit`) write `imgui.ini` — Kit's
ImGui UI-state file — into the process working directory. When Isaac Lab is launched from
the repository root (the common case), this dirties the checkout: an eight-minute session
produced a 128-byte `imgui.ini` at the repo root after ~5m43s; short bounded runs stayed
clean. This is Kit's own compiled `omni.kit.renderer.imgui` extension, not Isaac Lab code,
so there's no in-repo hook to redirect where it writes.

Adds `**/imgui.ini` to `.gitignore`, following the same pattern as the existing
`__tracked_surface.stl` rule for PyTetWild's generated artifact (#6648).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified `imgui.ini` at the repo root and at a nested path are both ignored
  (`git check-ignore -v`).
- Verified unrelated files are unaffected.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] Documentation is not required for this `.gitignore`-only change
- [x] My changes generate no new warnings
- [x] A changelog fragment is not required because no package was touched
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there