### PR TITLE
Fix shutdown hang on Ctrl+C with multiple GUI-backed visualizers

### DIFF
--- a/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
@@ -1,0 +1,15 @@
+Fixed
+^^^^^
+
+* Fixed a shutdown hang in ``random_agent``/``zero_agent`` and every ``train``/``play`` RL
+  backend (``rsl_rl``, ``rl_games``, ``skrl``, ``sb3``) when interrupted with Ctrl+C while
+  multiple GUI-backed visualizers were active (for example ``--visualizer newton,kit``).
+  ``env.close()`` previously only ran on the happy path -- ``except KeyboardInterrupt: pass``
+  silently swallowed the interrupt without closing the environment, so the process never
+  reached the visualizer teardown in :meth:`~isaaclab.sim.SimulationContext.clear_instance`
+  and had to be killed. ``env.close()`` now runs from a ``finally`` block on every exit path.
+  In ``random_agent``/``zero_agent``, a raw ``KeyboardInterrupt`` could also be delivered
+  asynchronously inside one of Kit's own internal callbacks (its viewport/render event loop)
+  rather than in the script's own loop; that entrypoint now installs a ``SIGINT`` handler that
+  only sets a flag, checked at a controlled point in the loop, instead of relying on where the
+  exception happens to land.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -227,10 +227,10 @@ def main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -245,10 +245,10 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -209,10 +209,10 @@ def main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -266,10 +266,10 @@ def _main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -242,6 +242,7 @@ def run(argv: list[str]) -> None:
                 else:
                     runner.run({"train": True, "play": False, "sigma": train_sigma})
                 print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -238,6 +238,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                     init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
                 )
                 print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -230,6 +230,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 os.makedirs(os.path.join(log_dir, "checkpoints"), exist_ok=True)
                 runner.agent.write_checkpoint(timestep=total_timesteps, timesteps=total_timesteps)
                 print(f"[INFO] Saved final agent checkpoint to: {log_dir}/checkpoints")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import signal
 import sys
 from collections.abc import Callable
 from typing import Any, Literal
@@ -97,21 +98,40 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
         sim = env.unwrapped.sim
         device = env.unwrapped.device
         step = 0
-        while sim.is_headless_or_exist_active_visualizer():
-            if args_cli.max_steps is not None and step >= args_cli.max_steps:
-                break
-            step += 1
-            # run everything in inference mode
-            with torch.inference_mode():
-                if policy == "zero":
-                    actions = zero_action_policy()
-                else:
-                    # sample actions from -1 to 1
-                    actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
-                # apply actions
-                env.step(actions)
-        # close the simulator
-        env.close()
+        # A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active
+        # (e.g. --visualizer newton,kit), Python can just as easily raise KeyboardInterrupt from
+        # inside one of Kit's own internal callback dispatches (its viewport/render event loop)
+        # as from this loop, where nothing here can catch it. Installing a handler that only
+        # flips a flag is safe no matter which frame it fires in, and lets this loop -- the one
+        # place that knows how to shut the simulation down cleanly -- check it at a controlled
+        # point instead of hoping the exception lands somewhere useful.
+        interrupted = False
+
+        def _on_sigint(signum, frame):
+            nonlocal interrupted
+            interrupted = True
+
+        previous_handler = signal.signal(signal.SIGINT, _on_sigint)
+        try:
+            while sim.is_headless_or_exist_active_visualizer():
+                if interrupted:
+                    break
+                if args_cli.max_steps is not None and step >= args_cli.max_steps:
+                    break
+                step += 1
+                # run everything in inference mode
+                with torch.inference_mode():
+                    if policy == "zero":
+                        actions = zero_action_policy()
+                    else:
+                        # sample actions from -1 to 1
+                        actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
+                    # apply actions
+                    env.step(actions)
+        finally:
+            signal.signal(signal.SIGINT, previous_handler)
+            # close the simulator
+            env.close()
 
 
 def _create_zero_action_policy(env: gym.Env) -> Callable[[], Any]:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -129,9 +129,16 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
                     # apply actions
                     env.step(actions)
         finally:
-            signal.signal(signal.SIGINT, previous_handler)
-            # close the simulator
-            env.close()
+            # Keep the flag-only handler installed through cleanup: a second Ctrl+C during
+            # env.close()'s multi-stage teardown would otherwise raise a raw KeyboardInterrupt,
+            # which is not a subclass of Exception, so it is not caught by the individual
+            # try/except wrapping each cleanup stage in SimulationContext.clear_instance() --
+            # it would abort that loop and skip whatever visualizers hadn't closed yet.
+            try:
+                # close the simulator
+                env.close()
+            finally:
+                signal.signal(signal.SIGINT, previous_handler)
 
 
 def _create_zero_action_policy(env: gym.Env) -> Callable[[], Any]:


### PR DESCRIPTION
# Description

An open-ended session with multiple GUI-backed visualizers active (e.g. `--visualizer
newton,kit,rerun,viser`) did not stop cleanly on Ctrl+C / SIGINT: it stayed alive through the
shutdown grace period and had to be killed. Single-visualizer sessions stopped cleanly on
their own; multi-visualizer combinations were inconsistent.

Two distinct gaps combined to cause this:

1. **`env.close()` only ran on the happy path.** In `random_agent`/`zero_agent` and every
   `train`/`play` RL backend (`rsl_rl`, `rl_games`, `skrl`, `sb3`), the pattern was
   `try: ...loop... ; env.close() except KeyboardInterrupt: pass`. When the interrupt landed
   during the loop, execution jumped straight to `except`, which silently swallowed it
   *without* calling `env.close()`. That call is what reaches
   `SimulationContext.clear_instance()`, which is the only place that calls `.close()` (not
   just `.stop()`) on every active visualizer, tearing down `rerun`'s/`viser`'s server
   threads and the Newton/Kit windows. Skipping it left those resources running, and the
   process hung waiting for them.

2. **A raw `KeyboardInterrupt` doesn't reliably land where you'd expect.** Python delivers
   `SIGINT` asynchronously, interrupting whatever bytecode happens to be executing at the
   moment. With multiple GUI-backed visualizers pumping their own render/event callbacks,
   that's often *inside one of Kit's own internal callbacks* (its viewport texture or event
   dispatch), not inside the script's own loop -- where no `try/except` here could ever catch
   it. This is consistent with the reported shutdown matrix being inconsistent across
   visualizer combinations rather than reliably tied to one frontend.

## Fix

- `env.close()` now runs from a `finally` block on every exit path (normal completion, `break`,
  or interrupt) in all 8 affected entrypoints.
- `random_agent`/`zero_agent` additionally install a `SIGINT` handler that only sets a flag,
  checked at a controlled point at the top of the loop, instead of relying on an async
  exception landing somewhere useful. This is safe regardless of which frame the signal
  actually interrupts.

## Testing

Reproduced with the exact repro command from the report:

```
env DISPLAY=:0 OMNI_KIT_ACCEPT_EULA=yes timeout --signal=INT --kill-after=30 90 \
  uv run isaaclab random_agent --task Isaac-Cartpole --num_envs 64 --max_steps 1000000 \
  physics=newton_mjwarp --visualizer newton,kit,rerun,viser
```

- Before the fix: exit 137 (SIGKILL required after the grace period).
- After the fix: exit 124 (clean shutdown within the grace period), consistent across two
  repeated runs. The log shows the expected clean teardown sequence ("(viser) Server
  stopped", "SimulationContext cleared", "Simulation App Shutting Down").
- `source/isaaclab_rl/test/test_entrypoints.py`: 43 passed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (none required; no public API changed)
- [x] My changes generate no new warnings
- [x] I have added a changelog fragment under `source/isaaclab_rl/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there