### PR TITLE
[VDR feedback] Fix shutdown hang on Ctrl+C with multiple visualizers

### DIFF
--- a/scripts/reinforcement_learning/leapp/deploy.py
+++ b/scripts/reinforcement_learning/leapp/deploy.py
@@ -67,14 +67,15 @@ def main():
     print(f"[INFO]: Num envs: {env.num_envs}, decimation: {env.cfg.decimation}, step_dt: {env.step_dt:.4f}s")
 
     # ── Run loop ──────────────────────────────────────────────────
-    env.reset()
     try:
+        env.reset()
         with torch.inference_mode():
             while simulation_app.is_running():
                 env.step()
-        env.close()
     except KeyboardInterrupt:
         pass
+    finally:
+        env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
@@ -1,26 +1,14 @@
 Fixed
 ^^^^^
 
-* Fixed a shutdown hang in ``random_agent``/``zero_agent`` and every ``train``/``play`` RL
-  backend (``rsl_rl``, ``rl_games``, ``skrl``, ``sb3``) when interrupted with Ctrl+C while
-  multiple GUI-backed visualizers were active (for example ``--visualizer newton,kit``).
-  ``env.close()`` previously only ran on the happy path -- ``except KeyboardInterrupt: pass``
-  silently swallowed the interrupt without closing the environment, so the process never
-  reached the visualizer teardown in :meth:`~isaaclab.sim.SimulationContext.clear_instance`
-  and had to be killed. ``env.close()`` is now registered on a :class:`contextlib.ExitStack`
-  immediately once the environment is created, so it always runs, including for an interrupt
-  during setup (``env.reset()``, wrapper/runner/checkpoint construction), not just one during
-  the final training or playback loop.
-  In ``random_agent``/``zero_agent`` and every ``play`` backend, a raw ``KeyboardInterrupt``
-  could also be delivered asynchronously inside one of Kit's own internal callbacks (its
-  viewport/render event loop) rather than in the script's own loop; those entrypoints now
-  install a ``SIGINT`` handler (``isaaclab_rl.entrypoints.common.flag_only_sigint``) that only
-  sets a flag, checked at a controlled point in the loop, instead of relying on where the
-  exception happens to land. The flag-only handler stays installed through ``env.close()``
-  itself, since restoring it beforehand let a second Ctrl+C during the multi-stage cleanup
-  raise a raw ``KeyboardInterrupt`` that bypassed ``clear_instance``'s per-stage error
-  isolation and could skip whatever visualizers had not closed yet. The ``train`` backends
-  cannot use that handler -- their step loop runs inside a third-party runner's blocking call
-  (``runner.learn()``/``runner.run()``), which needs a raw ``KeyboardInterrupt`` to interrupt
-  it -- so they instead suppress the interrupt only once it has propagated past the
-  ``ExitStack``, guaranteeing ``env.close()`` already ran.
+* Fixed a shutdown hang on Ctrl+C in ``random_agent``/``zero_agent``, every ``train``/``play``
+  RL backend (``rsl_rl``, ``rl_games``, ``skrl``, ``sb3``), and the LEAPP deployment script,
+  while multiple GUI-backed visualizers were active (for example ``--visualizer newton,kit``).
+  ``env.close()`` previously only ran on the happy path, so an interrupt skipped the
+  visualizer teardown in :meth:`~isaaclab.sim.SimulationContext.clear_instance` and the
+  process had to be killed. ``env.close()`` is now registered on a :class:`contextlib.ExitStack`
+  immediately once the environment is created, guaranteeing it runs
+  (``isaaclab_rl.entrypoints.common.suppressed_shutdown_guard``). ``random_agent``/
+  ``zero_agent`` additionally install a flag-only ``SIGINT`` handler
+  (``isaaclab_rl.entrypoints.common.flag_only_sigint``), since a raw interrupt there can land
+  asynchronously inside one of Kit's own internal callbacks rather than the script's own loop.

--- a/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
@@ -12,4 +12,10 @@ Fixed
   asynchronously inside one of Kit's own internal callbacks (its viewport/render event loop)
   rather than in the script's own loop; that entrypoint now installs a ``SIGINT`` handler that
   only sets a flag, checked at a controlled point in the loop, instead of relying on where the
-  exception happens to land.
+  exception happens to land. The flag-only handler stays installed through ``env.close()``
+  itself, since restoring it beforehand let a second Ctrl+C during the multi-stage cleanup
+  raise a raw ``KeyboardInterrupt`` that bypassed ``clear_instance``'s per-stage error
+  isolation and could skip whatever visualizers had not closed yet. The protected scope also
+  now starts immediately after each environment is created, covering ``env.reset()`` and
+  wrapper/runner/checkpoint setup, not just the final training or playback loop -- an
+  interrupt during that setup work could bypass ``env.close()`` the same way.

--- a/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
@@ -1,0 +1,15 @@
+Fixed
+^^^^^
+
+* Fixed a shutdown hang in ``random_agent``/``zero_agent`` and every ``train``/``play`` RL
+  backend (``rsl_rl``, ``rl_games``, ``skrl``, ``sb3``) when interrupted with Ctrl+C while
+  multiple GUI-backed visualizers were active (for example ``--visualizer newton,kit``).
+  ``env.close()`` previously only ran on the happy path -- ``except KeyboardInterrupt: pass``
+  silently swallowed the interrupt without closing the environment, so the process never
+  reached the visualizer teardown in :meth:`~isaaclab.sim.SimulationContext.clear_instance`
+  and had to be killed. ``env.close()`` now runs from a ``finally`` block on every exit path.
+  In ``random_agent``/``zero_agent``, a raw ``KeyboardInterrupt`` could also be delivered
+  asynchronously inside one of Kit's own internal callbacks (its viewport/render event loop)
+  rather than in the script's own loop; that entrypoint now installs a ``SIGINT`` handler that
+  only sets a flag, checked at a controlled point in the loop, instead of relying on where the
+  exception happens to land.

--- a/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
+++ b/source/isaaclab_rl/changelog.d/mtrepte-fix-shutdown-hang-multi-visualizer.rst
@@ -7,15 +7,20 @@ Fixed
   ``env.close()`` previously only ran on the happy path -- ``except KeyboardInterrupt: pass``
   silently swallowed the interrupt without closing the environment, so the process never
   reached the visualizer teardown in :meth:`~isaaclab.sim.SimulationContext.clear_instance`
-  and had to be killed. ``env.close()`` now runs from a ``finally`` block on every exit path.
-  In ``random_agent``/``zero_agent``, a raw ``KeyboardInterrupt`` could also be delivered
-  asynchronously inside one of Kit's own internal callbacks (its viewport/render event loop)
-  rather than in the script's own loop; that entrypoint now installs a ``SIGINT`` handler that
-  only sets a flag, checked at a controlled point in the loop, instead of relying on where the
+  and had to be killed. ``env.close()`` is now registered on a :class:`contextlib.ExitStack`
+  immediately once the environment is created, so it always runs, including for an interrupt
+  during setup (``env.reset()``, wrapper/runner/checkpoint construction), not just one during
+  the final training or playback loop.
+  In ``random_agent``/``zero_agent`` and every ``play`` backend, a raw ``KeyboardInterrupt``
+  could also be delivered asynchronously inside one of Kit's own internal callbacks (its
+  viewport/render event loop) rather than in the script's own loop; those entrypoints now
+  install a ``SIGINT`` handler (``isaaclab_rl.entrypoints.common.flag_only_sigint``) that only
+  sets a flag, checked at a controlled point in the loop, instead of relying on where the
   exception happens to land. The flag-only handler stays installed through ``env.close()``
   itself, since restoring it beforehand let a second Ctrl+C during the multi-stage cleanup
   raise a raw ``KeyboardInterrupt`` that bypassed ``clear_instance``'s per-stage error
-  isolation and could skip whatever visualizers had not closed yet. The protected scope also
-  now starts immediately after each environment is created, covering ``env.reset()`` and
-  wrapper/runner/checkpoint setup, not just the final training or playback loop -- an
-  interrupt during that setup work could bypass ``env.close()`` the same way.
+  isolation and could skip whatever visualizers had not closed yet. The ``train`` backends
+  cannot use that handler -- their step loop runs inside a third-party runner's blocking call
+  (``runner.learn()``/``runner.run()``), which needs a raw ``KeyboardInterrupt`` to interrupt
+  it -- so they instead suppress the interrupt only once it has propagated past the
+  ``ExitStack``, guaranteeing ``env.close()`` already ran.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -167,8 +167,7 @@ def main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt anywhere from
-            # here on (setup or the play loop) is handled the same way.
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             screen.stage("Loading policy")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -227,10 +227,10 @@ def main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -35,6 +35,7 @@ from isaaclab_rl.entrypoints.common import (
     resolve_play_task_name,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
 )
 from isaaclab_rl.rl_games import RlGamesGpuEnv, RlGamesVecEnvWrapper
 from isaaclab_rl.utils.pretrained_checkpoint import (
@@ -103,7 +104,7 @@ def main():
     with startup_screen(args_cli, num_stages=3) as screen:
         show_run_summary(screen, args_cli, env_cfg, library="rl_games", action="play")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             task_name = args_cli.task.split(":")[-1]
             train_task_name = task_name.replace("-Play", "")
 
@@ -166,74 +167,69 @@ def main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
+            # Register env.close() immediately once env exists, so an interrupt anywhere from
+            # here on (setup or the play loop) is handled the same way.
+            stack.callback(env.close)
 
-            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
-            # setup or during env.reset() bypasses env.close() just as easily as one during
-            # the play loop below, if it isn't inside this try/finally too.
-            try:
-                screen.stage("Loading policy")
-                env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
+            screen.stage("Loading policy")
+            env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
 
-                vecenv.register(
-                    "IsaacRlgWrapper",
-                    lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
-                )
-                env_configurations.register(
-                    "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
-                )
+            vecenv.register(
+                "IsaacRlgWrapper",
+                lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
+            )
+            env_configurations.register(
+                "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
+            )
 
-                agent_cfg["params"]["load_checkpoint"] = True
-                agent_cfg["params"]["load_path"] = resume_path
-                print(f"[INFO]: Loading model checkpoint from: {agent_cfg['params']['load_path']}")
+            agent_cfg["params"]["load_checkpoint"] = True
+            agent_cfg["params"]["load_path"] = resume_path
+            print(f"[INFO]: Loading model checkpoint from: {agent_cfg['params']['load_path']}")
 
-                agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
-                runner = Runner()
-                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
-                runner.load(agent_cfg)
-                agent: BasePlayer = runner.create_player()
-                agent.restore(resume_path)
-                agent.reset()
+            agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
+            runner = Runner()
+            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
+            runner.load(agent_cfg)
+            agent: BasePlayer = runner.create_player()
+            agent.restore(resume_path)
+            agent.reset()
 
-                dt = env.unwrapped.step_dt
+            dt = env.unwrapped.step_dt
 
-                screen.close()
-                obs = env.reset()
-                if isinstance(obs, dict):
-                    obs = obs["obs"]
-                timestep = 0
-                _ = agent.get_batch_size(obs, 1)
-                if agent.is_rnn:
-                    agent.init_rnn()
-                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
-                while True:
-                    start_time = time.time()
-                    with torch.inference_mode():
-                        obs = agent.obs_to_torch(obs)
-                        actions = agent.get_action(obs, is_deterministic=agent.is_deterministic)
-                        obs, _, dones, _ = env.step(actions)
+            screen.close()
+            obs = env.reset()
+            if isinstance(obs, dict):
+                obs = obs["obs"]
+            timestep = 0
+            _ = agent.get_batch_size(obs, 1)
+            if agent.is_rnn:
+                agent.init_rnn()
+            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            while True:
+                start_time = time.time()
+                with torch.inference_mode():
+                    obs = agent.obs_to_torch(obs)
+                    actions = agent.get_action(obs, is_deterministic=agent.is_deterministic)
+                    obs, _, dones, _ = env.step(actions)
 
-                        if len(dones) > 0:
-                            if agent.is_rnn and agent.states is not None:
-                                for s in agent.states:
-                                    s[:, dones, :] = 0.0
-                    if args_cli.video:
-                        timestep += 1
-                        video_stop = args_cli.video_length
-                        if video_stop is None:
-                            recorders = getattr(env_cfg, "video_recorders", [])
-                            video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
-                        if video_stop is not None and timestep >= video_stop:
-                            break
+                    if len(dones) > 0:
+                        if agent.is_rnn and agent.states is not None:
+                            for s in agent.states:
+                                s[:, dones, :] = 0.0
+                if args_cli.video:
+                    timestep += 1
+                    video_stop = args_cli.video_length
+                    if video_stop is None:
+                        recorders = getattr(env_cfg, "video_recorders", [])
+                        video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
+                    if video_stop is not None and timestep >= video_stop:
+                        break
 
-                    sleep_time = dt - (time.time() - start_time)
-                    if args_cli.real_time and sleep_time > 0:
-                        time.sleep(sleep_time)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+                sleep_time = dt - (time.time() - start_time)
+                if args_cli.real_time and sleep_time > 0:
+                    time.sleep(sleep_time)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -167,43 +167,46 @@ def main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
 
-            screen.stage("Loading policy")
-            env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
-
-            vecenv.register(
-                "IsaacRlgWrapper",
-                lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
-            )
-            env_configurations.register(
-                "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
-            )
-
-            agent_cfg["params"]["load_checkpoint"] = True
-            agent_cfg["params"]["load_path"] = resume_path
-            print(f"[INFO]: Loading model checkpoint from: {agent_cfg['params']['load_path']}")
-
-            agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
-            runner = Runner()
-            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-            runner.load(agent_cfg)
-            agent: BasePlayer = runner.create_player()
-            agent.restore(resume_path)
-            agent.reset()
-
-            dt = env.unwrapped.step_dt
-
-            screen.close()
-            obs = env.reset()
-            if isinstance(obs, dict):
-                obs = obs["obs"]
-            timestep = 0
-            _ = agent.get_batch_size(obs, 1)
-            if agent.is_rnn:
-                agent.init_rnn()
-            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
+            # setup or during env.reset() bypasses env.close() just as easily as one during
+            # the play loop below, if it isn't inside this try/finally too.
             try:
+                screen.stage("Loading policy")
+                env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
+
+                vecenv.register(
+                    "IsaacRlgWrapper",
+                    lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
+                )
+                env_configurations.register(
+                    "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
+                )
+
+                agent_cfg["params"]["load_checkpoint"] = True
+                agent_cfg["params"]["load_path"] = resume_path
+                print(f"[INFO]: Loading model checkpoint from: {agent_cfg['params']['load_path']}")
+
+                agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
+                runner = Runner()
+                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+                runner.load(agent_cfg)
+                agent: BasePlayer = runner.create_player()
+                agent.restore(resume_path)
+                agent.reset()
+
+                dt = env.unwrapped.step_dt
+
+                screen.close()
+                obs = env.reset()
+                if isinstance(obs, dict):
+                    obs = obs["obs"]
+                timestep = 0
+                _ = agent.get_batch_size(obs, 1)
+                if agent.is_rnn:
+                    agent.init_rnn()
+                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
                 while True:
                     start_time = time.time()
                     with torch.inference_mode():

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rl_games.py
@@ -168,7 +168,7 @@ def main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             screen.stage("Loading policy")
             env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -177,8 +177,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt anywhere from
-            # here on (setup or the play loop) is handled the same way.
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             screen.stage("Loading policy")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -177,52 +177,55 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
 
-            screen.stage("Loading policy")
-            env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
-
-            print(f"[INFO]: Loading model checkpoint from: {resume_path}")
-            if agent_cfg.class_name == "OnPolicyRunner":
-                runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
-            elif agent_cfg.class_name == "DistillationRunner":
-                runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
-            else:
-                raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
-            # configure_seed must run after runner construction so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-            runner.load(resume_path)
-
-            policy = runner.get_inference_policy(device=env.unwrapped.device)
-
-            export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
-
-            if version.parse(installed_version) >= version.parse("4.0.0"):
-                runner.export_policy_to_jit(path=export_model_dir, filename="policy.pt")
-                runner.export_policy_to_onnx(path=export_model_dir, filename="policy.onnx")
-                policy_nn = None  # Not needed for rsl-rl >= 4.0.0
-            else:
-                if version.parse(installed_version) >= version.parse("2.3.0"):
-                    policy_nn = runner.alg.policy
-                else:
-                    policy_nn = runner.alg.actor_critic
-
-                if hasattr(policy_nn, "actor_obs_normalizer"):
-                    normalizer = policy_nn.actor_obs_normalizer
-                elif hasattr(policy_nn, "student_obs_normalizer"):
-                    normalizer = policy_nn.student_obs_normalizer
-                else:
-                    normalizer = None
-
-                export_policy_as_jit(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.pt")
-                export_policy_as_onnx(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx")
-
-            dt = env.unwrapped.step_dt
-
-            screen.close()
-            obs = env.get_observations()
-            timestep = 0
-            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
+            # setup or during env.reset()-equivalent work bypasses env.close() just as easily
+            # as one during the play loop below, if it isn't inside this try/finally too.
             try:
+                screen.stage("Loading policy")
+                env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+
+                print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+                if agent_cfg.class_name == "OnPolicyRunner":
+                    runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+                elif agent_cfg.class_name == "DistillationRunner":
+                    runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+                else:
+                    raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+                # configure_seed must run after runner construction so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+                runner.load(resume_path)
+
+                policy = runner.get_inference_policy(device=env.unwrapped.device)
+
+                export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
+
+                if version.parse(installed_version) >= version.parse("4.0.0"):
+                    runner.export_policy_to_jit(path=export_model_dir, filename="policy.pt")
+                    runner.export_policy_to_onnx(path=export_model_dir, filename="policy.onnx")
+                    policy_nn = None  # Not needed for rsl-rl >= 4.0.0
+                else:
+                    if version.parse(installed_version) >= version.parse("2.3.0"):
+                        policy_nn = runner.alg.policy
+                    else:
+                        policy_nn = runner.alg.actor_critic
+
+                    if hasattr(policy_nn, "actor_obs_normalizer"):
+                        normalizer = policy_nn.actor_obs_normalizer
+                    elif hasattr(policy_nn, "student_obs_normalizer"):
+                        normalizer = policy_nn.student_obs_normalizer
+                    else:
+                        normalizer = None
+
+                    export_policy_as_jit(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.pt")
+                    export_policy_as_onnx(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx")
+
+                dt = env.unwrapped.step_dt
+
+                screen.close()
+                obs = env.get_observations()
+                timestep = 0
+                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
                 while True:
                     start_time = time.time()
                     with torch.inference_mode():

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -245,10 +245,10 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -218,7 +218,9 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                         normalizer = None
 
                     export_policy_as_jit(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.pt")
-                    export_policy_as_onnx(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx")
+                    export_policy_as_onnx(
+                        policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx"
+                    )
 
                 dt = env.unwrapped.step_dt
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -34,6 +34,7 @@ from isaaclab_rl.entrypoints.common import (
     resolve_play_task_name,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
 )
 from isaaclab_rl.rsl_rl import (
     RslRlBaseRunnerCfg,
@@ -121,7 +122,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     with startup_screen(args_cli, num_stages=3) as screen:
         show_run_summary(screen, args_cli, env_cfg, library="rsl_rl", action="play")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             task_name = args_cli.task.split(":")[-1]
             train_task_name = task_name.replace("-Play", "")
 
@@ -176,85 +177,78 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
+            # Register env.close() immediately once env exists, so an interrupt anywhere from
+            # here on (setup or the play loop) is handled the same way.
+            stack.callback(env.close)
 
-            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
-            # setup or during env.reset()-equivalent work bypasses env.close() just as easily
-            # as one during the play loop below, if it isn't inside this try/finally too.
-            try:
-                screen.stage("Loading policy")
-                env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+            screen.stage("Loading policy")
+            env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
 
-                print(f"[INFO]: Loading model checkpoint from: {resume_path}")
-                if agent_cfg.class_name == "OnPolicyRunner":
-                    runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
-                elif agent_cfg.class_name == "DistillationRunner":
-                    runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+            print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+            if agent_cfg.class_name == "OnPolicyRunner":
+                runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+            elif agent_cfg.class_name == "DistillationRunner":
+                runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+            else:
+                raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+            # configure_seed must run after runner construction so torch determinism does not disturb
+            # its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
+            runner.load(resume_path)
+
+            policy = runner.get_inference_policy(device=env.unwrapped.device)
+
+            export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
+
+            if version.parse(installed_version) >= version.parse("4.0.0"):
+                runner.export_policy_to_jit(path=export_model_dir, filename="policy.pt")
+                runner.export_policy_to_onnx(path=export_model_dir, filename="policy.onnx")
+                policy_nn = None  # Not needed for rsl-rl >= 4.0.0
+            else:
+                if version.parse(installed_version) >= version.parse("2.3.0"):
+                    policy_nn = runner.alg.policy
                 else:
-                    raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
-                # configure_seed must run after runner construction so torch determinism does not disturb
-                # its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
-                runner.load(resume_path)
+                    policy_nn = runner.alg.actor_critic
 
-                policy = runner.get_inference_policy(device=env.unwrapped.device)
-
-                export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
-
-                if version.parse(installed_version) >= version.parse("4.0.0"):
-                    runner.export_policy_to_jit(path=export_model_dir, filename="policy.pt")
-                    runner.export_policy_to_onnx(path=export_model_dir, filename="policy.onnx")
-                    policy_nn = None  # Not needed for rsl-rl >= 4.0.0
+                if hasattr(policy_nn, "actor_obs_normalizer"):
+                    normalizer = policy_nn.actor_obs_normalizer
+                elif hasattr(policy_nn, "student_obs_normalizer"):
+                    normalizer = policy_nn.student_obs_normalizer
                 else:
-                    if version.parse(installed_version) >= version.parse("2.3.0"):
-                        policy_nn = runner.alg.policy
+                    normalizer = None
+
+                export_policy_as_jit(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.pt")
+                export_policy_as_onnx(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx")
+
+            dt = env.unwrapped.step_dt
+
+            screen.close()
+            obs = env.get_observations()
+            timestep = 0
+            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            while True:
+                start_time = time.time()
+                with torch.inference_mode():
+                    actions = policy(obs)
+                    obs, _, dones, _ = env.step(actions)
+                    # reset recurrent states for episodes that have terminated
+                    if version.parse(installed_version) >= version.parse("4.0.0"):
+                        policy.reset(dones)
                     else:
-                        policy_nn = runner.alg.actor_critic
+                        policy_nn.reset(dones)
+                if args_cli.video:
+                    timestep += 1
+                    video_stop = args_cli.video_length
+                    if video_stop is None:
+                        recorders = getattr(env_cfg, "video_recorders", [])
+                        video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
+                    if video_stop is not None and timestep >= video_stop:
+                        break
 
-                    if hasattr(policy_nn, "actor_obs_normalizer"):
-                        normalizer = policy_nn.actor_obs_normalizer
-                    elif hasattr(policy_nn, "student_obs_normalizer"):
-                        normalizer = policy_nn.student_obs_normalizer
-                    else:
-                        normalizer = None
-
-                    export_policy_as_jit(policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.pt")
-                    export_policy_as_onnx(
-                        policy_nn, normalizer=normalizer, path=export_model_dir, filename="policy.onnx"
-                    )
-
-                dt = env.unwrapped.step_dt
-
-                screen.close()
-                obs = env.get_observations()
-                timestep = 0
-                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
-                while True:
-                    start_time = time.time()
-                    with torch.inference_mode():
-                        actions = policy(obs)
-                        obs, _, dones, _ = env.step(actions)
-                        # reset recurrent states for episodes that have terminated
-                        if version.parse(installed_version) >= version.parse("4.0.0"):
-                            policy.reset(dones)
-                        else:
-                            policy_nn.reset(dones)
-                    if args_cli.video:
-                        timestep += 1
-                        video_stop = args_cli.video_length
-                        if video_stop is None:
-                            recorders = getattr(env_cfg, "video_recorders", [])
-                            video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
-                        if video_stop is not None and timestep >= video_stop:
-                            break
-
-                    sleep_time = dt - (time.time() - start_time)
-                    if args_cli.real_time and sleep_time > 0:
-                        time.sleep(sleep_time)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+                sleep_time = dt - (time.time() - start_time)
+                if args_cli.real_time and sleep_time > 0:
+                    time.sleep(sleep_time)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -178,7 +178,7 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             screen.stage("Loading policy")
             env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_rsl_rl.py
@@ -191,7 +191,8 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
                     runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
                 else:
                     raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
-                # configure_seed must run after runner construction so torch determinism does not disturb its initialization
+                # configure_seed must run after runner construction so torch determinism does not disturb
+                # its initialization
                 if args_cli.deterministic:
                     configure_seed(env_cfg.seed, torch_deterministic=True)
                 runner.load(resume_path)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -32,6 +32,7 @@ from isaaclab_rl.entrypoints.common import (
     resolve_play_task_name,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
 )
 from isaaclab_rl.sb3 import Sb3VecEnvWrapper, process_sb3_cfg
 from isaaclab_rl.utils.pretrained_checkpoint import (
@@ -106,7 +107,7 @@ def main():
     with startup_screen(args_cli, num_stages=3) as screen:
         show_run_summary(screen, args_cli, env_cfg, library="sb3", action="play")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             task_name = args_cli.task.split(":")[-1]
             train_task_name = task_name.replace("-Play", "")
             if args_cli.seed == -1:
@@ -157,65 +158,60 @@ def main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
+            # Register env.close() immediately once env exists, so an interrupt anywhere from
+            # here on (setup or the play loop) is handled the same way.
+            stack.callback(env.close)
 
-            # Protect everything from here on: an interrupt during wrapper/checkpoint setup or
-            # during env.reset() bypasses env.close() just as easily as one during the play
-            # loop below, if it isn't inside this try/finally too.
-            try:
-                agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)
+            agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)
 
-                screen.stage("Loading policy")
-                env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
+            screen.stage("Loading policy")
+            env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
 
-                vec_norm_path = checkpoint_path.replace("/model", "/model_vecnormalize").replace(".zip", ".pkl")
-                vec_norm_path = Path(vec_norm_path)
+            vec_norm_path = checkpoint_path.replace("/model", "/model_vecnormalize").replace(".zip", ".pkl")
+            vec_norm_path = Path(vec_norm_path)
 
-                if vec_norm_path.exists():
-                    print(f"Loading saved normalization: {vec_norm_path}")
-                    env = VecNormalize.load(vec_norm_path, env)
-                    env.training = False
-                    env.norm_reward = False
-                elif "normalize_input" in agent_cfg:
-                    env = VecNormalize(
-                        env,
-                        training=True,
-                        norm_obs="normalize_input" in agent_cfg and agent_cfg.pop("normalize_input"),
-                        clip_obs="clip_obs" in agent_cfg and agent_cfg.pop("clip_obs"),
-                    )
+            if vec_norm_path.exists():
+                print(f"Loading saved normalization: {vec_norm_path}")
+                env = VecNormalize.load(vec_norm_path, env)
+                env.training = False
+                env.norm_reward = False
+            elif "normalize_input" in agent_cfg:
+                env = VecNormalize(
+                    env,
+                    training=True,
+                    norm_obs="normalize_input" in agent_cfg and agent_cfg.pop("normalize_input"),
+                    clip_obs="clip_obs" in agent_cfg and agent_cfg.pop("clip_obs"),
+                )
 
-                print(f"Loading checkpoint from: {checkpoint_path}")
-                agent = PPO.load(checkpoint_path, env, print_system_info=True)
-                # configure_seed must run after PPO.load so torch determinism does not disturb SB3's initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
+            print(f"Loading checkpoint from: {checkpoint_path}")
+            agent = PPO.load(checkpoint_path, env, print_system_info=True)
+            # configure_seed must run after PPO.load so torch determinism does not disturb SB3's initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
 
-                dt = env.unwrapped.step_dt
+            dt = env.unwrapped.step_dt
 
-                screen.close()
-                obs = env.reset()
-                timestep = 0
-                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
-                while True:
-                    start_time = time.time()
-                    with torch.inference_mode():
-                        actions, _ = agent.predict(obs, deterministic=True)
-                        obs, _, _, _ = env.step(actions)
-                    if args_cli.video:
-                        timestep += 1
-                        video_stop = args_cli.video_length
-                        if video_stop is None:
-                            recorders = getattr(env_cfg, "video_recorders", [])
-                            video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
-                        if video_stop is not None and timestep >= video_stop:
-                            break
+            screen.close()
+            obs = env.reset()
+            timestep = 0
+            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            while True:
+                start_time = time.time()
+                with torch.inference_mode():
+                    actions, _ = agent.predict(obs, deterministic=True)
+                    obs, _, _, _ = env.step(actions)
+                if args_cli.video:
+                    timestep += 1
+                    video_stop = args_cli.video_length
+                    if video_stop is None:
+                        recorders = getattr(env_cfg, "video_recorders", [])
+                        video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
+                    if video_stop is not None and timestep >= video_stop:
+                        break
 
-                    sleep_time = dt - (time.time() - start_time)
-                    if args_cli.real_time and sleep_time > 0:
-                        time.sleep(sleep_time)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+                sleep_time = dt - (time.time() - start_time)
+                if args_cli.real_time and sleep_time > 0:
+                    time.sleep(sleep_time)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -158,40 +158,43 @@ def main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
 
-            agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)
-
-            screen.stage("Loading policy")
-            env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
-
-            vec_norm_path = checkpoint_path.replace("/model", "/model_vecnormalize").replace(".zip", ".pkl")
-            vec_norm_path = Path(vec_norm_path)
-
-            if vec_norm_path.exists():
-                print(f"Loading saved normalization: {vec_norm_path}")
-                env = VecNormalize.load(vec_norm_path, env)
-                env.training = False
-                env.norm_reward = False
-            elif "normalize_input" in agent_cfg:
-                env = VecNormalize(
-                    env,
-                    training=True,
-                    norm_obs="normalize_input" in agent_cfg and agent_cfg.pop("normalize_input"),
-                    clip_obs="clip_obs" in agent_cfg and agent_cfg.pop("clip_obs"),
-                )
-
-            print(f"Loading checkpoint from: {checkpoint_path}")
-            agent = PPO.load(checkpoint_path, env, print_system_info=True)
-            # configure_seed must run after PPO.load so torch determinism does not disturb SB3's initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-
-            dt = env.unwrapped.step_dt
-
-            screen.close()
-            obs = env.reset()
-            timestep = 0
-            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            # Protect everything from here on: an interrupt during wrapper/checkpoint setup or
+            # during env.reset() bypasses env.close() just as easily as one during the play
+            # loop below, if it isn't inside this try/finally too.
             try:
+                agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)
+
+                screen.stage("Loading policy")
+                env = Sb3VecEnvWrapper(env, fast_variant=not args_cli.keep_all_info)
+
+                vec_norm_path = checkpoint_path.replace("/model", "/model_vecnormalize").replace(".zip", ".pkl")
+                vec_norm_path = Path(vec_norm_path)
+
+                if vec_norm_path.exists():
+                    print(f"Loading saved normalization: {vec_norm_path}")
+                    env = VecNormalize.load(vec_norm_path, env)
+                    env.training = False
+                    env.norm_reward = False
+                elif "normalize_input" in agent_cfg:
+                    env = VecNormalize(
+                        env,
+                        training=True,
+                        norm_obs="normalize_input" in agent_cfg and agent_cfg.pop("normalize_input"),
+                        clip_obs="clip_obs" in agent_cfg and agent_cfg.pop("clip_obs"),
+                    )
+
+                print(f"Loading checkpoint from: {checkpoint_path}")
+                agent = PPO.load(checkpoint_path, env, print_system_info=True)
+                # configure_seed must run after PPO.load so torch determinism does not disturb SB3's initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+
+                dt = env.unwrapped.step_dt
+
+                screen.close()
+                obs = env.reset()
+                timestep = 0
+                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
                 while True:
                     start_time = time.time()
                     with torch.inference_mode():

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -209,10 +209,10 @@ def main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -159,7 +159,7 @@ def main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_sb3.py
@@ -158,8 +158,7 @@ def main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt anywhere from
-            # here on (setup or the play loop) is handled the same way.
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             agent_cfg = process_sb3_cfg(agent_cfg, env.unwrapped.num_envs)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -37,6 +37,7 @@ from isaaclab_rl.entrypoints.common import (
     resolve_play_task_name,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
 )
 from isaaclab_rl.skrl import resolve_skrl_agent_cfg_entry_point, resolve_skrl_algorithm
 from isaaclab_rl.utils.pretrained_checkpoint import (
@@ -148,7 +149,7 @@ def _main():
     with startup_screen(args_cli, num_stages=3) as screen:
         show_run_summary(screen, args_cli, env_cfg, library="skrl", action="play")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             if args_cli.ml_framework.startswith("torch"):
                 from skrl.utils.runner.torch import Runner
             elif args_cli.ml_framework.startswith("jax"):
@@ -214,65 +215,58 @@ def _main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
+            # Register env.close() immediately once env exists, so an interrupt anywhere from
+            # here on (setup or the play loop) is handled the same way.
+            stack.callback(env.close)
 
-            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
-            # setup or during env.reset() bypasses env.close() just as easily as one during
-            # the play loop below, if it isn't inside this try/finally too.
             try:
-                try:
-                    dt = env.step_dt
-                except AttributeError:
-                    dt = env.unwrapped.step_dt
+                dt = env.step_dt
+            except AttributeError:
+                dt = env.unwrapped.step_dt
 
-                screen.stage("Loading policy")
-                env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
+            screen.stage("Loading policy")
+            env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
 
-                experiment_cfg["trainer"]["close_environment_at_exit"] = False
-                experiment_cfg["agent"]["experiment"]["write_interval"] = 0
-                experiment_cfg["agent"]["experiment"]["checkpoint_interval"] = 0
-                runner = Runner(env, experiment_cfg)
-                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
+            experiment_cfg["trainer"]["close_environment_at_exit"] = False
+            experiment_cfg["agent"]["experiment"]["write_interval"] = 0
+            experiment_cfg["agent"]["experiment"]["checkpoint_interval"] = 0
+            runner = Runner(env, experiment_cfg)
+            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
 
-                print(f"[INFO] Loading model checkpoint from: {resume_path}")
-                runner.agent.load(resume_path)
-                runner.agent.enable_training_mode(False, apply_to_models=True)
+            print(f"[INFO] Loading model checkpoint from: {resume_path}")
+            runner.agent.load(resume_path)
+            runner.agent.enable_training_mode(False, apply_to_models=True)
 
-                screen.close()
-                obs, _ = env.reset()
-                states = env.state()
-                timestep = 0
-                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
-                while True:
-                    start_time = time.time()
+            screen.close()
+            obs, _ = env.reset()
+            states = env.state()
+            timestep = 0
+            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
+            while True:
+                start_time = time.time()
 
-                    with torch.inference_mode():
-                        outputs = runner.agent.act(obs, states, timestep=0, timesteps=0)
-                        if hasattr(env, "possible_agents"):
-                            actions = {
-                                a: outputs[-1][a].get("mean_actions", outputs[0][a]) for a in env.possible_agents
-                            }
-                        else:
-                            actions = outputs[-1].get("mean_actions", outputs[0])
-                        obs, _, _, _, _ = env.step(actions)
-                        states = env.state()
-                    if args_cli.video:
-                        timestep += 1
-                        video_stop = args_cli.video_length
-                        if video_stop is None:
-                            recorders = getattr(env_cfg, "video_recorders", [])
-                            video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
-                        if video_stop is not None and timestep >= video_stop:
-                            break
+                with torch.inference_mode():
+                    outputs = runner.agent.act(obs, states, timestep=0, timesteps=0)
+                    if hasattr(env, "possible_agents"):
+                        actions = {a: outputs[-1][a].get("mean_actions", outputs[0][a]) for a in env.possible_agents}
+                    else:
+                        actions = outputs[-1].get("mean_actions", outputs[0])
+                    obs, _, _, _, _ = env.step(actions)
+                    states = env.state()
+                if args_cli.video:
+                    timestep += 1
+                    video_stop = args_cli.video_length
+                    if video_stop is None:
+                        recorders = getattr(env_cfg, "video_recorders", [])
+                        video_stop = recorders[0].video_length + recorders[0].step_offset if recorders else None
+                    if video_stop is not None and timestep >= video_stop:
+                        break
 
-                    sleep_time = dt - (time.time() - start_time)
-                    if args_cli.real_time and sleep_time > 0:
-                        time.sleep(sleep_time)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+                sleep_time = dt - (time.time() - start_time)
+                if args_cli.real_time and sleep_time > 0:
+                    time.sleep(sleep_time)
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -215,32 +215,35 @@ def _main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
 
+            # Protect everything from here on: an interrupt during wrapper/runner/checkpoint
+            # setup or during env.reset() bypasses env.close() just as easily as one during
+            # the play loop below, if it isn't inside this try/finally too.
             try:
-                dt = env.step_dt
-            except AttributeError:
-                dt = env.unwrapped.step_dt
+                try:
+                    dt = env.step_dt
+                except AttributeError:
+                    dt = env.unwrapped.step_dt
 
-            screen.stage("Loading policy")
-            env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
+                screen.stage("Loading policy")
+                env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
 
-            experiment_cfg["trainer"]["close_environment_at_exit"] = False
-            experiment_cfg["agent"]["experiment"]["write_interval"] = 0
-            experiment_cfg["agent"]["experiment"]["checkpoint_interval"] = 0
-            runner = Runner(env, experiment_cfg)
-            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
+                experiment_cfg["trainer"]["close_environment_at_exit"] = False
+                experiment_cfg["agent"]["experiment"]["write_interval"] = 0
+                experiment_cfg["agent"]["experiment"]["checkpoint_interval"] = 0
+                runner = Runner(env, experiment_cfg)
+                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
 
-            print(f"[INFO] Loading model checkpoint from: {resume_path}")
-            runner.agent.load(resume_path)
-            runner.agent.enable_training_mode(False, apply_to_models=True)
+                print(f"[INFO] Loading model checkpoint from: {resume_path}")
+                runner.agent.load(resume_path)
+                runner.agent.enable_training_mode(False, apply_to_models=True)
 
-            screen.close()
-            obs, _ = env.reset()
-            states = env.state()
-            timestep = 0
-            print("[INFO] Policy playback is running, press Ctrl+C to exit...")
-            try:
+                screen.close()
+                obs, _ = env.reset()
+                states = env.state()
+                timestep = 0
+                print("[INFO] Policy playback is running, press Ctrl+C to exit...")
                 while True:
                     start_time = time.time()
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -215,8 +215,7 @@ def _main():
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
-            # Register env.close() immediately once env exists, so an interrupt anywhere from
-            # here on (setup or the play loop) is handled the same way.
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             try:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -216,7 +216,7 @@ def _main():
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             try:
                 dt = env.step_dt

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/play_skrl.py
@@ -266,10 +266,10 @@ def _main():
                     sleep_time = dt - (time.time() - start_time)
                     if args_cli.real_time and sleep_time > 0:
                         time.sleep(sleep_time)
-
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()
 
 
 if __name__ == "__main__":

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -184,59 +184,62 @@ def run(argv: list[str]) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            env = wrap_training_capture(env, run_log_dir, args_cli)
-
-            screen.stage("Preparing agent")
-            start_time = time.time()
-            report_activity("Wrapping environment")
-            env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
-            report_activity(None)
-
-            vecenv.register(
-                "IsaacRlgWrapper",
-                lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
-            )
-            env_configurations.register(
-                "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
-            )
-
-            agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
-
-            report_activity("Building policy")
-            if "pbt" in agent_cfg and agent_cfg["pbt"]["enabled"]:
-                observers = MultiObserver([IsaacAlgoObserver(), PbtAlgoObserver(agent_cfg, args_cli)])
-                runner = Runner(observers)
-            else:
-                runner = Runner(IsaacAlgoObserver())
-            report_activity(None)
-
-            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-
-            runner.load(agent_cfg)
-            runner.reset()
-
-            global_rank = int(os.getenv("RANK", "0"))
-            if args_cli.track and global_rank == 0:
-                if args_cli.wandb_entity is None:
-                    raise ValueError("Weights and Biases entity must be specified for tracking.")
-                import wandb
-
-                wandb.init(
-                    project=wandb_project,
-                    entity=args_cli.wandb_entity,
-                    name=experiment_name,
-                    sync_tensorboard=True,
-                    monitor_gym=True,
-                    save_code=True,
-                )
-                if not wandb.run.resumed:
-                    wandb.config.update({"env_cfg": env_cfg.to_dict()})
-                    wandb.config.update({"agent_cfg": agent_cfg})
-
-            screen.close()
+            # Protect everything from here on: an interrupt during wrapper/runner setup or
+            # training bypasses env.close() just as easily as one during runner.run() below,
+            # if it isn't inside this try/finally too.
             try:
+                env = wrap_training_capture(env, run_log_dir, args_cli)
+
+                screen.stage("Preparing agent")
+                start_time = time.time()
+                report_activity("Wrapping environment")
+                env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
+                report_activity(None)
+
+                vecenv.register(
+                    "IsaacRlgWrapper",
+                    lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
+                )
+                env_configurations.register(
+                    "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
+                )
+
+                agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
+
+                report_activity("Building policy")
+                if "pbt" in agent_cfg and agent_cfg["pbt"]["enabled"]:
+                    observers = MultiObserver([IsaacAlgoObserver(), PbtAlgoObserver(agent_cfg, args_cli)])
+                    runner = Runner(observers)
+                else:
+                    runner = Runner(IsaacAlgoObserver())
+                report_activity(None)
+
+                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+
+                runner.load(agent_cfg)
+                runner.reset()
+
+                global_rank = int(os.getenv("RANK", "0"))
+                if args_cli.track and global_rank == 0:
+                    if args_cli.wandb_entity is None:
+                        raise ValueError("Weights and Biases entity must be specified for tracking.")
+                    import wandb
+
+                    wandb.init(
+                        project=wandb_project,
+                        entity=args_cli.wandb_entity,
+                        name=experiment_name,
+                        sync_tensorboard=True,
+                        monitor_gym=True,
+                        save_code=True,
+                    )
+                    if not wandb.run.resumed:
+                        wandb.config.update({"env_cfg": env_cfg.to_dict()})
+                        wandb.config.update({"agent_cfg": agent_cfg})
+
+                screen.close()
                 if args_cli.checkpoint is not None:
                     runner.run({"train": True, "play": False, "sigma": train_sigma, "checkpoint": resume_path})
                 else:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -242,6 +242,7 @@ def run(argv: list[str]) -> None:
                 else:
                     runner.run({"train": True, "play": False, "sigma": train_sigma})
                 print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -34,6 +34,7 @@ from isaaclab_rl.entrypoints.common import (
     set_hydra_args,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
     validate_distributed_device,
     wrap_training_capture,
     write_run_manifest,
@@ -99,7 +100,7 @@ def run(argv: list[str]) -> None:
         pre_launch_video_config(env_cfg, args_cli=args_cli)
         show_run_summary(screen, args_cli, env_cfg, library="rl_games", action="train")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             apply_env_overrides(args_cli, env_cfg)
             validate_distributed_device(args_cli)
 
@@ -184,68 +185,64 @@ def run(argv: list[str]) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Protect everything from here on: an interrupt during wrapper/runner setup or
-            # training bypasses env.close() just as easily as one during runner.run() below,
-            # if it isn't inside this try/finally too.
-            try:
-                env = wrap_training_capture(env, run_log_dir, args_cli)
+            # Register env.close() immediately once env exists, so an interrupt during
+            # wrapper/runner setup below is handled the same way as one during runner.run().
+            stack.callback(env.close)
 
-                screen.stage("Preparing agent")
-                start_time = time.time()
-                report_activity("Wrapping environment")
-                env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
-                report_activity(None)
+            env = wrap_training_capture(env, run_log_dir, args_cli)
 
-                vecenv.register(
-                    "IsaacRlgWrapper",
-                    lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
+            screen.stage("Preparing agent")
+            start_time = time.time()
+            report_activity("Wrapping environment")
+            env = RlGamesVecEnvWrapper(env, rl_device, clip_obs, clip_actions, obs_groups, concate_obs_groups)
+            report_activity(None)
+
+            vecenv.register(
+                "IsaacRlgWrapper",
+                lambda config_name, num_actors, **kwargs: RlGamesGpuEnv(config_name, num_actors, **kwargs),
+            )
+            env_configurations.register(
+                "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
+            )
+
+            agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
+
+            report_activity("Building policy")
+            if "pbt" in agent_cfg and agent_cfg["pbt"]["enabled"]:
+                observers = MultiObserver([IsaacAlgoObserver(), PbtAlgoObserver(agent_cfg, args_cli)])
+                runner = Runner(observers)
+            else:
+                runner = Runner(IsaacAlgoObserver())
+            report_activity(None)
+
+            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
+
+            runner.load(agent_cfg)
+            runner.reset()
+
+            global_rank = int(os.getenv("RANK", "0"))
+            if args_cli.track and global_rank == 0:
+                if args_cli.wandb_entity is None:
+                    raise ValueError("Weights and Biases entity must be specified for tracking.")
+                import wandb
+
+                wandb.init(
+                    project=wandb_project,
+                    entity=args_cli.wandb_entity,
+                    name=experiment_name,
+                    sync_tensorboard=True,
+                    monitor_gym=True,
+                    save_code=True,
                 )
-                env_configurations.register(
-                    "rlgpu", {"vecenv_type": "IsaacRlgWrapper", "env_creator": lambda **kwargs: env}
-                )
+                if not wandb.run.resumed:
+                    wandb.config.update({"env_cfg": env_cfg.to_dict()})
+                    wandb.config.update({"agent_cfg": agent_cfg})
 
-                agent_cfg["params"]["config"]["num_actors"] = env.unwrapped.num_envs
-
-                report_activity("Building policy")
-                if "pbt" in agent_cfg and agent_cfg["pbt"]["enabled"]:
-                    observers = MultiObserver([IsaacAlgoObserver(), PbtAlgoObserver(agent_cfg, args_cli)])
-                    runner = Runner(observers)
-                else:
-                    runner = Runner(IsaacAlgoObserver())
-                report_activity(None)
-
-                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
-
-                runner.load(agent_cfg)
-                runner.reset()
-
-                global_rank = int(os.getenv("RANK", "0"))
-                if args_cli.track and global_rank == 0:
-                    if args_cli.wandb_entity is None:
-                        raise ValueError("Weights and Biases entity must be specified for tracking.")
-                    import wandb
-
-                    wandb.init(
-                        project=wandb_project,
-                        entity=args_cli.wandb_entity,
-                        name=experiment_name,
-                        sync_tensorboard=True,
-                        monitor_gym=True,
-                        save_code=True,
-                    )
-                    if not wandb.run.resumed:
-                        wandb.config.update({"env_cfg": env_cfg.to_dict()})
-                        wandb.config.update({"agent_cfg": agent_cfg})
-
-                screen.close()
-                if args_cli.checkpoint is not None:
-                    runner.run({"train": True, "play": False, "sigma": train_sigma, "checkpoint": resume_path})
-                else:
-                    runner.run({"train": True, "play": False, "sigma": train_sigma})
-                print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+            screen.close()
+            if args_cli.checkpoint is not None:
+                runner.run({"train": True, "play": False, "sigma": train_sigma, "checkpoint": resume_path})
+            else:
+                runner.run({"train": True, "play": False, "sigma": train_sigma})
+            print(f"Training time: {round(time.time() - start_time, 2)} seconds")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -185,8 +185,7 @@ def run(argv: list[str]) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt during
-            # wrapper/runner setup below is handled the same way as one during runner.run().
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             env = wrap_training_capture(env, run_log_dir, args_cli)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rl_games.py
@@ -186,7 +186,7 @@ def run(argv: list[str]) -> None:
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             env = wrap_training_capture(env, run_log_dir, args_cli)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -238,6 +238,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                     init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
                 )
                 print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -183,56 +183,59 @@ def _run(args_cli: argparse.Namespace) -> None:
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
 
-            if args_cli.checkpoint in CHECKPOINT_SELECTORS:
-                resume_path = resolve_checkpoint_selector(
-                    log_root_path,
-                    args_cli.checkpoint,
-                    library="rsl_rl",
-                    task=args_cli.task,
-                    checkpoint_pattern=r"model_.*\.pt",
-                    metadata={"agent": args_cli.agent},
-                )
-            elif args_cli.checkpoint and os.path.isdir(args_cli.checkpoint):
-                resume_path = get_checkpoint_path(
-                    os.path.dirname(args_cli.checkpoint),
-                    os.path.basename(args_cli.checkpoint),
-                    agent_cfg.load_checkpoint,
-                )
-            elif args_cli.checkpoint:
-                resume_path = retrieve_file_path(args_cli.checkpoint)
-            elif agent_cfg.algorithm.class_name == "Distillation":
-                raise ValueError("Distillation training requires --checkpoint.")
-
-            env = wrap_training_capture(env, log_dir, args_cli)
-
-            screen.stage("Preparing agent")
-            start_time = time.time()
-            report_activity("Wrapping environment")
-            env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
-            report_activity(None)
-
-            report_activity("Building policy")
-            if agent_cfg.class_name == "OnPolicyRunner":
-                runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
-            elif agent_cfg.class_name == "DistillationRunner":
-                runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
-            else:
-                raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
-            report_activity(None)
-
-            # configure_seed must run after runner construction so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-
-            runner.add_git_repo_to_log(__file__)
-            if args_cli.checkpoint:
-                print(f"[INFO]: Loading model checkpoint from: {resume_path}")
-                runner.load(resume_path)
-
-            dump_train_configs(log_dir, env_cfg, agent_cfg)
-
-            screen.close()
+            # Protect everything from here on: an interrupt during checkpoint resolution,
+            # wrapper/runner setup, or training bypasses env.close() just as easily as one
+            # during runner.learn() below, if it isn't inside this try/finally too.
             try:
+                if args_cli.checkpoint in CHECKPOINT_SELECTORS:
+                    resume_path = resolve_checkpoint_selector(
+                        log_root_path,
+                        args_cli.checkpoint,
+                        library="rsl_rl",
+                        task=args_cli.task,
+                        checkpoint_pattern=r"model_.*\.pt",
+                        metadata={"agent": args_cli.agent},
+                    )
+                elif args_cli.checkpoint and os.path.isdir(args_cli.checkpoint):
+                    resume_path = get_checkpoint_path(
+                        os.path.dirname(args_cli.checkpoint),
+                        os.path.basename(args_cli.checkpoint),
+                        agent_cfg.load_checkpoint,
+                    )
+                elif args_cli.checkpoint:
+                    resume_path = retrieve_file_path(args_cli.checkpoint)
+                elif agent_cfg.algorithm.class_name == "Distillation":
+                    raise ValueError("Distillation training requires --checkpoint.")
+
+                env = wrap_training_capture(env, log_dir, args_cli)
+
+                screen.stage("Preparing agent")
+                start_time = time.time()
+                report_activity("Wrapping environment")
+                env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+                report_activity(None)
+
+                report_activity("Building policy")
+                if agent_cfg.class_name == "OnPolicyRunner":
+                    runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+                elif agent_cfg.class_name == "DistillationRunner":
+                    runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+                else:
+                    raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+                report_activity(None)
+
+                # configure_seed must run after runner construction so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+
+                runner.add_git_repo_to_log(__file__)
+                if args_cli.checkpoint:
+                    print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+                    runner.load(resume_path)
+
+                dump_train_configs(log_dir, env_cfg, agent_cfg)
+
+                screen.close()
                 runner.learn(
                     num_learning_iterations=agent_cfg.max_iterations,
                     init_at_random_ep_len=agent_cfg.init_at_random_ep_len,

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -36,6 +36,7 @@ from isaaclab_rl.entrypoints.common import (
     set_hydra_args,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
     validate_distributed_device,
     wrap_training_capture,
     write_run_manifest,
@@ -137,7 +138,7 @@ def _run(args_cli: argparse.Namespace) -> None:
         pre_launch_video_config(env_cfg, args_cli=args_cli)
         show_run_summary(screen, args_cli, env_cfg, library="rsl_rl", action="train")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             agent_cfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
             apply_env_overrides(args_cli, env_cfg)
             agent_cfg.max_iterations = (
@@ -182,67 +183,62 @@ def _run(args_cli: argparse.Namespace) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
+            # Register env.close() immediately once env exists, so an interrupt during
+            # checkpoint resolution or wrapper/runner setup below is handled the same way as
+            # one during runner.learn().
+            stack.callback(env.close)
 
-            # Protect everything from here on: an interrupt during checkpoint resolution,
-            # wrapper/runner setup, or training bypasses env.close() just as easily as one
-            # during runner.learn() below, if it isn't inside this try/finally too.
-            try:
-                if args_cli.checkpoint in CHECKPOINT_SELECTORS:
-                    resume_path = resolve_checkpoint_selector(
-                        log_root_path,
-                        args_cli.checkpoint,
-                        library="rsl_rl",
-                        task=args_cli.task,
-                        checkpoint_pattern=r"model_.*\.pt",
-                        metadata={"agent": args_cli.agent},
-                    )
-                elif args_cli.checkpoint and os.path.isdir(args_cli.checkpoint):
-                    resume_path = get_checkpoint_path(
-                        os.path.dirname(args_cli.checkpoint),
-                        os.path.basename(args_cli.checkpoint),
-                        agent_cfg.load_checkpoint,
-                    )
-                elif args_cli.checkpoint:
-                    resume_path = retrieve_file_path(args_cli.checkpoint)
-                elif agent_cfg.algorithm.class_name == "Distillation":
-                    raise ValueError("Distillation training requires --checkpoint.")
-
-                env = wrap_training_capture(env, log_dir, args_cli)
-
-                screen.stage("Preparing agent")
-                start_time = time.time()
-                report_activity("Wrapping environment")
-                env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
-                report_activity(None)
-
-                report_activity("Building policy")
-                if agent_cfg.class_name == "OnPolicyRunner":
-                    runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
-                elif agent_cfg.class_name == "DistillationRunner":
-                    runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
-                else:
-                    raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
-                report_activity(None)
-
-                # configure_seed must run after runner construction so torch determinism does not disturb
-                # its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
-
-                runner.add_git_repo_to_log(__file__)
-                if args_cli.checkpoint:
-                    print(f"[INFO]: Loading model checkpoint from: {resume_path}")
-                    runner.load(resume_path)
-
-                dump_train_configs(log_dir, env_cfg, agent_cfg)
-
-                screen.close()
-                runner.learn(
-                    num_learning_iterations=agent_cfg.max_iterations,
-                    init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
+            if args_cli.checkpoint in CHECKPOINT_SELECTORS:
+                resume_path = resolve_checkpoint_selector(
+                    log_root_path,
+                    args_cli.checkpoint,
+                    library="rsl_rl",
+                    task=args_cli.task,
+                    checkpoint_pattern=r"model_.*\.pt",
+                    metadata={"agent": args_cli.agent},
                 )
-                print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+            elif args_cli.checkpoint and os.path.isdir(args_cli.checkpoint):
+                resume_path = get_checkpoint_path(
+                    os.path.dirname(args_cli.checkpoint),
+                    os.path.basename(args_cli.checkpoint),
+                    agent_cfg.load_checkpoint,
+                )
+            elif args_cli.checkpoint:
+                resume_path = retrieve_file_path(args_cli.checkpoint)
+            elif agent_cfg.algorithm.class_name == "Distillation":
+                raise ValueError("Distillation training requires --checkpoint.")
+
+            env = wrap_training_capture(env, log_dir, args_cli)
+
+            screen.stage("Preparing agent")
+            start_time = time.time()
+            report_activity("Wrapping environment")
+            env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+            report_activity(None)
+
+            report_activity("Building policy")
+            if agent_cfg.class_name == "OnPolicyRunner":
+                runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+            elif agent_cfg.class_name == "DistillationRunner":
+                runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+            else:
+                raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+            report_activity(None)
+
+            # configure_seed must run after runner construction so torch determinism does not disturb its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
+
+            runner.add_git_repo_to_log(__file__)
+            if args_cli.checkpoint:
+                print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+                runner.load(resume_path)
+
+            dump_train_configs(log_dir, env_cfg, agent_cfg)
+
+            screen.close()
+            runner.learn(
+                num_learning_iterations=agent_cfg.max_iterations,
+                init_at_random_ep_len=agent_cfg.init_at_random_ep_len,
+            )
+            print(f"Training time: {round(time.time() - start_time, 2)} seconds")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -184,7 +184,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             if args_cli.checkpoint in CHECKPOINT_SELECTORS:
                 resume_path = resolve_checkpoint_selector(

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -224,7 +224,8 @@ def _run(args_cli: argparse.Namespace) -> None:
                     raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
                 report_activity(None)
 
-                # configure_seed must run after runner construction so torch determinism does not disturb its initialization
+                # configure_seed must run after runner construction so torch determinism does not disturb
+                # its initialization
                 if args_cli.deterministic:
                     configure_seed(env_cfg.seed, torch_deterministic=True)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_rsl_rl.py
@@ -183,9 +183,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt during
-            # checkpoint resolution or wrapper/runner setup below is handled the same way as
-            # one during runner.learn().
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             if args_cli.checkpoint in CHECKPOINT_SELECTORS:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
@@ -34,6 +34,7 @@ from isaaclab_rl.entrypoints.common import (
     set_hydra_args,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
     wrap_training_capture,
     write_run_manifest,
 )
@@ -107,7 +108,10 @@ def run(argv: list[str]) -> None:
         pre_launch_video_config(env_cfg, args_cli=args_cli)
         show_run_summary(screen, args_cli, env_cfg, library="sb3", action="train")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        # _cleanup_pbar (installed above) raises KeyboardInterrupt on Ctrl+C after cleaning up
+        # tqdm progress bars; suppressed_shutdown_guard() swallows it once it escapes this block,
+        # after it has already run env.close().
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             if args_cli.seed == -1:
                 args_cli.seed = random.randint(0, 10000)
 
@@ -149,6 +153,9 @@ def run(argv: list[str]) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
+            # Register env.close() immediately once env exists, so an interrupt during
+            # wrapper/agent setup below is handled the same way as one during agent.learn().
+            stack.callback(env.close)
             env = wrap_training_capture(env, log_dir, args_cli)
 
             screen.stage("Preparing agent")
@@ -218,4 +225,3 @@ def run(argv: list[str]) -> None:
                 env.save(os.path.join(log_dir, "model_vecnormalize.pkl"))
 
             print(f"Training time: {round(time.time() - start_time, 2)} seconds")
-            env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
@@ -153,8 +153,7 @@ def run(argv: list[str]) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
-            # Register env.close() immediately once env exists, so an interrupt during
-            # wrapper/agent setup below is handled the same way as one during agent.learn().
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
             env = wrap_training_capture(env, log_dir, args_cli)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_sb3.py
@@ -154,7 +154,7 @@ def run(argv: list[str]) -> None:
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg),
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
             env = wrap_training_capture(env, log_dir, args_cli)
 
             screen.stage("Preparing agent")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -204,7 +204,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
             # Guarantee env.close() runs; see suppressed_shutdown_guard().
-            stack.callback(env.close)
+            stack.callback(lambda: env.close())
 
             env = wrap_training_capture(env, log_dir, args_cli)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -203,8 +203,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
-            # Register env.close() immediately once env exists, so an interrupt during
-            # wrapper/runner setup below is handled the same way as one during runner.run().
+            # Guarantee env.close() runs; see suppressed_shutdown_guard().
             stack.callback(env.close)
 
             env = wrap_training_capture(env, log_dir, args_cli)

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -34,6 +34,7 @@ from isaaclab_rl.entrypoints.common import (
     set_hydra_args,
     show_run_summary,
     startup_screen,
+    suppressed_shutdown_guard,
     validate_distributed_device,
     wrap_training_capture,
     write_run_manifest,
@@ -128,7 +129,7 @@ def _run(args_cli: argparse.Namespace) -> None:
         pre_launch_video_config(env_cfg, args_cli=args_cli)
         show_run_summary(screen, args_cli, env_cfg, library="skrl", action="train")
         screen.stage("Launching simulation")
-        with launch_simulation(env_cfg, args_cli):
+        with launch_simulation(env_cfg, args_cli), suppressed_shutdown_guard() as stack:
             if args_cli.ml_framework.startswith("torch"):
                 from skrl.utils.runner.torch import Runner
             elif args_cli.ml_framework.startswith("jax"):
@@ -202,38 +203,34 @@ def _run(args_cli: argparse.Namespace) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
-            # Protect everything from here on: an interrupt during wrapper/runner setup or
-            # training bypasses env.close() just as easily as one during runner.run() below,
-            # if it isn't inside this try/finally too.
-            try:
-                env = wrap_training_capture(env, log_dir, args_cli)
+            # Register env.close() immediately once env exists, so an interrupt during
+            # wrapper/runner setup below is handled the same way as one during runner.run().
+            stack.callback(env.close)
 
-                screen.stage("Preparing agent")
-                start_time = time.time()
-                report_activity("Wrapping environment")
-                env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
-                report_activity(None)
-                report_activity("Building policy")
-                runner = Runner(env, agent_cfg)
-                report_activity(None)
+            env = wrap_training_capture(env, log_dir, args_cli)
 
-                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-                if args_cli.deterministic:
-                    configure_seed(env_cfg.seed, torch_deterministic=True)
+            screen.stage("Preparing agent")
+            start_time = time.time()
+            report_activity("Wrapping environment")
+            env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
+            report_activity(None)
+            report_activity("Building policy")
+            runner = Runner(env, agent_cfg)
+            report_activity(None)
 
-                if resume_path:
-                    print(f"[INFO] Loading model checkpoint from: {resume_path}")
-                    runner.agent.load(resume_path)
+            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+            if args_cli.deterministic:
+                configure_seed(env_cfg.seed, torch_deterministic=True)
 
-                screen.close()
-                runner.run()
-                print(f"Training time: {round(time.time() - start_time, 2)} seconds")
+            if resume_path:
+                print(f"[INFO] Loading model checkpoint from: {resume_path}")
+                runner.agent.load(resume_path)
 
-                total_timesteps = agent_cfg["trainer"]["timesteps"]
-                os.makedirs(os.path.join(log_dir, "checkpoints"), exist_ok=True)
-                runner.agent.write_checkpoint(timestep=total_timesteps, timesteps=total_timesteps)
-                print(f"[INFO] Saved final agent checkpoint to: {log_dir}/checkpoints")
-            except KeyboardInterrupt:
-                pass
-            finally:
-                env.close()
+            screen.close()
+            runner.run()
+            print(f"Training time: {round(time.time() - start_time, 2)} seconds")
+
+            total_timesteps = agent_cfg["trainer"]["timesteps"]
+            os.makedirs(os.path.join(log_dir, "checkpoints"), exist_ok=True)
+            runner.agent.write_checkpoint(timestep=total_timesteps, timesteps=total_timesteps)
+            print(f"[INFO] Saved final agent checkpoint to: {log_dir}/checkpoints")

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -230,6 +230,7 @@ def _run(args_cli: argparse.Namespace) -> None:
                 os.makedirs(os.path.join(log_dir, "checkpoints"), exist_ok=True)
                 runner.agent.write_checkpoint(timestep=total_timesteps, timesteps=total_timesteps)
                 print(f"[INFO] Saved final agent checkpoint to: {log_dir}/checkpoints")
-                env.close()
             except KeyboardInterrupt:
                 pass
+            finally:
+                env.close()

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/train_skrl.py
@@ -202,27 +202,30 @@ def _run(args_cli: argparse.Namespace) -> None:
                 args_cli,
                 convert_marl_to_single_agent=isinstance(env_cfg, DirectMARLEnvCfg) and algorithm in ["ppo"],
             )
-            env = wrap_training_capture(env, log_dir, args_cli)
-
-            screen.stage("Preparing agent")
-            start_time = time.time()
-            report_activity("Wrapping environment")
-            env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
-            report_activity(None)
-            report_activity("Building policy")
-            runner = Runner(env, agent_cfg)
-            report_activity(None)
-
-            # configure_seed must run after Runner() so torch determinism does not disturb its initialization
-            if args_cli.deterministic:
-                configure_seed(env_cfg.seed, torch_deterministic=True)
-
-            if resume_path:
-                print(f"[INFO] Loading model checkpoint from: {resume_path}")
-                runner.agent.load(resume_path)
-
-            screen.close()
+            # Protect everything from here on: an interrupt during wrapper/runner setup or
+            # training bypasses env.close() just as easily as one during runner.run() below,
+            # if it isn't inside this try/finally too.
             try:
+                env = wrap_training_capture(env, log_dir, args_cli)
+
+                screen.stage("Preparing agent")
+                start_time = time.time()
+                report_activity("Wrapping environment")
+                env = SkrlVecEnvWrapper(env, ml_framework=args_cli.ml_framework)
+                report_activity(None)
+                report_activity("Building policy")
+                runner = Runner(env, agent_cfg)
+                report_activity(None)
+
+                # configure_seed must run after Runner() so torch determinism does not disturb its initialization
+                if args_cli.deterministic:
+                    configure_seed(env_cfg.seed, torch_deterministic=True)
+
+                if resume_path:
+                    print(f"[INFO] Loading model checkpoint from: {resume_path}")
+                    runner.agent.load(resume_path)
+
+                screen.close()
                 runner.run()
                 print(f"Training time: {round(time.time() - start_time, 2)} seconds")
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -49,16 +49,13 @@ _MISSING = object()
 def flag_only_sigint() -> Iterator[Callable[[], bool]]:
     """Swap SIGINT for a handler that only flips a flag, checked at a controlled point.
 
-    A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active (e.g.
-    ``--visualizer newton,kit``), it can just as easily land inside one of Kit's own internal
-    callback dispatches (its viewport/render event loop), or inside ``env.close()``'s own
-    multi-stage teardown, as inside a script's own step loop -- anywhere nothing here can catch
-    it without aborting cleanup partway through. Yields a callable reporting whether SIGINT fired
-    since entry, for callers with their own step loop to check explicitly.
+    A raw SIGINT can be delivered anywhere -- e.g. inside one of Kit's own render callbacks --
+    where an ordinary ``try/except`` can't catch it. Yields a callable reporting whether SIGINT
+    fired, for a caller's own step loop to check.
 
-    Not suitable for scripts that block inside a third-party call (e.g. an RL library's own
-    training loop) they need Ctrl+C to interrupt: this handler never raises, so it cannot stop
-    that call. Use :func:`contextlib.suppress` (``KeyboardInterrupt``) around those instead.
+    Only use this around code the caller fully owns. It never raises, so it must not wrap a
+    blocking third-party call (e.g. an RL library's training loop) that needs a raw
+    ``KeyboardInterrupt`` to stop -- use :func:`suppressed_shutdown_guard` there instead.
     """
     interrupted = False
 
@@ -77,14 +74,11 @@ def flag_only_sigint() -> Iterator[Callable[[], bool]]:
 def suppressed_shutdown_guard() -> Iterator[ExitStack]:
     """Guarantee registered cleanup runs, then silently swallow ``KeyboardInterrupt``.
 
-    Yields an :class:`~contextlib.ExitStack`: register ``env.close`` on it (via
-    ``stack.callback(env.close)``) immediately once ``env`` exists, so a ``KeyboardInterrupt``
-    raised anywhere afterward -- during setup, a script's own step loop, or a third-party call
-    (e.g. an RL library's own training loop) that needs a raw interrupt to stop it -- still runs
-    cleanup before this context silently swallows the exception, instead of bypassing cleanup or
-    letting a traceback escape to the terminal. Ordering matters: ``ExitStack`` must be nested
-    inside ``suppress`` so cleanup runs while the exception is still live, before it is
-    discarded.
+    Yields an :class:`~contextlib.ExitStack`; register ``env.close`` on it
+    (``stack.callback(env.close)``) right after ``env`` exists. A ``KeyboardInterrupt`` raised
+    anywhere after that -- including inside a blocking third-party call, like an RL library's
+    training loop, that needs a raw interrupt to stop -- still runs cleanup before being
+    swallowed here.
     """
     with suppress(KeyboardInterrupt), ExitStack() as stack:
         yield stack

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -14,10 +14,11 @@ import logging
 import os
 import re
 import runpy
+import signal
 import sys
 import warnings
 from collections.abc import Callable, Iterator
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
@@ -42,6 +43,51 @@ RUN_MANIFEST_VERSION = 1
 CHECKPOINT_SELECTORS = frozenset({"latest", "best"})
 logger = logging.getLogger(__name__)
 _MISSING = object()
+
+
+@contextmanager
+def flag_only_sigint() -> Iterator[Callable[[], bool]]:
+    """Swap SIGINT for a handler that only flips a flag, checked at a controlled point.
+
+    A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active (e.g.
+    ``--visualizer newton,kit``), it can just as easily land inside one of Kit's own internal
+    callback dispatches (its viewport/render event loop), or inside ``env.close()``'s own
+    multi-stage teardown, as inside a script's own step loop -- anywhere nothing here can catch
+    it without aborting cleanup partway through. Yields a callable reporting whether SIGINT fired
+    since entry, for callers with their own step loop to check explicitly.
+
+    Not suitable for scripts that block inside a third-party call (e.g. an RL library's own
+    training loop) they need Ctrl+C to interrupt: this handler never raises, so it cannot stop
+    that call. Use :func:`contextlib.suppress` (``KeyboardInterrupt``) around those instead.
+    """
+    interrupted = False
+
+    def _on_sigint(signum, frame):
+        nonlocal interrupted
+        interrupted = True
+
+    previous_handler = signal.signal(signal.SIGINT, _on_sigint)
+    try:
+        yield lambda: interrupted
+    finally:
+        signal.signal(signal.SIGINT, previous_handler)
+
+
+@contextmanager
+def suppressed_shutdown_guard() -> Iterator[ExitStack]:
+    """Guarantee registered cleanup runs, then silently swallow ``KeyboardInterrupt``.
+
+    Yields an :class:`~contextlib.ExitStack`: register ``env.close`` on it (via
+    ``stack.callback(env.close)``) immediately once ``env`` exists, so a ``KeyboardInterrupt``
+    raised anywhere afterward -- during setup, a script's own step loop, or a third-party call
+    (e.g. an RL library's own training loop) that needs a raw interrupt to stop it -- still runs
+    cleanup before this context silently swallows the exception, instead of bypassing cleanup or
+    letting a traceback escape to the terminal. Ordering matters: ``ExitStack`` must be nested
+    inside ``suppress`` so cleanup runs while the exception is still live, before it is
+    discarded.
+    """
+    with suppress(KeyboardInterrupt), ExitStack() as stack:
+        yield stack
 
 
 @contextmanager

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/common.py
@@ -74,11 +74,15 @@ def flag_only_sigint() -> Iterator[Callable[[], bool]]:
 def suppressed_shutdown_guard() -> Iterator[ExitStack]:
     """Guarantee registered cleanup runs, then silently swallow ``KeyboardInterrupt``.
 
-    Yields an :class:`~contextlib.ExitStack`; register ``env.close`` on it
-    (``stack.callback(env.close)``) right after ``env`` exists. A ``KeyboardInterrupt`` raised
-    anywhere after that -- including inside a blocking third-party call, like an RL library's
-    training loop, that needs a raw interrupt to stop -- still runs cleanup before being
-    swallowed here.
+    Yields an :class:`~contextlib.ExitStack`; register cleanup on it
+    (``stack.callback(lambda: env.close())``) right after ``env`` exists. A ``KeyboardInterrupt``
+    raised anywhere after that -- including inside a blocking third-party call, like an RL
+    library's training loop, that needs a raw interrupt to stop -- still runs cleanup before
+    being swallowed here.
+
+    Use ``lambda: env.close()``, not ``env.close``: the latter binds the current ``env`` object
+    immediately, so if ``env`` is later reassigned to a wrapper (as every entrypoint here does),
+    the callback would still close the original, unwrapped object instead of the final one.
     """
     with suppress(KeyboardInterrupt), ExitStack() as stack:
         yield stack

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import signal
 import sys
 from collections.abc import Callable
 from typing import Any, Literal
@@ -24,6 +23,8 @@ import torch
 from isaaclab.app import add_launcher_args, launch_simulation
 from isaaclab.envs.utils.spaces import sample_space
 from isaaclab.utils import math as math_utils
+
+from isaaclab_rl.entrypoints.common import flag_only_sigint
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import (
@@ -79,69 +80,45 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
     except (TypeError, ValueError) as exc:
         raise SystemExit(f"Invalid environment configuration: {exc}") from None
 
-    with launch_simulation(env_cfg, args_cli):
+    with launch_simulation(env_cfg, args_cli), contextlib.ExitStack() as stack:
         # create environment
         env = gym.make(args_cli.task, cfg=env_cfg)
+        # Install the flag-only handler, and register env.close() to run under it, immediately
+        # once env exists -- so an interrupt anywhere from here on (setup, the step loop, or
+        # env.close() itself) is handled the same way instead of only the step loop.
+        is_interrupted = stack.enter_context(flag_only_sigint())
+        stack.callback(env.close)
 
-        # A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active
-        # (e.g. --visualizer newton,kit), Python can just as easily raise KeyboardInterrupt from
-        # inside env.reset(), policy construction, one of Kit's own internal callback dispatches
-        # (its viewport/render event loop), or the step loop below -- anywhere after the
-        # environment exists -- as from the step loop itself, where nothing here can catch it.
-        # Installing a handler that only flips a flag is safe no matter which frame it fires in,
-        # and lets this function -- the one place that knows how to shut the simulation down
-        # cleanly -- check it at a controlled point instead of hoping the exception lands
-        # somewhere useful. Install it immediately once ``env`` exists, so an interrupt during
-        # setup can't bypass env.close() any more easily than one during the step loop.
-        interrupted = False
-
-        def _on_sigint(signum, frame):
-            nonlocal interrupted
-            interrupted = True
-
-        previous_handler = signal.signal(signal.SIGINT, _on_sigint)
-        try:
-            # print info (this is vectorized environment)
-            print(f"[INFO]: Gym observation space: {env.observation_space}")
-            print(f"[INFO]: Gym action space: {env.action_space}")
-            # reset environment
-            env.reset()
-            zero_action_policy = _create_zero_action_policy(env) if policy == "zero" else None
-            if policy == "zero":
-                print("[INFO] Zero agent is running, press Ctrl+C to exit...")
-            else:
-                print("[INFO] Random agent is running, press Ctrl+C to exit...")
-            # simulate environment
-            # keep running while any visualizer is open, and until the step budget is exhausted
-            sim = env.unwrapped.sim
-            device = env.unwrapped.device
-            step = 0
-            while sim.is_headless_or_exist_active_visualizer():
-                if interrupted:
-                    break
-                if args_cli.max_steps is not None and step >= args_cli.max_steps:
-                    break
-                step += 1
-                # run everything in inference mode
-                with torch.inference_mode():
-                    if policy == "zero":
-                        actions = zero_action_policy()
-                    else:
-                        # sample actions from -1 to 1
-                        actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
-                    # apply actions
-                    env.step(actions)
-        finally:
-            # Keep the flag-only handler installed through cleanup: a second Ctrl+C during
-            # env.close()'s multi-stage teardown would otherwise raise a raw KeyboardInterrupt,
-            # which is not a subclass of Exception, so it is not caught by the individual
-            # try/except wrapping each cleanup stage in SimulationContext.clear_instance() --
-            # it would abort that loop and skip whatever visualizers hadn't closed yet.
-            try:
-                # close the simulator
-                env.close()
-            finally:
-                signal.signal(signal.SIGINT, previous_handler)
+        # print info (this is vectorized environment)
+        print(f"[INFO]: Gym observation space: {env.observation_space}")
+        print(f"[INFO]: Gym action space: {env.action_space}")
+        # reset environment
+        env.reset()
+        zero_action_policy = _create_zero_action_policy(env) if policy == "zero" else None
+        if policy == "zero":
+            print("[INFO] Zero agent is running, press Ctrl+C to exit...")
+        else:
+            print("[INFO] Random agent is running, press Ctrl+C to exit...")
+        # simulate environment
+        # keep running while any visualizer is open, and until the step budget is exhausted
+        sim = env.unwrapped.sim
+        device = env.unwrapped.device
+        step = 0
+        while sim.is_headless_or_exist_active_visualizer():
+            if is_interrupted():
+                break
+            if args_cli.max_steps is not None and step >= args_cli.max_steps:
+                break
+            step += 1
+            # run everything in inference mode
+            with torch.inference_mode():
+                if policy == "zero":
+                    actions = zero_action_policy()
+                else:
+                    # sample actions from -1 to 1
+                    actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
+                # apply actions
+                env.step(actions)
 
 
 def _create_zero_action_policy(env: gym.Env) -> Callable[[], Any]:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -83,9 +83,8 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
     with launch_simulation(env_cfg, args_cli), contextlib.ExitStack() as stack:
         # create environment
         env = gym.make(args_cli.task, cfg=env_cfg)
-        # Install the flag-only handler, and register env.close() to run under it, immediately
-        # once env exists -- so an interrupt anywhere from here on (setup, the step loop, or
-        # env.close() itself) is handled the same way instead of only the step loop.
+        # See flag_only_sigint(): covers env.close() too, so a second Ctrl+C mid-teardown
+        # can't abort it.
         is_interrupted = stack.enter_context(flag_only_sigint())
         stack.callback(env.close)
 

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import signal
 import sys
 from collections.abc import Callable
 from typing import Any, Literal
@@ -97,21 +98,40 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
         sim = env.unwrapped.sim
         device = env.unwrapped.device
         step = 0
-        while sim.is_headless_or_exist_active_visualizer():
-            if args_cli.max_steps is not None and step >= args_cli.max_steps:
-                break
-            step += 1
-            # run everything in inference mode
-            with torch.inference_mode():
-                if policy == "zero":
-                    actions = zero_action_policy()
-                else:
-                    # sample actions from -1 to 1
-                    actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
-                # apply actions
-                env.step(actions)
-        # close the simulator
-        env.close()
+        # A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active
+        # (e.g. --visualizer newton,kit), Python can just as easily raise KeyboardInterrupt from
+        # inside one of Kit's own internal callback dispatches (its viewport/render event loop)
+        # as from this loop, where nothing here can catch it. Installing a handler that only
+        # flips a flag is safe no matter which frame it fires in, and lets this loop -- the one
+        # place that knows how to shut the simulation down cleanly -- check it at a controlled
+        # point instead of hoping the exception lands somewhere useful.
+        interrupted = False
+
+        def _on_sigint(signum, frame):
+            nonlocal interrupted
+            interrupted = True
+
+        previous_handler = signal.signal(signal.SIGINT, _on_sigint)
+        try:
+            while sim.is_headless_or_exist_active_visualizer():
+                if interrupted:
+                    break
+                if args_cli.max_steps is not None and step >= args_cli.max_steps:
+                    break
+                step += 1
+                # run everything in inference mode
+                with torch.inference_mode():
+                    if policy == "zero":
+                        actions = zero_action_policy()
+                    else:
+                        # sample actions from -1 to 1
+                        actions = 2 * torch.rand(env.action_space.shape, device=device) - 1
+                    # apply actions
+                    env.step(actions)
+        finally:
+            signal.signal(signal.SIGINT, previous_handler)
+            # close the simulator
+            env.close()
 
 
 def _create_zero_action_policy(env: gym.Env) -> Callable[[], Any]:

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -83,28 +83,16 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
         # create environment
         env = gym.make(args_cli.task, cfg=env_cfg)
 
-        # print info (this is vectorized environment)
-        print(f"[INFO]: Gym observation space: {env.observation_space}")
-        print(f"[INFO]: Gym action space: {env.action_space}")
-        # reset environment
-        env.reset()
-        zero_action_policy = _create_zero_action_policy(env) if policy == "zero" else None
-        if policy == "zero":
-            print("[INFO] Zero agent is running, press Ctrl+C to exit...")
-        else:
-            print("[INFO] Random agent is running, press Ctrl+C to exit...")
-        # simulate environment
-        # keep running while any visualizer is open, and until the step budget is exhausted
-        sim = env.unwrapped.sim
-        device = env.unwrapped.device
-        step = 0
         # A raw SIGINT is delivered asynchronously: with multiple GUI-backed visualizers active
         # (e.g. --visualizer newton,kit), Python can just as easily raise KeyboardInterrupt from
-        # inside one of Kit's own internal callback dispatches (its viewport/render event loop)
-        # as from this loop, where nothing here can catch it. Installing a handler that only
-        # flips a flag is safe no matter which frame it fires in, and lets this loop -- the one
-        # place that knows how to shut the simulation down cleanly -- check it at a controlled
-        # point instead of hoping the exception lands somewhere useful.
+        # inside env.reset(), policy construction, one of Kit's own internal callback dispatches
+        # (its viewport/render event loop), or the step loop below -- anywhere after the
+        # environment exists -- as from the step loop itself, where nothing here can catch it.
+        # Installing a handler that only flips a flag is safe no matter which frame it fires in,
+        # and lets this function -- the one place that knows how to shut the simulation down
+        # cleanly -- check it at a controlled point instead of hoping the exception lands
+        # somewhere useful. Install it immediately once ``env`` exists, so an interrupt during
+        # setup can't bypass env.close() any more easily than one during the step loop.
         interrupted = False
 
         def _on_sigint(signum, frame):
@@ -113,6 +101,21 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
 
         previous_handler = signal.signal(signal.SIGINT, _on_sigint)
         try:
+            # print info (this is vectorized environment)
+            print(f"[INFO]: Gym observation space: {env.observation_space}")
+            print(f"[INFO]: Gym action space: {env.action_space}")
+            # reset environment
+            env.reset()
+            zero_action_policy = _create_zero_action_policy(env) if policy == "zero" else None
+            if policy == "zero":
+                print("[INFO] Zero agent is running, press Ctrl+C to exit...")
+            else:
+                print("[INFO] Random agent is running, press Ctrl+C to exit...")
+            # simulate environment
+            # keep running while any visualizer is open, and until the step budget is exhausted
+            sim = env.unwrapped.sim
+            device = env.unwrapped.device
+            step = 0
             while sim.is_headless_or_exist_active_visualizer():
                 if interrupted:
                     break

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/simple_agents.py
@@ -129,9 +129,16 @@ def run(argv: list[str] | None = None, *, policy: PolicyName) -> None:
                     # apply actions
                     env.step(actions)
         finally:
-            signal.signal(signal.SIGINT, previous_handler)
-            # close the simulator
-            env.close()
+            # Keep the flag-only handler installed through cleanup: a second Ctrl+C during
+            # env.close()'s multi-stage teardown would otherwise raise a raw KeyboardInterrupt,
+            # which is not a subclass of Exception, so it is not caught by the individual
+            # try/except wrapping each cleanup stage in SimulationContext.clear_instance() --
+            # it would abort that loop and skip whatever visualizers hadn't closed yet.
+            try:
+                # close the simulator
+                env.close()
+            finally:
+                signal.signal(signal.SIGINT, previous_handler)
 
 
 def _create_zero_action_policy(env: gym.Env) -> Callable[[], Any]:

--- a/source/isaaclab_rl/test/test_entrypoints_common.py
+++ b/source/isaaclab_rl/test/test_entrypoints_common.py
@@ -27,6 +27,7 @@ from isaaclab_rl.entrypoints.common import (
     enable_cameras_for_video,
     flag_only_sigint,
     resolve_play_task_name,
+    suppressed_shutdown_guard,
     wrap_sensor_capture,
 )
 
@@ -45,6 +46,33 @@ def test_flag_only_sigint_restores_previous_handler_on_exit() -> None:
     with flag_only_sigint():
         assert signal.getsignal(signal.SIGINT) is not previous_handler
     assert signal.getsignal(signal.SIGINT) is previous_handler
+
+
+def test_suppressed_shutdown_guard_closes_env_reassigned_after_registration() -> None:
+    """A callback registered as ``lambda: env.close()`` must close the final, rewrapped env.
+
+    Every train/play entrypoint reassigns ``env`` to one or more wrappers after registering the
+    close callback (e.g. ``env = SomeVecEnvWrapper(env)``). Registering ``env.close`` directly
+    would bind the pre-wrap object, silently skipping any wrapper-specific cleanup -- e.g.
+    ``CaptureEnvSensors`` flushing its writer before delegating to the wrapped env.
+    """
+
+    class _TrackingWrapper(gym.Wrapper):
+        def __init__(self, env: gym.Env) -> None:
+            super().__init__(env)
+            self.wrapper_closed = False
+
+        def close(self) -> None:
+            self.wrapper_closed = True
+            super().close()
+
+    inner = _FakeEnv()
+    with suppressed_shutdown_guard() as stack:
+        env = inner
+        stack.callback(lambda: env.close())
+        env = _TrackingWrapper(env)  # reassign, as every entrypoint does when wrapping
+    assert env.wrapper_closed
+    assert inner.closed
 
 
 class _FakeEnv(gym.Env):

--- a/source/isaaclab_rl/test/test_entrypoints_common.py
+++ b/source/isaaclab_rl/test/test_entrypoints_common.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import signal
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -23,9 +25,26 @@ from isaaclab_rl.entrypoints.common import (
     create_isaaclab_env,
     dispatch_library_entrypoint,
     enable_cameras_for_video,
+    flag_only_sigint,
     resolve_play_task_name,
     wrap_sensor_capture,
 )
+
+
+def test_flag_only_sigint_sets_flag_instead_of_raising() -> None:
+    """A SIGINT delivered inside the context should flip the flag, not raise."""
+    with flag_only_sigint() as is_interrupted:
+        assert not is_interrupted()
+        os.kill(os.getpid(), signal.SIGINT)
+        assert is_interrupted()
+
+
+def test_flag_only_sigint_restores_previous_handler_on_exit() -> None:
+    """The previous SIGINT handler must be back in place once the context exits."""
+    previous_handler = signal.getsignal(signal.SIGINT)
+    with flag_only_sigint():
+        assert signal.getsignal(signal.SIGINT) is not previous_handler
+    assert signal.getsignal(signal.SIGINT) is previous_handler
 
 
 class _FakeEnv(gym.Env):


### PR DESCRIPTION
# Description

When the case when the user launches multiple visualizers, and uses Ctrl+C multiple times, the processes do not shut down cleanly.

Root causes:
- `env.close()` only ran on the happy path (`try: ...loop... env.close() except
  KeyboardInterrupt: pass`), so an interrupt during the loop skipped the visualizer teardown in
  `SimulationContext.clear_instance()`.
- SIGINT is delivered asynchronously and can land inside Kit's own render/event callbacks rather
  than the script's own loop, where no local `try/except` can catch it.
- A second Ctrl+C during `env.close()`'s own multi-stage teardown could abort it partway through.

## Fix

Two small context managers in `isaaclab_rl.entrypoints.common` replace the ad-hoc
per-entrypoint `try/except/finally`:

- `flag_only_sigint()` — swaps SIGINT for a flag checked by a caller's own step loop. Used only
  by `random_agent`/`zero_agent`, the one entrypoint with a fully self-owned loop.
- `suppressed_shutdown_guard()` — registers `env.close()` on an `ExitStack` right after the env
  is created, and swallows `KeyboardInterrupt` only once it escapes (after cleanup ran). Used by
  every train/play backend; a raw interrupt still reaches `runner.learn()`/`runner.run()` to stop
  it.


## Testing

- Repro: `env DISPLAY=:0 OMNI_KIT_ACCEPT_EULA=yes timeout --signal=INT --kill-after=30 90 uv run
  isaaclab random_agent --task Isaac-Cartpole --num_envs 64 --max_steps 1000000
  physics=newton_mjwarp --visualizer newton,kit,rerun,viser` — exit 137 before, exit 124 (clean)
  after.
- Happy path unaffected: `isaaclab train --rl_library rsl_rl --task Isaac-Cartpole
  --max_iterations 3` exits 0.
- `source/isaaclab_rl/test/test_entrypoints.py`, `test_entrypoints_common.py` (new unit tests for
  `flag_only_sigint`): 81 passed.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (none required; no public API changed)
- [x] My changes generate no new warnings
- [x] I have added a changelog fragment under `source/isaaclab_rl/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

🤖 Generated with [Claude Code](https://claude.com/claude-code)