### PR TITLE
[Draft] Document the Agibot A2D reversed-joint Newton importer limitation

### DIFF
--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -125,6 +125,33 @@ Passing ``presets=newton_mjwarp`` to these tasks is rejected, because the preset
 selected a Newton backend on them; it only stripped a center-of-mass randomization from a
 PhysX run. Use the default PhysX configuration for Digit-based environments.
 
+.. _known-issues-reversed-joints-newton:
+
+Reversed-joint assets are rejected by Newton's importer (e.g. Agibot A2D)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``physics=newton_mjwarp``, ``physics=newton_kamino``, and any Newton-backed
+visualizer (``--visualizer newton``, ``newton_gl``, ``newton_rtx``, ``rerun``, ``viser``) even
+when the active physics backend is PhysX — those visualizers build a Newton shadow model from
+the same USD importer to render the scene.
+
+Some robot assets author a joint's parent body as ``physics:body1`` and the child as
+``physics:body0`` — the reverse of USD Physics convention. PhysX tolerates this, but Newton's
+``parse_usd`` importer does not and raises ``Reversed joints are not supported`` deep in scene
+creation. The Agibot A2D gripper support-link revolute joints are affected, on both contrib
+tasks that use that robot:
+
+* ``IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow``
+* ``IsaacContrib-Place-Mug-Agibot-Left-Arm-RmpFlow``
+
+These tasks fail fast with an actionable ``ValueError`` before either import path
+initializes, rather than surfacing the raw Newton error. Use ``physics=isaacsim_physx`` with
+``--visualizer kit``, or ``--visualizer none`` for headless execution, to work around it. This
+is a fail-fast guard, not a functional fix — a corrected asset is expected to make Newton and
+Newton-backed visualizers work again for these tasks. Remove the guard in
+:func:`~isaaclab_tasks.contrib.place.config.agibot.place_toy2box_rmp_rel_env_cfg.raise_if_reversed_joints_on_newton`
+once that lands.
+
 
 Renderers
 ---------


### PR DESCRIPTION
# Description

Addresses the reported bug: `zero_agent.py --task IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow
--visualizer rerun,viser physics=isaacsim_physx` crashed with a raw
`RuntimeError` from the rerun visualizer's initializer, complaining that several joints on the
Agibot A2D robot are authored with a reversed parent/child body order (`physics:body0`/
`physics:body1` swapped), which Newton's `parse_usd` importer rejects outright.

PhysX tolerates the reversed ordering, but Newton-backed visualizers (`rerun`, `viser`,
`newton*`) build a Newton shadow model from the same importer to render the scene, even when
PhysX is the active physics backend — so they hit the same rejection.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## No code change needed

This was already fixed as of today by PR #7678 ("Fix Agibot place visualizer startup"), which
added a `validate_config()` guard (`raise_if_reversed_joints_on_newton`) that fails fast with
an actionable `ValueError` before either import path initializes, instead of surfacing the raw
Newton error. I reproduced the original bug against `develop` tip and confirmed:

- `IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow` (the task from the bug report): raises
  the clean, actionable error immediately, no crash or hang.
- `IsaacContrib-Place-Mug-Agibot-Left-Arm-RmpFlow` (the sibling task using the same robot, not
  explicitly mentioned in the bug report): also covered, via inheriting `validate_config` from
  the Toy2Box task's base config class.
- The documented workaround (`physics=isaacsim_physx --visualizer none`) actually runs the
  zero-agent loop successfully.

This PR only adds a Known Issues doc entry so users hitting this understand it's a known
asset/importer limitation with a documented workaround, rather than an unexplained failure —
matching the format of the other Newton-backend entries in the same file (e.g. the existing
"Closed-loop articulations are not available on Newton" entry).

## Type of change

- Documentation update

## Testing

- Reproduced the original crash's replacement behavior on `develop` tip for both affected
  tasks: clean `ValueError`, no crash or hang.
- Verified the documented workaround (`physics=isaacsim_physx --visualizer none`) completes the
  zero-agent loop successfully.
- `uv run isaaclab -f` — RST formatting/lint checks pass.
- Ran `/code-review`: no findings.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] A changelog fragment is not required for this docs-only change (matching precedent, e.g. #7573)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there