### PR TITLE
Document task limitations and guard missing Pink IK dependencies

### DIFF
--- a/docs/source/api/lab/isaaclab.controllers.rst
+++ b/docs/source/api/lab/isaaclab.controllers.rst
@@ -47,6 +47,13 @@ Operational Space controllers
 Pink IK Controller
 ------------------
 
+.. note::
+
+   The standard Isaac Lab installation provides Pink IK dependencies only on Linux x86_64 and aarch64.
+   Pink IK requires ``pin`` (Pinocchio), ``pin-pink``, and ``daqp``. The Windows uv/pip installation does not
+   provide Pinocchio, so Pink IK tasks cannot run with that installation. This is an installation limitation;
+   upstream Pinocchio supports Windows through other distribution methods.
+
 .. automodule:: isaaclab.controllers.pink_ik
 
 .. autoclass:: PinkIKController

--- a/docs/source/features/isaac_teleop.rst
+++ b/docs/source/features/isaac_teleop.rst
@@ -850,6 +850,8 @@ follows.
        controller to overtune and the arm to drift. Move the
        end-effector close to and just above the cube, stop, then
        close the suction cup.
+
+       **CPU simulation only:** pass ``--device cpu`` for teleoperation.
      - Keyboard, SpaceMouse
      - **Arm:** end-effector pose via RMPFlow.
        **Suction:** ``K`` on keyboard, left button on SpaceMouse.
@@ -865,10 +867,14 @@ follows.
      - **Arm:** right-arm end-effector pose via RMPFlow.
        **Gripper:** ``K`` on keyboard, left button on SpaceMouse.
    * - ``IsaacContrib-Stack-Cube-UR10-Long-Suction-IK-Rel``
+
+       **CPU simulation only:** pass ``--device cpu`` for teleoperation.
      - Keyboard, SpaceMouse
      - **Arm:** relative IK end-effector control.
        **Suction:** ``K`` on keyboard, left button on SpaceMouse.
    * - ``IsaacContrib-Stack-Cube-UR10-Short-Suction-IK-Rel``
+
+       **CPU simulation only:** pass ``--device cpu`` for teleoperation.
      - Keyboard, SpaceMouse
      - Same as long-suction UR10 above with a shorter suction cup.
    * - ``Isaac-Reach-Franka`` with ``physics=isaacsim_physx presets=diffik``

--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -16,6 +16,16 @@ apply to the others unless it says so.
 PhysX backends
 --------------
 
+Surface grippers require CPU simulation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Affects:** ``physics=isaacsim_physx`` surface-gripper tasks.
+
+Surface grippers require CPU simulation. This includes the UR10 Long/Short Suction stacking tasks,
+the Galbot Right Arm Suction stacking task, and its relative and absolute Mimic variants.
+Pass ``--device cpu`` when running teleoperation. Zero and random agents preserve these tasks'
+CPU defaults when ``--device`` is omitted; an explicit GPU override is unsupported.
+
 Sensor readings are stale immediately after a reset
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/refs/release_notes.rst
+++ b/docs/source/refs/release_notes.rst
@@ -271,6 +271,11 @@ Known Limitations
   release. We anticipate the branch will stabilize towards a final Isaac Lab 3.0 release in the coming 1-2 months.
 * Newton remains under active development. Some features, task presets, and surface gripper workflows remain
   backend-specific or unsupported.
+* Surface grippers require CPU simulation with ``physics=isaacsim_physx``, including the UR10 Long/Short Suction
+  and Galbot Right Arm Suction stacking tasks and the Galbot Mimic variants. Pass ``--device cpu`` for teleoperation;
+  zero and random agents preserve the tasks' CPU defaults when ``--device`` is omitted.
+* Pink IK dependencies are provided by the standard installation only on Linux x86_64 and aarch64. The Windows
+  uv/pip installation does not provide Pinocchio, so Pink IK tasks cannot run with that installation.
 * OVRTX and OVPhysX require their optional runtime wheels. Isaac Lab now reports clearer install guidance when those
   wheels are missing, but those backends are still optional installs.
 

--- a/docs/source/tutorials/01_assets/run_surface_gripper.rst
+++ b/docs/source/tutorials/01_assets/run_surface_gripper.rst
@@ -10,8 +10,8 @@ Interacting with a surface gripper
 
 This tutorial shows how to interact with an articulated robot with a surface gripper attached to its end-effector in
 the simulation. It is a continuation of the :ref:`tutorial-interact-articulation` tutorial, where we learned how to
-interact with an articulated robot. Note that as of IsaacSim 5.0 the surface gripper are only supported on the cpu
-backend.
+interact with an articulated robot. In Isaac Lab 3.0 with Isaac Sim 6.x, surface grippers support only CPU
+simulation. Run this tutorial with ``--device cpu``.
 
 
 The Code

--- a/source/isaaclab_tasks/changelog.d/pink-ik-missing-dependencies.rst
+++ b/source/isaaclab_tasks/changelog.d/pink-ik-missing-dependencies.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Added task-specific installation guidance when loading a task configuration failed because a Pink IK dependency
+  was missing, including the standard Windows installation's missing Pinocchio dependency.

--- a/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/utils/parse_cfg.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import inspect
 import os
 import re
@@ -60,6 +61,7 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
 
     Raises:
         ValueError: If the entry point key is not available in the gym registry for the task.
+        ImportError: If a Python configuration requires a missing Pink IK dependency.
     """
     spec = gym.spec(task_name.split(":")[-1])
     # Emit a FutureWarning when loading the env cfg for a retired task
@@ -112,24 +114,43 @@ def load_cfg_from_registry(task_name: str, entry_point_key: str) -> dict | objec
         with open(config_file, encoding="utf-8") as f:
             cfg = yaml.full_load(f)
     else:
-        if callable(cfg_entry_point):
-            # resolve path to the module location
-            mod_path = inspect.getfile(cfg_entry_point)
+        try:
+            if callable(cfg_entry_point):
+                # resolve path to the module location
+                mod_path = inspect.getfile(cfg_entry_point)
+                # load the configuration
+                cfg_cls = cfg_entry_point()
+            elif isinstance(cfg_entry_point, str):
+                # resolve path to the module location
+                mod_name, attr_name = cfg_entry_point.split(":")
+                mod = importlib.import_module(mod_name)
+                cfg_cls = getattr(mod, attr_name)
+            else:
+                cfg_cls = cfg_entry_point
             # load the configuration
-            cfg_cls = cfg_entry_point()
-        elif isinstance(cfg_entry_point, str):
-            # resolve path to the module location
-            mod_name, attr_name = cfg_entry_point.split(":")
-            mod = importlib.import_module(mod_name)
-            cfg_cls = getattr(mod, attr_name)
-        else:
-            cfg_cls = cfg_entry_point
-        # load the configuration
-        print(f"[INFO]: Parsing configuration from: {cfg_entry_point}")
-        if callable(cfg_cls):
-            cfg = cfg_cls()
-        else:
-            cfg = cfg_cls
+            print(f"[INFO]: Parsing configuration from: {cfg_entry_point}")
+            if callable(cfg_cls):
+                cfg = cfg_cls()
+            else:
+                cfg = cfg_cls
+            if entry_point_key == "env_cfg_entry_point" and getattr(cfg, "actions", None) is not None:
+                from isaaclab.envs.mdp.actions.pink_actions_cfg import PinkInverseKinematicsActionCfg
+
+                # Pink action implementations load lazily; report missing dependencies before simulator startup.
+                actions = cfg.actions if isinstance(cfg.actions, dict) else vars(cfg.actions)
+                if any(isinstance(action, PinkInverseKinematicsActionCfg) for action in actions.values()):
+                    for module_name in ("pinocchio", "pink", "qpsolvers", "daqp"):
+                        if importlib.util.find_spec(module_name) is None:
+                            raise ModuleNotFoundError(f"No module named '{module_name}'", name=module_name)
+        except ModuleNotFoundError as exc:
+            if exc.name not in {"pinocchio", "pink", "qpsolvers", "daqp"}:
+                raise
+            raise ImportError(
+                f"Task '{task_name}' could not load Pink IK dependency '{exc.name}'. "
+                "Pink IK requires Linux x86_64 or aarch64 with the standard Isaac Lab installation. "
+                "Install the pin, pin-pink, and daqp versions specified in pyproject.toml on a supported platform. "
+                "The standard Windows installation does not provide Pinocchio."
+            ) from exc
     return cfg
 
 

--- a/source/isaaclab_tasks/test/core/test_parse_cfg.py
+++ b/source/isaaclab_tasks/test/core/test_parse_cfg.py
@@ -36,3 +36,41 @@ def test_parse_env_cfg_applies_explicit_device_override():
     env_cfg = parse_env_cfg("Isaac-Cartpole", device="cpu")
 
     assert env_cfg.sim.device == "cpu"
+
+
+@pytest.mark.parametrize("missing_module", ["pinocchio", "pink", "qpsolvers", "daqp", "unrelated_dependency"])
+def test_task_config_missing_pink_dependency(monkeypatch: pytest.MonkeyPatch, missing_module: str):
+    """Missing Pink dependencies should identify the task without hiding unrelated import errors."""
+    from isaaclab_tasks.utils import parse_cfg
+
+    task_name = "IsaacContrib-PickPlace-GR1T2-Abs"
+    original_error = ModuleNotFoundError(f"No module named '{missing_module}'", name=missing_module)
+
+    def import_missing_dependency(name: str):
+        raise original_error
+
+    monkeypatch.setattr(parse_cfg.importlib, "import_module", import_missing_dependency)
+    if missing_module == "unrelated_dependency":
+        with pytest.raises(ModuleNotFoundError) as exc_info:
+            parse_cfg.load_cfg_from_registry(task_name, "env_cfg_entry_point")
+        assert exc_info.value is original_error
+    else:
+        with pytest.raises(ImportError, match=f"{task_name}.*Pink IK requires Linux x86_64 or aarch64") as exc_info:
+            parse_cfg.load_cfg_from_registry(task_name, "env_cfg_entry_point")
+        assert exc_info.value.__cause__ is original_error
+
+
+def test_pink_task_checks_lazy_dependencies(monkeypatch: pytest.MonkeyPatch):
+    """A real Pink task must report missing dependencies even when its config imports lazily."""
+    from isaaclab_tasks.utils import parse_cfg
+
+    task_name = "IsaacContrib-PickPlace-GR1T2-Abs"
+    original_find_spec = parse_cfg.importlib.util.find_spec
+
+    def without_pinocchio(name: str, *args, **kwargs):
+        return None if name == "pinocchio" else original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(parse_cfg.importlib.util, "find_spec", without_pinocchio)
+    with pytest.raises(ImportError, match=f"{task_name}.*Pink IK requires Linux x86_64 or aarch64"):
+        parse_cfg.load_cfg_from_registry(task_name, "env_cfg_entry_point")
+    assert parse_cfg.load_cfg_from_registry("Isaac-Cartpole", "env_cfg_entry_point") is not None


### PR DESCRIPTION
# Description

Suction-task teleoperation requires `--device cpu`, and the standard Windows uv/pip installation omits the Pinocchio dependency required by Pink IK tasks. Document these limitations in the teleop task table, Known Issues, controller API documentation, and Isaac Lab 3.0 Known Limitations, and refresh the surface-gripper tutorial's release reference.

Task configuration loading now reports the task name and Pink IK installation requirements when a dependency is missing. It also checks availability for deferred Pink action imports before simulator startup, preserves unrelated import errors, and allows an independently installed Windows dependency stack. The environment browser and command generator are unchanged; #7627 already handles CPU defaults for zero/random agents.

No new dependencies.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- `uv run --frozen --extra test --extra teleop python -m pytest source/isaaclab_tasks/test/core/test_parse_cfg.py -q --disable-warnings`: 10 passed.
- Verified the missing-dependency regression cases failed before the fix; covered deferred imports with a real Pink task config and verified an unrelated task still loads.
- `uv run --frozen isaaclab -f`: passed with `ISAACLAB_CHANGELOG_BASE_REF` pointing to a fetched copy of upstream `develop`. The default fork base included unrelated changelog differences.

- `uv run --isolated --extra dev -- make -C docs current-docs`: passed with warnings treated as errors. The `dev` extra supplies Sphinx; `test` alone does not.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment for every touched source package
- [x] My name already exists in `CONTRIBUTORS.md`
