### PR TITLE
Warn about incompatible environment browser runtimes

### DIFF
--- a/docs/source/_static/css/environment-browser.css
+++ b/docs/source/_static/css/environment-browser.css
@@ -244,6 +244,20 @@ html[data-theme="dark"] .environment-browser {
     background: color-mix(in srgb, var(--pst-color-surface) 70%, transparent);
 }
 
+.environment-backend-warning {
+    margin: 0.75rem 0 0;
+    color: var(--pst-color-warning);
+}
+
+.environment-command-output.is-disabled {
+    opacity: 0.5;
+    border-left-color: var(--pst-color-text-muted);
+}
+
+.environment-copy-button:disabled {
+    cursor: not-allowed;
+}
+
 .environment-command-output code {
     min-width: 0;
     color: inherit;

--- a/docs/source/_static/css/environment-browser.js
+++ b/docs/source/_static/css/environment-browser.js
@@ -391,6 +391,20 @@
         }
     };
 
+    const incompatibleBackends = () => (
+        (fields.physics.value === "ovphysx" && fields.renderer.value === "isaacsim_rtx")
+        || (fields.physics.value === "isaacsim_physx" && fields.renderer.value === "ovrtx")
+    );
+
+    const updateCommand = () => {
+        const incompatible = incompatibleBackends();
+        commandOutput.textContent = currentCommand();
+        commandOutput.closest(".environment-command-output").classList.toggle("is-disabled", incompatible);
+        builder.querySelector("[data-backend-warning]").hidden = !incompatible;
+        copyButton.disabled = incompatible;
+        copyStatus.textContent = "";
+    };
+
     const currentCommand = () => {
         const extras = [];
         if (fields.physics.value === "ovphysx" && fields.renderer.value === "ovrtx") {
@@ -489,7 +503,7 @@
         fields.task.value = state.task;
         updateTaskControls();
         updateModeControls();
-        commandOutput.textContent = currentCommand();
+        updateCommand();
         updatePreview();
         for (const card of taskList.querySelectorAll(".environment-task-card")) {
             taskCardRefreshers.get(card)?.();
@@ -819,7 +833,7 @@
     for (const field of [fields.rl, fields.physics, fields.renderer, fields.presets, fields.checkpoint]) {
         field.addEventListener("change", () => {
             updateModeControls();
-            commandOutput.textContent = currentCommand();
+            updateCommand();
             updatePreview();
         });
     }
@@ -835,7 +849,7 @@
                 modeButton.setAttribute("aria-pressed", String(isActive));
             }
             updateModeControls();
-            commandOutput.textContent = currentCommand();
+            updateCommand();
             updatePreview();
         });
     }
@@ -872,7 +886,7 @@
             modeButton.classList.toggle("is-active", isActive);
             modeButton.setAttribute("aria-pressed", String(isActive));
         }
-        commandOutput.textContent = currentCommand();
+        updateCommand();
         updatePreview();
     });
     for (const button of benchmarks?.querySelectorAll("[data-benchmark-workload]") || []) {
@@ -887,6 +901,9 @@
         });
     }
     copyButton.addEventListener("click", async () => {
+        if (incompatibleBackends()) {
+            return;
+        }
         const command = currentCommand();
         try {
             await navigator.clipboard.writeText(command);

--- a/docs/source/setup/environments.rst
+++ b/docs/source/setup/environments.rst
@@ -55,6 +55,9 @@ Command Builder
          This environment does not support RL training or playback. The command runs it with the
          zero-action agent instead.
        </p>
+       <p class="environment-backend-warning" data-backend-warning role="status" hidden>
+         OV and Isaac Sim can't be mixed. Choose matching physics and renderer backends.
+       </p>
        <div class="environment-command-output">
          <code data-command-output></code>
          <div class="environment-command-actions">


### PR DESCRIPTION
# Description

Selecting `ovphysx` with `isaacsim_rtx`, or `isaacsim_physx` with `ovrtx`, now greys out the environment browser's command and disables Copy. A short warning explains the conflict: “OV and Isaac Sim can't be mixed. Choose matching physics and renderer backends.”

The selectors remain editable. Choosing a compatible pair restores the command and Copy button, including after task or mode changes. Valid Newton combinations remain available.

No new dependencies. This is a separate branch based on `develop` and does not include #7701.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Testing

- Headless Chrome / Playwright checks passed for both incompatible pairs, valid OV/Isaac Sim/Newton pairs, mode changes, and recovery after changing tasks. No browser JavaScript errors.
- Visually inspected the disabled command and warning.
- `uv run --frozen isaaclab -f`: passed using the fetched upstream `develop` as the changelog comparison base.

- `uv run --isolated --extra dev -- make -C docs current-docs`: passed with warnings treated as errors.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have verified the changed behavior in a browser
- [x] No source package changelog fragment is needed (documentation-only changes)
- [x] My name already exists in `CONTRIBUTORS.md`
