### PR TITLE
Fix Kit visualizer taskbar icon showing generic instead of Isaac Sim

### DIFF
--- a/docs/source/developer-tools/editor_setup.rst
+++ b/docs/source/developer-tools/editor_setup.rst
@@ -84,6 +84,11 @@ The command creates or updates these machine-local files:
 * ``.vscode/launch.json``: Debugging configurations. An existing file is preserved.
 * ``.vscode/settings.json``: The interpreter and shared editor settings.
 * ``pyrightconfig.json``: Import paths for Pyright-compatible language servers.
+* ``~/.local/share/applications/isaaclab.desktop`` (Linux only): A desktop entry so the Kit
+  visualizer window's taskbar/dock icon shows the Isaac Sim icon instead of a generic one. Most
+  Linux desktop environments look up taskbar icons through a ``.desktop`` file's
+  ``StartupWMClass``, not the window's own icon hint, so this is required for the icon to
+  resolve correctly. Delete the file to remove the entry; it does not affect running Isaac Lab.
 
 The generated files are ignored by Git because interpreter and extension paths
 vary between machines. Rerun the command after changing Python environments or

--- a/source/isaaclab/changelog.d/mtrepte-fix-kit-taskbar-icon.rst
+++ b/source/isaaclab/changelog.d/mtrepte-fix-kit-taskbar-icon.rst
@@ -1,0 +1,10 @@
+Added
+^^^^^
+
+* ``isaaclab --editor`` now also generates a ``.desktop`` file at
+  ``~/.local/share/applications/isaaclab.desktop`` on Linux, fixing the Kit visualizer window
+  showing a generic taskbar/dock icon instead of the Isaac Sim icon. Most Linux desktop
+  environments resolve taskbar icons by matching a running window's ``WM_CLASS`` against an
+  installed ``.desktop`` file's ``StartupWMClass``, not from the window's own ``_NET_WM_ICON``
+  hint (which Kit already sets correctly). The generated ``StartupWMClass`` is read from
+  ``apps/isaaclab.python.kit``, matching what Kit composes for the running window.

--- a/source/isaaclab/isaaclab/utils/editor.py
+++ b/source/isaaclab/isaaclab/utils/editor.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import os
 import pathlib
+import platform
 import re
 import subprocess
 import sys
@@ -77,6 +78,130 @@ def setup_editor(project_dir: pathlib.Path, isaac_path: str | None = None, verbo
 
     print(f"Editor settings generated at {settings_path}")
     print(f"Pyright configuration generated at {project_dir / 'pyrightconfig.json'}")
+
+    # Desktop icon integration is a convenience, not something that should block the rest of
+    # this command -- an unwritable home directory or unreadable kit file shouldn't turn a
+    # successful editor-settings run into a hard crash.
+    try:
+        setup_desktop_entry(project_dir)
+    except OSError as error:
+        print(f"[WARN] Skipped desktop entry generation: {error}")
+
+
+def setup_desktop_entry(project_dir: pathlib.Path) -> None:
+    """Generate a Linux desktop entry so the taskbar shows the Isaac Sim icon, not a generic one.
+
+    Kit's window manager class (``WM_CLASS``) is composed from the ``[settings.app.window] title``
+    and ``[settings.app] version`` values in ``apps/isaaclab.python.kit`` (for example
+    ``"Isaac Lab 3.0.0"``), with no exposed setting to make it version-independent: overriding
+    ``/app/version`` to empty falls back to the raw Kit SDK build string instead of dropping the
+    suffix. Most Linux desktop environments (GNOME included) resolve taskbar/dock icons by
+    matching a running window's ``WM_CLASS`` against an installed ``.desktop`` file's
+    ``StartupWMClass`` -- not from the window's own ``_NET_WM_ICON`` hint, which Kit does set
+    correctly (confirmed with ``xprop``) but which most taskbars ignore for this purpose. Without
+    a matching ``.desktop`` file, the desktop environment falls back to a generic icon.
+
+    Because ``WM_CLASS`` embeds the app title and version, ``StartupWMClass`` here is read from
+    the same ``apps/isaaclab.python.kit`` file rather than hardcoded, so it self-updates on every
+    ``isaaclab --editor`` run. Requirement to track: if a future Isaac Lab release changes
+    ``apps/isaaclab.python.kit``'s ``[settings.app.window] title`` or ``[settings.app] version``
+    (or Kit changes how it composes ``WM_CLASS`` at all), this needs re-running -- there is no way
+    to keep the ``.desktop`` file in sync automatically without that rerun, since the desktop
+    entry is a static file, not a live setting.
+
+    No-op on non-Linux platforms, or if the kit file or the Isaac Sim icon asset cannot be found;
+    desktop icon integration is a convenience, not something that should block the rest of
+    ``isaaclab --editor``.
+
+    Args:
+        project_dir: Project root, used to locate ``apps/isaaclab.python.kit``.
+    """
+    if platform.system() != "Linux":
+        return
+
+    kit_file = project_dir / "apps" / "isaaclab.python.kit"
+    identity = _read_kit_window_identity(kit_file)
+    if identity is None:
+        return
+    title, version = identity
+
+    icon_path = _find_isaac_sim_icon()
+    if icon_path is None:
+        return
+
+    applications_dir = pathlib.Path.home() / ".local" / "share" / "applications"
+    applications_dir.mkdir(parents=True, exist_ok=True)
+    desktop_path = applications_dir / "isaaclab.desktop"
+    desktop_path.write_text(
+        "[Desktop Entry]\n"
+        "Version=1.0\n"
+        "Type=Application\n"
+        "Name=Isaac Lab\n"
+        f"Exec={sys.executable} -m isaaclab\n"
+        f"Icon={icon_path}\n"
+        "Terminal=true\n"
+        f"StartupWMClass={title} {version}\n",
+        encoding="utf-8",
+    )
+    print(f"Desktop entry generated at {desktop_path}")
+
+
+def _read_kit_window_identity(kit_file: pathlib.Path) -> tuple[str, str] | None:
+    """Read the ``(title, version)`` pair Kit composes this app's ``WM_CLASS`` from.
+
+    ``.kit`` files are TOML-like but redeclare the ``[settings]`` table across multiple
+    sections (Kit's own parser merges them), which is invalid under strict TOML and rejects
+    :mod:`tomllib`. Since only these two known scalars are needed, this scans lines under the
+    exact ``[settings.app]`` and ``[settings.app.window]`` headers instead of parsing the whole
+    file as TOML.
+
+    Args:
+        kit_file: Path to ``apps/isaaclab.python.kit``.
+
+    Returns:
+        The ``(title, version)`` pair, or None if the file or either value is missing.
+    """
+    if not kit_file.is_file():
+        return None
+
+    title: str | None = None
+    version: str | None = None
+    section = ""
+    scalar_pattern = re.compile(r'^(\w+)\s*=\s*"([^"]*)"')
+    for raw_line in kit_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        match = scalar_pattern.match(line)
+        if not match:
+            continue
+        key, value = match.groups()
+        if section == "settings.app.window" and key == "title":
+            title = value
+        elif section == "settings.app" and key == "version":
+            version = value
+
+    if not title or not version:
+        return None
+    return title, version
+
+
+def _find_isaac_sim_icon() -> pathlib.Path | None:
+    """Locate the Isaac Sim icon asset shipped with the installed ``isaacsim`` package.
+
+    Returns:
+        Absolute path to the icon, or None if the ``isaacsim`` package is not installed or does
+        not ship the expected asset.
+    """
+    spec = importlib.util.find_spec("isaacsim")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    for location in spec.submodule_search_locations:
+        icon_path = pathlib.Path(location) / "exts" / "isaacsim.simulation_app" / "data" / "omni.isaac.sim.png"
+        if icon_path.is_file():
+            return icon_path
+    return None
 
 
 def resolve_isaacsim_dir(project_dir: pathlib.Path, isaac_path: str | None = None) -> pathlib.Path | None:

--- a/source/isaaclab/test/utils/test_editor.py
+++ b/source/isaaclab/test/utils/test_editor.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pathlib
+
+import pytest
+
+from isaaclab.utils.editor import _find_isaac_sim_icon, _read_kit_window_identity, setup_desktop_entry
+
+pytestmark = pytest.mark.unit
+
+# A minimal excerpt of apps/isaaclab.python.kit's shape: [settings] is re-declared across
+# multiple sections, which is invalid under strict TOML but is what Kit's own files look like.
+_KIT_FILE_CONTENT = """
+[package]
+version = "3.0.0"
+
+[settings]
+app.name = "IsaacLab"
+
+[settings.app]
+name = "IsaacLab"
+version = "3.0.0"
+
+[settings.app.window]
+iconPath = "${isaacsim.simulation_app}/data/omni.isaac.sim.png"
+title = "Isaac Lab"
+
+[settings]
+physics.updateToUsd = false
+"""
+
+
+def test_read_kit_window_identity_parses_duplicate_settings_sections(tmp_path: pathlib.Path):
+    """Test title/version are read correctly despite the repeated [settings] header."""
+    kit_file = tmp_path / "isaaclab.python.kit"
+    kit_file.write_text(_KIT_FILE_CONTENT)
+
+    identity = _read_kit_window_identity(kit_file)
+
+    assert identity == ("Isaac Lab", "3.0.0")
+
+
+def test_read_kit_window_identity_missing_file_returns_none(tmp_path: pathlib.Path):
+    """Test a missing kit file is reported as no identity rather than raising."""
+    assert _read_kit_window_identity(tmp_path / "does_not_exist.kit") is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        # No [settings.app.window] title.
+        '[settings.app]\nversion = "3.0.0"\n',
+        # No [settings.app] version.
+        '[settings.app.window]\ntitle = "Isaac Lab"\n',
+    ],
+)
+def test_read_kit_window_identity_missing_value_returns_none(tmp_path: pathlib.Path, content: str):
+    """Test a kit file missing either title or version is reported as no identity."""
+    kit_file = tmp_path / "isaaclab.python.kit"
+    kit_file.write_text(content)
+
+    assert _read_kit_window_identity(kit_file) is None
+
+
+def test_find_isaac_sim_icon_locates_asset_under_package(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the icon is found when the isaacsim package ships the expected asset path."""
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    icon_file = icon_dir / "omni.isaac.sim.png"
+    icon_file.write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    assert _find_isaac_sim_icon() == icon_file
+
+
+def test_find_isaac_sim_icon_missing_package_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """Test an uninstalled isaacsim package is reported as no icon rather than raising."""
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: None)
+
+    assert _find_isaac_sim_icon() is None
+
+
+def test_setup_desktop_entry_noop_on_non_linux(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the desktop entry is not generated on non-Linux platforms."""
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Windows")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    setup_desktop_entry(tmp_path)
+
+    assert not (home / ".local" / "share" / "applications" / "isaaclab.desktop").exists()
+
+
+def test_setup_desktop_entry_writes_startup_wm_class_matching_kit_identity(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test the generated .desktop file's StartupWMClass matches Kit's composed WM_CLASS.
+
+    Kit composes the running window's WM_CLASS from the kit file's window title and app
+    version (e.g. "Isaac Lab 3.0.0"). The whole point of generating this file is for
+    StartupWMClass to match that exactly, so a desktop environment's .desktop-based taskbar
+    icon lookup succeeds instead of falling back to a generic icon.
+    """
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    project_dir = tmp_path / "project"
+    apps_dir = project_dir / "apps"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "isaaclab.python.kit").write_text(_KIT_FILE_CONTENT)
+
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    icon_file = icon_dir / "omni.isaac.sim.png"
+    icon_file.write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    setup_desktop_entry(project_dir)
+
+    desktop_file = home / ".local" / "share" / "applications" / "isaaclab.desktop"
+    content = desktop_file.read_text()
+    assert "StartupWMClass=Isaac Lab 3.0.0" in content
+    assert f"Icon={icon_file}" in content
+    assert "Name=Isaac Lab" in content
+
+
+def test_setup_desktop_entry_noop_when_kit_file_missing(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test a missing kit file skips desktop entry generation instead of raising."""
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    setup_desktop_entry(tmp_path / "project_without_apps_dir")
+
+    assert not (home / ".local" / "share" / "applications" / "isaaclab.desktop").exists()


### PR DESCRIPTION
# Description

Launching `--visualizer kit` shows a generic icon in the taskbar/dock instead of the Isaac Sim
icon, on Linux.

## Root cause

The Kit window's `WM_CLASS` is composed from `apps/isaaclab.python.kit`'s
`[settings.app.window] title` and `[settings.app] version` (e.g. `"Isaac Lab 3.0.0"`) with no
exposed setting to disable the version suffix -- overriding `/app/version` to empty just falls
back to the raw Kit SDK build string instead of dropping it. Most Linux desktop environments
(GNOME included) resolve taskbar/dock icons by matching a running window's `WM_CLASS` against
an installed `.desktop` file's `StartupWMClass`, not from the window's own `_NET_WM_ICON` hint.
Verified with `xprop` that Kit *does* set `_NET_WM_ICON` correctly (a valid 128x128 icon was
present) -- the icon itself was never the problem, only the taskbar's lookup mechanism, which
had nothing to match against since Isaac Lab shipped no `.desktop` file.

## Fix

`isaaclab --editor` now also generates `~/.local/share/applications/isaaclab.desktop` on Linux.
`StartupWMClass` is read from `apps/isaaclab.python.kit` rather than hardcoded, so it stays
derived from a single source instead of duplicating the title/version. It's read with a
targeted line scan rather than `tomllib`, since `.kit` files redeclare the `[settings]` table
across multiple sections -- valid for Kit's own lenient parser, but rejected by strict TOML.
Desktop entry generation is wrapped so an `OSError` (e.g. an unwritable home directory) doesn't
block the rest of the command -- editor settings and `pyrightconfig.json` should still get
written either way.

**Requirement to track:** `apps/isaaclab.python.kit`'s `[settings.app.window] title` and
`[settings.app] version` are what Kit composes `WM_CLASS` from. If either changes, or Kit
changes how it composes `WM_CLASS`, rerun `isaaclab --editor` to regenerate the desktop entry --
there is no way to keep a static `.desktop` file in sync automatically. Documented this in both
the code and `docs/source/developer-tools/editor_setup.rst`.

## Testing

- Verified end-to-end: ran `isaaclab --editor`, then `update-desktop-database`, relaunched the
  Kit visualizer, and confirmed via GNOME's own `Gio.DesktopAppInfo` API (the same mechanism its
  window tracker uses) that the generated entry's `StartupWMClass` (`"Isaac Lab 3.0.0"`) matches
  the running window's `WM_CLASS` exactly and resolves to the correct Isaac Sim icon file.
- `desktop-file-validate` passes on the generated file.
- `source/isaaclab/test/utils/test_editor.py`: 9 new unit tests (parsing the kit file's
  redeclared `[settings]` sections, missing-file/missing-value handling, icon discovery,
  non-Linux no-op, full desktop-entry generation) -- all passing.
- `uv run isaaclab -f` passes.
- Ran `/code-review`; addressed all three findings (uncaught `OSError` from
  `setup_desktop_entry` could crash `isaaclab --editor`, missing changelog fragment, missing
  docs update).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there