### PR TITLE
Fix SIGSEGV on second play() after stop() without reset() on GPU PhysX

### DIFF
--- a/source/isaaclab/changelog.d/mtrepte-fix-timeline-callbacks-weakref-segfault.skip
+++ b/source/isaaclab/changelog.d/mtrepte-fix-timeline-callbacks-weakref-segfault.skip
@@ -1,0 +1,1 @@
+Test-only change: added a regression assertion to test_timeline_callbacks_with_weakref.

--- a/source/isaaclab/test/sim/test_simulation_context.py
+++ b/source/isaaclab/test/sim/test_simulation_context.py
@@ -681,6 +681,10 @@ def test_timeline_callbacks_with_weakref():
 
         # trigger events again - callbacks should handle the deleted object gracefully
         sim.play()
+        # regression check: a second play() after stop() with no reset() in between used to
+        # SIGSEGV inside PhysX's tensor view registry (see PhysxManager._on_stop); it must also
+        # still warm up and recreate the simulation view, not just avoid crashing
+        assert PhysxManager._view is not None
         # disable app control again
         sim._disable_app_control_on_stop_handle = True  # type: ignore
         sim.stop()

--- a/source/isaaclab_physx/changelog.d/mtrepte-fix-timeline-callbacks-weakref-segfault.rst
+++ b/source/isaaclab_physx/changelog.d/mtrepte-fix-timeline-callbacks-weakref-segfault.rst
@@ -1,0 +1,9 @@
+Fixed
+^^^^^
+
+* Fixed a SIGSEGV crash when calling ``SimulationContext.play()`` a second time after
+  ``SimulationContext.stop()`` without an intervening ``reset()``, e.g. registering a raw
+  ``omni.timeline`` event subscription and cycling play/stop twice on the GPU PhysX pipeline.
+  ``PhysxManager`` now detaches the PhysX stage on ``stop()`` so the next play's automatic
+  re-warmup reattaches cleanly instead of calling ``attach_stage`` on a stage that PhysX still
+  considered attached, which corrupted its internal view registry.

--- a/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
+++ b/source/isaaclab_physx/isaaclab_physx/physics/physx_manager.py
@@ -1009,6 +1009,15 @@ class PhysxManager(PhysicsManager):
     def _on_stop(cls, event: Any) -> None:
         cls._warmup_needed = True
         cls._invalidate_views()
+        # Detach the stage `_warmup_and_create_views` attached (GPU pipeline only, matching its own
+        # is_gpu guard) so the next play() can reattach cleanly. Without this, a second
+        # `_warmup_and_create_views` (e.g. play() -> stop() -> play() with no reset() in between)
+        # calls attach_stage() on a stage that is still attached ("Stage already attached") and
+        # corrupts PhysX's native view registry (SIGSEGV inside omni.physx.tensors). Guarded by
+        # get_attached_stage() so this is a no-op when close() already detached it.
+        if "cuda" in PhysicsManager.get_device() and (physx_sim := omni.physx.get_physx_simulation_interface()):
+            if physx_sim.get_attached_stage():
+                physx_sim.detach_stage()
 
     @classmethod
     def _on_stage_open(cls, event: Any) -> None:


### PR DESCRIPTION
## Summary
Fixes the `isaac-lab-integration` crash reported for `test_timeline_callbacks_with_weakref` (`source/isaaclab/test/sim/test_simulation_context.py`), where the Kit process is killed by SIGSEGV.

Root cause: on the GPU PhysX pipeline, `PhysxManager._on_stop` invalidated cached tensor views but never detached the physics stage. Calling `play()` again without an intervening `reset()` (this test registers a raw `omni.timeline` PLAY/STOP subscription and cycles play/stop twice) makes the automatic re-warmup call `attach_stage()` on a stage PhysX still considers attached ("Stage already attached"), which corrupts its internal view registry and crashes the process inside `omni.physx.tensors`.

`_on_stop` now detaches the stage (GPU-only, matching `_warmup_and_create_views`'s own `is_gpu` guard, and itself guarded by `get_attached_stage()` so it's a no-op once `close()` has already detached it) so the next `play()` reattaches cleanly.

- Verified this isn't just papering over the crash: `PhysxManager._view` is correctly `None` after `stop()` and correctly recreated (non-`None`) after the next `play()` — an earlier attempt at this fix (suppressing `/app/player/playSimulations` during the pump) silently skipped view recreation instead of fixing the race, which this version does not do.
- Repro'd the crash outside pytest with a tight play/stop/play/stop loop: unpatched code crashes reliably (SIGSEGV inside `omni.physx.tensors`' internal view registry, consistent stack trace across multiple runs); patched code ran clean across 180+ iterations. Inside the full test file the race is intermittent (matches the original bug report describing it as a CI-only crash), so a regression assertion was added directly to the reported test rather than relying on crash absence alone.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Test plan
- [x] `uv run pytest source/isaaclab/test/sim/test_simulation_context.py -q` — 51 passed (previously crashed with SIGSEGV before the fix, confirmed via git stash A/B)
- [x] `uv run pytest source/isaaclab_physx/test/sim/test_physx_scene_data_backend.py source/isaaclab_physx/test/assets/test_rigid_object.py -q` — 103 passed, 1 skipped (broader PhysX view/reset regression check)
- [x] `uv run isaaclab -f`
- [x] `/code-review` — no findings on final diff