### PR TITLE
Tune visualization docs hero-tile framing and playback

### DIFF
--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -25,7 +25,7 @@ This page covers:
    .viz-grid > div { flex:1 1 0; min-width:0; }
    .viz-grid video, .viz-grid img { display:block; width:100%; border-radius:0 !important; padding:0 !important; background:none !important; }
    .viz-grid-stretch video, .viz-grid-stretch img { height:260px; object-fit:cover; }
-   .viz-grid-stretch.viz-grid-hero-tiles video { height:286px; }
+   .viz-grid-stretch.viz-grid-hero-tiles video { height:315px; }
    .viz-grid-fit { justify-content:center; }
    .viz-grid-fit > div { flex:0 0 auto; }
    .viz-grid-fit video, .viz-grid-fit img { width:auto; height:488px; }
@@ -35,17 +35,17 @@ This page covers:
    /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
       the same size and position across all 5 hero tiles. object-position stays centered; each
       video's own (taller) height sets the zoom and its negative margin-top picks which slice
-      of the 241px-tall wrap is shown. Newton RTX/Rerun/Kit/Viser are pinned against their clip's
+      of the 265px-tall wrap is shown. Newton RTX/Rerun/Kit/Viser are pinned against their clip's
       frame edge or UI chrome, so they're a few percent larger than a plain center crop; Newton
       GL was shrunk to match. Viser's clip also shows a sliver of a baked-in info panel at this
       zoom level -- a known trade-off. */
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:241px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:402px; margin-top:-97px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:273px; margin-top:-32px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:267px; margin-top:-26px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:287px; margin-top:-36px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:274px; margin-top:-33px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:425px; margin-top:-97px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:288px; margin-top:-23px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:282px; margin-top:-17px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:303px; margin-top:-27px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:289px; margin-top:-24px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }
@@ -536,11 +536,11 @@ Visualization markers draw debug geometry over the scene via
 
    <div class="viz-grid viz-grid-stretch">
      <div>
-       <img src="../../_static/markers_anymal_d.jpg" alt="Velocity arrow marker on an AnymalD robot">
+       <img src="../../_static/visualizers/markers_anymal_d.jpg" alt="Velocity arrow marker on an AnymalD robot">
        <p class="viz-cap">Large green/blue arrow markers showing target and base velocity for an AnymalD robot</p>
      </div>
      <div>
-       <img src="../../_static/markers_franka.jpg" alt="Joint arrow markers on a Franka arm and contact sensor markers on a cube" class="viz-crop-top">
+       <img src="../../_static/visualizers/markers_franka.jpg" alt="Joint arrow markers on a Franka arm and contact sensor markers on a cube" class="viz-crop-top">
        <p class="viz-cap">Arrow markers on the Franka arm's joints, with contact sensor markers on the cube</p>
      </div>
    </div>

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -40,14 +40,18 @@ This page covers:
       _main_hero() only bakes in a small fixed trim (mainly to clear each visualizer's own UI
       chrome), the actual zoom/framing lives here in CSS. If the hero clips are ever
       regenerated and republished, re-check these values against the new source dimensions.
-      Kit/Newton RTX have clean captures with room to zoom out further; Rerun and Viser each
-      bake in their own UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for
-      Viser) that the crop has to clear, which caps how far they can zoom out -- both are
-      cropped to their maximum safe zoom (just past the chrome) so their panels stay fully out
-      of frame. */
+      height/margin-top are chosen so margin-top + height == the 265px wrap exactly (i.e. the
+      video's own bottom edge lines up with the wrap's bottom edge, cropping only off the top) --
+      the native <video controls> bar is anchored to the video element's own box, so this keeps
+      it inside the visible/interactive area instead of clipped off by overflow:hidden. Kit and
+      Newton RTX have clean captures with room to zoom out further; Rerun and Viser each bake in
+      their own UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for Viser)
+      that the crop has to clear, which caps how far they can zoom out -- both are already
+      cropped to their maximum safe zoom (just past the chrome), with zero room left before their
+      panels would reappear. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:360px; margin-top:-95px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:288px; margin-top:-12px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -40,11 +40,11 @@ This page covers:
       crop here; Kit/Newton RTX have clean captures and are shown uncropped (full native
       960x580). Rerun and Viser each bake in their own UI chrome (a "3D View"/physics-backend
       bar for Rerun, an info panel for Viser) that the crop has to clear, which caps how far they
-      can zoom out -- Viser in particular still shows a sliver of its panel at this zoom level, a
-      known trade-off. */
+      can zoom out -- both are cropped to their maximum safe zoom (just past the chrome) rather
+      than a fixed ratio, so their info panels stay fully out of frame. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:300px; margin-top:-35px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:288px; margin-top:-12px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
@@ -896,6 +896,14 @@ The Rerun web viewer may slow down or crash with many environments. Reduce load 
       .. code-block:: bash
 
           ./isaaclab.sh train --rl_library rsl_rl --task Isaac-Cartpole --viz rerun --num_envs 512
+
+**Rerun: blank page until the first payload loads**
+
+The Rerun browser tab opens blank and stays that way for several seconds (up to ~10s,
+depending on scene size) before the scene and live plots appear. This is expected -- it's the
+time for the web viewer to connect to the local Rerun server and receive its first batch of
+logged data -- but the page gives no loading indicator in the meantime, so it can look stuck.
+No action is needed; wait for the first frame to arrive.
 
 **Newton GL: CUDA/OpenGL interoperability warnings**
 

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -62,13 +62,13 @@ This page covers:
    <div class="viz-hero-stack">
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-gl">
-       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay loop muted playsinline preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton GL</div>
      </div>
      <div class="viz-hero-wrap viz-crop-viser">
-       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay loop muted playsinline preload="auto" class="viz-hero-start-1s">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Viser</div>
@@ -76,19 +76,19 @@ This page covers:
    </div>
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-rtx">
-       <video autoplay muted playsinline preload="auto" class="viz-hero-speedup viz-hero-sync">
+       <video autoplay loop muted playsinline preload="auto" class="viz-hero-speedup">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
      <div class="viz-hero-wrap viz-crop-kit">
-       <video autoplay muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup viz-hero-sync">
+       <video autoplay loop muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
      </div>
      <div class="viz-hero-wrap viz-crop-rerun">
-       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay loop muted playsinline preload="auto" class="viz-hero-start-1s">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Rerun</div>
@@ -97,35 +97,17 @@ This page covers:
    </div>
 
    <script>
-   // The 5 clips already start in phase at file time 0 (capture_visualizer.py step_offset
-   // synchronizes Kit/Newton RTX's start to Newton GL/Rerun/Viser's). The autoplay attribute is
-   // kept as a no-JS/blocked-script fallback (each clip still starts on its own, just not necessarily in
-   // phase); when this script runs, it re-syncs all 5 to a shared start point, waiting for
-   // whichever clips aren't ready yet, then resets that sync point on every loop restart.
-   var heroVideos = Array.from(document.querySelectorAll(".viz-hero-sync"));
    // Kit/Newton RTX are encoded 10% slower than the other 3 (output_speed_factor in
-   // capture_visualizer.py); undo that so all 5 stay in phase as they play.
+   // capture_visualizer.py); undo that so all 5 independently-looping clips stay in phase.
    document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
      v.playbackRate = 1 / 0.9;
    });
-   var resyncing = false;
-   function resyncAll() {
-     if (resyncing) return;
-     resyncing = true;
-     heroVideos.forEach(function (o) { o.currentTime = 0; });
-     heroVideos.forEach(function (o) { o.play(); });
-     // Frame-rounding can make one clip's "ended" fire fractionally before the others; ignore
-     // any more of them for the rest of this loop instead of re-triggering a reset mid-loop.
-     setTimeout(function () { resyncing = false; }, 1000);
-   }
-   heroVideos.forEach(function (v) { v.addEventListener("ended", resyncAll); });
-   Promise.all(
-     heroVideos.map(function (v) {
-       return v.readyState >= 3
-         ? Promise.resolve()
-         : new Promise(function (resolve) { v.addEventListener("canplay", resolve, { once: true }); });
-     })
-   ).then(resyncAll);
+   // Start Viser/Rerun 1s into their clip instead of at 0; native loop still wraps to 0 as usual.
+   document.querySelectorAll(".viz-hero-start-1s").forEach(function (v) {
+     var seek = function () { v.currentTime = 1; };
+     if (v.readyState >= 1) seek();
+     else v.addEventListener("loadedmetadata", seek, { once: true });
+   });
    </script>
 
    <p class="viz-cap">Note: Newton RTX has no velocity arrows, since it doesn't yet support visualization markers.</p>

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -51,7 +51,7 @@ This page covers:
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:345px; margin-top:-46px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:293px; margin-top:-19px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -62,13 +62,13 @@ This page covers:
    <div class="viz-hero-stack">
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-gl">
-       <video muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton GL</div>
      </div>
      <div class="viz-hero-wrap viz-crop-viser">
-       <video muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Viser</div>
@@ -76,19 +76,19 @@ This page covers:
    </div>
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-rtx">
-       <video muted playsinline preload="auto" class="viz-hero-speedup viz-hero-sync">
+       <video autoplay muted playsinline preload="auto" class="viz-hero-speedup viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
      <div class="viz-hero-wrap viz-crop-kit">
-       <video muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup viz-hero-sync">
+       <video autoplay muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
      </div>
      <div class="viz-hero-wrap viz-crop-rerun">
-       <video muted playsinline preload="auto" class="viz-hero-sync">
+       <video autoplay muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Rerun</div>
@@ -98,32 +98,34 @@ This page covers:
 
    <script>
    // The 5 clips already start in phase at file time 0 (capture_visualizer.py step_offset
-   // synchronizes Kit/Newton RTX's start to Newton GL/Rerun/Viser's), so instead of the autoplay
-   // attribute (which starts each element independently, whenever its own data happens to be
-   // ready) wait for every clip to be ready, then call play() on all of them in the same tick,
-   // and reset that sync point on every loop restart.
+   // synchronizes Kit/Newton RTX's start to Newton GL/Rerun/Viser's). The autoplay attribute is
+   // kept as a no-JS/blocked-script fallback (each clip still starts on its own, just not necessarily in
+   // phase); when this script runs, it re-syncs all 5 to a shared start point, waiting for
+   // whichever clips aren't ready yet, then resets that sync point on every loop restart.
    var heroVideos = Array.from(document.querySelectorAll(".viz-hero-sync"));
    // Kit/Newton RTX are encoded 10% slower than the other 3 (output_speed_factor in
    // capture_visualizer.py); undo that so all 5 stay in phase as they play.
    document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
      v.playbackRate = 1 / 0.9;
    });
-   heroVideos.forEach(function (v) {
-     v.addEventListener("ended", function () {
-       heroVideos.forEach(function (o) { o.currentTime = 0; });
-       heroVideos.forEach(function (o) { o.play(); });
-     });
-   });
+   var resyncing = false;
+   function resyncAll() {
+     if (resyncing) return;
+     resyncing = true;
+     heroVideos.forEach(function (o) { o.currentTime = 0; });
+     heroVideos.forEach(function (o) { o.play(); });
+     // Frame-rounding can make one clip's "ended" fire fractionally before the others; ignore
+     // any more of them for the rest of this loop instead of re-triggering a reset mid-loop.
+     setTimeout(function () { resyncing = false; }, 1000);
+   }
+   heroVideos.forEach(function (v) { v.addEventListener("ended", resyncAll); });
    Promise.all(
      heroVideos.map(function (v) {
        return v.readyState >= 3
          ? Promise.resolve()
          : new Promise(function (resolve) { v.addEventListener("canplay", resolve, { once: true }); });
      })
-   ).then(function () {
-     heroVideos.forEach(function (v) { v.currentTime = 0; });
-     heroVideos.forEach(function (v) { v.play(); });
-   });
+   ).then(resyncAll);
    </script>
 
    <p class="viz-cap">Note: Newton RTX has no velocity arrows, since it doesn't yet support visualization markers.</p>

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -51,7 +51,7 @@ This page covers:
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:370px; margin-top:-59px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:345px; margin-top:-46px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -73,13 +73,13 @@ This page covers:
    <div class="viz-hero-stack">
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-gl">
-       <video autoplay loop muted playsinline controls preload="auto">
+       <video autoplay loop muted playsinline preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton GL</div>
      </div>
      <div class="viz-hero-wrap viz-crop-viser">
-       <video autoplay loop muted playsinline controls preload="auto">
+       <video autoplay loop muted playsinline preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Viser</div>
@@ -87,19 +87,19 @@ This page covers:
    </div>
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-rtx">
-       <video autoplay loop muted playsinline controls preload="auto">
+       <video autoplay loop muted playsinline preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
      <div class="viz-hero-wrap viz-crop-kit">
-       <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-x8">
+       <video autoplay loop muted playsinline preload="auto" class="viz-crop-x8">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
      </div>
      <div class="viz-hero-wrap viz-crop-rerun">
-       <video autoplay loop muted playsinline controls preload="auto">
+       <video autoplay loop muted playsinline preload="auto">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Rerun</div>

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -32,21 +32,12 @@ This page covers:
    .viz-grid-stretch video.viz-no-crop { object-fit:contain; background:#000; }
    .viz-grid-stretch video.viz-crop-x8 { width:calc(100% + 16px); margin-left:-8px; }
    .viz-grid-stretch img.viz-crop-top { object-position:center 25%; }
-   /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
-      a matched size within each row (top row: Newton GL/Viser; bottom row: Newton RTX/Rerun/
-      Kit). object-position stays centered; each video's own (taller) height sets the zoom and
-      its negative margin-top picks which slice of the 265px-tall wrap is shown. These values
-      are tuned against the *currently hosted* clips, not against what capture_visualizer.py's
-      own crop constants would produce -- _main_hero() only bakes in a small fixed trim (mainly
-      to clear each visualizer's own UI chrome), the actual zoom/framing lives here in CSS. If
-      the hero clips are ever regenerated and republished, re-check these values against the new
-      source dimensions. The 5 hero videos have no `controls` attribute (see the markup below),
-      so nothing here needs to keep a controls bar in the visible area -- Newton GL/Kit/Newton
-      RTX are clean captures with plenty of room to crop; Rerun and Viser each bake in their own
-      UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for Viser) that the
-      crop has to clear, which caps how far *out* they can zoom -- Viser is already at that
-      maximum-zoom-out limit; Rerun still has room and is zoomed in further here to match the
-      bottom row's size, well clear of its chrome on both edges. */
+   /* Per-tile crop windows: each video's (taller) height sets the zoom and its negative
+      margin-top picks which slice of the 265px wrap is shown, matching robot size within each
+      row. Tuned against the currently hosted clips, not capture_visualizer.py's own (much
+      smaller) fixed trim -- re-check if the clips are ever regenerated. Rerun/Viser cap how far
+      they can zoom out before their own baked-in UI chrome reappears; Viser is already at that
+      limit. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
@@ -106,11 +97,8 @@ This page covers:
    </div>
 
    <script>
-   // Kit/Newton RTX's clips are encoded 10% slower than the other 3 (see _hero_record_visualizer
-   // in tools/docs/media/visualizers/capture_visualizer.py) and loop independently, so without
-   // compensation they drift out of rotational phase with Newton GL/Viser/Rerun as each clip
-   // loops. Playing them back at 1/0.9 undoes that baked-in slowdown so all 5 finish a loop
-   // (and stay in phase) at the same wall-clock rate.
+   // Kit/Newton RTX are encoded 10% slower than the other 3 (output_speed_factor in
+   // capture_visualizer.py); undo that so all 5 independently-looping clips stay in phase.
    document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
      v.playbackRate = 1 / 0.9;
    });

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -35,15 +35,19 @@ This page covers:
    /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
       the same size and position across all 5 hero tiles. object-position stays centered; each
       video's own (taller) height sets the zoom and its negative margin-top picks which slice
-      of the 265px-tall wrap is shown. Newton GL's crop is baked into the clip itself (see
-      _main_hero() in tools/docs/media/visualizers/capture_visualizer.py), so it needs no extra
-      crop here; Kit/Newton RTX have clean captures and are shown uncropped (full native
-      960x580). Rerun and Viser each bake in their own UI chrome (a "3D View"/physics-backend
-      bar for Rerun, an info panel for Viser) that the crop has to clear, which caps how far they
-      can zoom out -- both are cropped to their maximum safe zoom (just past the chrome) rather
-      than a fixed ratio, so their info panels stay fully out of frame. */
+      of the 265px-tall wrap is shown. These values are tuned against the *currently hosted*
+      clips, not against what capture_visualizer.py's own crop constants would produce --
+      _main_hero() only bakes in a small fixed trim (mainly to clear each visualizer's own UI
+      chrome), the actual zoom/framing lives here in CSS. If the hero clips are ever
+      regenerated and republished, re-check these values against the new source dimensions.
+      Kit/Newton RTX have clean captures with room to zoom out further; Rerun and Viser each
+      bake in their own UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for
+      Viser) that the crop has to clear, which caps how far they can zoom out -- both are
+      cropped to their maximum safe zoom (just past the chrome) so their panels stay fully out
+      of frame. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:288px; margin-top:-12px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
@@ -84,17 +88,17 @@ This page covers:
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
-     <div class="viz-hero-wrap viz-crop-rerun">
-       <video autoplay loop muted playsinline controls preload="auto">
-         <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
-       </video>
-       <div class="viz-label">Rerun</div>
-     </div>
      <div class="viz-hero-wrap viz-crop-kit">
        <video autoplay loop muted playsinline controls preload="auto" class="viz-crop-x8">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
+     </div>
+     <div class="viz-hero-wrap viz-crop-rerun">
+       <video autoplay loop muted playsinline controls preload="auto">
+         <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
+       </video>
+       <div class="viz-label">Rerun</div>
      </div>
    </div>
    </div>

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -102,9 +102,9 @@ This page covers:
    document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
      v.playbackRate = 1 / 0.9;
    });
-   // Start Viser/Rerun 1s into their clip instead of at 0; native loop still wraps to 0 as usual.
+   // Start Viser/Rerun 1.2s into their clip instead of at 0; native loop still wraps to 0 as usual.
    document.querySelectorAll(".viz-hero-start-1s").forEach(function (v) {
-     var seek = function () { v.currentTime = 1; };
+     var seek = function () { v.currentTime = 1.2; };
      if (v.readyState >= 1) seek();
      else v.addEventListener("loadedmetadata", seek, { once: true });
    });

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -62,13 +62,13 @@ This page covers:
    <div class="viz-hero-stack">
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-gl">
-       <video autoplay loop muted playsinline preload="auto">
+       <video muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_gl.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton GL</div>
      </div>
      <div class="viz-hero-wrap viz-crop-viser">
-       <video autoplay loop muted playsinline preload="auto">
+       <video muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_viser.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Viser</div>
@@ -76,19 +76,19 @@ This page covers:
    </div>
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-rtx">
-       <video autoplay loop muted playsinline preload="auto" class="viz-hero-speedup">
+       <video muted playsinline preload="auto" class="viz-hero-speedup viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
      <div class="viz-hero-wrap viz-crop-kit">
-       <video autoplay loop muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup">
+       <video muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
      </div>
      <div class="viz-hero-wrap viz-crop-rerun">
-       <video autoplay loop muted playsinline preload="auto">
+       <video muted playsinline preload="auto" class="viz-hero-sync">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_rerun.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Rerun</div>
@@ -97,10 +97,32 @@ This page covers:
    </div>
 
    <script>
+   // The 5 clips already start in phase at file time 0 (capture_visualizer.py step_offset
+   // synchronizes Kit/Newton RTX's start to Newton GL/Rerun/Viser's), so instead of the autoplay
+   // attribute (which starts each element independently, whenever its own data happens to be
+   // ready) wait for every clip to be ready, then call play() on all of them in the same tick,
+   // and reset that sync point on every loop restart.
+   var heroVideos = Array.from(document.querySelectorAll(".viz-hero-sync"));
    // Kit/Newton RTX are encoded 10% slower than the other 3 (output_speed_factor in
-   // capture_visualizer.py); undo that so all 5 independently-looping clips stay in phase.
+   // capture_visualizer.py); undo that so all 5 stay in phase as they play.
    document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
      v.playbackRate = 1 / 0.9;
+   });
+   heroVideos.forEach(function (v) {
+     v.addEventListener("ended", function () {
+       heroVideos.forEach(function (o) { o.currentTime = 0; });
+       heroVideos.forEach(function (o) { o.play(); });
+     });
+   });
+   Promise.all(
+     heroVideos.map(function (v) {
+       return v.readyState >= 3
+         ? Promise.resolve()
+         : new Promise(function (resolve) { v.addEventListener("canplay", resolve, { once: true }); });
+     })
+   ).then(function () {
+     heroVideos.forEach(function (v) { v.currentTime = 0; });
+     heroVideos.forEach(function (v) { v.play(); });
    });
    </script>
 

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -35,17 +35,17 @@ This page covers:
    /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
       the same size and position across all 5 hero tiles. object-position stays centered; each
       video's own (taller) height sets the zoom and its negative margin-top picks which slice
-      of the 265px-tall wrap is shown. Newton RTX/Rerun/Kit/Viser are pinned against their clip's
-      frame edge or UI chrome, so they're a few percent larger than a plain center crop; Newton
-      GL was shrunk to match. Viser's clip also shows a sliver of a baked-in info panel at this
-      zoom level -- a known trade-off. */
+      of the 265px-tall wrap is shown. Newton GL's crop is baked into the clip itself (see
+      _main_hero() in tools/docs/media/visualizers/capture_visualizer.py), so it needs no extra
+      crop here; Kit/Newton RTX have clean captures and are shown uncropped (full native
+      960x580). Rerun and Viser each bake in their own UI chrome (a "3D View"/physics-backend
+      bar for Rerun, an info panel for Viser) that the crop has to clear, which caps how far they
+      can zoom out -- Viser in particular still shows a sliver of its panel at this zoom level, a
+      known trade-off. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:425px; margin-top:-97px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:288px; margin-top:-23px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-rtx video { height:282px; margin-top:-17px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:303px; margin-top:-27px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-kit video { height:289px; margin-top:-24px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:300px; margin-top:-35px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:288px; margin-top:-12px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -33,27 +33,25 @@ This page covers:
    .viz-grid-stretch video.viz-crop-x8 { width:calc(100% + 16px); margin-left:-8px; }
    .viz-grid-stretch img.viz-crop-top { object-position:center 25%; }
    /* Per-tile crop windows, sized and positioned from the source clips so the robot renders at
-      the same size and position across all 5 hero tiles. object-position stays centered; each
-      video's own (taller) height sets the zoom and its negative margin-top picks which slice
-      of the 265px-tall wrap is shown. These values are tuned against the *currently hosted*
-      clips, not against what capture_visualizer.py's own crop constants would produce --
-      _main_hero() only bakes in a small fixed trim (mainly to clear each visualizer's own UI
-      chrome), the actual zoom/framing lives here in CSS. If the hero clips are ever
-      regenerated and republished, re-check these values against the new source dimensions.
-      height/margin-top are chosen so margin-top + height == the 265px wrap exactly (i.e. the
-      video's own bottom edge lines up with the wrap's bottom edge, cropping only off the top) --
-      the native <video controls> bar is anchored to the video element's own box, so this keeps
-      it inside the visible/interactive area instead of clipped off by overflow:hidden. Kit and
-      Newton RTX have clean captures with room to zoom out further; Rerun and Viser each bake in
-      their own UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for Viser)
-      that the crop has to clear, which caps how far they can zoom out -- both are already
-      cropped to their maximum safe zoom (just past the chrome), with zero room left before their
-      panels would reappear. */
+      a matched size within each row (top row: Newton GL/Viser; bottom row: Newton RTX/Rerun/
+      Kit). object-position stays centered; each video's own (taller) height sets the zoom and
+      its negative margin-top picks which slice of the 265px-tall wrap is shown. These values
+      are tuned against the *currently hosted* clips, not against what capture_visualizer.py's
+      own crop constants would produce -- _main_hero() only bakes in a small fixed trim (mainly
+      to clear each visualizer's own UI chrome), the actual zoom/framing lives here in CSS. If
+      the hero clips are ever regenerated and republished, re-check these values against the new
+      source dimensions. The 5 hero videos have no `controls` attribute (see the markup below),
+      so nothing here needs to keep a controls bar in the visible area -- Newton GL/Kit/Newton
+      RTX are clean captures with plenty of room to crop; Rerun and Viser each bake in their own
+      UI chrome (a "3D View"/physics-backend bar for Rerun, an info panel for Viser) that the
+      crop has to clear, which caps how far *out* they can zoom -- Viser is already at that
+      maximum-zoom-out limit; Rerun still has room and is zoomed in further here to match the
+      bottom row's size, well clear of its chrome on both edges. */
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap { height:265px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap video { object-position:center center; height:265px; margin-top:0; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:360px; margin-top:-95px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-newton-gl video { height:480px; margin-top:-105px; }
    .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-viser video { height:314px; margin-top:-49px; }
-   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:288px; margin-top:-12px; }
+   .viz-grid-stretch.viz-grid-hero-tiles .viz-hero-wrap.viz-crop-rerun video { height:370px; margin-top:-59px; }
    .viz-grid-record { justify-content:center; align-items:flex-start; }
    .viz-grid-record > div { flex:0 0 auto; }
    .viz-grid-record video { display:block; width:auto; height:300px; }

--- a/docs/source/concepts/visualization.rst
+++ b/docs/source/concepts/visualization.rst
@@ -85,13 +85,13 @@ This page covers:
    </div>
    <div class="viz-grid viz-grid-stretch viz-grid-hero-tiles">
      <div class="viz-hero-wrap viz-crop-newton-rtx">
-       <video autoplay loop muted playsinline preload="auto">
+       <video autoplay loop muted playsinline preload="auto" class="viz-hero-speedup">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_newton_rtx.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Newton RTX</div>
      </div>
      <div class="viz-hero-wrap viz-crop-kit">
-       <video autoplay loop muted playsinline preload="auto" class="viz-crop-x8">
+       <video autoplay loop muted playsinline preload="auto" class="viz-crop-x8 viz-hero-speedup">
          <source src="https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/hero_kit.mp4" type="video/mp4">
        </video>
        <div class="viz-label">Kit</div>
@@ -104,6 +104,17 @@ This page covers:
      </div>
    </div>
    </div>
+
+   <script>
+   // Kit/Newton RTX's clips are encoded 10% slower than the other 3 (see _hero_record_visualizer
+   // in tools/docs/media/visualizers/capture_visualizer.py) and loop independently, so without
+   // compensation they drift out of rotational phase with Newton GL/Viser/Rerun as each clip
+   // loops. Playing them back at 1/0.9 undoes that baked-in slowdown so all 5 finish a loop
+   // (and stay in phase) at the same wall-clock rate.
+   document.querySelectorAll(".viz-hero-speedup").forEach(function (v) {
+     v.playbackRate = 1 / 0.9;
+   });
+   </script>
 
    <p class="viz-cap">Note: Newton RTX has no velocity arrows, since it doesn't yet support visualization markers.</p>
 

--- a/tools/docs/media/visualizers/capture_visualizer.py
+++ b/tools/docs/media/visualizers/capture_visualizer.py
@@ -452,16 +452,22 @@ def record_windowed(
 _HERO_TASK = "Isaac-Velocity-Flat-AnymalD"
 
 # Streaming/tiled follow-camera (Kit): same offset/target as the tiled-camera tutorial
-# (scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py), zoomed in further.
+# (scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py), zoomed in further, then
+# pulled back another 25% (matching the 1/0.8 pull-back below) since Kit's streaming-camera FOV
+# renders the robot noticeably larger than Newton GL/RTX at the same eye distance.
 _HERO_STREAMING_TARGET_PRIM = "/World/envs/*/Robot/base"
-_HERO_STREAMING_EYE = (1.98, 1.98, 1.8)
-# Per-step follow-camera (Kit windowed, Newton GL): same offset as the streaming clip.
-_HERO_FOLLOW_EYE_OFFSET = _HERO_STREAMING_EYE
+_HERO_KIT_EYE_OFFSET = (2.48, 2.48, 2.25)
+# Per-step follow-camera (Newton GL only -- Kit uses _HERO_KIT_EYE_OFFSET for both its headless
+# streaming-view and windowed capture paths, since its streaming-camera FOV needs a different
+# distance than Newton GL to frame the same apparent robot size).
+_HERO_FOLLOW_EYE_OFFSET = (1.98, 1.98, 1.8)
 # Newton RTX/Rerun/Viser framed closer than Kit/Newton GL: their panels leave more empty
 # space around the robot at the shared offset above. Newton RTX framed a bit further back
-# than Rerun/Viser, whose tighter framing looked too tight for RTX at the same offset.
-_HERO_RTX_FOLLOW_EYE_OFFSET = (1.4, 1.4, 1.28)
-_HERO_BROWSER_FOLLOW_EYE_OFFSET = (1.0, 1.0, 0.91)
+# than Rerun/Viser, whose tighter framing looked too tight for RTX at the same offset. Newton
+# RTX and Rerun are then pulled back another 25% (~1/0.8) to shrink their apparent robot size by
+# ~20%, matching Newton GL/Viser -- Kit gets the same treatment via _HERO_KIT_EYE_OFFSET above.
+_HERO_RTX_FOLLOW_EYE_OFFSET = (1.75, 1.75, 1.6)
+_HERO_BROWSER_FOLLOW_EYE_OFFSET = (1.25, 1.25, 1.14)
 _HERO_VISER_FOLLOW_EYE_OFFSET = (0.8, 0.8, 0.73)
 # Narrows Newton GL/RTX's FOV to match Kit's streaming-camera framing at this eye distance;
 # no effect on Rerun (no FOV field) or Viser (already matches at the default 12mm).
@@ -613,7 +619,7 @@ def _hero_make_kit_visualizer_cfg() -> VisualizerCfg:
             streaming_view=True,
             streaming_envs=1,
             streaming_cam_target_prim_path=_HERO_STREAMING_TARGET_PRIM,
-            streaming_cam_eye=_HERO_STREAMING_EYE,
+            streaming_cam_eye=_HERO_KIT_EYE_OFFSET,
             enable_markers=True,
         )
     # Windowed capture records the "Viewport" tab, not "Streaming View", so it follows via
@@ -623,7 +629,7 @@ def _hero_make_kit_visualizer_cfg() -> VisualizerCfg:
         window_width=_HERO_WINDOW_WIDTH,
         window_height=_HERO_WINDOW_HEIGHT,
         streaming_view=False,
-        eye=_HERO_FOLLOW_EYE_OFFSET,
+        eye=_HERO_KIT_EYE_OFFSET,
         lookat=(0.0, 0.0, 0.0),
         enable_markers=True,
     )
@@ -1323,13 +1329,13 @@ def _main_hero(seed: int = 42) -> None:
                 "-i",
                 str(newton_gl_raw),
                 "-filter:v",
-                # Crops the raw 960x600 capture down to the exact window the docs page displays
-                # (matching the .viz-crop-newton-gl framing in visualization.rst), instead of
-                # relying on a CSS overflow:hidden wrap to hide the rest. Baking the crop into
-                # the clip itself means the native <video controls> bar -- anchored to the
-                # <video> element's own box, which used to be much taller than the visible
-                # window -- has no extra offscreen area to reappear in on hover.
-                f"setpts=PTS/{newton_gl_speedup},crop=960:452:0:98",
+                # Matches the crop=iw:ih-20:0:10 the other 4 hero clips already get in
+                # _hero_record_visualizer()/_run_combined_capture() -- a small fixed trim, not
+                # the full robot-framing zoom (that lives in the .viz-crop-newton-gl CSS rule in
+                # visualization.rst). Without even this much, Newton GL's raw capture is 20px
+                # taller than the rest, and its native <video controls> bar has extra offscreen
+                # room in the CSS wrap to reappear in on hover.
+                f"setpts=PTS/{newton_gl_speedup},crop=iw:ih-20:0:10",
                 "-c:v",
                 "libx264",
                 "-preset",

--- a/tools/docs/media/visualizers/capture_visualizer.py
+++ b/tools/docs/media/visualizers/capture_visualizer.py
@@ -1323,7 +1323,12 @@ def _main_hero(seed: int = 42) -> None:
                 "-i",
                 str(newton_gl_raw),
                 "-filter:v",
-                f"setpts=PTS/{newton_gl_speedup}",
+                # Matches the crop=iw:ih-20:0:10 the other 4 hero clips already get in
+                # _hero_record_visualizer()/_run_combined_capture(). Without it, Newton GL's
+                # raw 960x600 capture is 20px taller than the rest, and the CSS crop window on
+                # the docs page (tuned for a 960x580 source) doesn't clip its native <video
+                # controls> bar out of the visible frame the way it does for the others.
+                f"setpts=PTS/{newton_gl_speedup},crop=iw:ih-20:0:10",
                 "-c:v",
                 "libx264",
                 "-preset",

--- a/tools/docs/media/visualizers/capture_visualizer.py
+++ b/tools/docs/media/visualizers/capture_visualizer.py
@@ -1333,8 +1333,7 @@ def _main_hero(seed: int = 42) -> None:
                 # _hero_record_visualizer()/_run_combined_capture() -- a small fixed trim, not
                 # the full robot-framing zoom (that lives in the .viz-crop-newton-gl CSS rule in
                 # visualization.rst). Without even this much, Newton GL's raw capture is 20px
-                # taller than the rest, and its native <video controls> bar has extra offscreen
-                # room in the CSS wrap to reappear in on hover.
+                # taller than the rest, throwing off that CSS crop's framing.
                 f"setpts=PTS/{newton_gl_speedup},crop=iw:ih-20:0:10",
                 "-c:v",
                 "libx264",

--- a/tools/docs/media/visualizers/capture_visualizer.py
+++ b/tools/docs/media/visualizers/capture_visualizer.py
@@ -1323,12 +1323,13 @@ def _main_hero(seed: int = 42) -> None:
                 "-i",
                 str(newton_gl_raw),
                 "-filter:v",
-                # Matches the crop=iw:ih-20:0:10 the other 4 hero clips already get in
-                # _hero_record_visualizer()/_run_combined_capture(). Without it, Newton GL's
-                # raw 960x600 capture is 20px taller than the rest, and the CSS crop window on
-                # the docs page (tuned for a 960x580 source) doesn't clip its native <video
-                # controls> bar out of the visible frame the way it does for the others.
-                f"setpts=PTS/{newton_gl_speedup},crop=iw:ih-20:0:10",
+                # Crops the raw 960x600 capture down to the exact window the docs page displays
+                # (matching the .viz-crop-newton-gl framing in visualization.rst), instead of
+                # relying on a CSS overflow:hidden wrap to hide the rest. Baking the crop into
+                # the clip itself means the native <video controls> bar -- anchored to the
+                # <video> element's own box, which used to be much taller than the visible
+                # window -- has no extra offscreen area to reappear in on hover.
+                f"setpts=PTS/{newton_gl_speedup},crop=960:452:0:98",
                 "-c:v",
                 "libx264",
                 "-preset",

--- a/tools/docs/media/visualizers/capture_visualizer.py
+++ b/tools/docs/media/visualizers/capture_visualizer.py
@@ -595,6 +595,8 @@ def _follow_camera(env, env_ids) -> None:
             offset = _HERO_VISER_FOLLOW_EYE_OFFSET
         elif visualizer_name == "NewtonRTXVisualizer":
             offset = _HERO_RTX_FOLLOW_EYE_OFFSET
+        elif visualizer_name == "KitVisualizer":
+            offset = _HERO_KIT_EYE_OFFSET
         else:
             offset = _HERO_FOLLOW_EYE_OFFSET
         eye = (target[0] + offset[0], target[1] + offset[1], target[2] + offset[2])


### PR DESCRIPTION
## Summary
- Matches robot size within each row of the visualization docs hero tile grid (top: Newton GL/Viser; bottom: Newton RTX/Kit/Rerun), reordered to Newton RTX/Kit/Rerun.
- Removes the native `<video controls>` bar from the 5 decorative hero clips (autoplay/loop/muted background tiles, not meant to be scrubbed).
- Syncs Kit/Newton RTX's playback rate to the other 3 clips, which are baked 10% slower in `capture_visualizer.py`.
- Starts Viser/Rerun 1.2s into their clip instead of 0 for better starting-pose alignment with the other 3.
- Fixes broken marker image paths (`_static/markers_*.jpg` → `_static/visualizers/markers_*.jpg`).
- Documents Rerun's blank-page-on-startup behavior in the Limitations section.
- Minor `capture_visualizer.py` tweaks (crop trim, camera eye-offset constants for a possible future recapture) with updated comments.

## Test plan
- [x] `uv run isaaclab -f` passes
- [x] Built the docs locally (`sphinx-build`) and visually verified the hero tile grid against the actual hosted clips using headless Chromium/Playwright screenshots
- [x] Verified Kit/Newton RTX playback-rate correction and Viser/Rerun start-offset with Playwright (`currentTime`/`playbackRate` assertions against the built page)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`