### PR TITLE
[Workflow] Use Newton 1.5 release branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "onnxscript>=0.5",
     # ----- newton (default physics engine) -----
     # Loose bound so the wheel co-resolves with isaacsim's newton[sim]==1.2.0 pin; the
-    # exact PyPI release is forced via [tool.uv].override-dependencies (uv sync only).
+    # exact git commit is forced via [tool.uv].override-dependencies (uv sync only).
     "newton[sim]>=1.2.0",
     # Import and mesh-processing packages used by Newton, including the ones that honoring
     # USD-authored ``physics:approximation`` requires. Keep these explicit instead of selecting
@@ -214,6 +214,7 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.11"
 ovrtx = "0.4.1.364340"
 ovstage = "0.1.1.355824"
+newton = "release-1.5"
 warp = "1.16.0"
 
 [tool.ruff]
@@ -401,7 +402,7 @@ override-dependencies = [
     "numpy>=2",
     "mujoco~=3.11.0",
     "mujoco-warp~=3.11.0",
-    "newton[sim]==1.5.1",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.4.1",
     "torch==2.11.0",

--- a/source/isaaclab/changelog.d/newton-1-5-release-branch.rst
+++ b/source/isaaclab/changelog.d/newton-1-5-release-branch.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed the Newton dependency from the ``newton[sim]==1.5.1`` PyPI release to the
+  ``release-1.5`` Git branch to include the latest actuator fixes.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -167,9 +167,9 @@ def test_version_single_source_matches_literal_pins():
     for package in ("torch", "torchvision", "torchaudio"):
         assert f"{package}=={versions[package]}" in overrides
 
-    # The Newton uv override is its single pin and may select a release or Git revision.
+    # The Newton uv override mirrors the authoritative release branch.
     newton_spec = next(requirement for requirement in overrides if requirement.startswith("newton[sim]"))
-    assert "==" in newton_spec or " @ git+" in newton_spec
+    assert newton_spec.endswith(f"newton.git@{versions['newton']}")
 
     # warp-lang is a core dependency whose table value may be an exact pin
     # ("1.2.3" -> ``==``) or a range (">=1.2.3" -> mirrored verbatim).

--- a/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
+++ b/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
@@ -90,7 +90,7 @@ class Test_Cli_Install_In_Uvenv_Smoke(UV_Mixin):
 
         ``newton`` is an extra feature selector: it reinstalls the already-present
         core packages (``isaaclab_newton``, ``isaaclab_physx``, ``isaaclab_visualizers``)
-        with their newton extras, pulling in the pinned ``newton[sim]`` release.
+        with their newton extras, pulling in the ``newton[sim]`` release-branch build.
         """
 
         try:

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
@@ -15,7 +15,7 @@ Setup:
          Reinstall AFTER the wheel install: unsafe-best-match re-resolves torch from PyPI to CPU.)
     - (aarch64 only) export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
 Tests:
-    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.5.1'"
+    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.5.2'"
         -> verify the wheel resolves Newton 1.5
     - uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct --num_envs 16
         presets=newton_mjwarp --max_iterations 5; uv run isaaclab train --rl_library rsl_rl
@@ -57,7 +57,7 @@ class Test_Uv_Pip_Install_Isaaclab_All_Trains_Cartpole(UV_Mixin):
             assert result.returncode == 0, f"uv pip install {wheel}[all] failed:\n{result.stdout}\n{result.stderr}"
 
             result = self.run_in_uv_env(
-                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.5.1'"],
+                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.5.2'"],
                 cwd=isaaclab_root,
             )
             assert result.returncode == 0, (

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
@@ -7,7 +7,7 @@
 Setup:
     - (wheel supplied by runner: tools/run_install_ci.py --build-wheel or --wheel <path>)
     - ./isaaclab.sh -u
-    - uv --no-config pip install <wheel>[all]
+    - uv --no-config pip install <wheel>[all] --overrides uv_pip/uv-overrides.txt
     - uv pip install --reinstall-package torch --reinstall-package torchvision
         torch==<pinned> torchvision==<pinned> --index-url <cu128|cu130>
         (versions read from [tool.isaaclab.versions] in the root pyproject.)
@@ -46,13 +46,17 @@ class Test_Uv_Pip_Install_Isaaclab_All_Trains_Cartpole(UV_Mixin):
     @pytest.mark.slow
     @pytest.mark.gpu
     @pytest.mark.timeout(4800)
-    def test_uv_pip_install_isaaclab_all_trains_cartpole(self, isaaclab_root, wheel, cartpole_smoke_script):
+    def test_uv_pip_install_isaaclab_all_trains_cartpole(
+        self, isaaclab_root, wheel, uv_overrides, cartpole_smoke_script
+    ):
         """Install the runner-supplied wheel with ``[all]`` via ``uv pip``, then train."""
         try:
             self.create_uv_env(isaaclab_root)
 
             result = self.run_in_uv_env(
-                ["uv", "--no-config", "pip", "install", f"{wheel}[all]"], cwd=isaaclab_root, timeout=1800
+                ["uv", "--no-config", "pip", "install", f"{wheel}[all]", "--overrides", str(uv_overrides)],
+                cwd=isaaclab_root,
+                timeout=1800,
             )
             assert result.returncode == 0, f"uv pip install {wheel}[all] failed:\n{result.stdout}\n{result.stderr}"
 

--- a/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
+++ b/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim]==1.5.1
+newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/tools/wheel_builder/uv-overrides.txt
+++ b/tools/wheel_builder/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim]==1.5.1
+newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.5
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ overrides = [
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "mujoco", specifier = "~=3.11.0" },
     { name = "mujoco-warp", specifier = "~=3.11.0" },
-    { name = "newton", extras = ["sim"], specifier = "==1.5.1" },
+    { name = "newton", extras = ["sim"], git = "https://github.com/newton-physics/newton.git?rev=release-1.5" },
     { name = "newton-usd-schemas", specifier = ">=0.4.1" },
     { name = "numpy", specifier = ">=2" },
     { name = "packaging", specifier = ">=20,<27" },
@@ -3354,13 +3354,10 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.5.2"
+source = { git = "https://github.com/newton-physics/newton.git?rev=release-1.5#cf5378db6002b5c19b86344737cdd40cb8e08f0c" }
 dependencies = [
     { name = "warp-lang" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d6a3e799c25cf04b5ab35b9903cafd09731df123a0c91f4d27caed28d431/newton-1.5.1-py3-none-any.whl", hash = "sha256:a757269fe03ca2e50edb9636b3c7eb91c2d1e359b6e9c992b33dc6d9058b5285", size = 5564220, upload-time = "2026-08-27T20:33:23.381Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Description

This updates `release/3.0.0` to consume Newton from its `release-1.5` Git branch instead of the `newton[sim]==1.5.1` PyPI wheel. The regenerated lock resolves Newton 1.5.2 at `cf5378db`, which includes the latest actuator fixes, including newton-physics/newton#4101.

The wheel-builder and install-CI overrides, install smoke expectations, pin-consistency coverage, and changelog fragment are updated in sync. The Isaac Lab actuator-path default is intentionally unchanged in this release PR and is handled separately on `develop`.

## Type of change

- Bug fix (picks up the latest Newton 1.5 actuator fixes)
- Workflow/dependency update

## Release backport

- [ ] <!-- backport-active-release --> Not applicable; this PR targets `release/3.0.0` directly.

## Screenshots

Not applicable.

## Validation

- `uv lock --check`
- Wheel resolver dry-run: without install-CI overrides resolves `newton==1.5.1`; with overrides resolves `newton==1.5.2` at `cf5378db`
- `uv run --extra test python -m pytest source/isaaclab/test/cli/test_install.py source/isaaclab/test/cli/test_uv_run_pyproject.py source/isaaclab/test/cli/test_wheel_builder_metadata.py -k 'EnsureNewton or version_single_source or wheel_builder_uv_overrides'` (6 passed)
- Newton upstream `TestActuatorStateAssign` and `TestControllerStateGraphCapture` against the locked build (10 passed)
- `uv run isaaclab -f` with `ISAACLAB_CHANGELOG_BASE_REF=release/3.0.0`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation is not affected
- [x] My changes generate no new warnings
- [x] I have added tests that prove the dependency metadata is synchronized
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`