### PR TITLE
Restore Agibot Newton-backed visualizers

### DIFF
--- a/source/isaaclab_tasks/changelog.d/remove-agibot-reversed-joint-guard.rst
+++ b/source/isaaclab_tasks/changelog.d/remove-agibot-reversed-joint-guard.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Restored Newton-backed visualizers for Agibot place tasks after the robot asset's reversed joint ordering was
+  corrected. Newton physics remains unsupported because of an incompatible generated collision mesh.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/place/config/agibot/place_toy2box_rmp_rel_env_cfg.py
@@ -9,7 +9,6 @@ from dataclasses import MISSING
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
-from isaaclab.app import get_settings_manager
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
 from isaaclab.devices.device_base import DevicesCfg
 from isaaclab.devices.keyboard import Se3KeyboardCfg
@@ -209,58 +208,12 @@ class PhysicsCfg(PresetCfg):
     default = isaacsim_physx
 
 
-# Robot USD assets whose gripper revolute joints are authored with reversed
-# body0/body1 ordering, which the Newton MJWarp USD parser rejects.
-_NEWTON_REVERSED_JOINT_ASSETS = ("Robots/Agibot/A2D/",)
-_NEWTON_MODEL_VISUALIZER_TYPES = {"newton", "newton_gl", "newton_rtx", "rerun", "viser"}
-
-
-def _get_active_visualizer_types(env_cfg: ManagerBasedRLEnvCfg) -> set[str]:
-    """Return visualizer types selected by config or launcher settings."""
-    settings = get_settings_manager()
-    if settings.get("/isaaclab/visualizer/disable_all", False):
-        return set()
-
-    if settings.get("/isaaclab/visualizer/explicit", False):
-        value = settings.get("/isaaclab/visualizer/types", "")
-        return {item for chunk in str(value).split(",") for item in chunk.split() if item}
-
-    visualizer_cfgs = env_cfg.sim.visualizer_cfgs
-    if not isinstance(visualizer_cfgs, list):
-        visualizer_cfgs = [visualizer_cfgs]
-    return {cfg.visualizer_type for cfg in visualizer_cfgs if getattr(cfg, "visualizer_type", None)}
-
-
-def raise_if_reversed_joints_on_newton(env_cfg: ManagerBasedRLEnvCfg) -> None:
-    """Reject Newton import paths for robots whose USD has reversed gripper joints.
-
-    The Newton MJWarp ``parse_usd`` importer requires each joint prim to define the parent
-    body as ``physics:body0`` and the child as ``physics:body1``. Some robot assets (e.g. the
-    Agibot A2D gripper support-link revolute joints) author these reversed; PhysX tolerates
-    this, but Newton raises ``Reversed joints are not supported`` deep in scene creation.
-    Newton-backed visualizers also use this importer to build a shadow model when PhysX is
-    active. This raises an actionable error before either import path is initialized.
-
-    Args:
-        env_cfg: The resolved environment config to inspect.
-    """
-    robot_cfg = getattr(env_cfg.scene, "robot", None)
-    usd_path = getattr(getattr(robot_cfg, "spawn", None), "usd_path", None)
-    newton_model_visualizers = sorted(_get_active_visualizer_types(env_cfg) & _NEWTON_MODEL_VISUALIZER_TYPES)
-
-    if usd_path is None or not (isinstance(env_cfg.sim.physics, NewtonCfg) or newton_model_visualizers):
-        return
-    if any(marker in usd_path for marker in _NEWTON_REVERSED_JOINT_ASSETS):
-        visualizer_reason = (
-            f" The selected Newton-backed visualizer(s) {newton_model_visualizers} require the same importer."
-            if newton_model_visualizers
-            else ""
-        )
+def raise_if_unsupported_newton_physics(env_cfg: ManagerBasedRLEnvCfg) -> None:
+    """Reject Newton physics while the Agibot collision mesh cannot compile."""
+    if isinstance(env_cfg.sim.physics, NewtonCfg):
         raise ValueError(
-            "This task's robot has gripper joints authored with reversed body0/body1 ordering, "
-            "which Newton's USD importer does not support ('Reversed joints are not supported')."
-            f"{visualizer_reason} Use physics=isaacsim_physx with --visualizer kit, or use "
-            "--visualizer none for headless execution."
+            "The Agibot A2D asset contains a generated convex collision mesh whose volume is too small for "
+            "Newton MJWarp. Re-run this task with physics=isaacsim_physx (the default)."
         )
 
 
@@ -294,7 +247,7 @@ class PlaceToy2BoxEnvCfg(ManagerBasedRLEnvCfg):
 
     def validate_config(self):
         """Reject backend combinations that the configured robot cannot run on."""
-        raise_if_reversed_joints_on_newton(self)
+        raise_if_unsupported_newton_physics(self)
 
 
 """

--- a/source/isaaclab_tasks/test/contrib/test_agibot_place_env_cfg.py
+++ b/source/isaaclab_tasks/test/contrib/test_agibot_place_env_cfg.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for Agibot place environment backend compatibility."""
+
+import pytest
+from isaaclab_newton.physics import NewtonCfg
+from isaaclab_ov.physics import OvPhysxCfg
+from isaaclab_physx.physics import PhysxCfg
+from isaaclab_visualizers.newton import NewtonGLVisualizerCfg
+
+from isaaclab_tasks.contrib.place.config.agibot.place_toy2box_rmp_rel_env_cfg import RmpFlowAgibotPlaceToy2BoxEnvCfg
+
+
+@pytest.mark.parametrize(
+    "physics_cfg",
+    (PhysxCfg(), OvPhysxCfg()),
+    ids=("isaacsim_physx", "ovphysx"),
+)
+def test_agibot_accepts_newton_visualizer_with_physx_backends(physics_cfg) -> None:
+    """NewtonGL visualization should remain available with either supported PhysX backend."""
+    env_cfg = RmpFlowAgibotPlaceToy2BoxEnvCfg()
+    env_cfg.sim.physics = physics_cfg
+    env_cfg.sim.visualizer_cfgs = NewtonGLVisualizerCfg(headless=True)
+
+    env_cfg.validate_config()
+
+
+def test_agibot_rejects_newton_physics_for_incompatible_collision_mesh() -> None:
+    """Newton physics should report the remaining asset collision-mesh limitation."""
+    env_cfg = RmpFlowAgibotPlaceToy2BoxEnvCfg()
+    env_cfg.sim.physics = NewtonCfg()
+    env_cfg.sim.visualizer_cfgs = NewtonGLVisualizerCfg(headless=True)
+
+    with pytest.raises(ValueError, match=r"generated convex collision mesh.*physics=isaacsim_physx"):
+        env_cfg.validate_config()


### PR DESCRIPTION
# Description

The Isaac 6.1 Agibot A2D asset now has the corrected `physics:body0`/`physics:body1` ordering for its four gripper revolute joints. The path-based validation added in #7678 therefore became stale and prevented the corrected asset from running with Newton-backed visualizers under Isaac Sim PhysX.

This change:

- removes visualizer-specific rejection for the Agibot asset;
- keeps the one-environment, replicated-physics defaults from #7678;
- retains an early error for Newton MJWarp physics, which currently fails for a separate generated convex-mesh volume limitation; and
- updates that error to report the actual remaining limitation.

This addresses NVBug 6696477 and makes the asset limitation proposed in #7700 obsolete.

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this changes backend validation behavior.

## Validation

- Inspected the live Isaac 6.1 Agibot A2D asset: 46 articulation joints, zero reversed joints; all four previously reversed gripper joints now have parent-to-child body ordering.
- `uv run --extra teleop isaaclab zero_agent --task IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow --num_envs 1 --max_steps 1 --visualizer newton_gl` — completed successfully with Isaac Sim PhysX.
- Diagnostic Newton MJWarp launch imported the corrected articulation and then reproduced the separate solver error: `mesh volume is too small` for a generated Agibot base-link convex mesh.
- The final Newton MJWarp configuration now fails early with the corresponding actionable message.
- `uv run python tools/changelog/cli.py check develop`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the repository formatting and pre-commit checks
- [x] I have made the corresponding changelog change
- [x] My changes generate no new warnings
- [x] I validated the fix with the affected environment and backend combination
- [x] I added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
