### PR TITLE
Fix visualizer app taskbar icons

### DIFF
--- a/docs/source/developer-tools/editor_setup.rst
+++ b/docs/source/developer-tools/editor_setup.rst
@@ -84,6 +84,11 @@ The command creates or updates these machine-local files:
 * ``.vscode/launch.json``: Debugging configurations. An existing file is preserved.
 * ``.vscode/settings.json``: The interpreter and shared editor settings.
 * ``pyrightconfig.json``: Import paths for Pyright-compatible language servers.
+* ``~/.local/share/applications/isaaclab.desktop`` (Linux only): A desktop entry so the Kit
+  visualizer window's taskbar/dock icon shows the Isaac Sim icon instead of a generic one. Most
+  Linux desktop environments look up taskbar icons through a ``.desktop`` file's
+  ``StartupWMClass``, not the window's own icon hint, so this is required for the icon to
+  resolve correctly. Delete the file to remove the entry; it does not affect running Isaac Lab.
 
 The generated files are ignored by Git because interpreter and extension paths
 vary between machines. Rerun the command after changing Python environments or

--- a/source/isaaclab/changelog.d/mtrepte-fix-kit-taskbar-icon.rst
+++ b/source/isaaclab/changelog.d/mtrepte-fix-kit-taskbar-icon.rst
@@ -1,0 +1,10 @@
+Added
+^^^^^
+
+* ``isaaclab --editor`` now also generates a ``.desktop`` file at
+  ``~/.local/share/applications/isaaclab.desktop`` on Linux, fixing the Kit visualizer window
+  showing a generic taskbar/dock icon instead of the Isaac Sim icon. Most Linux desktop
+  environments resolve taskbar icons by matching a running window's ``WM_CLASS`` against an
+  installed ``.desktop`` file's ``StartupWMClass``, not from the window's own ``_NET_WM_ICON``
+  hint (which Kit already sets correctly). The generated ``StartupWMClass`` is read from
+  ``apps/isaaclab.python.kit``, matching what Kit composes for the running window.

--- a/source/isaaclab/changelog.d/mtrepte-newton-viewer-desktop-icons.rst
+++ b/source/isaaclab/changelog.d/mtrepte-newton-viewer-desktop-icons.rst
@@ -1,0 +1,9 @@
+Added
+^^^^^
+
+* Added a best-effort install step (``isaaclab.sh -i``) that writes XDG ``.desktop``
+  entries for the Newton GL and RTX viewer windows on Linux graphical sessions. Desktop
+  environments such as GNOME resolve dock/Alt-Tab icons via a window's ``WM_CLASS``
+  matched against an installed ``.desktop`` file rather than the window's own icon hint,
+  so without this the dock/Alt-Tab showed a generic icon even though the window itself
+  reported the correct one. No-ops on headless, CI, Docker, or Windows environments.

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -1359,3 +1359,9 @@ def command_install(install_type: str = "all") -> None:
     # Update editor settings unless we're in Docker.
     if not (os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")):
         command_editor([], project_dir=ISAACLAB_ROOT)
+
+    # Best-effort: install desktop icons for the Newton viewer windows (Linux graphical
+    # sessions only; no-op elsewhere, including Docker/CI/Windows).
+    from ...utils.desktop_icons import install_desktop_icons
+
+    install_desktop_icons()

--- a/source/isaaclab/isaaclab/cli/commands/install.py
+++ b/source/isaaclab/isaaclab/cli/commands/install.py
@@ -1360,8 +1360,21 @@ def command_install(install_type: str = "all") -> None:
     if not (os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")):
         command_editor([], project_dir=ISAACLAB_ROOT)
 
-    # Best-effort: install desktop icons for the Newton viewer windows (Linux graphical
-    # sessions only; no-op elsewhere, including Docker/CI/Windows).
-    from ...utils.desktop_icons import install_desktop_icons
+    _install_desktop_icons_best_effort()
 
-    install_desktop_icons()
+
+def _install_desktop_icons_best_effort() -> None:
+    """Install desktop icons for the Newton viewer windows, never raising.
+
+    Linux graphical sessions only; no-op elsewhere, including Docker/CI/Windows (see
+    :func:`isaaclab.utils.desktop_icons.install_desktop_icons`). Guards the import itself, not
+    just the call: ``isaaclab.utils``'s own ``__init__`` can fail to import in some environments
+    (e.g. a transitive dependency briefly missing mid-install), and this step is cosmetic -- it
+    should never be able to turn a completed install into a crash.
+    """
+    try:
+        from ...utils.desktop_icons import install_desktop_icons
+
+        install_desktop_icons()
+    except Exception as error:
+        print_debug(f"Skipped desktop icon install: {error}")

--- a/source/isaaclab/isaaclab/utils/desktop_icons.py
+++ b/source/isaaclab/isaaclab/utils/desktop_icons.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Installs XDG ``.desktop`` entries so Linux desktop docks/window-switchers show a real
+icon for the Newton viewer windows instead of a generic fallback.
+
+Desktop environments such as GNOME resolve dock and Alt-Tab icons by matching a window's
+``WM_CLASS`` against an installed ``.desktop`` file's ``StartupWMClass`` — they do not use
+the window's own ``_NET_WM_ICON`` hint for that purpose. Newton's GL and RTX viewer windows
+already set (or, for RTX, are made to set — see ``isaaclab_visualizers``) that hint
+correctly, but without a matching ``.desktop`` file on the system, GNOME's dock/Alt-Tab
+still falls back to a generic icon. This is not specific to any one platform or GPU — it
+is generic Linux desktop-environment behavior wherever a ``.desktop`` file is absent.
+"""
+
+import contextlib
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+from isaaclab.cli.utils import print_debug, print_warning
+
+# WM_CLASS values pyglet derives from each viewer's window caption at creation time.
+# See ``newton/_src/viewer/gl/opengl.py`` (``title="Newton"``) and
+# ``newton/_src/viewer/viewer_rtx.py`` (``caption="Newton RTX Viewer"``).
+_NEWTON_GL_WM_CLASS = "Newton"
+_NEWTON_RTX_WM_CLASS = "Newton RTX Viewer"
+
+_ICON_NAME = "isaaclab-newton-viewer"
+_ICON_SIZES = (16, 32, 64)
+
+
+def _has_graphical_session() -> bool:
+    """Return whether a Linux graphical session is present to install desktop icons for."""
+    if platform.system().lower() != "linux":
+        return False
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return False
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _newton_icon_source_dir() -> Path | None:
+    """Return the directory containing Newton's bundled ``icon_{16,32,64}.png``, if importable."""
+    try:
+        import inspect
+
+        from newton._src.viewer.gl.opengl import RendererGL
+    except ImportError:
+        return None
+    return Path(inspect.getfile(RendererGL)).parent
+
+
+def _install_icon_files(icon_source_dir: Path, data_home: Path) -> bool:
+    """Copy Newton's icon into the user's hicolor icon theme. Returns whether all copies succeeded."""
+    ok = True
+    for size in _ICON_SIZES:
+        src = icon_source_dir / f"icon_{size}.png"
+        if not src.is_file():
+            ok = False
+            continue
+        dst_dir = data_home / "icons" / "hicolor" / f"{size}x{size}" / "apps"
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst_dir / f"{_ICON_NAME}.png")
+    return ok
+
+
+def _desktop_entry(name: str, wm_class: str) -> str:
+    return (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        f"Name={name}\n"
+        "Comment=Isaac Lab Newton physics visualizer\n"
+        f"Icon={_ICON_NAME}\n"
+        "Exec=true\n"
+        "Terminal=false\n"
+        "NoDisplay=true\n"
+        f"StartupWMClass={wm_class}\n"
+        "Categories=Development;\n"
+    )
+
+
+def _install_desktop_entries(data_home: Path) -> Path:
+    apps_dir = data_home / "applications"
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    (apps_dir / "isaaclab-newton-gl-viewer.desktop").write_text(_desktop_entry("Newton Viewer", _NEWTON_GL_WM_CLASS))
+    (apps_dir / "isaaclab-newton-rtx-viewer.desktop").write_text(
+        _desktop_entry("Newton RTX Viewer", _NEWTON_RTX_WM_CLASS)
+    )
+    return apps_dir
+
+
+def _refresh_desktop_caches(apps_dir: Path, data_home: Path) -> None:
+    # Best-effort: these tools may be absent (e.g. minimal Linux installs); a missing cache
+    # refresh just means the icon appears after the next login rather than immediately.
+    for cmd in (
+        ["update-desktop-database", str(apps_dir)],
+        ["gtk-update-icon-cache", "-f", "-t", str(data_home / "icons" / "hicolor")],
+    ):
+        if shutil.which(cmd[0]) is None:
+            continue
+        with contextlib.suppress(subprocess.SubprocessError, OSError):
+            subprocess.run(cmd, capture_output=True, check=False, timeout=30)
+
+
+def install_desktop_icons() -> None:
+    """Best-effort install of ``.desktop`` entries for Newton's viewer windows.
+
+    No-ops outside a Linux graphical session (headless servers, CI, Docker, Windows), and
+    never raises — a failure here should never break ``isaaclab.sh -i``.
+    """
+    if not _has_graphical_session():
+        return
+
+    icon_source_dir = _newton_icon_source_dir()
+    if icon_source_dir is None:
+        print_debug("Skipping desktop icon install: Newton is not installed in this environment.")
+        return
+
+    data_home = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    with contextlib.suppress(OSError):
+        if not _install_icon_files(icon_source_dir, data_home):
+            print_warning("Some Newton icon files were missing; desktop icons may be incomplete.")
+        apps_dir = _install_desktop_entries(data_home)
+        _refresh_desktop_caches(apps_dir, data_home)

--- a/source/isaaclab/isaaclab/utils/desktop_icons.py
+++ b/source/isaaclab/isaaclab/utils/desktop_icons.py
@@ -31,7 +31,11 @@ _NEWTON_GL_WM_CLASS = "Newton"
 _NEWTON_RTX_WM_CLASS = "Newton RTX Viewer"
 
 _ICON_NAME = "isaaclab-newton-viewer"
-_ICON_SIZES = (16, 32, 64)
+
+#: Pixel sizes of Newton's bundled icon (``newton/_src/viewer/gl/icon_*.png``). Shared with
+#: ``isaaclab_visualizers.newton.newton_visualizer``, which sets the same icon on the live
+#: Newton RTX window; keep both in sync if Newton's bundled sizes ever change.
+NEWTON_ICON_SIZES = (16, 32, 64)
 
 
 def _has_graphical_session() -> bool:
@@ -43,8 +47,13 @@ def _has_graphical_session() -> bool:
     return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
 
 
-def _newton_icon_source_dir() -> Path | None:
-    """Return the directory containing Newton's bundled ``icon_{16,32,64}.png``, if importable."""
+def newton_icon_source_dir() -> Path | None:
+    """Return the directory containing Newton's bundled ``icon_{16,32,64}.png``, if importable.
+
+    Single source of truth for locating Newton's bundled icon directory — also used by
+    ``isaaclab_visualizers.newton.newton_visualizer`` to set the live Newton RTX window's icon,
+    so both stay consistent if Newton ever moves these files.
+    """
     try:
         import inspect
 
@@ -54,18 +63,18 @@ def _newton_icon_source_dir() -> Path | None:
     return Path(inspect.getfile(RendererGL)).parent
 
 
-def _install_icon_files(icon_source_dir: Path, data_home: Path) -> bool:
-    """Copy Newton's icon into the user's hicolor icon theme. Returns whether all copies succeeded."""
-    ok = True
-    for size in _ICON_SIZES:
+def _install_icon_files(icon_source_dir: Path, data_home: Path) -> int:
+    """Copy Newton's icon into the user's hicolor icon theme. Returns how many sizes were copied."""
+    copied = 0
+    for size in NEWTON_ICON_SIZES:
         src = icon_source_dir / f"icon_{size}.png"
         if not src.is_file():
-            ok = False
             continue
         dst_dir = data_home / "icons" / "hicolor" / f"{size}x{size}" / "apps"
         dst_dir.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src, dst_dir / f"{_ICON_NAME}.png")
-    return ok
+        copied += 1
+    return copied
 
 
 def _desktop_entry(name: str, wm_class: str) -> str:
@@ -115,14 +124,18 @@ def install_desktop_icons() -> None:
     if not _has_graphical_session():
         return
 
-    icon_source_dir = _newton_icon_source_dir()
+    icon_source_dir = newton_icon_source_dir()
     if icon_source_dir is None:
         print_debug("Skipping desktop icon install: Newton is not installed in this environment.")
         return
 
     data_home = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
     with contextlib.suppress(OSError):
-        if not _install_icon_files(icon_source_dir, data_home):
+        copied = _install_icon_files(icon_source_dir, data_home)
+        if copied == 0:
+            print_warning("No Newton icon files found; skipping desktop icon install.")
+            return
+        if copied < len(NEWTON_ICON_SIZES):
             print_warning("Some Newton icon files were missing; desktop icons may be incomplete.")
         apps_dir = _install_desktop_entries(data_home)
         _refresh_desktop_caches(apps_dir, data_home)

--- a/source/isaaclab/isaaclab/utils/desktop_icons.py
+++ b/source/isaaclab/isaaclab/utils/desktop_icons.py
@@ -16,6 +16,7 @@ is generic Linux desktop-environment behavior wherever a ``.desktop`` file is ab
 """
 
 import contextlib
+import importlib.util
 import os
 import platform
 import shutil
@@ -38,6 +39,16 @@ _ICON_NAME = "isaaclab-newton-viewer"
 NEWTON_ICON_SIZES = (16, 32, 64)
 
 
+def xdg_data_home() -> Path:
+    """Return ``$XDG_DATA_HOME``, falling back to ``~/.local/share``.
+
+    Per the XDG Base Directory spec, an unset *or empty* ``XDG_DATA_HOME`` both mean "use the
+    default" — ``os.environ.get("XDG_DATA_HOME", default)`` alone does not handle the empty-string
+    case, since the key is still present in the environment.
+    """
+    return Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
+
+
 def _has_graphical_session() -> bool:
     """Return whether a Linux graphical session is present to install desktop icons for."""
     if platform.system().lower() != "linux":
@@ -48,19 +59,23 @@ def _has_graphical_session() -> bool:
 
 
 def newton_icon_source_dir() -> Path | None:
-    """Return the directory containing Newton's bundled ``icon_{16,32,64}.png``, if importable.
+    """Return the directory containing Newton's bundled ``icon_{16,32,64}.png``, if installed.
 
     Single source of truth for locating Newton's bundled icon directory — also used by
     ``isaaclab_visualizers.newton.newton_visualizer`` to set the live Newton RTX window's icon,
     so both stay consistent if Newton ever moves these files.
-    """
-    try:
-        import inspect
 
-        from newton._src.viewer.gl.opengl import RendererGL
-    except ImportError:
+    Resolves the path via :func:`importlib.util.find_spec` rather than importing
+    ``newton._src.viewer.gl.opengl`` — that module pulls in ``warp``/``pyglet``/GL at import
+    time, and importing it here (at the tail of ``isaaclab.sh -i``, best-effort) risks raising
+    something other than ``ImportError`` on a broken or partial install, which would violate
+    :func:`install_desktop_icons`'s documented never-raises contract.
+    """
+    spec = importlib.util.find_spec("newton")
+    if spec is None or not spec.submodule_search_locations:
         return None
-    return Path(inspect.getfile(RendererGL)).parent
+    icon_dir = Path(spec.submodule_search_locations[0]) / "_src" / "viewer" / "gl"
+    return icon_dir if icon_dir.is_dir() else None
 
 
 def _install_icon_files(icon_source_dir: Path, data_home: Path) -> int:
@@ -129,7 +144,7 @@ def install_desktop_icons() -> None:
         print_debug("Skipping desktop icon install: Newton is not installed in this environment.")
         return
 
-    data_home = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    data_home = xdg_data_home()
     with contextlib.suppress(OSError):
         copied = _install_icon_files(icon_source_dir, data_home)
         if copied == 0:

--- a/source/isaaclab/isaaclab/utils/editor.py
+++ b/source/isaaclab/isaaclab/utils/editor.py
@@ -15,6 +15,8 @@ import re
 import subprocess
 import sys
 
+from isaaclab.utils.desktop_icons import xdg_data_home
+
 _DEFAULT_VSCODE_SETTINGS_TEMPLATE = """
 {
     "editor.rulers": [120],
@@ -129,7 +131,7 @@ def setup_desktop_entry(project_dir: pathlib.Path) -> None:
     if icon_path is None:
         return
 
-    applications_dir = pathlib.Path.home() / ".local" / "share" / "applications"
+    applications_dir = xdg_data_home() / "applications"
     applications_dir.mkdir(parents=True, exist_ok=True)
     desktop_path = applications_dir / "isaaclab.desktop"
     desktop_path.write_text(
@@ -137,9 +139,13 @@ def setup_desktop_entry(project_dir: pathlib.Path) -> None:
         "Version=1.0\n"
         "Type=Application\n"
         "Name=Isaac Lab\n"
-        f"Exec={sys.executable} -m isaaclab\n"
+        # This entry exists only for StartupWMClass matching (see the docstring above), not as a
+        # real launcher: NoDisplay keeps it out of application menus, and Exec is a harmless no-op
+        # rather than re-invoking isaaclab, which would also need shell-quoting sys.executable for
+        # paths containing spaces.
+        "NoDisplay=true\n"
+        "Exec=true\n"
         f"Icon={icon_path}\n"
-        "Terminal=true\n"
         f"StartupWMClass={title} {version}\n",
         encoding="utf-8",
     )

--- a/source/isaaclab/isaaclab/utils/editor.py
+++ b/source/isaaclab/isaaclab/utils/editor.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import os
 import pathlib
+import platform
 import re
 import subprocess
 import sys
@@ -77,6 +78,130 @@ def setup_editor(project_dir: pathlib.Path, isaac_path: str | None = None, verbo
 
     print(f"Editor settings generated at {settings_path}")
     print(f"Pyright configuration generated at {project_dir / 'pyrightconfig.json'}")
+
+    # Desktop icon integration is a convenience, not something that should block the rest of
+    # this command -- an unwritable home directory or unreadable kit file shouldn't turn a
+    # successful editor-settings run into a hard crash.
+    try:
+        setup_desktop_entry(project_dir)
+    except OSError as error:
+        print(f"[WARN] Skipped desktop entry generation: {error}")
+
+
+def setup_desktop_entry(project_dir: pathlib.Path) -> None:
+    """Generate a Linux desktop entry so the taskbar shows the Isaac Sim icon, not a generic one.
+
+    Kit's window manager class (``WM_CLASS``) is composed from the ``[settings.app.window] title``
+    and ``[settings.app] version`` values in ``apps/isaaclab.python.kit`` (for example
+    ``"Isaac Lab 3.0.0"``), with no exposed setting to make it version-independent: overriding
+    ``/app/version`` to empty falls back to the raw Kit SDK build string instead of dropping the
+    suffix. Most Linux desktop environments (GNOME included) resolve taskbar/dock icons by
+    matching a running window's ``WM_CLASS`` against an installed ``.desktop`` file's
+    ``StartupWMClass`` -- not from the window's own ``_NET_WM_ICON`` hint, which Kit does set
+    correctly (confirmed with ``xprop``) but which most taskbars ignore for this purpose. Without
+    a matching ``.desktop`` file, the desktop environment falls back to a generic icon.
+
+    Because ``WM_CLASS`` embeds the app title and version, ``StartupWMClass`` here is read from
+    the same ``apps/isaaclab.python.kit`` file rather than hardcoded, so it self-updates on every
+    ``isaaclab --editor`` run. Requirement to track: if a future Isaac Lab release changes
+    ``apps/isaaclab.python.kit``'s ``[settings.app.window] title`` or ``[settings.app] version``
+    (or Kit changes how it composes ``WM_CLASS`` at all), this needs re-running -- there is no way
+    to keep the ``.desktop`` file in sync automatically without that rerun, since the desktop
+    entry is a static file, not a live setting.
+
+    No-op on non-Linux platforms, or if the kit file or the Isaac Sim icon asset cannot be found;
+    desktop icon integration is a convenience, not something that should block the rest of
+    ``isaaclab --editor``.
+
+    Args:
+        project_dir: Project root, used to locate ``apps/isaaclab.python.kit``.
+    """
+    if platform.system() != "Linux":
+        return
+
+    kit_file = project_dir / "apps" / "isaaclab.python.kit"
+    identity = _read_kit_window_identity(kit_file)
+    if identity is None:
+        return
+    title, version = identity
+
+    icon_path = _find_isaac_sim_icon()
+    if icon_path is None:
+        return
+
+    applications_dir = pathlib.Path.home() / ".local" / "share" / "applications"
+    applications_dir.mkdir(parents=True, exist_ok=True)
+    desktop_path = applications_dir / "isaaclab.desktop"
+    desktop_path.write_text(
+        "[Desktop Entry]\n"
+        "Version=1.0\n"
+        "Type=Application\n"
+        "Name=Isaac Lab\n"
+        f"Exec={sys.executable} -m isaaclab\n"
+        f"Icon={icon_path}\n"
+        "Terminal=true\n"
+        f"StartupWMClass={title} {version}\n",
+        encoding="utf-8",
+    )
+    print(f"Desktop entry generated at {desktop_path}")
+
+
+def _read_kit_window_identity(kit_file: pathlib.Path) -> tuple[str, str] | None:
+    """Read the ``(title, version)`` pair Kit composes this app's ``WM_CLASS`` from.
+
+    ``.kit`` files are TOML-like but redeclare the ``[settings]`` table across multiple
+    sections (Kit's own parser merges them), which is invalid under strict TOML and rejects
+    :mod:`tomllib`. Since only these two known scalars are needed, this scans lines under the
+    exact ``[settings.app]`` and ``[settings.app.window]`` headers instead of parsing the whole
+    file as TOML.
+
+    Args:
+        kit_file: Path to ``apps/isaaclab.python.kit``.
+
+    Returns:
+        The ``(title, version)`` pair, or None if the file or either value is missing.
+    """
+    if not kit_file.is_file():
+        return None
+
+    title: str | None = None
+    version: str | None = None
+    section = ""
+    scalar_pattern = re.compile(r'^(\w+)\s*=\s*"([^"]*)"')
+    for raw_line in kit_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        match = scalar_pattern.match(line)
+        if not match:
+            continue
+        key, value = match.groups()
+        if section == "settings.app.window" and key == "title":
+            title = value
+        elif section == "settings.app" and key == "version":
+            version = value
+
+    if not title or not version:
+        return None
+    return title, version
+
+
+def _find_isaac_sim_icon() -> pathlib.Path | None:
+    """Locate the Isaac Sim icon asset shipped with the installed ``isaacsim`` package.
+
+    Returns:
+        Absolute path to the icon, or None if the ``isaacsim`` package is not installed or does
+        not ship the expected asset.
+    """
+    spec = importlib.util.find_spec("isaacsim")
+    if spec is None or not spec.submodule_search_locations:
+        return None
+    for location in spec.submodule_search_locations:
+        icon_path = pathlib.Path(location) / "exts" / "isaacsim.simulation_app" / "data" / "omni.isaac.sim.png"
+        if icon_path.is_file():
+            return icon_path
+    return None
 
 
 def resolve_isaacsim_dir(project_dir: pathlib.Path, isaac_path: str | None = None) -> pathlib.Path | None:

--- a/source/isaaclab/isaaclab/utils/editor.py
+++ b/source/isaaclab/isaaclab/utils/editor.py
@@ -84,7 +84,7 @@ def setup_editor(project_dir: pathlib.Path, isaac_path: str | None = None, verbo
     # successful editor-settings run into a hard crash.
     try:
         setup_desktop_entry(project_dir)
-    except OSError as error:
+    except (OSError, UnicodeDecodeError) as error:
         print(f"[WARN] Skipped desktop entry generation: {error}")
 
 

--- a/source/isaaclab/test/cli/test_install_commands.py
+++ b/source/isaaclab/test/cli/test_install_commands.py
@@ -22,6 +22,7 @@ import isaaclab.cli.commands.install as install_cmd
 from isaaclab.cli.commands.install import (
     _PREBUNDLE_REPOINT_PACKAGES,
     _ensure_cuda_torch,
+    _install_desktop_icons_best_effort,
     _install_isaacsim,
     _maybe_uninstall_prebundled_torch,
     _repoint_prebundle_packages,
@@ -1058,3 +1059,45 @@ class TestInstallRootExtraExcludesIsaacSim:
         installed = " ".join(" ".join(call.args[0]) for call in mock_run.call_args_list)
         assert "isaacsim[all,extscache]" not in installed
         assert "isaacteleop" in installed
+
+
+# ---------------------------------------------------------------------------
+# _install_desktop_icons_best_effort
+# ---------------------------------------------------------------------------
+
+
+def test_install_desktop_icons_best_effort_calls_install_desktop_icons():
+    """Test the happy path actually invokes the underlying installer."""
+    with mock.patch("isaaclab.utils.desktop_icons.install_desktop_icons") as mock_install:
+        _install_desktop_icons_best_effort()
+
+    mock_install.assert_called_once_with()
+
+
+def test_install_desktop_icons_best_effort_swallows_import_errors():
+    """Test a broken transitive import never escapes ``./isaaclab.sh -i``.
+
+    Regression test for an ARM installation-test failure: ``isaaclab.utils``'s own
+    ``__init__`` (needed by ``from ...utils.desktop_icons import install_desktop_icons``) can
+    fail with ``ModuleNotFoundError`` if a transitive dependency (e.g. ``lazy_loader``) is
+    briefly missing mid-install. The previous, unguarded ``from ...utils.desktop_icons import
+    install_desktop_icons`` at the ``command_install`` call site let that escape and crash a
+    completed install; this cosmetic step must never be able to do that.
+    """
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "isaaclab.utils.desktop_icons" or name.endswith(".utils.desktop_icons"):
+            raise ModuleNotFoundError("No module named 'lazy_loader'")
+        return real_import(name, *args, **kwargs)
+
+    with mock.patch("builtins.__import__", side_effect=_raising_import):
+        # Must not raise.
+        _install_desktop_icons_best_effort()
+
+
+def test_install_desktop_icons_best_effort_swallows_runtime_errors():
+    """Test a failure inside install_desktop_icons() itself is also swallowed, not just import errors."""
+    with mock.patch("isaaclab.utils.desktop_icons.install_desktop_icons", side_effect=RuntimeError("boom")):
+        # Must not raise.
+        _install_desktop_icons_best_effort()

--- a/source/isaaclab/test/utils/test_desktop_icons.py
+++ b/source/isaaclab/test/utils/test_desktop_icons.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import builtins
 import pathlib
 
 import pytest
@@ -18,6 +17,7 @@ from isaaclab.utils.desktop_icons import (
     _install_icon_files,
     install_desktop_icons,
     newton_icon_source_dir,
+    xdg_data_home,
 )
 
 pytestmark = pytest.mark.unit
@@ -61,15 +61,28 @@ def test_has_graphical_session_false_in_docker(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_newton_icon_source_dir_returns_none_when_newton_missing(monkeypatch: pytest.MonkeyPatch):
-    """Test a missing Newton install is reported as no icon source rather than raising."""
-    real_import = builtins.__import__
+    """Test a missing Newton install is reported as no icon source rather than raising.
 
-    def _fake_import(name, *args, **kwargs):
-        if name == "newton._src.viewer.gl.opengl":
-            raise ImportError("no newton")
-        return real_import(name, *args, **kwargs)
+    Resolved via importlib.util.find_spec rather than importing newton's GL renderer module:
+    that module pulls in warp/pyglet/GL at import time, which could raise something other than
+    ImportError on a broken install and violate install_desktop_icons's never-raises contract.
+    """
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.importlib.util.find_spec", lambda name: None)
 
-    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    assert newton_icon_source_dir() is None
+
+
+def test_newton_icon_source_dir_returns_none_when_icon_dir_missing(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test a resolved package spec whose expected icon subdirectory doesn't exist returns None."""
+    package_root = tmp_path / "newton"
+    package_root.mkdir()
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.importlib.util.find_spec", lambda name: _FakeSpec())
 
     assert newton_icon_source_dir() is None
 
@@ -80,6 +93,30 @@ def test_newton_icon_source_dir_finds_real_package():
 
     assert icon_dir is not None
     assert (icon_dir / "icon_64.png").is_file()
+
+
+def test_xdg_data_home_defaults_to_local_share_when_unset(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test a missing XDG_DATA_HOME falls back to ~/.local/share."""
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+
+    assert xdg_data_home() == tmp_path / ".local" / "share"
+
+
+def test_xdg_data_home_defaults_to_local_share_when_empty(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test an empty-string XDG_DATA_HOME is treated as unset, per the XDG Base Directory spec."""
+    monkeypatch.setenv("XDG_DATA_HOME", "")
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+
+    assert xdg_data_home() == tmp_path / ".local" / "share"
+
+
+def test_xdg_data_home_honors_explicit_value(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test a non-empty XDG_DATA_HOME is used as-is."""
+    custom = tmp_path / "custom"
+    monkeypatch.setenv("XDG_DATA_HOME", str(custom))
+
+    assert xdg_data_home() == custom
 
 
 def test_install_icon_files_copies_available_sizes(tmp_path: pathlib.Path):

--- a/source/isaaclab/test/utils/test_desktop_icons.py
+++ b/source/isaaclab/test/utils/test_desktop_icons.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import builtins
+import pathlib
+
+import pytest
+
+from isaaclab.utils import desktop_icons
+from isaaclab.utils.desktop_icons import (
+    _NEWTON_GL_WM_CLASS,
+    _NEWTON_RTX_WM_CLASS,
+    _desktop_entry,
+    _has_graphical_session,
+    _install_desktop_entries,
+    _install_icon_files,
+    install_desktop_icons,
+    newton_icon_source_dir,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_has_graphical_session_true_on_linux_with_display(monkeypatch: pytest.MonkeyPatch):
+    """Test a Linux session with DISPLAY set is treated as graphical."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.platform.system", lambda: "Linux")
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.os.path.exists", lambda path: False)
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    assert _has_graphical_session() is True
+
+
+def test_has_graphical_session_false_on_non_linux(monkeypatch: pytest.MonkeyPatch):
+    """Test non-Linux platforms are never treated as a Linux graphical session."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.platform.system", lambda: "Windows")
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    assert _has_graphical_session() is False
+
+
+def test_has_graphical_session_false_without_display_or_wayland(monkeypatch: pytest.MonkeyPatch):
+    """Test a Linux session with neither DISPLAY nor WAYLAND_DISPLAY is not graphical."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.platform.system", lambda: "Linux")
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.os.path.exists", lambda path: False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    assert _has_graphical_session() is False
+
+
+def test_has_graphical_session_false_in_docker(monkeypatch: pytest.MonkeyPatch):
+    """Test a containerized session is skipped even with DISPLAY set, matching isaaclab.sh -i's Docker guard."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.platform.system", lambda: "Linux")
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.os.path.exists", lambda path: path == "/.dockerenv")
+    monkeypatch.setenv("DISPLAY", ":0")
+
+    assert _has_graphical_session() is False
+
+
+def test_newton_icon_source_dir_returns_none_when_newton_missing(monkeypatch: pytest.MonkeyPatch):
+    """Test a missing Newton install is reported as no icon source rather than raising."""
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "newton._src.viewer.gl.opengl":
+            raise ImportError("no newton")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    assert newton_icon_source_dir() is None
+
+
+def test_newton_icon_source_dir_finds_real_package():
+    """Test the real installed Newton package resolves to a directory containing its icon files."""
+    icon_dir = newton_icon_source_dir()
+
+    assert icon_dir is not None
+    assert (icon_dir / "icon_64.png").is_file()
+
+
+def test_install_icon_files_copies_available_sizes(tmp_path: pathlib.Path):
+    """Test each bundled Newton icon size is copied into the hicolor theme layout."""
+    icon_source_dir = tmp_path / "newton_gl"
+    icon_source_dir.mkdir()
+    for size in desktop_icons.NEWTON_ICON_SIZES:
+        (icon_source_dir / f"icon_{size}.png").write_bytes(b"fake-png")
+    data_home = tmp_path / "data_home"
+
+    copied = _install_icon_files(icon_source_dir, data_home)
+
+    assert copied == len(desktop_icons.NEWTON_ICON_SIZES)
+    for size in desktop_icons.NEWTON_ICON_SIZES:
+        dst = data_home / "icons" / "hicolor" / f"{size}x{size}" / "apps" / f"{desktop_icons._ICON_NAME}.png"
+        assert dst.read_bytes() == b"fake-png"
+
+
+def test_install_icon_files_reports_number_of_missing_sizes(tmp_path: pathlib.Path):
+    """Test a missing source size is skipped (not raised) but still reflected in the return count."""
+    icon_source_dir = tmp_path / "newton_gl"
+    icon_source_dir.mkdir()
+    sizes = list(desktop_icons.NEWTON_ICON_SIZES)
+    (icon_source_dir / f"icon_{sizes[0]}.png").write_bytes(b"fake-png")
+    data_home = tmp_path / "data_home"
+
+    copied = _install_icon_files(icon_source_dir, data_home)
+
+    assert copied == 1
+    present = data_home / "icons" / "hicolor" / f"{sizes[0]}x{sizes[0]}" / "apps" / f"{desktop_icons._ICON_NAME}.png"
+    assert present.is_file()
+    missing_dir = data_home / "icons" / "hicolor" / f"{sizes[1]}x{sizes[1]}" / "apps"
+    assert not missing_dir.exists()
+
+
+def test_install_icon_files_returns_zero_when_none_present(tmp_path: pathlib.Path):
+    """Test an icon source directory with none of the expected files copies nothing."""
+    icon_source_dir = tmp_path / "newton_gl"
+    icon_source_dir.mkdir()
+    data_home = tmp_path / "data_home"
+
+    copied = _install_icon_files(icon_source_dir, data_home)
+
+    assert copied == 0
+    assert not (data_home / "icons").exists()
+
+
+def test_desktop_entry_contains_name_icon_and_wm_class():
+    """Test the generated .desktop text has the fields GNOME needs to resolve the icon."""
+    entry = _desktop_entry("Newton Viewer", _NEWTON_GL_WM_CLASS)
+
+    assert "Type=Application" in entry
+    assert "Name=Newton Viewer" in entry
+    assert f"Icon={desktop_icons._ICON_NAME}" in entry
+    assert f"StartupWMClass={_NEWTON_GL_WM_CLASS}" in entry
+
+
+def test_install_desktop_entries_writes_distinct_wm_classes_for_gl_and_rtx(tmp_path: pathlib.Path):
+    """Test GL and RTX each get their own entry, since pyglet gives them different WM_CLASS values."""
+    apps_dir = _install_desktop_entries(tmp_path)
+
+    gl_content = (apps_dir / "isaaclab-newton-gl-viewer.desktop").read_text()
+    rtx_content = (apps_dir / "isaaclab-newton-rtx-viewer.desktop").read_text()
+    assert f"StartupWMClass={_NEWTON_GL_WM_CLASS}" in gl_content
+    assert f"StartupWMClass={_NEWTON_RTX_WM_CLASS}" in rtx_content
+
+
+def test_install_desktop_icons_noop_without_graphical_session(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test headless/CI/Windows sessions are skipped entirely, writing nothing."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons._has_graphical_session", lambda: False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    install_desktop_icons()
+
+    assert not (tmp_path / "applications").exists()
+    assert not (tmp_path / "icons").exists()
+
+
+def test_install_desktop_icons_full_flow(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test a graphical session with Newton installed writes both icons and both .desktop entries."""
+    icon_source_dir = tmp_path / "newton_gl"
+    icon_source_dir.mkdir()
+    for size in desktop_icons.NEWTON_ICON_SIZES:
+        (icon_source_dir / f"icon_{size}.png").write_bytes(b"fake-png")
+
+    monkeypatch.setattr("isaaclab.utils.desktop_icons._has_graphical_session", lambda: True)
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.newton_icon_source_dir", lambda: icon_source_dir)
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.shutil.which", lambda cmd: None)
+    data_home = tmp_path / "data_home"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+
+    install_desktop_icons()
+
+    assert (data_home / "applications" / "isaaclab-newton-gl-viewer.desktop").is_file()
+    assert (data_home / "applications" / "isaaclab-newton-rtx-viewer.desktop").is_file()
+    assert (data_home / "icons" / "hicolor" / "64x64" / "apps" / f"{desktop_icons._ICON_NAME}.png").is_file()
+
+
+def test_install_desktop_icons_skips_entries_when_no_icons_copied(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test no .desktop entries are written when zero icon files actually copied.
+
+    A partial/corrupted Newton install can resolve a real package directory that doesn't
+    contain any of the expected icon_{16,32,64}.png files. Writing .desktop entries in that
+    case would reference an Icon= that never resolves to any file, silently degrading to no
+    icon while looking successful.
+    """
+    icon_source_dir = tmp_path / "newton_gl_missing_icons"
+    icon_source_dir.mkdir()
+
+    monkeypatch.setattr("isaaclab.utils.desktop_icons._has_graphical_session", lambda: True)
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.newton_icon_source_dir", lambda: icon_source_dir)
+    data_home = tmp_path / "data_home"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+
+    install_desktop_icons()
+
+    assert not (data_home / "applications").exists()
+
+
+def test_install_desktop_icons_swallows_filesystem_errors(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test an unwritable data home doesn't propagate — isaaclab.sh -i must not fail because of this step."""
+    monkeypatch.setattr("isaaclab.utils.desktop_icons._has_graphical_session", lambda: True)
+    monkeypatch.setattr("isaaclab.utils.desktop_icons.newton_icon_source_dir", lambda: tmp_path)
+
+    def _raise(*args, **kwargs):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("isaaclab.utils.desktop_icons._install_icon_files", _raise)
+
+    install_desktop_icons()

--- a/source/isaaclab/test/utils/test_editor.py
+++ b/source/isaaclab/test/utils/test_editor.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pathlib
+
+import pytest
+
+from isaaclab.utils.editor import _find_isaac_sim_icon, _read_kit_window_identity, setup_desktop_entry
+
+pytestmark = pytest.mark.unit
+
+# A minimal excerpt of apps/isaaclab.python.kit's shape: [settings] is re-declared across
+# multiple sections, which is invalid under strict TOML but is what Kit's own files look like.
+_KIT_FILE_CONTENT = """
+[package]
+version = "3.0.0"
+
+[settings]
+app.name = "IsaacLab"
+
+[settings.app]
+name = "IsaacLab"
+version = "3.0.0"
+
+[settings.app.window]
+iconPath = "${isaacsim.simulation_app}/data/omni.isaac.sim.png"
+title = "Isaac Lab"
+
+[settings]
+physics.updateToUsd = false
+"""
+
+
+def test_read_kit_window_identity_parses_duplicate_settings_sections(tmp_path: pathlib.Path):
+    """Test title/version are read correctly despite the repeated [settings] header."""
+    kit_file = tmp_path / "isaaclab.python.kit"
+    kit_file.write_text(_KIT_FILE_CONTENT)
+
+    identity = _read_kit_window_identity(kit_file)
+
+    assert identity == ("Isaac Lab", "3.0.0")
+
+
+def test_read_kit_window_identity_missing_file_returns_none(tmp_path: pathlib.Path):
+    """Test a missing kit file is reported as no identity rather than raising."""
+    assert _read_kit_window_identity(tmp_path / "does_not_exist.kit") is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        # No [settings.app.window] title.
+        '[settings.app]\nversion = "3.0.0"\n',
+        # No [settings.app] version.
+        '[settings.app.window]\ntitle = "Isaac Lab"\n',
+    ],
+)
+def test_read_kit_window_identity_missing_value_returns_none(tmp_path: pathlib.Path, content: str):
+    """Test a kit file missing either title or version is reported as no identity."""
+    kit_file = tmp_path / "isaaclab.python.kit"
+    kit_file.write_text(content)
+
+    assert _read_kit_window_identity(kit_file) is None
+
+
+def test_find_isaac_sim_icon_locates_asset_under_package(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the icon is found when the isaacsim package ships the expected asset path."""
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    icon_file = icon_dir / "omni.isaac.sim.png"
+    icon_file.write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    assert _find_isaac_sim_icon() == icon_file
+
+
+def test_find_isaac_sim_icon_missing_package_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """Test an uninstalled isaacsim package is reported as no icon rather than raising."""
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: None)
+
+    assert _find_isaac_sim_icon() is None
+
+
+def test_setup_desktop_entry_noop_on_non_linux(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the desktop entry is not generated on non-Linux platforms."""
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Windows")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    setup_desktop_entry(tmp_path)
+
+    assert not (home / ".local" / "share" / "applications" / "isaaclab.desktop").exists()
+
+
+def test_setup_desktop_entry_writes_startup_wm_class_matching_kit_identity(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Test the generated .desktop file's StartupWMClass matches Kit's composed WM_CLASS.
+
+    Kit composes the running window's WM_CLASS from the kit file's window title and app
+    version (e.g. "Isaac Lab 3.0.0"). The whole point of generating this file is for
+    StartupWMClass to match that exactly, so a desktop environment's .desktop-based taskbar
+    icon lookup succeeds instead of falling back to a generic icon.
+    """
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    project_dir = tmp_path / "project"
+    apps_dir = project_dir / "apps"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "isaaclab.python.kit").write_text(_KIT_FILE_CONTENT)
+
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    icon_file = icon_dir / "omni.isaac.sim.png"
+    icon_file.write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    setup_desktop_entry(project_dir)
+
+    desktop_file = home / ".local" / "share" / "applications" / "isaaclab.desktop"
+    content = desktop_file.read_text()
+    assert "StartupWMClass=Isaac Lab 3.0.0" in content
+    assert f"Icon={icon_file}" in content
+    assert "Name=Isaac Lab" in content
+
+
+def test_setup_desktop_entry_noop_when_kit_file_missing(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test a missing kit file skips desktop entry generation instead of raising."""
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    setup_desktop_entry(tmp_path / "project_without_apps_dir")
+
+    assert not (home / ".local" / "share" / "applications" / "isaaclab.desktop").exists()

--- a/source/isaaclab/test/utils/test_editor.py
+++ b/source/isaaclab/test/utils/test_editor.py
@@ -11,7 +11,7 @@ from isaaclab.utils.editor import _find_isaac_sim_icon, _read_kit_window_identit
 
 pytestmark = pytest.mark.unit
 
-# A minimal excerpt of apps/isaaclab.python.kit's shape: [settings] is re-declared across
+# A minimal excerpt of apps/isaaclab.python.kit's shape: [settings] is redeclared across
 # multiple sections, which is invalid under strict TOML but is what Kit's own files look like.
 _KIT_FILE_CONTENT = """
 [package]

--- a/source/isaaclab/test/utils/test_editor.py
+++ b/source/isaaclab/test/utils/test_editor.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pathlib
+import sys
 
 import pytest
 
@@ -91,6 +92,7 @@ def test_find_isaac_sim_icon_missing_package_returns_none(monkeypatch: pytest.Mo
 def test_setup_desktop_entry_noop_on_non_linux(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
     """Test the desktop entry is not generated on non-Linux platforms."""
     monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Windows")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     home = tmp_path / "home"
     monkeypatch.setattr(pathlib.Path, "home", lambda: home)
 
@@ -110,6 +112,7 @@ def test_setup_desktop_entry_writes_startup_wm_class_matching_kit_identity(
     icon lookup succeeds instead of falling back to a generic icon.
     """
     monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     home = tmp_path / "home"
     monkeypatch.setattr(pathlib.Path, "home", lambda: home)
 
@@ -138,9 +141,81 @@ def test_setup_desktop_entry_writes_startup_wm_class_matching_kit_identity(
     assert "Name=Isaac Lab" in content
 
 
+def test_setup_desktop_entry_is_not_a_visible_launcher(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the entry is hidden from menus and uses a harmless Exec, not a real launcher.
+
+    This entry exists purely so a desktop environment can match the running Kit window's
+    WM_CLASS to an icon; it isn't meant to appear as a clickable "Isaac Lab" application, and
+    it must not re-invoke ``sys.executable`` unquoted (which would split into multiple Exec
+    tokens for interpreter paths containing spaces).
+    """
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: home)
+
+    project_dir = tmp_path / "project"
+    apps_dir = project_dir / "apps"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "isaaclab.python.kit").write_text(_KIT_FILE_CONTENT)
+
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    (icon_dir / "omni.isaac.sim.png").write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    setup_desktop_entry(project_dir)
+
+    content = (home / ".local" / "share" / "applications" / "isaaclab.desktop").read_text()
+    assert "NoDisplay=true" in content
+    assert "Exec=true" in content
+    assert sys.executable not in content
+
+
+def test_setup_desktop_entry_honors_xdg_data_home(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Test the applications directory is resolved from XDG_DATA_HOME, not hardcoded ~/.local/share.
+
+    A desktop environment only scans .desktop files under XDG_DATA_HOME's applications/
+    subdirectory; writing to ~/.local/share/applications when XDG_DATA_HOME points elsewhere
+    means the generated entry is never found.
+    """
+    monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    data_home = tmp_path / "custom_data_home"
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    # Path.home() must not be consulted when XDG_DATA_HOME is set; point it somewhere that
+    # would fail the test if it were.
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path / "unused_home")
+
+    project_dir = tmp_path / "project"
+    apps_dir = project_dir / "apps"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "isaaclab.python.kit").write_text(_KIT_FILE_CONTENT)
+
+    package_root = tmp_path / "isaacsim"
+    icon_dir = package_root / "exts" / "isaacsim.simulation_app" / "data"
+    icon_dir.mkdir(parents=True)
+    (icon_dir / "omni.isaac.sim.png").write_bytes(b"")
+
+    class _FakeSpec:
+        submodule_search_locations = [str(package_root)]
+
+    monkeypatch.setattr("isaaclab.utils.editor.importlib.util.find_spec", lambda name: _FakeSpec())
+
+    setup_desktop_entry(project_dir)
+
+    assert (data_home / "applications" / "isaaclab.desktop").is_file()
+    assert not (tmp_path / "unused_home").exists()
+
+
 def test_setup_desktop_entry_noop_when_kit_file_missing(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
     """Test a missing kit file skips desktop entry generation instead of raising."""
     monkeypatch.setattr("isaaclab.utils.editor.platform.system", lambda: "Linux")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     home = tmp_path / "home"
     monkeypatch.setattr(pathlib.Path, "home", lambda: home)
 

--- a/source/isaaclab_visualizers/changelog.d/mtrepte-newton-viewer-apple-icon.rst
+++ b/source/isaaclab_visualizers/changelog.d/mtrepte-newton-viewer-apple-icon.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed the ``newton_rtx`` visualizer window showing a generic application icon.
+  ``ViewerRTX`` creates its window directly and never set an icon, unlike ``ViewerGL``
+  (used by ``newton_gl``), whose ``RendererGL`` already sets Newton's own apple icon by
+  default. ``newton_rtx`` now reuses that same bundled Newton icon for consistency.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -85,6 +85,39 @@ CONTACT_ARROW_COLOR = (0.0, 1.0, 0.0)
 CONTACT_ARROW_LENGTH = 0.1
 """Length of synthesized contact arrows in meters."""
 
+_NEWTON_ICON_SIZES = (16, 32, 64)
+"""Pixel sizes of Newton's bundled apple icon (``newton/_src/viewer/gl/icon_*.png``)."""
+
+
+def _load_newton_icon_images() -> list:
+    """Load Newton's own bundled apple icon as a multi-resolution list of ``pyglet`` images.
+
+    ``RendererGL`` (the GL backend) already sets this icon on its window. ``ViewerRTX``
+    creates a bare ``pyglet.window.Window`` and never sets an icon at all, so it falls
+    back to the windowing toolkit's generic default. Reusing Newton's own icon file here
+    (rather than a new asset) keeps the RTX window consistent with the GL window.
+    """
+    import inspect
+    import io
+
+    import pyglet
+    from newton._src.viewer.gl.opengl import RendererGL
+
+    icon_dir = os.path.dirname(inspect.getfile(RendererGL))
+    images = []
+    for size in _NEWTON_ICON_SIZES:
+        filename = os.path.join(icon_dir, f"icon_{size}.png")
+        with open(filename, "rb") as f:
+            images.append(pyglet.image.load(filename=filename, file=io.BytesIO(f.read())))
+    return images
+
+
+def _apply_newton_icon(window) -> None:
+    """Set *window*'s icon to Newton's own apple icon, ignoring headless/EGL windows."""
+    with contextlib.suppress(Exception):
+        window.set_icon(*_load_newton_icon_images())
+
+
 if TYPE_CHECKING:
     from newton import State
 
@@ -697,6 +730,10 @@ class NewtonViewerRTX(_NewtonViewerUIMixin, ViewerRTX):
     def _init_window(self) -> None:
         """Create the viewer window and immediately apply Isaac Lab UI patches."""
         super()._init_window()
+        # ViewerRTX creates a bare pyglet window and never sets an icon, unlike ViewerGL's
+        # RendererGL which sets Newton's own apple icon — without this the RTX window shows
+        # the windowing toolkit's generic default icon.
+        _apply_newton_icon(self._window)
         # Disable imgui's automatic ini file I/O — the file would be written to the
         # current working directory (often the repo root), polluting it with
         # session-specific UI state and causing hard-to-diagnose bugs when a stale

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -85,9 +85,6 @@ CONTACT_ARROW_COLOR = (0.0, 1.0, 0.0)
 CONTACT_ARROW_LENGTH = 0.1
 """Length of synthesized contact arrows in meters."""
 
-_NEWTON_ICON_SIZES = (16, 32, 64)
-"""Pixel sizes of Newton's bundled apple icon (``newton/_src/viewer/gl/icon_*.png``)."""
-
 
 def _load_newton_icon_images() -> list:
     """Load Newton's own bundled apple icon as a multi-resolution list of ``pyglet`` images.
@@ -96,19 +93,25 @@ def _load_newton_icon_images() -> list:
     creates a bare ``pyglet.window.Window`` and never sets an icon at all, so it falls
     back to the windowing toolkit's generic default. Reusing Newton's own icon file here
     (rather than a new asset) keeps the RTX window consistent with the GL window.
+
+    Shares its icon-directory lookup with ``isaaclab.utils.desktop_icons``, which installs
+    the same icon as an XDG ``.desktop`` entry, so both stay in sync if Newton ever moves
+    these files.
     """
-    import inspect
     import io
 
     import pyglet
-    from newton._src.viewer.gl.opengl import RendererGL
 
-    icon_dir = os.path.dirname(inspect.getfile(RendererGL))
+    from isaaclab.utils.desktop_icons import NEWTON_ICON_SIZES, newton_icon_source_dir
+
+    icon_dir = newton_icon_source_dir()
+    if icon_dir is None:
+        raise FileNotFoundError("Newton's bundled icon directory could not be located.")
     images = []
-    for size in _NEWTON_ICON_SIZES:
-        filename = os.path.join(icon_dir, f"icon_{size}.png")
+    for size in NEWTON_ICON_SIZES:
+        filename = icon_dir / f"icon_{size}.png"
         with open(filename, "rb") as f:
-            images.append(pyglet.image.load(filename=filename, file=io.BytesIO(f.read())))
+            images.append(pyglet.image.load(filename=str(filename), file=io.BytesIO(f.read())))
     return images
 
 


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html

💡 Please try to keep PRs small and focused. Large PRs are harder to review and merge.
-->

Fixes the Newton GL, Newton RTX, and Kit visualizer windows showing a generic icon in the taskbar/dock instead of their real one.

On Linux, most desktop environments resolve taskbar/dock icons by matching a window's `WM_CLASS` against an installed `.desktop` file's `StartupWMClass`, not from the window's own icon hint. Kit and Newton already set the right icon hint on the window itself, but without a matching `.desktop` file installed, the desktop environment falls back to a generic icon. `isaaclab.sh -i` and `isaaclab --editor` now install `.desktop` entries for the Kit, Newton GL, and Newton RTX windows so they resolve correctly. Separately, `ViewerRTX` (`newton_rtx`) never set a window icon at all (unlike `ViewerGL`, used by `newton_gl`), so it's now reusing Newton's own bundled icon for consistency with `newton_gl`.

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [ ] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

