### PR TITLE
Make stack teleop dependency optional

### DIFF
--- a/source/isaaclab_tasks/changelog.d/optional-teleop-stack-config.rst
+++ b/source/isaaclab_tasks/changelog.d/optional-teleop-stack-config.rst
@@ -1,0 +1,4 @@
+Fixed
+^^^^^
+
+* Allowed stack-based environment configurations to load without the optional ``isaaclab_teleop`` package.

--- a/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/contrib/stack/stack_env_cfg.py
@@ -3,14 +3,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 from dataclasses import MISSING
+from typing import TYPE_CHECKING
 
 from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg, NewtonCollisionPipelineCfg, NewtonShapeCfg
 from isaaclab_physx.physics import PhysxCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
-from isaaclab.devices.openxr import XrCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
@@ -31,6 +33,9 @@ from isaaclab_tasks.utils import PresetCfg
 from . import mdp
 from .mdp import stack_events
 
+if TYPE_CHECKING:
+    from isaaclab_teleop import XrCfg
+
 # Shared rigid-body properties for the three stacking cubes (robot-neutral).
 _CUBE_PROPERTIES = RigidBodyPropertiesCfg(
     solver_position_iteration_count=16,
@@ -40,6 +45,20 @@ _CUBE_PROPERTIES = RigidBodyPropertiesCfg(
     max_depenetration_velocity=5.0,
     disable_gravity=False,
 )
+
+
+def _make_default_xr_cfg() -> XrCfg | None:
+    """Create the default stack XR configuration when Isaac Lab Teleop is installed."""
+    try:
+        from isaaclab_teleop import XrCfg
+    except ModuleNotFoundError as exc:
+        if exc.name != "isaaclab_teleop":
+            raise
+        return None
+    return XrCfg(
+        anchor_pos=(-0.1, -0.5, -1.05),
+        anchor_rot=(0, 0, -0.5, 0.866),
+    )
 
 
 def make_ee_frame_cfg(
@@ -74,7 +93,7 @@ def make_ee_frame_cfg(
     )
 
 
-def apply_default_semantics(scene: "ObjectTableSceneCfg") -> None:
+def apply_default_semantics(scene: ObjectTableSceneCfg) -> None:
     """Tag the table, ground, and robot with their semantic classes.
 
     Call this from a robot env cfg's ``__post_init__`` after the robot has been set (the robot is
@@ -374,10 +393,7 @@ class StackEnvCfg(ManagerBasedRLEnvCfg):
     events = None
     curriculum = None
 
-    xr: XrCfg = XrCfg(
-        anchor_pos=(-0.1, -0.5, -1.05),
-        anchor_rot=(0, 0, -0.5, 0.866),
-    )
+    xr: XrCfg | None = _make_default_xr_cfg()
 
     def __post_init__(self):
         """Post initialization."""

--- a/source/isaaclab_tasks/test/core/test_env_cfg_no_forbidden_imports.py
+++ b/source/isaaclab_tasks/test/core/test_env_cfg_no_forbidden_imports.py
@@ -191,3 +191,37 @@ def test_config_load_does_not_import_backend_modules(task_name: str, all_cfg_che
         "__init__.py, or move the import under TYPE_CHECKING and use a string "
         "reference for isinstance checks."
     )
+
+
+def test_agibot_place_config_loads_without_teleop():
+    """The Agibot place config must not require the optional teleop package."""
+    script = textwrap.dedent("""\
+        import builtins
+
+        original_import = builtins.__import__
+
+        def block_teleop(name, *args, **kwargs):
+            if name == "isaaclab_teleop" or name.startswith("isaaclab_teleop."):
+                raise ModuleNotFoundError("No module named 'isaaclab_teleop'", name="isaaclab_teleop")
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = block_teleop
+
+        import isaaclab_tasks  # noqa: F401
+        from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+        cfg = load_cfg_from_registry(
+            "IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow",
+            "env_cfg_entry_point",
+        )
+        assert cfg.xr is None
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"Subprocess failed:\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )


### PR DESCRIPTION
# Description

Make `isaaclab_teleop` optional when loading stack-based environment configurations. The Agibot Toy2Box place environment imports the shared stack scene config, which previously imported `XrCfg` eagerly and failed under the `isaacsim` extra alone.

This change:

- loads the XR configuration only when `isaaclab_teleop` is installed;
- preserves the existing stack XR anchor defaults when teleop is available;
- falls back to `xr=None` when teleop is absent; and
- adds a fresh-process regression test for `IsaacContrib-Place-Toy2Box-Agibot-Right-Arm-RmpFlow`.

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable.

## Testing

Passed:

- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `python3 -m py_compile` on the changed Python files
- standalone missing/present-`isaaclab_teleop` behavior probe
- changelog fragment validation

Not run locally:

- focused pytest and `uv run isaaclab -f`; the repository lockfile supports Linux and Windows, while the current host is macOS ARM

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the full pre-commit checks
- [x] Documentation changes are not required for this dependency-loading fix
- [x] The focused static checks generate no new warnings
- [x] I have added a regression test that proves the fix is effective
- [x] I have added a changelog fragment under `source/isaaclab_tasks/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`
