### PR TITLE
Add teleop extra to Galbot visualizer docs

### DIFF
--- a/docs/source/features/visualizer_tiled_camera.rst
+++ b/docs/source/features/visualizer_tiled_camera.rst
@@ -98,7 +98,7 @@ Example 2: Streaming from Robot-Mounted Cameras
 
 .. code-block:: bash
 
-   uv run python scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py \
+   uv run --extra teleop python scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py \
        --task IsaacContrib-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor --num_envs 25 --viz newton_gl
 
 The Galbot cube-stacking environment ships with wrist-mounted cameras giving an egocentric


### PR DESCRIPTION
## Description

The Galbot tiled-camera visualizer example requires the optional `isaaclab_teleop` package. Running the documented command from a base installation fails unless the `teleop` extra is enabled.

This updates the Galbot example command to use `uv run --extra teleop` so it installs the required optional dependency.

No new dependencies are introduced.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Type of change

- Documentation update

## Screenshots

Not applicable; this changes a command-line example only.

## Validation

- `uv run --isolated --extra test -- make -C docs current-docs`
- `uv run isaaclab -f`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made the corresponding documentation change
- [x] My changes generate no new warnings
- [x] My name is already present in the project contributor history
