### PR TITLE
Add teleop extra to Galbot visualizer docs

### DIFF
--- a/docs/source/features/visualizer_tiled_camera.rst
+++ b/docs/source/features/visualizer_tiled_camera.rst
@@ -98,7 +98,7 @@ Example 2: Streaming from Robot-Mounted Cameras
 
 .. code-block:: bash
 
-   uv run python scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py \
+   uv run --extra teleop python scripts/tutorials/07_visualizers/run_tiled_camera_visualizer.py \
        --task IsaacContrib-Stack-Cube-Galbot-Left-Arm-Gripper-Visuomotor --num_envs 25 --viz newton_gl
 
 The Galbot cube-stacking environment ships with wrist-mounted cameras giving an egocentric


### PR DESCRIPTION
## Description

Forward-port of #7717 from `release/3.0.0` to `develop`.

The Galbot tiled-camera visualizer example requires the optional `isaaclab_teleop` package. Running the documented command from a base installation fails unless the `teleop` extra is enabled.

This updates the Galbot example command to use `uv run --extra teleop` so it installs the required optional dependency.

No new dependencies are introduced.

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

The change is already present in `release/3.0.0` through #7717.

## Type of change

- Documentation update

## Screenshots

Not applicable; this changes a command-line example only.

## Validation

- `git diff --check upstream/develop..HEAD`
- Verified the stable patch ID matches #7717: `de32068896b4f351ec61e1e6163108392dde46f1`
- `uv run --isolated --extra test -- make -C docs current-docs` and `uv run isaaclab -f` could not start locally because the repository lockfile excludes macOS; Linux CI should run both checks.

## Checklist

- [x] I have read and understood the contribution guidelines
- [ ] I have run the pre-commit checks
- [x] I have made the corresponding documentation change
- [ ] My changes generate no new warnings
- [x] Tests are not applicable to this documentation-only forward-port
- [x] No source package is touched, so no changelog fragment is required
- [x] The original author's name is already present in the project contributor history
