### PR TITLE
Add SSH and HTTPS tabs to Windows uv installation docs

### DIFF
--- a/docs/source/setup/installation/index.rst
+++ b/docs/source/setup/installation/index.rst
@@ -201,8 +201,7 @@ Install ``uv``, clone Isaac Lab, and start a workflow:
 
          powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 
-      .. isaaclab-clone-https::
-         :platform: windows
+      .. isaaclab-clone-commands::
 
       .. code-block:: batch
 


### PR DESCRIPTION
## Description

The Windows instructions under automatic uv installation only offered an HTTPS clone command. Use the existing clone-tabs directive so Windows offers the same SSH and HTTPS choices as Linux x86_64 and DGX Spark.

## Type of change

- Documentation update

## Validation

- `uv run --isolated --extra dev -- make -C docs current-docs`: passed with warnings treated as errors.
- `ISAACLAB_CHANGELOG_BASE_REF=pr-validation-develop uv run isaaclab -f`: passed; comparison reference mirrors upstream develop.
- Checked that the generated Windows section includes both clone protocols.

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My name already exists in CONTRIBUTORS.md

No source packages changed; no changelog fragment or new tests are needed.
