### PR TITLE
Regenerate the Shadow Hand golden stage for the promoted asset

### DIFF
--- a/source/isaaclab_tasks/test/golden_stages/registered_tasks_Isaac-Reorient-Cube-Shadow-Camera-Direct/default_physics-default_renderer-stage.usda
+++ b/source/isaaclab_tasks/test/golden_stages/registered_tasks_Isaac-Reorient-Cube-Shadow-Camera-Direct/default_physics-default_renderer-stage.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b2274b3e911fa3ce83253e1b76b61ae74cc2d9eb03b4a6aeb743d8e67a3857d
-size 4366728
+oid sha256:4fa0e701d665e6ff0a2d20ec262b3e13d338ca281825e96974ed21b0488ebb74
+size 4150142


### PR DESCRIPTION
# Description

CI job `rendering-correctness` fails on several PRs today (2026-09-10) in
`source/isaaclab_tasks/test/core/test_rendering_registered_tasks.py::test_rendering_registered_tasks[Isaac-Reorient-Cube-Shadow-Camera-Direct-None-shadow_hand]`
with "USD stage mismatch": 80 added collider prims (58 Capsule, 18 Cube, 4 Mesh)
under `/World/envs/env_0/Robot/Geometry/rh_forearm/...` and 33 transform
differences vs the checked-in golden.

Cause: the public Shadow Hand asset
(`.../Isaac/6.1/Isaac/Robots_Multiphysics/ShadowRobot/ShadowHandMultiPhysics_v0/right_hand/right_hand.usda`)
was replaced in place (Last-Modified 2026-09-10 02:06 UTC) by the asset
promotion from #7715, which adds `Colliders` full/simplified variant sets.
The golden stage
`source/isaaclab_tasks/test/golden_stages/registered_tasks_Isaac-Reorient-Cube-Shadow-Camera-Direct/default_physics-default_renderer-stage.usda`
was last captured on 2026-09-05 in #7161 against the old asset. Runners with
a cached old asset pass, runners downloading fresh fail — hence the
interleaved pass/fail across PRs:

- https://github.com/isaac-sim/IsaacLab/actions/runs/34461544879
- https://github.com/isaac-sim/IsaacLab/actions/runs/34447770315
- https://github.com/isaac-sim/IsaacLab/actions/runs/34459718880

Fix: regenerate that golden against the promoted asset with develop's code
(develop selects `Colliders="simplified"` via #7715). Only the golden stage
file changed — no source code was touched. The pixel-comparison goldens for
this task still pass.

Related to #7715, #7161.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable — this change only regenerates a USD stage golden used for
structural diffing in the rendering-correctness test.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
