### PR TITLE
Mimic: hold the target of each gripper transition before commanding it

### DIFF
--- a/source/isaaclab/changelog.d/fix-mimic-settle-before-gripper.minor.rst
+++ b/source/isaaclab/changelog.d/fix-mimic-settle-before-gripper.minor.rst
@@ -1,0 +1,8 @@
+Added
+^^^^^
+
+* Added :attr:`~isaaclab.envs.mimic_env_cfg.SubTaskConfig.num_settle_steps_before_gripper`, which holds
+  the target of each gripper transition of a Mimic subtask for a number of noise-free steps before the
+  transition is commanded. Source demonstrations are replayed by frame index, which drops the pause a
+  human operator makes before acting the gripper; the generated arm is still moving when the gripper
+  closes or opens. Defaults to 0, which keeps the current behavior.

--- a/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
@@ -159,6 +159,28 @@ class SubTaskConfig:
     apply_noise_during_interpolation: bool = False
     """Whether to apply noise during interpolation."""
 
+    num_settle_steps_before_gripper: int = 0
+    """Number of noise-free steps to hold the target of each gripper transition in this subtask
+    before the transition is commanded.
+
+    Source demonstrations are replayed by frame index, but a human operator stops the arm before
+    closing or opening the gripper: in the source data the target and the achieved end-effector
+    pose coincide at the frame of the gripper command, while the generated arm, driven with action
+    noise from a different configuration, is still moving when that frame is reached. Holding the
+    transition's target for a few steps lets the generated arm settle where the source arm was
+    before the gripper acts. The held steps keep the pre-transition gripper action and carry no
+    action noise. 0 (default) keeps the source timing unchanged.
+
+    A transition is any change of the gripper action between consecutive frames of the subtask
+    segment, as discrete open/close commands produce; leave the option at 0 for continuous
+    hand-joint targets, where nearly every frame differs. A useful value is a few time constants
+    of the arm controller (20 steps for the Franka IK-Rel stack task).
+
+    Note:
+        :attr:`num_fixed_steps` also holds a target, but the subtask's first one, at its start;
+        this option holds at the gripper transition inside the subtask.
+    """
+
     description: str = ""
     """Description of the subtask"""
 

--- a/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
+++ b/source/isaaclab/isaaclab/envs/mimic_env_cfg.py
@@ -172,13 +172,19 @@ class SubTaskConfig:
     action noise. 0 (default) keeps the source timing unchanged.
 
     A transition is any change of the gripper action between consecutive frames of the subtask
-    segment, as discrete open/close commands produce; leave the option at 0 for continuous
-    hand-joint targets, where nearly every frame differs. A useful value is a few time constants
-    of the arm controller (20 steps for the Franka IK-Rel stack task).
+    segment, as discrete open/close commands produce, including a change between the source frame
+    just before the segment and its first frame; leave the option at 0 for continuous hand-joint
+    targets, where nearly every frame differs. A useful value is a few time constants of the arm
+    controller (20 steps for the Franka IK-Rel stack task).
 
     Note:
         :attr:`num_fixed_steps` also holds a target, but the subtask's first one, at its start;
         this option holds at the gripper transition inside the subtask.
+
+    Note:
+        Not supported on subtasks under a coordination constraint: the hold lengthens each
+        end effector's segment independently, which the synchronous-steps coordination does not
+        account for. The data generator raises at construction in that case.
     """
 
     description: str = ""

--- a/source/isaaclab_mimic/changelog.d/fix-mimic-settle-before-gripper.minor.rst
+++ b/source/isaaclab_mimic/changelog.d/fix-mimic-settle-before-gripper.minor.rst
@@ -7,4 +7,5 @@ Added
   action and no action noise, for that many steps before the transition is commanded, so the generated
   arm settles where the source arm was when its operator acted the gripper. On the Franka cube stack
   task this raised the generation success rate from 35% to 54% (five scene draws, 300 attempts each).
-  Off by default.
+  Off by default. Setting it on a subtask under a coordination constraint raises a ``ValueError`` when
+  the data generator is created, because the hold lengthens each end effector's segment independently.

--- a/source/isaaclab_mimic/changelog.d/fix-mimic-settle-before-gripper.minor.rst
+++ b/source/isaaclab_mimic/changelog.d/fix-mimic-settle-before-gripper.minor.rst
@@ -1,0 +1,10 @@
+Added
+^^^^^
+
+* Added a settle-before-gripper hold to Mimic data generation. When
+  :attr:`~isaaclab.envs.mimic_env_cfg.SubTaskConfig.num_settle_steps_before_gripper` is set, the
+  target of every gripper transition in a subtask segment is held, with the pre-transition gripper
+  action and no action noise, for that many steps before the transition is commanded, so the generated
+  arm settles where the source arm was when its operator acted the gripper. On the Franka cube stack
+  task this raised the generation success rate from 35% to 54% (five scene draws, 300 attempts each).
+  Off by default.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
@@ -48,6 +48,7 @@ def insert_settle_frames_before_gripper(
     gripper_actions: torch.Tensor,
     action_noise: float | torch.Tensor,
     num_steps: int,
+    previous_gripper_action: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, float | torch.Tensor]:
     """Hold the target of every gripper transition in a pose sequence before the transition.
 
@@ -57,7 +58,11 @@ def insert_settle_frames_before_gripper(
     noise from a different configuration, is still moving when that frame is reached. Before every
     frame ``c`` whose gripper action differs from that of frame ``c - 1``, this inserts ``num_steps``
     copies of the target pose of ``c`` with the gripper action of ``c - 1`` and zero action noise, so
-    the arm settles onto the target before the gripper acts.
+    the arm settles onto the target before the gripper acts. A segment that starts on a transition
+    (frame 0 differs from ``previous_gripper_action``, the source action just before the segment) is
+    held the same way, at frame 0's target with the previous action; that hold then leads the
+    segment, so the interpolation :meth:`WaypointTrajectory.merge` builds towards the segment carries
+    the pre-transition gripper action as well.
 
     A transition is any change of the gripper action vector between consecutive frames, which is what
     discrete open/close commands produce. With continuous hand-joint targets (dexterous hands) nearly
@@ -68,38 +73,73 @@ def insert_settle_frames_before_gripper(
         gripper_actions: Gripper actions of shape (T, D).
         action_noise: Action noise amplitude, a scalar or a per-frame tensor of shape (T,) or (T, 1).
         num_steps: Number of frames to insert before each transition.
+        previous_gripper_action: Gripper action of shape (D,) of the source frame just before the
+            segment, or None when the segment starts the demonstration.
 
     Returns:
         A tuple ``(poses, gripper_actions, action_noise)`` with the held frames inserted;
-        ``action_noise`` is then a per-frame tensor of shape (T', 1). The inputs are returned unchanged
-        when ``num_steps`` is not positive or the sequence has no gripper transition. A change of
-        gripper action between the previous subtask and frame 0 is not a transition of this sequence.
+        ``action_noise`` is then a per-frame tensor of shape (T', 1) on the device of ``poses``. The
+        inputs are returned unchanged when ``num_steps`` is not positive or the sequence has no
+        gripper transition.
     """
-    if num_steps <= 0 or poses.shape[0] < 2:
+    if num_steps <= 0 or poses.shape[0] < 1:
         return poses, gripper_actions, action_noise
-    transitions = torch.nonzero((gripper_actions[1:] != gripper_actions[:-1]).any(dim=-1)).flatten() + 1
-    if transitions.numel() == 0:
+    transitions = (torch.nonzero((gripper_actions[1:] != gripper_actions[:-1]).any(dim=-1)).flatten() + 1).tolist()
+    if previous_gripper_action is not None:
+        previous_gripper_action = previous_gripper_action.to(gripper_actions).reshape(1, -1)
+        if bool((gripper_actions[0:1] != previous_gripper_action).any()):
+            transitions.insert(0, 0)
+    if not transitions:
         return poses, gripper_actions, action_noise
 
     if isinstance(action_noise, torch.Tensor):
-        noise = action_noise.reshape(-1, 1).to(dtype=torch.float32)
+        noise = action_noise.reshape(-1, 1).to(dtype=torch.float32, device=poses.device)
     else:
-        noise = float(action_noise) * torch.ones((poses.shape[0], 1), dtype=torch.float32)
+        noise = float(action_noise) * torch.ones((poses.shape[0], 1), dtype=torch.float32, device=poses.device)
 
     pose_parts, gripper_parts, noise_parts = [], [], []
     prev_end = 0
-    for c in transitions.tolist():
+    for c in transitions:
+        held_gripper = previous_gripper_action if c == 0 else gripper_actions[c - 1 : c]
         pose_parts.append(poses[prev_end:c])
         gripper_parts.append(gripper_actions[prev_end:c])
         noise_parts.append(noise[prev_end:c])
         pose_parts.append(poses[c : c + 1].expand(num_steps, -1, -1))
-        gripper_parts.append(gripper_actions[c - 1 : c].expand(num_steps, -1))
+        gripper_parts.append(held_gripper.expand(num_steps, -1))
         noise_parts.append(torch.zeros((num_steps, 1), dtype=noise.dtype, device=noise.device))
         prev_end = c
     pose_parts.append(poses[prev_end:])
     gripper_parts.append(gripper_actions[prev_end:])
     noise_parts.append(noise[prev_end:])
     return torch.cat(pose_parts), torch.cat(gripper_parts), torch.cat(noise_parts)
+
+
+def check_settle_hold_compatible(env_cfg: MimicEnvCfg) -> None:
+    """Raise if ``num_settle_steps_before_gripper`` is set on a subtask under a coordination constraint.
+
+    Coordinated subtasks are kept in step through ``synchronous_steps``, a count of source frames at the
+    end of both segments. The settle hold lengthens each end effector's executed segment by its own
+    number of gripper transitions times ``num_settle_steps_before_gripper``, so the two segments would
+    no longer describe the same source frames over that window. Until the coordination logic accounts
+    for the inserted frames the two options are mutually exclusive.
+
+    Args:
+        env_cfg: The Mimic environment configuration to check.
+
+    Raises:
+        ValueError: If a subtask that takes part in a coordination constraint has
+            ``num_settle_steps_before_gripper`` greater than 0.
+    """
+    for constraint in env_cfg.task_constraint_configs:
+        if constraint.constraint_type != SubTaskConstraintType.COORDINATION:
+            continue
+        for eef_name, subtask_ind in constraint.eef_subtask_constraint_tuple:
+            if env_cfg.subtask_configs[eef_name][subtask_ind].num_settle_steps_before_gripper > 0:
+                raise ValueError(
+                    f"num_settle_steps_before_gripper is set on subtask {subtask_ind} of end effector"
+                    f" '{eef_name}', which is under a coordination constraint; the settle hold is not supported"
+                    " for coordinated subtasks"
+                )
 
 
 def transform_source_data_segment_using_delta_object_pose(
@@ -239,6 +279,7 @@ class DataGenerator:
         for subtask_configs in self.env_cfg.subtask_configs.values():
             assert subtask_configs[-1].subtask_term_offset_range[0] == 0
             assert subtask_configs[-1].subtask_term_offset_range[1] == 0
+        check_settle_hold_compatible(self.env_cfg)
 
         self.demo_keys = demo_keys
 
@@ -541,6 +582,12 @@ class DataGenerator:
         src_subtask_gripper_actions = src_ep_datagen_info.gripper_action[eef_name][
             selected_src_subtask_boundary[0] : selected_src_subtask_boundary[1]
         ]
+        # The source action just before the segment, so that a gripper transition on the segment's
+        # first frame is held as well (SubTaskConfig.num_settle_steps_before_gripper).
+        segment_start = int(selected_src_subtask_boundary[0])
+        previous_gripper_action = (
+            src_ep_datagen_info.gripper_action[eef_name][segment_start - 1] if segment_start > 0 else None
+        )
 
         # Get reference object pose from source demo
         src_subtask_object_pose = (
@@ -603,6 +650,7 @@ class DataGenerator:
             src_subtask_gripper_actions,
             subtask_config.action_noise,
             num_steps=subtask_config.num_settle_steps_before_gripper,
+            previous_gripper_action=previous_gripper_action,
         )
 
         # Construct trajectory for the transformed segment.

--- a/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/datagen/data_generator.py
@@ -43,6 +43,65 @@ async def _optional_lock(lock):
         yield
 
 
+def insert_settle_frames_before_gripper(
+    poses: torch.Tensor,
+    gripper_actions: torch.Tensor,
+    action_noise: float | torch.Tensor,
+    num_steps: int,
+) -> tuple[torch.Tensor, torch.Tensor, float | torch.Tensor]:
+    """Hold the target of every gripper transition in a pose sequence before the transition.
+
+    Source demonstrations are replayed by frame index, which drops the pause a human operator makes
+    before closing or opening the gripper: in the source data the target and the achieved end-effector
+    pose coincide at the frame of the gripper command, whereas the generated arm, driven with action
+    noise from a different configuration, is still moving when that frame is reached. Before every
+    frame ``c`` whose gripper action differs from that of frame ``c - 1``, this inserts ``num_steps``
+    copies of the target pose of ``c`` with the gripper action of ``c - 1`` and zero action noise, so
+    the arm settles onto the target before the gripper acts.
+
+    A transition is any change of the gripper action vector between consecutive frames, which is what
+    discrete open/close commands produce. With continuous hand-joint targets (dexterous hands) nearly
+    every frame differs and the option should stay at 0.
+
+    Args:
+        poses: Target pose sequence of shape (T, 4, 4).
+        gripper_actions: Gripper actions of shape (T, D).
+        action_noise: Action noise amplitude, a scalar or a per-frame tensor of shape (T,) or (T, 1).
+        num_steps: Number of frames to insert before each transition.
+
+    Returns:
+        A tuple ``(poses, gripper_actions, action_noise)`` with the held frames inserted;
+        ``action_noise`` is then a per-frame tensor of shape (T', 1). The inputs are returned unchanged
+        when ``num_steps`` is not positive or the sequence has no gripper transition. A change of
+        gripper action between the previous subtask and frame 0 is not a transition of this sequence.
+    """
+    if num_steps <= 0 or poses.shape[0] < 2:
+        return poses, gripper_actions, action_noise
+    transitions = torch.nonzero((gripper_actions[1:] != gripper_actions[:-1]).any(dim=-1)).flatten() + 1
+    if transitions.numel() == 0:
+        return poses, gripper_actions, action_noise
+
+    if isinstance(action_noise, torch.Tensor):
+        noise = action_noise.reshape(-1, 1).to(dtype=torch.float32)
+    else:
+        noise = float(action_noise) * torch.ones((poses.shape[0], 1), dtype=torch.float32)
+
+    pose_parts, gripper_parts, noise_parts = [], [], []
+    prev_end = 0
+    for c in transitions.tolist():
+        pose_parts.append(poses[prev_end:c])
+        gripper_parts.append(gripper_actions[prev_end:c])
+        noise_parts.append(noise[prev_end:c])
+        pose_parts.append(poses[c : c + 1].expand(num_steps, -1, -1))
+        gripper_parts.append(gripper_actions[c - 1 : c].expand(num_steps, -1))
+        noise_parts.append(torch.zeros((num_steps, 1), dtype=noise.dtype, device=noise.device))
+        prev_end = c
+    pose_parts.append(poses[prev_end:])
+    gripper_parts.append(gripper_actions[prev_end:])
+    noise_parts.append(noise[prev_end:])
+    return torch.cat(pose_parts), torch.cat(gripper_parts), torch.cat(noise_parts)
+
+
 def transform_source_data_segment_using_delta_object_pose(
     src_eef_poses: torch.Tensor,
     delta_obj_pose: torch.Tensor,
@@ -535,11 +594,22 @@ class DataGenerator:
                     # Skip transformation if no reference object is provided
                     transformed_eef_poses = src_eef_poses
 
+        # Hold the target of every gripper transition before the transition is commanded, so the
+        # generated arm settles where the source arm was when its operator acted the gripper
+        # (SubTaskConfig.num_settle_steps_before_gripper; unset by default).
+        subtask_config = subtask_configs[subtask_ind]
+        transformed_eef_poses, src_subtask_gripper_actions, subtask_action_noise = insert_settle_frames_before_gripper(
+            transformed_eef_poses,
+            src_subtask_gripper_actions,
+            subtask_config.action_noise,
+            num_steps=subtask_config.num_settle_steps_before_gripper,
+        )
+
         # Construct trajectory for the transformed segment.
         transformed_seq = WaypointSequence.from_poses(
             poses=transformed_eef_poses,
             gripper_actions=src_subtask_gripper_actions,
-            action_noise=subtask_configs[subtask_ind].action_noise,
+            action_noise=subtask_action_noise,
         )
         transformed_traj = WaypointTrajectory()
         transformed_traj.add_waypoint_sequence(transformed_seq)

--- a/source/isaaclab_mimic/test/test_settle_before_gripper.py
+++ b/source/isaaclab_mimic/test/test_settle_before_gripper.py
@@ -17,7 +17,9 @@ simulation_app = AppLauncher(headless=True).app
 import pytest
 import torch
 
-from isaaclab_mimic.datagen.data_generator import insert_settle_frames_before_gripper
+from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig, SubTaskConstraintConfig, SubTaskConstraintType
+
+from isaaclab_mimic.datagen.data_generator import check_settle_hold_compatible, insert_settle_frames_before_gripper
 from isaaclab_mimic.datagen.waypoint import Waypoint, WaypointSequence, WaypointTrajectory
 
 GRIPPER = [-1, -1, -1, -1, 1, 1, 1, -1, -1, -1]
@@ -105,3 +107,69 @@ def test_the_held_frames_reach_the_executed_sequence():
     held = [i for i in range(5, len(full)) if float(full[i].noise) == 0]
     assert held == [5 + 4, 5 + 5, 5 + 6, 5 + 10, 5 + 11, 5 + 12]
     assert all(int(full[i].gripper_action[0]) == (-1 if i < 5 + 10 else 1) for i in held)
+
+
+def test_a_transition_on_the_first_frame_is_held_with_the_previous_action():
+    """A segment that starts already closed, after an open frame in the source: the hold leads it."""
+    poses, gripper = _sequence([1, 1, 1])
+    new_poses, new_gripper, new_noise = insert_settle_frames_before_gripper(
+        poses, gripper, 0.03, num_steps=3, previous_gripper_action=torch.tensor([-1.0])
+    )
+    assert _frames(new_poses) == [0, 0, 0, 0, 1, 2]
+    assert new_gripper.flatten().tolist() == [-1, -1, -1, 1, 1, 1]
+    assert new_noise.flatten().tolist() == pytest.approx([0, 0, 0, 0.03, 0.03, 0.03])
+
+
+@pytest.mark.parametrize("previous", [None, torch.tensor([1.0])])
+def test_no_or_an_equal_previous_action_is_not_a_boundary_transition(previous):
+    poses, gripper = _sequence([1, 1, 1])
+    out_poses, _, _ = insert_settle_frames_before_gripper(
+        poses, gripper, 0.03, num_steps=3, previous_gripper_action=previous
+    )
+    assert out_poses is poses
+
+
+def test_a_leading_hold_reaches_the_executed_sequence_before_the_interpolated_target():
+    """merge() pops the first frame as the interpolation target, so the interpolation towards a segment
+    that starts on a transition carries the pre-transition gripper action, then the hold, then the flip."""
+    poses, gripper = _sequence([1, 1, 1])
+    new_poses, new_gripper, new_noise = insert_settle_frames_before_gripper(
+        poses, gripper, 0.03, num_steps=3, previous_gripper_action=torch.tensor([-1.0])
+    )
+    subtask_traj = WaypointTrajectory()
+    subtask_traj.add_waypoint_sequence(WaypointSequence.from_poses(new_poses, new_gripper, new_noise))
+    traj = WaypointTrajectory()
+    traj.add_waypoint_sequence(WaypointSequence(sequence=[Waypoint(torch.eye(4), torch.tensor([-1.0]), 0.03)]))
+    traj.merge(subtask_traj, num_steps_interp=5, num_steps_fixed=0, action_noise=0.0)
+    traj.pop_first()
+    grippers = [int(waypoint.gripper_action[0]) for waypoint in traj.get_full_sequence().sequence]
+    # 5 interpolation frames + the popped hold frame + 2 remaining hold frames stay open; frames 0..2 closed
+    assert grippers == [-1] * 8 + [1] * 3
+
+
+@pytest.mark.parametrize("noise", [0.03, torch.full((10,), 0.03)])
+def test_held_noise_lives_on_the_poses_device(noise):
+    poses, gripper = _sequence(GRIPPER)
+    if torch.cuda.is_available():
+        poses, gripper = poses.cuda(), gripper.cuda()
+    _, _, new_noise = insert_settle_frames_before_gripper(poses, gripper, noise, num_steps=2)
+    assert new_noise.device == poses.device
+
+
+def test_settle_hold_is_refused_under_a_coordination_constraint():
+    cfg = MimicEnvCfg()
+    cfg.subtask_configs = {"left": [SubTaskConfig(num_settle_steps_before_gripper=20)], "right": [SubTaskConfig()]}
+    cfg.task_constraint_configs = [
+        SubTaskConstraintConfig(
+            eef_subtask_constraint_tuple=[("left", 0), ("right", 0)],
+            constraint_type=SubTaskConstraintType.COORDINATION,
+        )
+    ]
+    with pytest.raises(ValueError, match="coordination"):
+        check_settle_hold_compatible(cfg)
+    # the same hold on a subtask that is not coordinated, or under a sequential constraint, is fine
+    cfg.subtask_configs["left"][0].num_settle_steps_before_gripper = 0
+    check_settle_hold_compatible(cfg)
+    cfg.subtask_configs["left"][0].num_settle_steps_before_gripper = 20
+    cfg.task_constraint_configs[0].constraint_type = SubTaskConstraintType.SEQUENTIAL
+    check_settle_hold_compatible(cfg)

--- a/source/isaaclab_mimic/test/test_settle_before_gripper.py
+++ b/source/isaaclab_mimic/test/test_settle_before_gripper.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2024-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the settle-before-gripper hold in Mimic data generation.
+
+``insert_settle_frames_before_gripper`` is pure tensor logic; the last test checks that the held frames
+survive the trajectory merge that ``generate()`` executes.
+"""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+simulation_app = AppLauncher(headless=True).app
+
+import pytest
+import torch
+
+from isaaclab_mimic.datagen.data_generator import insert_settle_frames_before_gripper
+from isaaclab_mimic.datagen.waypoint import Waypoint, WaypointSequence, WaypointTrajectory
+
+GRIPPER = [-1, -1, -1, -1, 1, 1, 1, -1, -1, -1]
+"""A segment that closes the gripper at frame 4 and opens it again at frame 7."""
+
+
+def _sequence(gripper_values, num_dofs=1):
+    """Poses whose x translation is the frame index, and gripper actions of shape (T, num_dofs)."""
+    num_frames = len(gripper_values)
+    poses = torch.eye(4).repeat(num_frames, 1, 1)
+    poses[:, 0, 3] = torch.arange(num_frames, dtype=torch.float32)
+    gripper_actions = torch.tensor(gripper_values, dtype=torch.float32).unsqueeze(1).repeat(1, num_dofs)
+    return poses, gripper_actions
+
+
+def _frames(poses):
+    return [int(x) for x in poses[:, 0, 3].tolist()]
+
+
+def test_zero_steps_returns_the_inputs_unchanged():
+    poses, gripper = _sequence(GRIPPER)
+    out_poses, out_gripper, out_noise = insert_settle_frames_before_gripper(poses, gripper, 0.03, num_steps=0)
+    assert out_poses is poses and out_gripper is gripper and out_noise == 0.03
+
+
+def test_a_sequence_without_gripper_transition_is_unchanged():
+    poses, gripper = _sequence([1] * 6)
+    out_poses, out_gripper, out_noise = insert_settle_frames_before_gripper(poses, gripper, 0.03, num_steps=5)
+    assert out_poses is poses and out_gripper is gripper and out_noise == 0.03
+
+
+def test_a_single_frame_is_unchanged():
+    poses, gripper = _sequence([1])
+    out_poses, _, _ = insert_settle_frames_before_gripper(poses, gripper, 0.03, num_steps=5)
+    assert out_poses is poses
+
+
+@pytest.mark.parametrize("num_dofs", [1, 2])
+def test_hold_inserts_copies_before_every_transition(num_dofs):
+    poses, gripper = _sequence(GRIPPER, num_dofs)
+    new_poses, new_gripper, new_noise = insert_settle_frames_before_gripper(poses, gripper, 0.03, num_steps=3)
+    assert new_poses.shape[0] == new_gripper.shape[0] == new_noise.shape[0] == 16
+    # 0..3 | hold at frame 4 x3 | 4..6 | hold at frame 7 x3 | 7..9
+    assert _frames(new_poses) == [0, 1, 2, 3, 4, 4, 4, 4, 5, 6, 7, 7, 7, 7, 8, 9]
+    # the held frames keep the gripper action of the frame before the transition and carry no noise
+    assert new_gripper[4:7].eq(gripper[3]).all() and new_gripper[10:13].eq(gripper[6]).all()
+    assert new_noise[4:7].eq(0).all() and new_noise[10:13].eq(0).all()
+    # the source frames are untouched, in order, and keep their noise
+    kept = torch.ones(16, dtype=torch.bool)
+    kept[4:7] = False
+    kept[10:13] = False
+    assert torch.equal(new_poses[kept], poses) and torch.equal(new_gripper[kept], gripper)
+    assert new_noise[kept].eq(0.03).all()
+
+
+def test_per_frame_noise_is_zeroed_on_the_held_frames_only():
+    poses, gripper = _sequence(GRIPPER)
+    noise = torch.arange(1, 11, dtype=torch.float32) / 100
+    _, _, new_noise = insert_settle_frames_before_gripper(poses, gripper, noise, num_steps=2)
+    expected = noise[:4].tolist() + [0, 0] + noise[4:7].tolist() + [0, 0] + noise[7:].tolist()
+    assert new_noise.flatten().tolist() == pytest.approx(expected)
+
+
+def test_a_transition_at_the_last_frame_is_held():
+    poses, gripper = _sequence([-1, -1, -1, 1])
+    new_poses, new_gripper, _ = insert_settle_frames_before_gripper(poses, gripper, 0.0, num_steps=2)
+    assert _frames(new_poses) == [0, 1, 2, 3, 3, 3]
+    assert new_gripper.flatten().tolist() == [-1, -1, -1, -1, -1, 1]
+
+
+def test_the_held_frames_reach_the_executed_sequence():
+    """The held frames must survive the interpolate-merge-pop that merge_eef_subtask_trajectory does."""
+    poses, gripper = _sequence(GRIPPER)
+    new_poses, new_gripper, new_noise = insert_settle_frames_before_gripper(poses, gripper, 0.03, num_steps=3)
+    subtask_traj = WaypointTrajectory()
+    subtask_traj.add_waypoint_sequence(WaypointSequence.from_poses(new_poses, new_gripper, new_noise))
+    traj = WaypointTrajectory()
+    traj.add_waypoint_sequence(WaypointSequence(sequence=[Waypoint(torch.eye(4), gripper[0], 0.03)]))
+    traj.merge(subtask_traj, num_steps_interp=5, num_steps_fixed=0, action_noise=0.0)
+    traj.pop_first()
+    full = traj.get_full_sequence()
+    # five interpolation frames precede the subtask segment, which then follows frame by frame
+    executed = [int(waypoint.pose[0, 3]) for waypoint in full.sequence[5:]]
+    assert executed == _frames(new_poses)
+    held = [i for i in range(5, len(full)) if float(full[i].noise) == 0]
+    assert held == [5 + 4, 5 + 5, 5 + 6, 5 + 10, 5 + 11, 5 + 12]
+    assert all(int(full[i].gripper_action[0]) == (-1 if i < 5 + 10 else 1) for i in held)


### PR DESCRIPTION
# Description

MimicGen replays a source subtask **by frame index**: the gripper command is issued on the frame it had in the source demonstration, whatever the generated arm is doing at that moment. The human who recorded the source did something the replay drops: they stopped the arm before closing or opening the gripper. Over the 10 shipped Franka stack-cube source demos, `|target_eef_pose - eef_pose|` is **4.86 cm median on ordinary frames and 0.00 cm on the gripper-command frames** (97% of them under 0.3 cm). The generated arm, driven with the default `action_noise=0.03` from a different joint configuration, is still moving when that frame arrives: 1.12 cm from the cube at closure against the human's 0.56 cm, and the cube is released 3.7 cm (p90) off the cube below, past the 2.34 cm tipping threshold. The placement and the second grasp pay for it.

This PR adds one `SubTaskConfig` option, **off by default**, that gives the generated arm the pause the operator had:

```python
num_settle_steps_before_gripper: int = 0
```

When set, `insert_settle_frames_before_gripper()` inserts, before every gripper transition of the transformed subtask segment, that many copies of the transition's target pose with the pre-transition gripper action and **zero action noise**, so the arm settles onto the target before the gripper acts. Nothing else in the pipeline changes; with the default 0 the trajectory is byte-identical to today's.

`num_fixed_steps` already exists and is also a noise-free hold, but `WaypointTrajectory.merge()` places it at the **start of the subtask** (the subtask's first pose), a whole subtask and 10–20 offset frames away from the gripper event; every shipped config sets it to 0. NVlabs/mimicgen has the same `merge`, so the gap is inherited from the original design rather than introduced by the port.

## Evidence

All runs: stock `Isaac-Stack-Cube-Franka-IK-Rel-Mimic-v0`, the shipped annotated source dataset, `num_envs=10`, 300 attempts per run, `generation_guarantee=False`, five scene draws (per-episode reseeding so the settings of a draw see the same scenes). ± is the standard error of the mean paired delta over the five draws; a single run's binomial SE is about 2.8 pp. Measured on Isaac Lab 2.3.2 + this patch (the change applies unmodified to both).

| setting | d1 | d2 | d3 | d4 | d5 | mean | Δ vs stock | episode frames |
|---|---|---|---|---|---|---|---|---|
| stock (0 steps) | 30.3 | 38.7 | 34.7 | 36.7 | 36.7 | 35.4 | — | 230 |
| hold 5 | 45.0 | 51.0 | 46.3 | 48.0 | 49.3 | 47.9 | +12.5 ± 0.6 | 250 |
| hold 10 | 48.7 | 53.0 | 51.0 | 50.0 | 52.3 | 51.0 | +15.6 ± 0.9 | 270 |
| **hold 20** | 54.7 | 53.3 | 54.0 | 51.0 | 56.7 | **53.9** | **+18.5 ± 1.9** | 310 |
| hold 30 | 54.3 | 56.7 | 56.7 | 55.3 | 56.3 | 55.9 | +20.5 ± 1.1 | 350 |
| hold 40 | 53.3 | 53.7 | 55.7 | 53.3 | 56.0 | 54.4 | +19.0 ± 1.4 | 390 |
| hold 60 | 50.0 | 54.0 | 56.3 | 54.3 | 58.3 | 54.6 | +19.2 ± 1.2 | 470 |

Mechanism (cm, median / p90, pooled over draws): gripper-to-cube distance at the first closure 1.17 / 2.10 → 0.83 / 1.73 (source demos 0.56); cube-to-cube xy offset at the first release 1.25 / 3.66 → 0.87 / 1.65 (source demos 0.90, tipping threshold 2.34). The curve is flat from 20 steps on: the arm controller is a first-order tracker with a ~10-frame time constant, so a few time constants is the rule and there is no penalty for overshooting it except episode length.

Ablations (same five draws):

| variant | mean | Δ vs stock | what it says |
|---|---|---|---|
| stock `num_fixed_steps=20` (hold at subtask start, same +80 frames) | 45.7 | +10.3 ± 1.8 | position matters: the arm still arrives unsettled (closure 1.16 cm) |
| hold 20 with the action noise kept on the held frames | 39.3 | +3.9 ± 1.6 | noise-free is most of the effect (closure 1.26 cm) |
| hold 20 before closing transitions only | 44.8 | +9.4 ± 1.3 | both transition types matter, roughly additively |
| hold 20 before opening transitions only | 42.9 | +7.5 ± 0.9 | |
| convergence-gated hold (repeat until within 0.3 cm, ≤40) | 54.5 | +19.1 ± 1.3 | no better than the fixed hold; not included to keep the change small |

Boundary: on `Isaac-Stack-Cube-Franka-IK-Abs-Mimic-v0` (absolute-pose IK, `action_noise=0.01`) the arm already arrives settled (stock release p90 1.6 cm, where IK-Rel only gets *with* the hold) and the option is neutral: 84.0% → 83.1%, −0.9 ± 0.6 pp. The option helps when the generated arm reaches the gripper frames unsettled, i.e. a lagging controller driven with sizeable action noise; the source demos' residual at the gripper frames (≈0) against a stock run's release offset is the tell.

## Tests

`source/isaaclab_mimic/test/test_settle_before_gripper.py` covers the insertion as pure tensor logic: zero steps and no-transition inputs returned unchanged, a single frame, copies inserted before every transition with the pre-transition gripper action and zero noise (1- and 2-DoF grippers), per-frame noise tensors zeroed on the held frames only, a transition on the last frame, and the held frames surviving the interpolate-merge-pop that `merge_eef_subtask_trajectory` performs.

The option assumes discrete open/close gripper commands (a transition is any change of the gripper action between consecutive frames); the docstring says to leave it at 0 for continuous hand-joint targets, where nearly every frame differs.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the `pre-commit` checks on the changed files (ruff, codespell, and the repository hooks)
- [x] I have made corresponding changes to the documentation (config docstrings)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
