### PR TITLE
[Changelog] Discover release branches for nightly compilation

### DIFF
--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -13,10 +13,10 @@
 # Scheduled workflow — must live on the default branch (``main``) for the
 # cron to register. See ``.github/workflows/README.md``.
 #
-# Adding a branch to the nightly set is a one-line edit to ``env.CRON_BRANCHES``
-# below. Each target branch uses its own ``tools/changelog/cli.py`` (the
-# same copy the PR gate already runs), so the nightly compile honours the
-# same rules that validated the fragments.
+# Scheduled runs combine ``env.CRON_BRANCHES`` with every remote
+# ``release/*`` branch that carries ``tools/changelog/cli.py``. This picks up
+# new compiler-enabled release branches automatically while leaving historical
+# branches that predate the fragment system untouched.
 #
 # The push uses a short-lived GitHub App installation token minted from
 # ``CHANGELOG_APP_ID`` + ``CHANGELOG_APP_PRIVATE_KEY`` (repo secrets). The
@@ -30,13 +30,11 @@
 
 name: Nightly Changelog Compilation
 
-# Branches the nightly cron compiles. Single source of truth — append a
-# ref here to extend the nightly set (the active release branch belongs
-# here). Each branch must carry ``tools/changelog/cli.py`` and the
-# isaaclab-bot App must be in its branch-ruleset bypass list.
-# Surrounding whitespace per entry is stripped by the resolver below.
+# Static branches the nightly cron compiles. The resolver also discovers every
+# remote ``release/*`` branch that carries ``tools/changelog/cli.py``. Every
+# resolved branch must allow the isaaclab-bot App to bypass its ruleset.
 env:
-  CRON_BRANCHES: develop,release/3.0.0
+  CRON_BRANCHES: develop
 
 on:
   schedule:
@@ -67,10 +65,8 @@ permissions:
 
 jobs:
   resolve-branches:
-    # CSV → JSON array bridge. ``workflow_dispatch`` inputs can only be
-    # string / bool / choice, so the branch list arrives as a comma-
-    # separated string; the matrix below needs a JSON list to fan out.
-    # Mirrors the ``setup-versions`` job in ``daily-compatibility.yml``.
+    # Static/manual branches plus supported ``release/*`` refs → JSON array.
+    # ``workflow_dispatch`` remains exactly one explicitly requested branch.
     name: Resolve branch list
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -79,18 +75,39 @@ jobs:
     steps:
       - id: b
         env:
-          # Schedule → the CRON_BRANCHES list. Manual → the single branch
-          # the maintainer entered. The two paths are intentionally
-          # asymmetric: cron is the configured set, manual is exactly one
-          # branch (required input).
+          # Schedule → static branches plus supported remote ``release/*``
+          # refs. Manual → exactly the branch the maintainer entered.
           BRANCHES: ${{ github.event_name == 'schedule' && env.CRON_BRANCHES || inputs.branch }}
           # ``EVENT_NAME`` mirrors ``github.event_name`` so the guard below
           # branches on it without re-interpolating into the shell.
           EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          API_TOKEN: ${{ github.token }}
         run: |
-          # CSV → JSON array, trimming surrounding whitespace per entry.
-          # Manual produces a 1-element array; cron produces N elements.
-          arr=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1 | jq -R . | jq -s -c .)
+          branches=$(echo "$BRANCHES" | tr ',' '\n' | xargs -n1)
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            release_branches=$(git ls-remote --heads "https://github.com/$REPOSITORY.git" 'refs/heads/release/*' \
+              | awk '{sub(/^refs\/heads\//, "", $2); print $2}')
+            while IFS= read -r branch; do
+              [ -z "$branch" ] && continue
+              encoded_branch=$(jq -rn --arg branch "$branch" '$branch | @uri')
+              http_status=$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+                --header "Authorization: Bearer $API_TOKEN" \
+                --header 'Accept: application/vnd.github+json' \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "https://api.github.com/repos/$REPOSITORY/contents/tools/changelog/cli.py?ref=$encoded_branch")
+              case "$http_status" in
+                200) branches=$(printf '%s\n%s\n' "$branches" "$branch") ;;
+                404) echo "::notice::Skipping $branch because it predates the changelog compiler." ;;
+                *)
+                  echo "::error::GitHub Contents API returned HTTP $http_status for $branch."
+                  exit 1
+                  ;;
+              esac
+            done <<< "$release_branches"
+          fi
+          # Trim, de-duplicate, and convert the resolved branches to a JSON array.
+          arr=$(printf '%s\n' "$branches" | sed '/^$/d' | sort -u | jq -R . | jq -s -c .)
           # Manual trigger contract: exactly one branch. A maintainer who
           # pastes a comma-separated list into the dispatch form should
           # see a clear error, not a silent multi-branch fan-out.
@@ -109,9 +126,8 @@ jobs:
     strategy:
       # Independent branches: one failing shouldn't cancel the others.
       # Each matrix entry shows up as a separate job tile in the Actions
-      # UI, so ``release/3.0.0`` failing doesn't hide ``develop``'s
-      # success (and ``gh run rerun --failed`` re-runs only the failed
-      # entry). Mirrors ``daily-compatibility.yml``'s matrix style.
+      # UI, so one release ref failing doesn't hide another ref's success
+      # (and ``gh run rerun --failed`` re-runs only the failed entry).
       fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.resolve-branches.outputs.branches) }}

--- a/.github/workflows/nightly-changelog.yml
+++ b/.github/workflows/nightly-changelog.yml
@@ -36,7 +36,7 @@ name: Nightly Changelog Compilation
 # isaaclab-bot App must be in its branch-ruleset bypass list.
 # Surrounding whitespace per entry is stripped by the resolver below.
 env:
-  CRON_BRANCHES: develop,release/3.0.0-beta2
+  CRON_BRANCHES: develop,release/3.0.0
 
 on:
   schedule:
@@ -51,7 +51,7 @@ on:
         # develop) without needing to update the workflow. A branch
         # that lacks ``tools/changelog/cli.py`` fails the verify step
         # below with a clear error, which is the desired failure mode.
-        description: 'Branch to compile (e.g. develop, release/3.0.0-beta2). Must carry tools/changelog/cli.py.'
+        description: 'Branch to compile (e.g. develop, release/3.0.0). Must carry tools/changelog/cli.py.'
         required: true
         type: string
       dry_run:
@@ -109,7 +109,7 @@ jobs:
     strategy:
       # Independent branches: one failing shouldn't cancel the others.
       # Each matrix entry shows up as a separate job tile in the Actions
-      # UI, so ``release/3.0.0-beta2`` failing doesn't hide ``develop``'s
+      # UI, so ``release/3.0.0`` failing doesn't hide ``develop``'s
       # success (and ``gh run rerun --failed`` re-runs only the failed
       # entry). Mirrors ``daily-compatibility.yml``'s matrix style.
       fail-fast: false


### PR DESCRIPTION
# Description

Updates the scheduled changelog resolver to discover every remote `release/*` branch automatically instead of naming one release branch. `develop` remains a static target.

A discovered release branch is included when it contains `tools/changelog/cli.py`. The historical 2.x release branches predate that compiler and are reported as skipped rather than creating permanently failing nightly jobs. The current resolved release set is `release/3.0.0` and `release/3.0.0-beta2`; future compiler-enabled release branches are picked up without another workflow edit. Manual dispatch still accepts exactly one explicit branch.

Companion default-branch PR: #7737

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- Full `pre-commit run --all-files` passed, including changelog and Git LFS pointer checks.
- YAML parsing passed.
- The scheduled resolver produced `["develop","release/3.0.0","release/3.0.0-beta2"]`.
- The manual resolver produced `["release/3.0.0"]`.
- Unsupported `release/2.1.0`, `release/2.2.0`, and `release/2.3.0` refs were detected and skipped.
- `git diff --check` passed.

## Release backport

- [x] Backport automation is not requested; the default-branch companion PR applies the live scheduling fix directly.

## Checklist

- [x] I have read and understood the contribution guidelines.
- [x] I have run the repository pre-commit checks.
- [x] My changes generate no new warnings.
- [x] No source package changed, so no changelog fragment is required.
- [x] Documentation and screenshots are not applicable to this workflow-only change.