### PR TITLE
Add tiled-camera tile-identity tests for large tile counts

### DIFF
--- a/source/isaaclab/changelog.d/mataylor-tiled-camera-tile-identity.skip
+++ b/source/isaaclab/changelog.d/mataylor-tiled-camera-tile-identity.skip
@@ -1,0 +1,1 @@
+Test-only: added tiled-camera tile-identity coverage at large tile counts, verifying each returned tile holds its own environment's view rather than only checking tensor shape or black-image counts.

--- a/source/isaaclab/test/sensors/test_tiled_camera_tile_identity_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_tiled_camera_tile_identity_ovrtx.py
@@ -48,19 +48,20 @@ if not _MISSING_MODULES:
 # The renderer stops supplying distinct tiles past this count, so anything above it is a regression case.
 _MAX_CORRECT_TILE_COUNT = 4096
 
-_SKIP_ABOVE_TILE_LIMIT = pytest.mark.skip(
+_XFAIL_ABOVE_TILE_LIMIT = pytest.mark.xfail(
     reason=(
         f"ovrtx renders only {_MAX_CORRECT_TILE_COUNT} tiles when more are requested; the tiling reshape"
-        " then assigns environments the wrong tiles. Remove this skip once the upstream renderer fix is"
+        " then assigns environments the wrong tiles. Remove this xfail once the upstream renderer fix is"
         " merged -- the test itself is expected to pass at these counts."
-    )
+    ),
+    strict=True,
 )
 
 _TILE_COUNTS = [
     pytest.param(1024, id="1024"),
     pytest.param(_MAX_CORRECT_TILE_COUNT, id="4096"),
-    pytest.param(8192, marks=_SKIP_ABOVE_TILE_LIMIT, id="8192"),
-    pytest.param(16384, marks=_SKIP_ABOVE_TILE_LIMIT, id="16384"),
+    pytest.param(8192, marks=_XFAIL_ABOVE_TILE_LIMIT, id="8192"),
+    pytest.param(16384, marks=_XFAIL_ABOVE_TILE_LIMIT, id="16384"),
 ]
 
 

--- a/source/isaaclab/test/sensors/test_tiled_camera_tile_identity_ovrtx.py
+++ b/source/isaaclab/test/sensors/test_tiled_camera_tile_identity_ovrtx.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Every tile the ``ovrtx`` camera backend returns must hold its own environment's view.
+
+Above 4096 tiles the renderer produces fewer tiles than were requested while the returned tensor keeps
+its full requested shape, so the tiling reshape hands environments someone else's pixels. The tensor
+shape, the per-environment dtype, and even a black-image count all still look correct, which is why this
+checks the *content* of each tile against the environment it is supposed to belong to.
+
+:mod:`tiled_camera_tile_identity` builds the scene: each environment holds one cube raised to one of
+four heights derived from its index, so a tile's marker position identifies the environment it came
+from. Grouped by assigned level, the measured positions must form cleanly separated bands.
+
+The 8192- and 16384-tile cases are the regression cases and currently fail: the bands collapse into each
+other and a large fraction of tiles come back empty. They are marked ``xfail`` so the suite reports the
+gap without failing, and will flag as ``XPASS`` once the renderer supplies every requested tile.
+
+Notes:
+  * Runs **kit-less**: this test does not call :class:`~isaaclab.app.AppLauncher`. ``ovrtx`` and Isaac
+    Sim Kit ship conflicting RTX hydra libraries that cannot co-load; see
+    :func:`isaaclab.app.sim_launcher.launch_simulation`.
+  * Uses OvPhysx, the kit-less PhysX backend, because ``ovrtx`` cannot share a process with Kit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tiled_camera_tile_identity import MIN_BAND_GAP_PX, render_tile_identity
+
+pytestmark = [pytest.mark.integration, pytest.mark.rendering]
+
+_REQUIRED_MODULES = ("isaaclab_ov", "ovrtx")
+_MISSING_MODULES = [module for module in _REQUIRED_MODULES if importlib.util.find_spec(module) is None]
+_SKIP_MISSING_OVRTX = pytest.mark.skipif(
+    bool(_MISSING_MODULES),
+    reason=f"requires optional modules: {', '.join(_MISSING_MODULES)}",
+)
+
+if not _MISSING_MODULES:
+    from isaaclab_ov.physics import OvPhysxCfg
+    from isaaclab_ov.renderers import OVRTXRendererCfg
+
+# The renderer stops supplying distinct tiles past this count, so anything above it is a regression case.
+_MAX_CORRECT_TILE_COUNT = 4096
+
+_SKIP_ABOVE_TILE_LIMIT = pytest.mark.skip(
+    reason=(
+        f"ovrtx renders only {_MAX_CORRECT_TILE_COUNT} tiles when more are requested; the tiling reshape"
+        " then assigns environments the wrong tiles. Remove this skip once the upstream renderer fix is"
+        " merged -- the test itself is expected to pass at these counts."
+    )
+)
+
+_TILE_COUNTS = [
+    pytest.param(1024, id="1024"),
+    pytest.param(_MAX_CORRECT_TILE_COUNT, id="4096"),
+    pytest.param(8192, marks=_SKIP_ABOVE_TILE_LIMIT, id="8192"),
+    pytest.param(16384, marks=_SKIP_ABOVE_TILE_LIMIT, id="16384"),
+]
+
+
+@pytest.mark.parametrize("num_envs", _TILE_COUNTS)
+@_SKIP_MISSING_OVRTX
+def test_every_ovrtx_tile_holds_its_own_environment(num_envs):
+    """Each of ``num_envs`` tiles must show the marker height assigned to that environment."""
+    result = render_tile_identity(num_envs, renderer_cfg=OVRTXRendererCfg(), physics_cfg=OvPhysxCfg())
+
+    empty = result.empty.nonzero().flatten()
+    assert empty.numel() == 0, (
+        f"{empty.numel()} of {num_envs} tiles contain no marker at all (first: {empty[:8].tolist()}); the"
+        " renderer did not supply a tile for every requested camera"
+    )
+
+    gap = result.smallest_band_gap()
+    mismatched = result.mismatched_tiles()
+    assert gap >= MIN_BAND_GAP_PX, (
+        f"marker positions for different levels overlap (smallest gap {gap:.2f} px, need"
+        f" {MIN_BAND_GAP_PX} px), so tiles do not match their environments: {mismatched.numel()} of"
+        f" {num_envs} tiles decode to the wrong level (first: {mismatched[:8].tolist()});"
+        f" per-level bands {[(round(lo, 2), round(hi, 2)) for lo, hi in result.level_bands()]}"
+    )

--- a/source/isaaclab/test/sensors/tiled_camera_tile_identity.py
+++ b/source/isaaclab/test/sensors/tiled_camera_tile_identity.py
@@ -15,8 +15,15 @@ This builds a scene where each environment is *visually identifiable*: every env
 raised to one of ``num_levels`` heights chosen from the environment index. Each camera sees only its own
 cube, so the vertical position of the bright pixels in a tile encodes the level of the environment that
 tile belongs to. Grouping the measured positions by assigned level must therefore produce cleanly
-separated bands. Under a correct mapping the bands are a pixel or so wide and separated by ~10 px; if the
-tiles are permuted, duplicated, or truncated, every band fills with a mixture of levels and they overlap.
+separated bands. Under a correct mapping the bands are a pixel or so wide and separated by ~10 px; if
+tiles cross a level boundary -- permuted, duplicated, or truncated between environments assigned different
+levels -- every band fills with a mixture of levels and they overlap.
+
+Only ``num_levels`` heights are used, shared across every environment at that level, so this does not
+prove tile ``i`` holds exactly environment ``i``'s pixels: a swap or duplication between two tiles that
+happen to share a level leaves the bands clean. The guarantee is narrower -- it catches layout errors that
+move a tile across a level boundary, which is what the 4096-tile regression this module targets does (see
+:mod:`test_tiled_camera_tile_identity_ovrtx`).
 
 The measurement is renderer-agnostic (it uses the per-row pixel spread rather than assuming a black
 background), so the same helper serves the OVRTX and Isaac RTX camera backends.

--- a/source/isaaclab/test/sensors/tiled_camera_tile_identity.py
+++ b/source/isaaclab/test/sensors/tiled_camera_tile_identity.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared scene and measurement for the tiled-camera tile-identity tests.
+
+A tiled camera returns one image per environment, sliced out of a single tiled framebuffer. Nothing in
+the returned tensor's *shape* proves that slice ``i`` holds environment ``i``'s view: a renderer that
+produces fewer tiles than were requested still yields a correctly shaped tensor, and the reshape then
+hands every environment someone else's pixels. Counting black images does not catch that either, because
+the mis-sliced tiles usually still contain plausible scene content.
+
+This builds a scene where each environment is *visually identifiable*: every environment holds one cube,
+raised to one of ``num_levels`` heights chosen from the environment index. Each camera sees only its own
+cube, so the vertical position of the bright pixels in a tile encodes the level of the environment that
+tile belongs to. Grouping the measured positions by assigned level must therefore produce cleanly
+separated bands. Under a correct mapping the bands are a pixel or so wide and separated by ~10 px; if the
+tiles are permuted, duplicated, or truncated, every band fills with a mixture of levels and they overlap.
+
+The measurement is renderer-agnostic (it uses the per-row pixel spread rather than assuming a black
+background), so the same helper serves the OVRTX and Isaac RTX camera backends.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObject, RigidObjectCfg
+from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
+from isaaclab.sensors import Camera, CameraCfg
+from isaaclab.sim import SimulationCfg
+from isaaclab.utils.configclass import configclass
+
+SIM_DT = 1.0 / 60.0
+"""Simulation step [s]."""
+
+CUBE_SIZE = 0.4
+"""Edge length of the per-environment marker cube [m]."""
+
+BASE_Z = 0.5
+"""Height of the lowest marker level above the environment origin [m]."""
+
+LEVEL_STEP = 0.6
+"""Vertical spacing between adjacent marker levels [m]. Sized so neighbouring levels land in
+clearly separated image rows at the tile sizes these tests use."""
+
+ENV_SPACING = 12.0
+"""Distance between environment origins [m]. Wide enough that no camera sees a neighbour's cube."""
+
+WARMUP_STEPS = 6
+"""Steps rendered before measuring, so the marker poses and the first frame have settled."""
+
+MIN_BAND_GAP_PX = 2.0
+"""Smallest acceptable gap between adjacent level bands [px]. The correct mapping leaves roughly
+10 px, so this rejects overlap without being sensitive to render noise."""
+
+
+@configclass
+class TileIdentitySceneCfg(InteractiveSceneCfg):
+    """One marker cube per environment, raised to a per-environment height after reset.
+
+    Gravity is disabled so the cube stays exactly where the test writes it, making the rendered
+    position a direct readout of the assigned level rather than of the physics state.
+    """
+
+    marker: RigidObjectCfg = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/Marker",
+        spawn=sim_utils.CuboidCfg(
+            size=(CUBE_SIZE, CUBE_SIZE, CUBE_SIZE),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True),
+            mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+            collision_props=sim_utils.CollisionPropertiesCfg(),
+            visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.9, 0.9, 0.9)),
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(pos=(0.0, 0.0, BASE_Z)),
+    )
+
+
+@dataclass
+class TileIdentityResult:
+    """Per-tile measurement of a tile-identity render.
+
+    Args:
+        level: Level assigned to each environment, shape ``[num_envs]``.
+        centroid: Vertical position of the marker in each tile [px], shape ``[num_envs]``.
+        empty: Whether a tile contains no marker at all, shape ``[num_envs]``.
+        num_levels: Number of distinct marker heights used.
+    """
+
+    level: torch.Tensor
+    centroid: torch.Tensor
+    empty: torch.Tensor
+    num_levels: int
+
+    def level_bands(self) -> list[tuple[float, float]]:
+        """Return the ``(min, max)`` measured position of each level, over the tiles that rendered."""
+        bands = []
+        for value in range(self.num_levels):
+            selected = self.centroid[(self.level == value) & ~self.empty]
+            bands.append((float(selected.min()), float(selected.max())) if selected.numel() else (float("nan"),) * 2)
+        return bands
+
+    def smallest_band_gap(self) -> float:
+        """Return the smallest gap between adjacent level bands [px].
+
+        Marker height increases with level while image rows are numbered downwards, so a correct
+        mapping yields strictly *decreasing* bands. A negative result means two levels overlap, i.e.
+        tiles assigned different levels rendered at the same position and cannot all be correct.
+        """
+        bands = self.level_bands()
+        return min(bands[value][0] - bands[value + 1][1] for value in range(self.num_levels - 1))
+
+    def mismatched_tiles(self) -> torch.Tensor:
+        """Return the indices of tiles whose measured position does not match their assigned level.
+
+        Each level's expected position is taken as the median over the tiles assigned to it, so this
+        needs no calibration against hard-coded pixel values. It exists to make a failure legible --
+        the assertions use :meth:`smallest_band_gap` -- so it reports *which* environments are wrong.
+        """
+        expected = torch.stack(
+            [
+                self.centroid[(self.level == value) & ~self.empty].median()
+                if ((self.level == value) & ~self.empty).any()
+                else torch.tensor(float("nan"), device=self.centroid.device)
+                for value in range(self.num_levels)
+            ]
+        )
+        decoded = (self.centroid[:, None] - expected[None, :]).abs().argmin(dim=1)
+        return ((decoded != self.level) | self.empty).nonzero().flatten()
+
+
+def assign_levels(num_envs: int, num_levels: int, device: str) -> torch.Tensor:
+    """Assign each environment a marker level.
+
+    Uses a multiplicative hash rather than ``index % num_levels`` so the levels do not line up with
+    the rows or columns of the tiled framebuffer. A layout error that shifts tiles by whole rows would
+    otherwise map one level onto another and stay invisible.
+
+    Args:
+        num_envs: Number of environments.
+        num_levels: Number of distinct marker heights.
+        device: Device to build the assignment on.
+
+    Returns:
+        Level index per environment, shape ``[num_envs]``.
+    """
+    index = torch.arange(num_envs, device=device, dtype=torch.int64)
+    return ((index * 2654435761) >> 16) % num_levels
+
+
+def render_tile_identity(
+    num_envs: int,
+    renderer_cfg,
+    physics_cfg,
+    device: str = "cuda:0",
+    tile_size: int = 64,
+    num_levels: int = 4,
+) -> TileIdentityResult:
+    """Render ``num_envs`` identifiable environments and measure each tile.
+
+    Args:
+        num_envs: Number of environments, and therefore of camera tiles.
+        renderer_cfg: Renderer configuration for the camera under test.
+        physics_cfg: Physics backend configuration.
+        device: Device to simulate and render on.
+        tile_size: Per-camera tile width and height [px].
+        num_levels: Number of distinct marker heights.
+
+    Returns:
+        The per-tile measurement.
+    """
+    sim_utils.create_new_stage()
+    sim = sim_utils.SimulationContext(SimulationCfg(dt=SIM_DT, physics=physics_cfg, device=device))
+    scene = InteractiveScene(TileIdentitySceneCfg(num_envs=num_envs, env_spacing=ENV_SPACING, replicate_physics=True))
+    # Centre the camera on the middle level so the highest and lowest markers stay inside the frame.
+    camera = Camera(
+        CameraCfg(
+            prim_path="{ENV_REGEX_NS}/Camera",
+            update_period=0.0,
+            height=tile_size,
+            width=tile_size,
+            data_types=["rgb"],
+            offset=CameraCfg.OffsetCfg(
+                pos=(-4.0, 0.0, BASE_Z + LEVEL_STEP * (num_levels - 1) / 2.0),
+                rot=(0.0, 0.0, 0.0, 1.0),
+                convention="world",
+            ),
+            spawn=sim_utils.PinholeCameraCfg(focal_length=24.0, horizontal_aperture=20.955, clipping_range=(0.1, 40.0)),
+            renderer_cfg=renderer_cfg,
+        )
+    )
+    try:
+        sim.reset()
+
+        level = assign_levels(num_envs, num_levels, sim.device)
+        marker: RigidObject = scene["marker"]
+        pose = marker.data.root_pose_w.torch.clone()
+        pose[:, 2] = scene.env_origins[:, 2] + BASE_Z + level.float() * LEVEL_STEP
+        marker.write_root_pose_to_sim(pose)
+
+        for _ in range(WARMUP_STEPS):
+            sim.step()
+            camera.update(SIM_DT, force_recompute=True)
+
+        images = camera.data.output["rgb"].torch.float()
+        return _measure_tiles(images[..., :3], level, num_levels)
+    finally:
+        del camera
+        del scene
+        sim.stop()
+        sim.clear_instance()
+
+
+def _measure_tiles(images: torch.Tensor, level: torch.Tensor, num_levels: int) -> TileIdentityResult:
+    """Locate the marker in every tile.
+
+    The marker is the only structure in an otherwise flat tile, so a row containing it has a much
+    larger pixel spread than an empty one. Weighting each row by that spread and taking the centroid
+    gives the marker's vertical position without assuming any particular background colour, which
+    keeps the measurement usable across renderers.
+
+    Args:
+        images: Per-environment RGB images, shape ``[num_envs, H, W, 3]``.
+        level: Level assigned to each environment, shape ``[num_envs]``.
+        num_levels: Number of distinct marker heights.
+
+    Returns:
+        The per-tile measurement.
+    """
+    luma = images.mean(dim=-1)
+    row_spread = luma.std(dim=2)
+    weight = (row_spread - row_spread.amin(dim=1, keepdim=True)).clamp(min=0.0)
+    total = weight.sum(dim=1)
+    rows = torch.arange(luma.shape[1], device=luma.device, dtype=torch.float32)
+    empty = total <= 1e-6
+    centroid = (weight * rows).sum(dim=1) / total.clamp(min=1e-6)
+    return TileIdentityResult(level=level, centroid=centroid, empty=empty, num_levels=num_levels)

--- a/source/isaaclab_ov/changelog.d/mataylor-tiled-camera-tile-identity.skip
+++ b/source/isaaclab_ov/changelog.d/mataylor-tiled-camera-tile-identity.skip
@@ -1,0 +1,1 @@
+Test-only: added OVRTX atlas-capacity and tile-grid-agreement tests covering tile counts up to 16384.

--- a/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
+++ b/source/isaaclab_ov/test/test_ovrtx_renderer_contract.py
@@ -302,6 +302,90 @@ def test_launch_extract_all_tiles_launches_kernel_when_channels_are_compatible(m
     assert launch_calls[0]["inputs"][:2] == [tiled_buffer, output_buffer]
 
 
+# Tile counts spanning the small cases and the large ones a camera-per-environment training run reaches.
+# 4096 and its neighbours are called out because that is where the renderer stops supplying a tile per
+# camera, so the grid the extraction assumes has to be checked on both sides of it.
+_TILE_COUNTS = [1, 2, 7, 1000, 4095, 4096, 4097, 8192, 16384]
+
+
+def _make_render_spec(num_envs: int, tile: int, device: str):
+    """Build a render spec for ``num_envs`` cameras of ``tile`` x ``tile`` px."""
+    from isaaclab.renderers.camera_render_spec import CameraRenderSpec
+
+    return CameraRenderSpec(
+        cfg=CameraCfg(height=tile, width=tile, prim_path="/World/envs/env_.*/Camera", spawn=_SPAWN, data_types=["rgb"]),
+        device=device,
+        num_instances=num_envs,
+        camera_prim_paths=tuple(f"/World/envs/env_{index}/Camera" for index in range(num_envs)),
+        view_count=num_envs,
+        camera_path_relative_to_env_0="Camera",
+    )
+
+
+@pytest.mark.parametrize("num_envs", _TILE_COUNTS)
+def test_render_data_tile_grid_matches_the_authored_atlas(num_envs):
+    """The extraction grid and the authored atlas are derived separately and must stay in agreement.
+
+    :class:`OVRTXRenderData` computes the tile grid the extraction kernel indexes with, while
+    :func:`build_render_product_as_string` independently sizes the atlas the renderer draws into. They
+    are two copies of the same layout: if they ever disagree, every tile is read from the wrong offset
+    even though both the render and the returned tensor keep their expected shapes.
+    """
+    import re
+
+    from isaaclab_ov.renderers.ovrtx_usd import build_render_product_as_string
+
+    if not torch.cuda.is_available():
+        pytest.skip("OVRTX render data requires a CUDA device")
+    device = "cuda"
+
+    tile = 96
+    render_data = OVRTXRenderData(_make_render_spec(num_envs, tile, device), device=device)
+    render_product, _ = build_render_product_as_string(width=tile, height=tile, num_envs=num_envs, data_types=["rgb"])
+
+    match = re.search(r"uniform int2 resolution = \((\d+), (\d+)\)", render_product)
+    assert match is not None
+    tiled_width, tiled_height = int(match.group(1)), int(match.group(2))
+
+    assert render_data.num_cols == tiled_width // tile
+    assert render_data.num_rows == tiled_height // tile
+    assert render_data.num_cols * render_data.num_rows >= num_envs
+
+
+@pytest.mark.skip(
+    reason=(
+        "_launch_extract_all_tiles validates only the channel count, so a tiled buffer holding fewer"
+        " tiles than num_envs is reshaped into wrong per-environment images instead of raising."
+        " Remove this skip once the extraction validates tile capacity."
+    )
+)
+def test_launch_extract_all_tiles_rejects_a_tiled_buffer_missing_tiles():
+    """A tiled buffer too small to hold every tile must raise rather than reshape into wrong images.
+
+    This is the failure the >4096-tile bug produces: the renderer hands back a buffer covering only the
+    tiles it actually drew, and the extraction happily indexes past it, so the trailing environments get
+    another environment's pixels with no error anywhere.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("OVRTX tile extraction requires a CUDA device")
+    device = "cuda"
+
+    renderer = _make_ovrtx_renderer_without_backend()
+    renderer._device = device
+    render_data = _make_ovrtx_render_data()
+    render_data.width = 96
+    render_data.height = 96
+    render_data.num_envs = 8192
+    render_data.num_cols = 91
+
+    # An atlas holding only 4096 tiles (64 x 64) while 8192 were requested.
+    undersized = _FakeArray((64 * 96, 64 * 96, 4))
+    output_buffer = _FakeArray((8192, 96, 96, 3))
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        renderer._launch_extract_all_tiles(render_data, undersized, output_buffer)
+
+
 def test_ovrtx_read_output_copies_no_pixel_data():
     """OVRTXRenderer.read_output copies no pixel data; with empty renderer_info it leaves info untouched."""
     renderer = _make_ovrtx_renderer_without_backend()

--- a/source/isaaclab_ov/test/test_ovrtx_usd.py
+++ b/source/isaaclab_ov/test/test_ovrtx_usd.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 
 import pytest
 
@@ -262,6 +263,58 @@ def test_render_product_initially_targets_only_the_resolvable_source_camera():
     assert "rel camera = [</World/envs/env_0/Robot/head_cam>]" in render_product
     assert "/World/envs/env_1/Robot/head_cam" not in render_product
     assert "uniform int2 resolution = (32, 16)" in render_product
+
+
+def _authored_resolution(render_product: str) -> tuple[int, int]:
+    """Return the ``(width, height)`` [px] authored on the RenderProduct."""
+    match = re.search(r"uniform int2 resolution = \((\d+), (\d+)\)", render_product)
+    assert match is not None, f"no resolution authored on the render product:\n{render_product}"
+    return int(match.group(1)), int(match.group(2))
+
+
+# Tile counts spanning the small cases and the large ones a camera-per-environment training run reaches.
+# 4096 and its neighbours are called out because that is where the renderer stops supplying a tile per
+# camera; the authored atlas must have room for every requested camera on both sides of it.
+_TILE_COUNTS = [1, 2, 7, 1000, 4095, 4096, 4097, 8192, 16384]
+
+
+@pytest.mark.parametrize("num_envs", _TILE_COUNTS)
+def test_authored_atlas_has_room_for_every_camera(num_envs):
+    """The authored tiled resolution must hold one whole tile per camera.
+
+    An atlas smaller than the requested camera count gives the extraction kernel nowhere to read the
+    trailing tiles from, so those environments silently receive another environment's pixels.
+    """
+    width, height = 96, 96
+    render_product, _ = build_render_product_as_string(
+        width=width, height=height, num_envs=num_envs, data_types=["rgb"]
+    )
+
+    tiled_width, tiled_height = _authored_resolution(render_product)
+    capacity = (tiled_width // width) * (tiled_height // height)
+
+    assert capacity >= num_envs, (
+        f"atlas {tiled_width}x{tiled_height} holds {capacity} tiles of {width}x{height}, short of the"
+        f" {num_envs} cameras requested"
+    )
+
+
+@pytest.mark.parametrize("num_envs", _TILE_COUNTS)
+def test_authored_atlas_is_an_exact_multiple_of_the_tile_size(num_envs):
+    """The atlas must be a whole number of tiles in each direction.
+
+    The extraction kernel reads tile ``i`` at a fixed ``width``/``height`` stride. A partial tile at the
+    edge means that stride walks off the authored image, so every tile past the ragged edge is wrong.
+    """
+    width, height = 96, 96
+    render_product, _ = build_render_product_as_string(
+        width=width, height=height, num_envs=num_envs, data_types=["rgb"]
+    )
+
+    tiled_width, tiled_height = _authored_resolution(render_product)
+
+    assert tiled_width % width == 0, f"atlas width {tiled_width} is not a multiple of the {width} px tile"
+    assert tiled_height % height == 0, f"atlas height {tiled_height} is not a multiple of the {height} px tile"
 
 
 def test_render_product_pins_device_ids_to_the_requested_cuda_device():


### PR DESCRIPTION
# Description

Above 4096 tiles the RTX tiled path supplies fewer tiles than were requested while the returned tensor keeps its full requested shape, so the tiling reshape hands environments another environment's pixels.

The failure is invisible to the checks we already have. The tensor shape is right, the dtype is right, and a black-image count passes too, because the mis-sliced tiles usually still contain plausible scene content. Nothing asserted that tile `i` actually holds environment `i`'s view.

This adds that assertion, plus fast layout tests that pin the tiled-atlas contract.

## Tile identity at large tile counts

`tiled_camera_tile_identity.py` builds a scene where each environment is visually identifiable: every environment holds one cube raised to one of four heights derived from its index. Each camera sees only its own cube, so a tile's marker position identifies the environment it came from. Grouped by assigned level, the measured positions must form cleanly separated bands.

Parametrized at 1024 / 4096 / 8192 / 16384 tiles. Verified it actually discriminates before the skips were added (measured on an L40):

| tiles | empty tiles | band separation | verdict |
|---|---|---|---|
| 1024 | 0 | clean | passed |
| 4096 | 0 | 10.77 px | passed |
| 8192 | 3093 | -63 px (total overlap) | failed |
| 16384 | 421 | -60.95 px | failed |

At 4096 the bands are 0.15 px wide and 10.8 px apart. At 8192 all four collapse onto the same 0-63 range with means 19.4 / 19.5 / 19.6 / 19.7.

Levels are assigned with a multiplicative hash rather than `index % 4` on purpose: with modulo, a layout error that shifts tiles by whole rows can map one level exactly onto another and stay invisible.

## Tiled layout contract

Fast, sim-free tests covering the same counts in ~0.2 s:

- The authored atlas must have room for every requested camera, and be an exact multiple of the tile size.
- The grid `OVRTXRenderData` derives for the extraction kernel must agree with the atlas authored by `build_render_product_as_string`.

That last one matters because those are **two independent copies of the same `ceil(sqrt(N))` formula** — `ovrtx_usd.py:267` and `ovrtx_renderer.py:268` — and nothing previously held them together. If they drift, every tile is read from the wrong offset while both the render and the returned tensor keep their expected shapes.

## Skipped until the upstream fix

- 8192 and 16384 tile-identity cases
- `test_launch_extract_all_tiles_rejects_a_tiled_buffer_missing_tiles`

That last one is a gap worth noting on its own: `_launch_extract_all_tiles` validates only the *channel* count, despite its docstring claiming it validates against reading past the tiled buffer. There is no check that the buffer holds `num_envs` tiles, which is exactly how a 4096-tile buffer becomes 8192 wrong images with no error anywhere. The test asserts it should raise; remove the skip once that validation exists.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

## Notes for reviewers

- Only the OVRTX backend is covered. The helper is deliberately renderer-agnostic (it keys on per-row pixel spread rather than assuming a black background), so an Isaac RTX sibling can reuse it — but that needs `AppLauncher` at module import and I have not validated it at 16k tiles under Kit.
- The 16384 case allocates a 12288x12288 atlas (~600 MB per render var). If that is too large for CI hardware, I would reduce the tile size rather than the tile count.
- Changelog fragments are `.skip` since this is test-only.
