### PR TITLE
Fixes CI base image pulls when the registry refuses the inherited credential

### DIFF
--- a/.github/actions/_lib/compute-deps-hash/action.yml
+++ b/.github/actions/_lib/compute-deps-hash/action.yml
@@ -62,16 +62,61 @@ runs:
         deps_manifest_pattern='(setup\.py|pyproject\.toml|setup\.cfg|extension\.toml|requirements[^/]*\.txt|uv\.lock)$'
 
         # Resolve the actual base image digest so a new push of a mutable tag
-        # (e.g. latest-develop) invalidates the deps cache automatically.
-        base_image_digest=$(docker buildx imagetools inspect \
-          "${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}" \
-          --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"' || true)
-        if [ -n "${base_image_digest}" ]; then
-          base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}:${base_image_digest}"
-        else
-          echo "🟠 Could not resolve base image digest, falling back to tag string"
-          base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}"
-        fi
+        # (e.g. latest-develop) invalidates the deps cache. A tag that already
+        # carries a digest is its own identity, so it is used directly.
+        case "${ISAACSIM_VERSION}" in
+          *@sha256:*)
+            base_image_digest="${ISAACSIM_VERSION##*@}"
+            if ! printf '%s' "${base_image_digest}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "::error::Base image tag ${ISAACSIM_VERSION} carries a malformed digest pin."
+              exit 1
+            fi
+            echo "🔵 Base image tag is digest-pinned; using it as the cache identity"
+            ;;
+          *)
+            # Reading the manifest can fail transiently, so retry. Failing hard
+            # afterwards is deliberate: falling back to the tag string drops the
+            # digest from the cache key and hides an unreadable manifest until a
+            # later, far less obvious build error. stderr is kept off stdout so
+            # a warning can never be concatenated into the digest.
+            base_image_digest=""
+            inspect_err="$(mktemp)"
+            attempts=5
+            attempt=1
+            while [ "${attempt}" -le "${attempts}" ]; do
+              inspect_out=$(docker buildx imagetools inspect \
+                "${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}" \
+                --format '{{json .Manifest.Digest}}' 2>"${inspect_err}" || true)
+              candidate=$(printf '%s' "${inspect_out}" | tr -d '"')
+              # A digest is exactly sha256: plus 64 hex characters. Anything
+              # looser lets stray stdout into the cache key, and a stable
+              # diagnostic string would then stop a changed base image from
+              # invalidating it.
+              if printf '%s' "${candidate}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+                base_image_digest="${candidate}"
+                break
+              fi
+              echo "🟠 Base image manifest read attempt ${attempt}/${attempts} failed: $(tr '\n' ' ' < "${inspect_err}")"
+              # An authorization refusal will not clear on its own, so stop
+              # retrying and report it as the configuration error it is.
+              if grep -Eqi 'denied|unauthorized|forbidden|insufficient_scope|401|403' "${inspect_err}"; then
+                echo "::error::${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION} cannot be read with the credentials available to this job."
+                rm -f "${inspect_err}"
+                exit 1
+              fi
+              if [ "${attempt}" -lt "${attempts}" ]; then
+                sleep $((attempt * 5))
+              fi
+              attempt=$((attempt + 1))
+            done
+            rm -f "${inspect_err}"
+            if [ -z "${base_image_digest}" ]; then
+              echo "::error::Cannot read the manifest for ${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION} after ${attempts} attempts (see the attempt logs above)."
+              exit 1
+            fi
+            ;;
+        esac
+        base_image_uniq_id="${ISAACSIM_BASE_IMAGE}:${ISAACSIM_VERSION}:${base_image_digest}"
 
         mapfile -t manifest_files < <(git ls-files | grep -E "${deps_manifest_pattern}" || true)
         file_hash=$(git ls-files -s "${deps_files[@]}" "${manifest_files[@]}" 2>/dev/null \

--- a/.github/actions/_lib/setup-docker-config/action.yml
+++ b/.github/actions/_lib/setup-docker-config/action.yml
@@ -114,8 +114,23 @@ runs:
         anon_config_dir="$(mktemp -d)"
         trap 'rm -f "${probe_err}"; rm -rf "${anon_config_dir}"' EXIT
         echo '{"credsStore":"","auths":{}}' > "${anon_config_dir}/config.json"
-        if ! DOCKER_CONFIG="${anon_config_dir}" \
-          docker buildx imagetools inspect "${BASE_IMAGE_REF}" >/dev/null 2>&1; then
+        # Retried like the credentialed probe above: a transient failure here
+        # would otherwise keep a credential already proven to be denied, and the
+        # build would then fail on the very pull this fallback exists to rescue.
+        anon_readable=""
+        for attempt in 1 2 3; do
+          if DOCKER_CONFIG="${anon_config_dir}" \
+            docker buildx imagetools inspect "${BASE_IMAGE_REF}" >/dev/null 2>"${probe_err}"; then
+            anon_readable="yes"
+            break
+          fi
+          echo "🟠 Anonymous read attempt ${attempt}/3 failed: $(tr '\n' ' ' < "${probe_err}")"
+          if [ "${attempt}" -lt 3 ]; then
+            sleep $((attempt * 5))
+          fi
+        done
+
+        if [ -z "${anon_readable}" ]; then
           echo "::warning::${BASE_IMAGE_REF} is unreadable with the configured credentials and anonymously; leaving the docker config unchanged"
           exit 0
         fi

--- a/.github/actions/_lib/setup-docker-config/action.yml
+++ b/.github/actions/_lib/setup-docker-config/action.yml
@@ -10,34 +10,117 @@ description: >
   Idempotent: re-invoking it in the same job is a no-op, so callers (e.g.
   ecr-build-push-pull delegating to docker-build) don't need to coordinate.
   Reads NGC_API_KEY from the environment (optional; warns when missing).
+  When base-image-ref names an nvcr.io image that the configured credentials are
+  refused, falls back to anonymous access for that registry.
+
+inputs:
+  base-image-ref:
+    description: >
+      Optional "<image>:<tag>" that this job must be able to read. nvcr.io can
+      refuse a credential scoped to another organization a pull token for a
+      public repository instead of downgrading to anonymous, so when the
+      configured credentials are denied this image and anonymous access can read
+      it, the stored nvcr.io credential is dropped from the temp config. Only
+      nvcr.io refs are eligible; empty skips the check.
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        BASE_IMAGE_REF: ${{ inputs.base-image-ref }}
+        STRIP_HELPER: ${{ github.action_path }}/strip_registry_auth.py
       run: |
         # The runner's credential helper backend is broken ("not implemented")
         # and causes docker login calls to fail unless we point DOCKER_CONFIG at
         # a temp config with credsStore disabled. The value is written to
         # $GITHUB_ENV so subsequent steps in the job inherit it; a second
-        # invocation sees it already set and short-circuits.
+        # invocation reuses it and only re-runs the base-image check.
         if [ -n "${DOCKER_CONFIG:-}" ] && [ -f "${DOCKER_CONFIG}/config.json" ]; then
-          echo "🟢 Docker config already set up at ${DOCKER_CONFIG}, skipping"
+          echo "🟢 Docker config already set up at ${DOCKER_CONFIG}, keeping it"
+          DOCKER_CONFIG_DIR="${DOCKER_CONFIG}"
+        else
+          DOCKER_CONFIG_DIR=$(mktemp -d)
+          if [ -f "${HOME}/.docker/config.json" ]; then
+            python3 -c "import json; cfg=json.load(open('${HOME}/.docker/config.json')); cfg['credsStore']=''; cfg.pop('credHelpers',None); json.dump(cfg,open('${DOCKER_CONFIG_DIR}/config.json','w'))"
+          else
+            echo '{"credsStore":""}' > "${DOCKER_CONFIG_DIR}/config.json"
+          fi
+          export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
+          echo "DOCKER_CONFIG=${DOCKER_CONFIG_DIR}" >> "$GITHUB_ENV"
+          # Mark this directory as ours, so a later invocation only ever edits a
+          # config this action created and never the runner's persistent one.
+          echo "SETUP_DOCKER_CONFIG_OWNED=${DOCKER_CONFIG_DIR}" >> "$GITHUB_ENV"
+          SETUP_DOCKER_CONFIG_OWNED="${DOCKER_CONFIG_DIR}"
+
+          if [ -n "${NGC_API_KEY:-}" ]; then
+            echo "🔵 Logging into nvcr.io..."
+            printf '%s' "${NGC_API_KEY}" | docker login -u '$oauthtoken' --password-stdin nvcr.io
+          else
+            echo "🟠 NGC_API_KEY not set - skipping nvcr.io login (normal for fork PRs)"
+          fi
+        fi
+
+        if [ -z "${BASE_IMAGE_REF:-}" ]; then
           exit 0
         fi
 
-        DOCKER_CONFIG_DIR=$(mktemp -d)
-        if [ -f "${HOME}/.docker/config.json" ]; then
-          python3 -c "import json; cfg=json.load(open('${HOME}/.docker/config.json')); cfg['credsStore']=''; cfg.pop('credHelpers',None); json.dump(cfg,open('${DOCKER_CONFIG_DIR}/config.json','w'))"
-        else
-          echo '{"credsStore":""}' > "${DOCKER_CONFIG_DIR}/config.json"
-        fi
-        export DOCKER_CONFIG="${DOCKER_CONFIG_DIR}"
-        echo "DOCKER_CONFIG=${DOCKER_CONFIG_DIR}" >> "$GITHUB_ENV"
+        # Scope: only nvcr.io shows the refuse-instead-of-downgrade behaviour.
+        # Other registries (Docker Hub in particular) must keep their
+        # credentials, which also serve as pull-rate-limit budget.
+        base_registry="$(printf '%s' "${BASE_IMAGE_REF%%/*}" | tr '[:upper:]' '[:lower:]')"
+        case "${BASE_IMAGE_REF}" in
+          */*) ;;
+          *) base_registry="" ;;
+        esac
+        case "${base_registry%%:*}" in
+          nvcr.io) ;;
+          *)
+            echo "🔵 ${BASE_IMAGE_REF} is not an nvcr.io image; leaving the docker config unchanged"
+            exit 0
+            ;;
+        esac
 
-        if [ -n "${NGC_API_KEY:-}" ]; then
-          echo "🔵 Logging into nvcr.io..."
-          docker login -u '$oauthtoken' -p "${NGC_API_KEY}" nvcr.io
-        else
-          echo "🟠 NGC_API_KEY not set - skipping nvcr.io login (normal for fork PRs)"
+        if [ "${SETUP_DOCKER_CONFIG_OWNED:-}" != "${DOCKER_CONFIG_DIR}" ]; then
+          echo "🔵 ${DOCKER_CONFIG_DIR} was not created by this action; leaving it unchanged"
+          exit 0
+        fi
+
+        # One transient error must not cost a working credential, so retry and
+        # keep stderr: only an authorization refusal justifies dropping it.
+        probe_err="$(mktemp)"
+        trap 'rm -f "${probe_err}"' EXIT
+        creds_denied=""
+        for attempt in 1 2 3; do
+          if docker buildx imagetools inspect "${BASE_IMAGE_REF}" >/dev/null 2>"${probe_err}"; then
+            echo "🟢 Configured credentials can read ${BASE_IMAGE_REF}"
+            exit 0
+          fi
+          if grep -Eqi 'denied|unauthorized|forbidden|insufficient_scope|401|403' "${probe_err}"; then
+            creds_denied="yes"
+            break
+          fi
+          echo "🟠 Base image read attempt ${attempt}/3 failed for a non-authorization reason: $(tr '\n' ' ' < "${probe_err}")"
+          [ "${attempt}" -lt 3 ] && sleep $((attempt * 5))
+        done
+
+        if [ -z "${creds_denied}" ]; then
+          echo "::warning::${BASE_IMAGE_REF} could not be read and the failure does not look like an authorization refusal; leaving the docker config unchanged"
+          exit 0
+        fi
+
+        anon_config_dir="$(mktemp -d)"
+        trap 'rm -f "${probe_err}"; rm -rf "${anon_config_dir}"' EXIT
+        echo '{"credsStore":"","auths":{}}' > "${anon_config_dir}/config.json"
+        if ! DOCKER_CONFIG="${anon_config_dir}" \
+          docker buildx imagetools inspect "${BASE_IMAGE_REF}" >/dev/null 2>&1; then
+          echo "::warning::${BASE_IMAGE_REF} is unreadable with the configured credentials and anonymously; leaving the docker config unchanged"
+          exit 0
+        fi
+
+        echo "🟠 Configured credentials cannot read ${BASE_IMAGE_REF}; using anonymous access for nvcr.io"
+        if ! python3 "${STRIP_HELPER}" "${DOCKER_CONFIG_DIR}/config.json" "${BASE_IMAGE_REF}"; then
+          echo "::warning::Could not drop the stored nvcr.io credential; the build may still fail to read ${BASE_IMAGE_REF}"
         fi

--- a/.github/actions/_lib/setup-docker-config/action.yml
+++ b/.github/actions/_lib/setup-docker-config/action.yml
@@ -7,8 +7,9 @@ name: 'Setup docker config'
 description: >
   Point DOCKER_CONFIG at a temp config with the credential helper disabled and
   log into nvcr.io. Shared by the docker-build and ecr-build-push-pull actions.
-  Idempotent: re-invoking it in the same job is a no-op, so callers (e.g.
-  ecr-build-push-pull delegating to docker-build) don't need to coordinate.
+  Idempotent: re-invoking it in the same job reuses the existing config, and a
+  base-image-ref already checked in this job is not probed again, so callers
+  (e.g. ecr-build-push-pull delegating to docker-build) don't need to coordinate.
   Reads NGC_API_KEY from the environment (optional; warns when missing).
   When base-image-ref names an nvcr.io image that the configured credentials are
   refused, falls back to anonymous access for that registry.
@@ -66,6 +67,16 @@ runs:
         if [ -z "${BASE_IMAGE_REF:-}" ]; then
           exit 0
         fi
+
+        # ecr-build-push-pull delegates to docker-build, so this action can run
+        # twice in one job with the same ref. The probes are network calls with
+        # backoff, and the first run already settled the outcome, so a ref
+        # checked in this job is not probed again.
+        if [ "${SETUP_DOCKER_CONFIG_CHECKED_REF:-}" = "${BASE_IMAGE_REF}" ]; then
+          echo "🟢 ${BASE_IMAGE_REF} was already checked in this job, skipping"
+          exit 0
+        fi
+        echo "SETUP_DOCKER_CONFIG_CHECKED_REF=${BASE_IMAGE_REF}" >> "$GITHUB_ENV"
 
         # Scope: only nvcr.io shows the refuse-instead-of-downgrade behaviour.
         # Other registries (Docker Hub in particular) must keep their

--- a/.github/actions/_lib/setup-docker-config/strip_registry_auth.py
+++ b/.github/actions/_lib/setup-docker-config/strip_registry_auth.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Drop the stored credential for one image's registry from a docker config.
+
+A registry can refuse a credential scoped to another organization a pull token
+for a public repository instead of downgrading the request to anonymous, which
+makes a public base image unreadable. Removing just that registry's entry lets
+the pull proceed anonymously while every other registry in the same config
+keeps working.
+
+Usage: strip_registry_auth.py <config.json> <image-ref>
+Exits 0 when a credential was dropped, 3 when nothing matched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# Docker Hub is stored under several spellings; treat them as one registry.
+_HUB_ALIASES = frozenset(
+    {
+        "docker.io",
+        "index.docker.io",
+        "registry-1.docker.io",
+    }
+)
+
+
+def registry_host(image_ref):
+    """Return the canonical registry host for a docker image reference."""
+    first = image_ref.split("/")[0]
+    if "/" in image_ref and ("." in first or ":" in first or first == "localhost"):
+        # A registry may carry a port, and hosts are case-insensitive.
+        host = first.lower().rsplit(":", 1)[0] if ":" in first else first.lower()
+    else:
+        # No registry component means Docker Hub.
+        host = "index.docker.io"
+    if host in _HUB_ALIASES:
+        return "index.docker.io"
+    return host
+
+
+def _normalize(auth_key):
+    """Reduce a config.json auths key to a comparable registry host."""
+    trimmed = auth_key.split("://", 1)[-1]
+    host = trimmed.split("/", 1)[0].lower()
+    if ":" in host:
+        host = host.rsplit(":", 1)[0]
+    if host in _HUB_ALIASES:
+        return "index.docker.io"
+    return host
+
+
+def main(argv):
+    config_path, image_ref = argv[1], argv[2]
+    target = registry_host(image_ref)
+
+    with open(config_path) as handle:
+        config = json.load(handle)
+
+    auths = config.get("auths") or {}
+    removed = sorted(key for key in auths if _normalize(key) == target)
+
+    # A credHelpers entry would re-supply the credential from an external helper
+    # even after its `auths` entry is gone, so the mapping for this registry is
+    # removed too. A credential held only by a global credsStore is outside this
+    # file, which is why the caller treats exit 3 as "nothing was dropped".
+    helpers = config.get("credHelpers") or {}
+    helper_keys = sorted(key for key in helpers if _normalize(key) == target)
+    for key in helper_keys:
+        del helpers[key]
+    if helper_keys:
+        config["credHelpers"] = helpers
+
+    if not removed and not helper_keys:
+        print(f"No stored credential for {target} was found in the docker config")
+        return 3
+
+    for key in removed:
+        del auths[key]
+    config["auths"] = auths
+    with open(config_path, "w") as handle:
+        json.dump(config, handle)
+
+    dropped = ", ".join(removed + helper_keys)
+    print(f"Dropped stored credential(s) for {target}: {dropped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/actions/_lib/test_registry_credential_fallback.py
+++ b/.github/actions/_lib/test_registry_credential_fallback.py
@@ -123,6 +123,37 @@ def test_transient_failure_keeps_credentials(tmp_path: Path) -> None:
     assert "::warning::" in result.stdout
 
 
+def test_transient_anonymous_failure_is_retried(tmp_path: Path) -> None:
+    """A flaky anonymous probe must not leave a credential that is already denied.
+
+    Without a retry the action would keep the denied credential and the build
+    would fail on the pull this fallback exists to rescue.
+    """
+    stub = """
+config="${DOCKER_CONFIG:-}/config.json"
+if [ -f "$config" ] && grep -q '"auths":{}' "$config"; then
+  counter=/tmp/il_anon_attempts
+  n=$(cat "$counter" 2>/dev/null || echo 0)
+  n=$((n + 1))
+  echo "$n" > "$counter"
+  if [ "$n" -lt 2 ]; then
+    echo "error: received unexpected HTTP status: 503" >&2
+    exit 1
+  fi
+  exit 0
+fi
+echo "denied: Access Denied" >&2
+exit 1
+"""
+    Path("/tmp/il_anon_attempts").unlink(missing_ok=True)
+    try:
+        result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", stub)
+        assert result.returncode == 0, result.stderr
+        assert _auths(tmp_path / "cfg" / "config.json") == {_ECR, _HUB}
+    finally:
+        Path("/tmp/il_anon_attempts").unlink(missing_ok=True)
+
+
 def test_unowned_config_is_never_modified(tmp_path: Path) -> None:
     """A config this action did not create belongs to the runner and stays intact."""
     result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", _DENY_UNLESS_ANONYMOUS, owned=False)

--- a/.github/actions/_lib/test_registry_credential_fallback.py
+++ b/.github/actions/_lib/test_registry_credential_fallback.py
@@ -60,7 +60,14 @@ def _write_stub_docker(bin_dir: Path, body: str) -> None:
     script.chmod(0o755)
 
 
-def _run_setup(tmp_path: Path, base_image_ref: str, stub: str, *, owned: bool = True) -> subprocess.CompletedProcess:
+def _run_setup(
+    tmp_path: Path,
+    base_image_ref: str,
+    stub: str,
+    *,
+    owned: bool = True,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     bin_dir = tmp_path / "bin"
     _write_stub_docker(bin_dir, stub)
     config_dir = tmp_path / "cfg"
@@ -78,6 +85,8 @@ def _run_setup(tmp_path: Path, base_image_ref: str, stub: str, *, owned: bool = 
     }
     if owned:
         env["SETUP_DOCKER_CONFIG_OWNED"] = str(config_dir)
+    if extra_env:
+        env.update(extra_env)
     Path(env["GITHUB_ENV"]).touch()
     return subprocess.run(["bash", str(body)], env=env, capture_output=True, text=True, check=False)
 
@@ -158,6 +167,25 @@ def test_unowned_config_is_never_modified(tmp_path: Path) -> None:
     """A config this action did not create belongs to the runner and stays intact."""
     result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", _DENY_UNLESS_ANONYMOUS, owned=False)
     assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
+
+
+def test_already_checked_reference_is_not_probed_again(tmp_path: Path) -> None:
+    """ecr-build-push-pull delegates to docker-build, so the probe must not repeat.
+
+    The probes are network calls with backoff, and the first invocation already
+    settled the outcome for this ref.
+    """
+    ref = "nvcr.io/nvidia/isaac-sim:6.1.0"
+    stub = 'echo "the probe must not run again" >&2\nexit 1'
+    result = _run_setup(
+        tmp_path,
+        ref,
+        stub,
+        extra_env={"SETUP_DOCKER_CONFIG_CHECKED_REF": ref},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "already checked" in result.stdout
     assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
 
 

--- a/.github/actions/_lib/test_registry_credential_fallback.py
+++ b/.github/actions/_lib/test_registry_credential_fallback.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the registry-scoped docker credential fallback.
+
+Covers the helper that drops one registry's stored credential and the composite
+action's guards around it, plus the base image digest resolution that feeds the
+dependency-cache key. The action bodies are extracted from their action.yml and
+run under bash against stubbed executables, so no registry access is needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+_LIB_DIR = Path(__file__).resolve().parent
+_SETUP_ACTION = _LIB_DIR / "setup-docker-config" / "action.yml"
+_HASH_ACTION = _LIB_DIR / "compute-deps-hash" / "action.yml"
+_STRIP_HELPER = _LIB_DIR / "setup-docker-config" / "strip_registry_auth.py"
+
+_ECR = "968945269301.dkr.ecr.us-west-2.amazonaws.com"
+_HUB = "https://index.docker.io/v1/"
+_DIGEST = "sha256:" + "a" * 64
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location("strip_registry_auth", _STRIP_HELPER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _step_body(action_path: Path) -> str:
+    action = yaml.safe_load(action_path.read_text(encoding="utf-8"))
+    return action["runs"]["steps"][0]["run"]
+
+
+def _write_config(path: Path, registries: list[str]) -> Path:
+    config = {"credsStore": "", "auths": {name: {"auth": "redacted"} for name in registries}}
+    path.write_text(json.dumps(config), encoding="utf-8")
+    return path
+
+
+def _auths(path: Path) -> set[str]:
+    return set((json.loads(path.read_text(encoding="utf-8")).get("auths") or {}).keys())
+
+
+def _write_stub_docker(bin_dir: Path, body: str) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "docker"
+    script.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    script.chmod(0o755)
+
+
+def _run_setup(tmp_path: Path, base_image_ref: str, stub: str, *, owned: bool = True) -> subprocess.CompletedProcess:
+    bin_dir = tmp_path / "bin"
+    _write_stub_docker(bin_dir, stub)
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(exist_ok=True)
+    _write_config(config_dir / "config.json", ["nvcr.io", _ECR, _HUB])
+    body = tmp_path / "setup.sh"
+    body.write_text(_step_body(_SETUP_ACTION), encoding="utf-8")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "HOME": str(tmp_path / "home"),
+        "DOCKER_CONFIG": str(config_dir),
+        "GITHUB_ENV": str(tmp_path / "github-env"),
+        "BASE_IMAGE_REF": base_image_ref,
+        "STRIP_HELPER": str(_STRIP_HELPER),
+    }
+    if owned:
+        env["SETUP_DOCKER_CONFIG_OWNED"] = str(config_dir)
+    Path(env["GITHUB_ENV"]).touch()
+    return subprocess.run(["bash", str(body)], env=env, capture_output=True, text=True, check=False)
+
+
+# A stub that refuses credentials but serves an anonymous config (empty auths).
+_DENY_UNLESS_ANONYMOUS = """
+config="${DOCKER_CONFIG:-}/config.json"
+if [ -f "$config" ] && grep -q '"auths":{}' "$config"; then
+  exit 0
+fi
+echo "denied: Access Denied" >&2
+exit 1
+"""
+
+
+def test_public_nvcr_drops_only_that_registry(tmp_path: Path) -> None:
+    """The refused nvcr.io credential goes; the push credentials stay."""
+    result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", _DENY_UNLESS_ANONYMOUS)
+    assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {_ECR, _HUB}
+
+
+def test_non_nvcr_reference_is_left_alone(tmp_path: Path) -> None:
+    """A Docker Hub base image keeps its credential, which is also pull-rate budget."""
+    result = _run_setup(tmp_path, "ubuntu:24.04", _DENY_UNLESS_ANONYMOUS)
+    assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
+
+
+def test_readable_image_keeps_credentials(tmp_path: Path) -> None:
+    """A private image the credentials can read must not trigger the fallback."""
+    result = _run_setup(tmp_path, "nvcr.io/example/isaac-sim:latest", "exit 0")
+    assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
+
+
+def test_transient_failure_keeps_credentials(tmp_path: Path) -> None:
+    """A registry outage is not an authorization refusal, so nothing is dropped."""
+    stub = 'echo "error: received unexpected HTTP status: 503" >&2\nexit 1'
+    result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", stub)
+    assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
+    assert "::warning::" in result.stdout
+
+
+def test_unowned_config_is_never_modified(tmp_path: Path) -> None:
+    """A config this action did not create belongs to the runner and stays intact."""
+    result = _run_setup(tmp_path, "nvcr.io/nvidia/isaac-sim:6.1.0", _DENY_UNLESS_ANONYMOUS, owned=False)
+    assert result.returncode == 0, result.stderr
+    assert _auths(tmp_path / "cfg" / "config.json") == {"nvcr.io", _ECR, _HUB}
+
+
+def test_registry_host_canonicalization() -> None:
+    """Case, port, and Docker Hub spellings resolve to one registry identity."""
+    helper = _load_helper()
+    assert helper.registry_host("nvcr.io/nvidia/isaac-sim:6.1.0") == "nvcr.io"
+    assert helper.registry_host("NVCR.IO/nvidia/isaac-sim:6.1.0") == "nvcr.io"
+    assert helper.registry_host("nvcr.io:443/nvidia/isaac-sim:6.1.0") == "nvcr.io"
+    assert helper.registry_host("ubuntu:24.04") == "index.docker.io"
+    assert helper.registry_host("docker.io/library/ubuntu:24.04") == "index.docker.io"
+    assert helper.registry_host("nvcr.io.example.com/team/image:1") == "nvcr.io.example.com"
+
+
+def test_helper_reports_when_nothing_matched(tmp_path: Path) -> None:
+    """No stored credential for the registry is reported rather than claimed as success."""
+    config = _write_config(tmp_path / "config.json", [_ECR])
+    result = subprocess.run(
+        ["python3", str(_STRIP_HELPER), str(config), "nvcr.io/nvidia/isaac-sim:6.1.0"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 3
+    assert _auths(config) == {_ECR}
+
+
+def test_helper_also_clears_credential_helpers(tmp_path: Path) -> None:
+    """A credHelpers entry would re-supply the credential, so it goes too."""
+    config = tmp_path / "config.json"
+    config.write_text(
+        json.dumps({"credHelpers": {"nvcr.io": "example"}, "auths": {"nvcr.io": {"auth": "redacted"}}}),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["python3", str(_STRIP_HELPER), str(config), "nvcr.io/nvidia/isaac-sim:6.1.0"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    written = json.loads(config.read_text(encoding="utf-8"))
+    assert not written.get("auths")
+    assert not written.get("credHelpers")
+
+
+def _run_hash(tmp_path: Path, image: str, version: str, stub: str) -> subprocess.CompletedProcess:
+    bin_dir = tmp_path / "bin"
+    _write_stub_docker(bin_dir, stub)
+    body = _step_body(_HASH_ACTION)
+    marker = 'case "${ISAACSIM_VERSION}" in'
+    lines = body.splitlines()
+    start = next(index for index, line in enumerate(lines) if marker in line)
+    end = next(index for index, line in enumerate(lines) if "base_image_uniq_id=" in line)
+    script = tmp_path / "digest.sh"
+    script.write_text(
+        "\n".join(lines[start : end + 1]) + '\necho "RESULT=${base_image_uniq_id}"\n',
+        encoding="utf-8",
+    )
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        "ISAACSIM_BASE_IMAGE": image,
+        "ISAACSIM_VERSION": version,
+    }
+    return subprocess.run(["bash", str(script)], env=env, capture_output=True, text=True, check=False)
+
+
+def test_digest_pinned_tag_skips_the_network(tmp_path: Path) -> None:
+    """A tag that already carries a digest is its own cache identity."""
+    stub = 'echo "the manifest read must not run" >&2\nexit 1'
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", f"latest-develop@{_DIGEST}", stub)
+    assert result.returncode == 0, result.stderr
+    assert f"RESULT=nvcr.io/example/isaac-sim:latest-develop@{_DIGEST}:{_DIGEST}" in result.stdout
+
+
+def test_malformed_digest_pin_fails(tmp_path: Path) -> None:
+    """A malformed pin must not reach the cache key."""
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", "latest@sha256:short", "exit 0")
+    assert result.returncode == 1
+    assert "malformed digest pin" in result.stdout
+
+
+def test_authorization_refusal_fails_without_retrying(tmp_path: Path) -> None:
+    """An authorization refusal will not clear on its own, so it fails immediately."""
+    stub = 'echo "denied: Access Denied" >&2\nexit 1'
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", "latest-release-6-1", stub)
+    assert result.returncode == 1
+    assert "cannot be read with the credentials available" in result.stdout
+    assert "attempt 2/" not in result.stdout
+
+
+def test_truncated_digest_is_rejected(tmp_path: Path) -> None:
+    """A value that merely starts with sha256: is not a digest and must not be accepted.
+
+    This distinguishes an exact-format check from a prefix check: a prefix check
+    would accept the value below and fold it into the dependency-cache key.
+    """
+    stub = "echo '\"sha256:abc123\"'"
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", "latest-release-6-1", stub)
+    assert result.returncode == 1
+    assert "RESULT=" not in result.stdout
+
+
+def test_trailing_output_after_a_digest_is_rejected(tmp_path: Path) -> None:
+    """Extra stdout alongside a well-formed digest must not reach the cache key."""
+    stub = f"echo '\"{_DIGEST} unexpected\"'"
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", "latest-release-6-1", stub)
+    assert result.returncode == 1
+    assert "RESULT=" not in result.stdout
+
+
+def test_successful_read_ignores_stderr_noise(tmp_path: Path) -> None:
+    """A warning emitted alongside a good digest is not concatenated into it."""
+    stub = f'echo "buildx warning" >&2\necho \'"{_DIGEST}"\''
+    result = _run_hash(tmp_path, "nvcr.io/example/isaac-sim", "latest-release-6-1", stub)
+    assert result.returncode == 0, result.stderr
+    assert f"RESULT=nvcr.io/example/isaac-sim:latest-release-6-1:{_DIGEST}" in result.stdout

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -65,6 +65,8 @@ runs:
 
     - name: Setup docker config and login to nvcr.io
       uses: ./.github/actions/_lib/setup-docker-config
+      with:
+        base-image-ref: ${{ inputs.isaacsim-base-image }}:${{ inputs.isaacsim-version }}
 
     ##### 2: Host disk snapshot (pre) #####
 

--- a/.github/actions/ecr-build-push-pull/action.yml
+++ b/.github/actions/ecr-build-push-pull/action.yml
@@ -74,6 +74,8 @@ runs:
 
     - name: Setup docker config and login to nvcr.io
       uses: ./.github/actions/_lib/setup-docker-config
+      with:
+        base-image-ref: ${{ inputs.isaacsim-base-image }}:${{ inputs.isaacsim-version }}
 
     ##### 2: Resolve ECR URL #####
 

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -198,6 +198,8 @@ jobs:
 
     - name: Log in to NGC for the base image
       uses: ./.github/actions/_lib/setup-docker-config
+      with:
+        base-image-ref: ${{ steps.config.outputs.base_image }}
 
     - name: Ensure Isaac Lab image is available locally
       shell: bash

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -14,6 +14,8 @@ on:
       # Top-level tools modules and their tests. Deliberately not "tools/**": the
       # subpackages (changelog/, skills/, wheel_builder/) have their own gates.
       - "tools/*.py"
+      # Shared CI action helpers and their co-located tests.
+      - ".github/actions/_lib/**"
       - ".github/workflows/tools-tests.yml"
   workflow_dispatch:
 
@@ -51,7 +53,7 @@ jobs:
       # rerun in test_crash_during_a_flaky_retry_is_blamed_on_the_retried_test; without it
       # installed that test skips itself rather than failing, so keep it in this list.
       - name: Install test dependencies
-        run: bash "$GITHUB_WORKSPACE/.github/actions/_lib/with-python-package-retries.sh" python3 -m pip install pytest junitparser flaky
+        run: bash "$GITHUB_WORKSPACE/.github/actions/_lib/with-python-package-retries.sh" python3 -m pip install pytest junitparser flaky pyyaml
 
       - name: Run tools tests
         env:
@@ -63,4 +65,5 @@ jobs:
         # --noconftest keeps tools/conftest.py out of the session. That file is the CI test
         # orchestrator - its pytest_sessionstart scans source/ and scripts/ and runs the whole
         # suite, so loading it here would ignore the files named below.
-        run: python3 -m pytest tools/test_crash_journal.py tools/test_device_split.py -v --noconftest
+        run: python3 -m pytest tools/test_crash_journal.py tools/test_device_split.py
+          .github/actions/_lib/test_registry_credential_fallback.py -v --noconftest


### PR DESCRIPTION
# Description

A job that pulls a public `nvcr.io/nvidia/*` base image fails with `denied: Access Denied`. The runners carry an ambient docker credential for a private NGC organization, and nvcr.io refuses that credential a pull token for a public repository instead of downgrading the request to anonymous. `_lib/setup-docker-config` now takes an optional `base-image-ref`: when the configured credentials are denied that image and anonymous access can read it, the stored nvcr.io credential is dropped from the job's temp config so the pull proceeds anonymously. `_lib/compute-deps-hash` stops swallowing an unreadable base image manifest, which silently dropped the digest from the dependency-cache key.

| Before | After |
| ------ | ----- |
| `load metadata for nvcr.io/nvidia/isaac-sim:6.1.0` fails with `failed to fetch oauth token: denied: Access Denied`, and an unreadable manifest degrades the deps-cache key to a bare tag string with only a `🟠` note | The credential is dropped for nvcr.io only when it is provably the obstacle, the pull proceeds anonymously, and an unreadable manifest fails with a named `::error::` |

## Reproduction

1. Point `.github/workflows/config.yaml` at a public base image:
   `isaacsim_image_name: nvcr.io/nvidia/isaac-sim` and `isaacsim_image_tag: 6.1.0`.
2. Open a pull request from a fork, so no `NGC_API_KEY` is available and the runner's ambient credential is the only one present.
3. Observe any job that builds the base image, for example `Docker Dependency Licenses Check`:

```
#3 [auth] nvidia/isaac-sim:pull token for nvcr.io
#4 [internal] load metadata for nvcr.io/nvidia/isaac-sim:6.1.0
#4 ERROR: failed to authorize: failed to fetch oauth token: denied: Access Denied
ERROR: failed to build: failed to solve: failed to fetch oauth token: denied: Access Denied
```

4. The same step also logs `🔵 Base image ID: nvcr.io/nvidia/isaac-sim:6.1.0` with no `sha256:` suffix, which is the silent digest fallback in `compute-deps-hash`.

## Scope

Every workflow on this branch pins the private `nvcr.io/0947644777160149/internal/isaac-sim` image today, where the configured credentials succeed and the fallback stays dormant. This change is the prerequisite that lets a public base image be configured without the failure above; it does not change which image any workflow uses.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

Not applicable; this changes CI action behavior only.

## Validation

The fallback only narrows credentials, never widens them, so each guard was exercised against a stubbed `docker` and a realistic three-registry config (nvcr.io, ECR, Docker Hub):

- Public nvcr.io image, credentials denied, anonymous readable: the nvcr.io entry is dropped and the ECR and Docker Hub entries survive, so pushes keep working.
- `ubuntu:24.04`, which `kitless-docker.yml` passes: the ref is not an nvcr.io image, so the config is left untouched and the Docker Hub credential keeps its pull-rate budget.
- Private internal image readable with credentials: no probe fallback, no change.
- Registry 503 rather than an authorization refusal: retried, then a warning, and the credential is kept, so a transient error cannot cost a working credential.
- A docker config this action did not create: left unchanged, so a runner-level `DOCKER_CONFIG` is never edited.
- `NVCR.IO/...` and `nvcr.io:443/...` resolve to the same registry as `nvcr.io/...`; `nvcr.io.evil.com/...` does not match.
- `compute-deps-hash`: a digest-pinned tag such as `latest-develop@sha256:...` is used directly with no network call, a malformed digest pin fails with a named error, an authorization refusal fails immediately, a transient failure is retried 5 times over about 50 seconds, and a warning on stderr during a successful read is no longer concatenated into the digest.
- These are committed as `.github/actions/_lib/test_registry_credential_fallback.py` (14 tests, the co-located pattern of `run-package-tests/test_cleanup_docker_storage.py`) and registered in `tools-tests.yml` so they run in CI.
- Mutation checks: removing the nvcr.io scope, the exact-digest check, the ownership guard, or the `credHelpers` handling each makes the corresponding test fail, so the suite exercises the intended behavior rather than only the happy path.
- `python -m py_compile` on the new helper, `bash -n` on every `run:` block in the five changed files, YAML parse of each, and `codespell` clean.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format` — not run; this change touches only `.github/`, validated with `bash -n`, `py_compile`, a YAML parse and `codespell`, and the repository's own `pre-commit` check on this branch
- [x] I have made corresponding changes to the documentation — the action's `description` and the new input document the fallback
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that) — not applicable; no package is touched
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

