### PR TITLE
Use legacy Franka asset for PhysX Reach

### DIFF
--- a/source/isaaclab_tasks/changelog.d/use-legacy-franka-reach.rst
+++ b/source/isaaclab_tasks/changelog.d/use-legacy-franka-reach.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Used the legacy instanceable Franka asset for PhysX Reach tasks to preserve link collisions without
+  de-instancing or large-environment performance regressions.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/franka/franka_reach_env_cfg.py
@@ -21,7 +21,6 @@ from isaaclab.devices.gamepad import Se3GamepadCfg
 from isaaclab.devices.keyboard import Se3KeyboardCfg
 from isaaclab.devices.spacemouse import Se3SpaceMouseCfg
 from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg
-from isaaclab.sim.schemas import UsdPhysicsCollisionCfg
 from isaaclab.utils import configclass
 
 from isaaclab_tasks.core.reach.reach_env_cfg import ReachEnvCfg
@@ -30,7 +29,7 @@ from isaaclab_tasks.utils import PresetCfg, preset
 ##
 # Pre-defined configs
 ##
-from isaaclab_assets import FRANKA_PANDA_MENAGERIE_CFG  # isort: skip
+from isaaclab_assets import FRANKA_PANDA_CFG, FRANKA_PANDA_MENAGERIE_CFG  # isort: skip
 
 
 ##
@@ -101,8 +100,14 @@ class FrankaReachEnvCfg(ReachEnvCfg):
         # post init of parent
         super().__post_init__()
 
-        # switch robot to franka
+        # Use the collision-complete legacy asset in PhysX until the Menagerie asset is corrected.
         self.scene.robot = FRANKA_PANDA_MENAGERIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
+        self.scene.robot.spawn.usd_path = preset(
+            default=self.scene.robot.spawn.usd_path,
+            isaacsim_physx=FRANKA_PANDA_CFG.spawn.usd_path,
+            physx=FRANKA_PANDA_CFG.spawn.usd_path,
+            ovphysx=FRANKA_PANDA_CFG.spawn.usd_path,
+        )
         # IK targets need backend-native gravity control to hold steady between commands.
         self.scene.robot.spawn.rigid_props = [
             PhysxRigidBodyCfg(
@@ -111,17 +116,6 @@ class FrankaReachEnvCfg(ReachEnvCfg):
             ),
             MujocoRigidBodyCfg(gravcomp=preset(default=None, diffik=1.0, diffik_abs=1.0, newton_ik=1.0)),
         ]
-        # The Menagerie asset ships its designated convex link-collision meshes disabled.
-        physx_collision_props = {"/Geometry/.*_c.*": [UsdPhysicsCollisionCfg(collision_enabled=True)]}
-        self.scene.robot.spawn.make_uninstanceable = preset(
-            default=False, isaacsim_physx=True, physx=True, ovphysx=True
-        )
-        self.scene.robot.spawn.collision_props = preset(
-            default=None,
-            isaacsim_physx=physx_collision_props,
-            physx=physx_collision_props,
-            ovphysx=physx_collision_props,
-        )
         # override rewards
         self.rewards.end_effector_position_tracking.params["asset_cfg"].body_names = ["panda_hand"]
         self.rewards.end_effector_orientation_tracking.params["asset_cfg"].body_names = ["panda_hand"]

--- a/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
+++ b/source/isaaclab_tasks/test/core/test_reach_franka_presets.py
@@ -136,8 +136,9 @@ def test_reach_diffik_physx_configures_teleop_physics():
     physx_props = next(props for props in rigid_props if isinstance(props, PhysxRigidBodyCfg))
     assert physx_props.disable_gravity
     assert physx_props.max_depenetration_velocity == pytest.approx(5.0)
-    assert cfg.scene.robot.spawn.make_uninstanceable
-    assert cfg.scene.robot.spawn.collision_props["/Geometry/.*_c.*"][0].collision_enabled
+    assert not cfg.scene.robot.spawn.make_uninstanceable
+    assert cfg.scene.robot.spawn.collision_props is None
+    assert cfg.scene.robot.spawn.usd_path.endswith("/FrankaEmika/Legacy/panda_instanceable.usd")
 
 
 def test_reach_newton_ik_configures_gravity_compensation():
@@ -146,6 +147,7 @@ def test_reach_newton_ik_configures_gravity_compensation():
 
     mujoco_props = next(props for props in rigid_props if isinstance(props, MujocoRigidBodyCfg))
     assert mujoco_props.gravcomp == pytest.approx(1.0)
+    assert cfg.scene.robot.spawn.usd_path.endswith("/FrankaEmika/franka_panda.usda")
 
 
 def test_reach_newton_ik_uses_native_se3_command_convention():


### PR DESCRIPTION
# Description

Follow-up to #7679. This preserves the collision and teleoperation fixes for NVBug 6740415 and NVBug 6740433 while removing the large-environment PhysX performance regression introduced by the Menagerie collision workaround.

The Menagerie Franka currently authors its collision candidates inside instanceable geometry. #7679 made every robot clone editable and enabled the `*_c` collision meshes from the task configuration. That prevents table penetration, but de-instancing the asset and adding the collision shapes in every environment scales poorly.

This change:

- selects the collision-complete `Legacy/panda_instanceable.usd` only for the `isaacsim_physx`, `physx`, and `ovphysx` physics presets;
- retains `franka_panda.usda` for Newton, where the multi-backend Menagerie authoring is required;
- applies the backend choice only to `spawn.usd_path`, leaving the concrete Menagerie robot and actuator configuration available to derived tasks such as Franka Reach OSC;
- removes the task-level collision override and `make_uninstanceable` requirement; and
- adds focused assertions for the PhysX and Newton asset selections.

No new dependencies are required.

## What was tried

1. **Enable the Menagerie `*_c` convex meshes at task load time.** This fixed penetration, but required de-instancing every robot clone. The supplied two-run E8192 comparison confirmed the regression:

   | Task | Before `bb3f3661` | With `7e62e78c` | Mean change |
   | --- | --- | --- | --- |
   | Franka Reach | 60.36, 52.60 it/s | 28.73, 26.95 it/s | -50.7% |
   | Franka Reach OSC | 26.61, 26.54 it/s | 19.57, 19.55 it/s | -26.4% |

2. **Add six task-local primitive box colliders.** This avoided the full mesh override and prevented visible penetration, but still reduced the clean E8192 Reach result from 364,455 steps/s (44.489 it/s) to 283,019 steps/s (34.548 it/s), a 22.3% regression.

3. **Use the legacy instanceable Franka asset for PhysX.** The E8192 Reach result was 385,125 steps/s (47.01 it/s), 5.7% above the clean 364,455 steps/s reference rather than a regression. A runtime collision probe found all 11 legacy robot convex-hull colliders and the table collider enabled. A sustained downward IK command produced contact forces up to 680 N and did not pass the hand through the tabletop.

Other maintained Franka manipulation tasks already use `FRANKA_PANDA_CFG`, so this follows the existing PhysX asset path instead of introducing task-specific collision geometry.

## Required Menagerie asset follow-up

This task change is a compatibility workaround. The proper fix belongs in the generated Menagerie asset and its source/conversion pipeline:

1. The current PhysX composition contains 80 prims with collision schemas. Only three primitive guide colliders are enabled (`hand_capsule`, `left_finger_pad`, and `right_finger_pad`); 77 are disabled. Eleven of those disabled prims are the intended `*_c` convex-hull guides for the links and hand.
2. Author `physics:collisionEnabled = true` for those 11 `*_c` shapes in their shared asset/prototype layer. Do not override the instance proxies from each task or set `make_uninstanceable`.
3. Preserve the `instanceable = true` references in `payloads/base.usda`, so every environment reuses the collision prototypes. Visual-only meshes should remain non-colliding; ideally their unused collision schemas should be removed by the converter rather than emitted disabled.
4. Profile the authored `*_c` hulls at E8192 and E16384. If they remain too expensive, regenerate lower-vertex per-link convex hulls or equivalent compound primitives, especially the three link-5 hulls, while matching the visual contact envelope.
5. Validate table contact, self-collision, gripper contact, PhysX/Newton behavior, startup memory, and large-environment throughput before making the Menagerie asset the PhysX default again.

Once that asset is published and validated, this temporary PhysX path selection can be removed and all backends can return to `FRANKA_PANDA_MENAGERIE_CFG`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

The patch applies cleanly to the current `origin/release/3.0.0` tip.

## Screenshots

No new media is attached. The collision behavior was checked with the NVBug reproduction and a runtime contact probe.

## Validation

- `uv run --frozen python -m pytest source/isaaclab_tasks/test/core/test_reach_franka_presets.py -q` — 31 passed.
- `uv run --frozen isaaclab -f` — passed.
- `uv run --frozen python tools/changelog/cli.py check develop` — passed.
- Runtime collision probe — 11/11 robot colliders and 1/1 table collider enabled; peak contact force 680 N; no table pass-through.
- E8192 runtime benchmark — 385,125 steps/s (47.01 it/s), with no regression against the 364,455 steps/s clean reference.
- `git apply --check` against `origin/release/3.0.0` — passed.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation through the package changelog fragment
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
