### PR TITLE
[Deps] Bump Newton to 1.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,7 +401,7 @@ override-dependencies = [
     "numpy>=2",
     "mujoco~=3.11.0",
     "mujoco-warp~=3.11.0",
-    "newton[sim]==1.5.1",
+    "newton[sim]==1.5.2",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.4.1",
     "torch==2.11.0",

--- a/source/isaaclab/changelog.d/kellyg-newton-1-5-2.rst
+++ b/source/isaaclab/changelog.d/kellyg-newton-1-5-2.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed the pinned Newton version from ``1.5.1`` to ``1.5.2``. Existing installations update
+  automatically.

--- a/source/isaaclab/test/cli/test_install.py
+++ b/source/isaaclab/test/cli/test_install.py
@@ -357,7 +357,7 @@ class TestEnsureNewton:
     @pytest.mark.parametrize(
         ("requirement", "freeze_line"),
         [
-            ("newton[sim]==1.5.1", "newton==1.5.1"),
+            ("newton[sim]==1.5.2", "newton==1.5.2"),
             (
                 "newton[sim] @ git+https://github.com/newton-physics/newton.git@cca3bb8",
                 "newton @ git+https://github.com/newton-physics/newton.git@cca3bb8",

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
@@ -15,7 +15,7 @@ Setup:
          Reinstall AFTER the wheel install: unsafe-best-match re-resolves torch from PyPI to CPU.)
     - (aarch64 only) export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
 Tests:
-    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.5.1'"
+    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.5.2'"
         -> verify the wheel resolves Newton 1.5
     - uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct --num_envs 16
         presets=newton_mjwarp --max_iterations 5; uv run isaaclab train --rl_library rsl_rl
@@ -57,7 +57,7 @@ class Test_Uv_Pip_Install_Isaaclab_All_Trains_Cartpole(UV_Mixin):
             assert result.returncode == 0, f"uv pip install {wheel}[all] failed:\n{result.stdout}\n{result.stderr}"
 
             result = self.run_in_uv_env(
-                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.5.1'"],
+                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.5.2'"],
                 cwd=isaaclab_root,
             )
             assert result.returncode == 0, (

--- a/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
+++ b/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim]==1.5.1
+newton[sim]==1.5.2
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/source/isaaclab_assets/changelog.d/shadow-hand-collider-variant.rst
+++ b/source/isaaclab_assets/changelog.d/shadow-hand-collider-variant.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Changed :attr:`SHADOW_HAND_PHYSX_CFG` and :attr:`SHADOW_HAND_NEWTON_CFG` to select the
+  Shadow Hand asset's ``Colliders="simplified"`` variant. Set ``spawn.variants["Colliders"]``
+  to ``"full"`` to use the previous collision model.

--- a/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/shadow_hand.py
@@ -145,7 +145,7 @@ SHADOW_HAND_CFG = ArticulationCfg(
         ),
     },
 )
-"""Shadow Hand, with the asset's own ``Physics`` variant left selected.
+"""Shadow Hand, with the asset's own ``Physics`` and ``Colliders`` variants left selected.
 
 One asset serves both engines; per-engine values are authored in the asset rather than restated
 here. Prefer :data:`SHADOW_HAND_PHYSX_CFG` or :data:`SHADOW_HAND_NEWTON_CFG`, which name the
@@ -153,9 +153,9 @@ engine at the call site instead of relying on the asset's default.
 """
 
 SHADOW_HAND_PHYSX_CFG = SHADOW_HAND_CFG.copy()
-SHADOW_HAND_PHYSX_CFG.spawn.variants = {"Physics": "physx"}
-"""Shadow Hand on the asset's PhysX variant."""
+SHADOW_HAND_PHYSX_CFG.spawn.variants = {"Physics": "physx", "Colliders": "simplified"}
+"""Shadow Hand on the asset's PhysX variant, with simplified colliders."""
 
 SHADOW_HAND_NEWTON_CFG = SHADOW_HAND_CFG.copy()
-SHADOW_HAND_NEWTON_CFG.spawn.variants = {"Physics": "mujoco"}
-"""Shadow Hand on the asset's MuJoCo variant, for the Newton (MJWarp) solver."""
+SHADOW_HAND_NEWTON_CFG.spawn.variants = {"Physics": "mujoco", "Colliders": "simplified"}
+"""Shadow Hand on the asset's MuJoCo variant, with simplified colliders, for the Newton (MJWarp) solver."""

--- a/tools/wheel_builder/uv-overrides.txt
+++ b/tools/wheel_builder/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.11.0
 mujoco-warp~=3.11.0
-newton[sim]==1.5.1
+newton[sim]==1.5.2
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ prerelease-mode = "allow"
 overrides = [
     { name = "mujoco", specifier = "~=3.11.0" },
     { name = "mujoco-warp", specifier = "~=3.11.0" },
-    { name = "newton", extras = ["sim"], specifier = "==1.5.1" },
+    { name = "newton", extras = ["sim"], specifier = "==1.5.2" },
     { name = "newton-usd-schemas", specifier = ">=0.4.1" },
     { name = "numpy", specifier = ">=2" },
     { name = "packaging", specifier = ">=20,<27" },
@@ -1754,12 +1754,12 @@ wheels = [
 
 [[package]]
 name = "isaaclab"
-version = "16.4.0"
+version = "17.0.0"
 source = { editable = "source/isaaclab" }
 
 [[package]]
 name = "isaaclab-assets"
-version = "0.6.4"
+version = "0.7.0"
 source = { editable = "source/isaaclab_assets" }
 dependencies = [
     { name = "isaaclab" },
@@ -1778,7 +1778,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-contrib"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "source/isaaclab_contrib" }
 dependencies = [
     { name = "isaaclab" },
@@ -2131,7 +2131,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-mimic"
-version = "2.0.5"
+version = "2.0.6"
 source = { editable = "source/isaaclab_mimic" }
 dependencies = [
     { name = "isaaclab" },
@@ -2148,7 +2148,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-newton"
-version = "5.3.0"
+version = "5.4.0"
 source = { editable = "source/isaaclab_newton" }
 dependencies = [
     { name = "isaaclab" },
@@ -2159,7 +2159,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-ov"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "source/isaaclab_ov" }
 dependencies = [
     { name = "isaaclab" },
@@ -2174,7 +2174,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-physx"
-version = "5.1.0"
+version = "6.0.0"
 source = { editable = "source/isaaclab_physx" }
 dependencies = [
     { name = "isaaclab" },
@@ -2196,7 +2196,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-rl"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "source/isaaclab_rl" }
 dependencies = [
     { name = "isaaclab" },
@@ -2213,7 +2213,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-tasks"
-version = "17.0.0"
+version = "18.0.0"
 source = { editable = "source/isaaclab_tasks" }
 dependencies = [
     { name = "isaaclab" },
@@ -2243,7 +2243,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-teleop"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "source/isaaclab_teleop" }
 dependencies = [
     { name = "isaaclab" },
@@ -2254,7 +2254,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-visualizers"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "source/isaaclab_visualizers" }
 dependencies = [
     { name = "isaaclab" },
@@ -3348,13 +3348,13 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.5.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "warp-lang" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1d/d6a3e799c25cf04b5ab35b9903cafd09731df123a0c91f4d27caed28d431/newton-1.5.1-py3-none-any.whl", hash = "sha256:a757269fe03ca2e50edb9636b3c7eb91c2d1e359b6e9c992b33dc6d9058b5285", size = 5564220, upload-time = "2026-08-27T20:33:23.381Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a5/fba1e550b36cae939aaaea40612a6f70a754747b5129ef978add2569da49/newton-1.5.2-py3-none-any.whl", hash = "sha256:b432b0db9ee963c1fe570b88952d913b9eb98c9ca190c58f80882f28dd0dd5d6", size = 5567727, upload-time = "2026-09-10T16:43:59.648Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Description

Bumps the authoritative Newton dependency pin from `newton[sim]==1.5.1` to `newton[sim]==1.5.2` on the `release/3.0.0` branch.

This also regenerates the wheel-builder and install-CI overrides, refreshes `uv.lock`, updates the install validation assertions, and adds a changelog fragment. The lock refresh includes the workspace package versions from the latest release-branch automated version bump.

## CI dependency

This branch temporarily carries the exact `isaaclab_assets` patch from #7724. The release branch has the regenerated simplified-collider Shadow Hand golden, but not yet the matching collider selector, so fresh runners fail rendering. Conversely, #7724 installation CI resolves Newton 1.5.2 from PyPI while still asserting 1.5.1. Testing both changes together breaks that circular CI dependency. After either PR lands first, the duplicate patch disappears from the remaining PR diff.

## Type of change

- Dependency update (non-breaking)
- Release CI compatibility fix already proposed in #7724

## Release backport

- [ ] <!-- backport-active-release --> Not applicable; this pull request directly targets `release/3.0.0`.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation is not affected; changelog fragments are included
- [x] My changes generate no new warnings
- [x] I have updated the install and pin-consistency assertions
- [x] I have added the required changelog fragments
- [x] My name already exists in `CONTRIBUTORS.md`

## Validation

- `uv run --extra test python -m pytest source/isaaclab/test/cli/test_install.py source/isaaclab/test/cli/test_uv_run_pyproject.py -k "EnsureNewton or version_single_source"` (4 passed)
- Shadow Hand PhysX and Newton configs import with `Colliders="simplified"`
- `uv lock --check`
- Imported package metadata reports Newton `1.5.2`
- Changelog validation against the `release/3.0.0` base
- `uv run isaaclab -f`
