### PR TITLE
[Workflow] Use Newton 1.6 release branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,11 +87,9 @@ dependencies = [
     "rsl-rl-lib==5.4.1",  # default RL framework
     "onnxscript>=0.5",
     # ----- newton (default physics engine) -----
-    # Pin the Newton release used by both workspace and wheel installs until 1.6.0 final.
-    # [tool.uv].override-dependencies only reaches uv sync, so a wheel built from this
-    # metadata would otherwise resolve the newest stable (1.5.1) and miss newton#4017:
-    # 1.6.0rc1 is a prerelease, which a default resolve skips.
-    "newton[sim]==1.6.0rc1",
+    # Loose bound so the wheel co-resolves with isaacsim's newton[sim]==1.2.0 pin; the
+    # exact git commit is forced via [tool.uv].override-dependencies (uv sync only).
+    "newton[sim]>=1.2.0",
     # Import and mesh-processing packages used by Newton, including the ones that honoring
     # USD-authored ``physics:approximation`` requires. Keep these explicit instead of selecting
     # newton[importers], whose standalone USD dependency would overlap with usd-exchange.
@@ -225,6 +223,7 @@ torchaudio = "2.11.0"
 ovphysx = "0.5.11"
 ovrtx = "0.4.1.364340"
 ovstage = "0.1.1.355824"
+newton = "release-1.6"
 warp = "1.17.0"
 
 [tool.ruff]
@@ -412,7 +411,7 @@ override-dependencies = [
     "numpy>=2",
     "mujoco~=3.12.0",
     "mujoco-warp~=3.12.0",
-    "newton[sim]==1.6.0rc1",
+    "newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.6",
     # Force the Newton-matched schemas over isaacsim's ==0.2.0 pin.
     "newton-usd-schemas>=0.4.1",
     "torch==2.11.0",

--- a/source/isaaclab/changelog.d/kellyg-newton-release-1-6.rst
+++ b/source/isaaclab/changelog.d/kellyg-newton-release-1-6.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Changed the Newton dependency from the ``1.6.0rc1`` PyPI release to the ``release-1.6`` Git branch.
+  Existing uv installations update automatically.

--- a/source/isaaclab/test/cli/test_uv_run_pyproject.py
+++ b/source/isaaclab/test/cli/test_uv_run_pyproject.py
@@ -160,9 +160,9 @@ def test_version_single_source_matches_literal_pins(source_checkout_root: Path):
     for package in ("torch", "torchvision", "torchaudio"):
         assert f"{package}=={versions[package]}" in overrides
 
-    # The Newton uv override is its single pin and may select a release or Git revision.
+    # The Newton uv override mirrors the authoritative release branch.
     newton_spec = next(requirement for requirement in overrides if requirement.startswith("newton[sim]"))
-    assert "==" in newton_spec or " @ git+" in newton_spec
+    assert newton_spec.endswith(f"newton.git@{versions['newton']}")
 
     # warp-lang is a core dependency whose table value may be an exact pin
     # ("1.2.3" -> ``==``) or a range (">=1.2.3" -> mirrored verbatim).

--- a/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
+++ b/source/isaaclab/test/install_ci/cli/test_cli_install_in_uvenv_smoke.py
@@ -90,7 +90,7 @@ class Test_Cli_Install_In_Uvenv_Smoke(UV_Mixin):
 
         ``newton`` is an extra feature selector: it reinstalls the already-present
         core packages (``isaaclab_newton``, ``isaaclab_physx``, ``isaaclab_visualizers``)
-        with their newton extras, pulling in the pinned ``newton[sim]`` release.
+        with their newton extras, pulling in the ``newton[sim]`` release-branch build.
         """
 
         try:

--- a/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
+++ b/source/isaaclab/test/install_ci/uv_pip/test_uv_pip_install_isaaclab_all_trains_cartpole.py
@@ -7,7 +7,7 @@
 Setup:
     - (wheel supplied by runner: tools/run_install_ci.py --build-wheel or --wheel <path>)
     - ./isaaclab.sh -u
-    - uv --no-config pip install <wheel>[all]
+    - uv --no-config pip install <wheel>[all] --overrides uv_pip/uv-overrides.txt
     - uv pip install --reinstall-package torch --reinstall-package torchvision
         torch==<pinned> torchvision==<pinned> --index-url <cu128|cu130>
         (versions read from [tool.isaaclab.versions] in the root pyproject.)
@@ -15,8 +15,8 @@ Setup:
          Reinstall AFTER the wheel install: unsafe-best-match re-resolves torch from PyPI to CPU.)
     - (aarch64 only) export LD_PRELOAD=/lib/aarch64-linux-gnu/libgomp.so.1
 Tests:
-    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.6.0rc1'"
-        -> verify the wheel resolves the pinned Newton release
+    - python -c "import importlib.metadata as m; assert m.version('newton') == '1.6.0'"
+        -> verify the wheel resolver override selects the Newton release-branch build
     - uv run isaaclab train --rl_library rsl_rl --task Isaac-Cartpole-Direct --num_envs 16
         presets=newton_mjwarp --max_iterations 5; uv run isaaclab train --rl_library rsl_rl
         --task Isaac-Cartpole-Camera-Direct --num_envs 16 presets=newton_mjwarp,newton_renderer --max_iterations 2
@@ -46,18 +46,22 @@ class Test_Uv_Pip_Install_Isaaclab_All_Trains_Cartpole(UV_Mixin):
     @pytest.mark.slow
     @pytest.mark.gpu
     @pytest.mark.timeout(4800)
-    def test_uv_pip_install_isaaclab_all_trains_cartpole(self, isaaclab_root, wheel, cartpole_smoke_script):
+    def test_uv_pip_install_isaaclab_all_trains_cartpole(
+        self, isaaclab_root, wheel, uv_overrides, cartpole_smoke_script
+    ):
         """Install the runner-supplied wheel with ``[all]`` via ``uv pip``, then train."""
         try:
             self.create_uv_env(isaaclab_root)
 
             result = self.run_in_uv_env(
-                ["uv", "--no-config", "pip", "install", f"{wheel}[all]"], cwd=isaaclab_root, timeout=1800
+                ["uv", "--no-config", "pip", "install", f"{wheel}[all]", "--overrides", str(uv_overrides)],
+                cwd=isaaclab_root,
+                timeout=1800,
             )
             assert result.returncode == 0, f"uv pip install {wheel}[all] failed:\n{result.stdout}\n{result.stderr}"
 
             result = self.run_in_uv_env(
-                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.6.0rc1'"],
+                ["python", "-c", "import importlib.metadata as m; assert m.version('newton') == '1.6.0'"],
                 cwd=isaaclab_root,
             )
             assert result.returncode == 0, (

--- a/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
+++ b/source/isaaclab/test/install_ci/uv_pip/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.12.0
 mujoco-warp~=3.12.0
-newton[sim]==1.6.0rc1
+newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.6
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/tools/wheel_builder/uv-overrides.txt
+++ b/tools/wheel_builder/uv-overrides.txt
@@ -1,7 +1,7 @@
 numpy>=2
 mujoco~=3.12.0
 mujoco-warp~=3.12.0
-newton[sim]==1.6.0rc1
+newton[sim] @ git+https://github.com/newton-physics/newton.git@release-1.6
 newton-usd-schemas>=0.4.1
 torch==2.11.0
 torchvision==0.26.0

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ prerelease-mode = "allow"
 overrides = [
     { name = "mujoco", specifier = "~=3.12.0" },
     { name = "mujoco-warp", specifier = "~=3.12.0" },
-    { name = "newton", extras = ["sim"], specifier = "==1.6.0rc1" },
+    { name = "newton", extras = ["sim"], git = "https://github.com/newton-physics/newton.git?rev=release-1.6" },
     { name = "newton-usd-schemas", specifier = ">=0.4.1" },
     { name = "numpy", specifier = ">=2" },
     { name = "packaging", specifier = ">=20,<27" },
@@ -1754,7 +1754,7 @@ wheels = [
 
 [[package]]
 name = "isaaclab"
-version = "24.1.1"
+version = "24.1.2"
 source = { editable = "source/isaaclab" }
 
 [[package]]
@@ -2040,7 +2040,7 @@ requires-dist = [
     { name = "meshio", specifier = ">=5.3.5" },
     { name = "moviepy", marker = "extra == 'video'", specifier = ">=1.0.3,<2.0.0.dev0" },
     { name = "myst-parser", marker = "extra == 'dev'" },
-    { name = "newton", extras = ["sim"], specifier = "==1.6.0rc1" },
+    { name = "newton", extras = ["sim"], specifier = ">=1.2.0" },
     { name = "newton-usd-schemas", specifier = ">=0.2.0" },
     { name = "numba", specifier = ">=0.63.1" },
     { name = "numpy", specifier = ">=2" },
@@ -2137,7 +2137,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-mimic"
-version = "2.0.6"
+version = "2.0.7"
 source = { editable = "source/isaaclab_mimic" }
 dependencies = [
     { name = "isaaclab" },
@@ -2154,7 +2154,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-newton"
-version = "6.2.0"
+version = "6.2.1"
 source = { editable = "source/isaaclab_newton" }
 dependencies = [
     { name = "isaaclab" },
@@ -2180,7 +2180,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-physx"
-version = "7.1.1"
+version = "7.1.2"
 source = { editable = "source/isaaclab_physx" }
 dependencies = [
     { name = "isaaclab" },
@@ -2202,7 +2202,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-rl"
-version = "0.17.2"
+version = "0.17.3"
 source = { editable = "source/isaaclab_rl" }
 dependencies = [
     { name = "isaaclab" },
@@ -2219,7 +2219,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-tasks"
-version = "20.1.2"
+version = "20.1.3"
 source = { editable = "source/isaaclab_tasks" }
 dependencies = [
     { name = "isaaclab" },
@@ -2249,7 +2249,7 @@ requires-dist = [
 
 [[package]]
 name = "isaaclab-teleop"
-version = "0.8.4"
+version = "0.9.0"
 source = { editable = "source/isaaclab_teleop" }
 dependencies = [
     { name = "isaaclab" },
@@ -2260,7 +2260,7 @@ requires-dist = [{ name = "isaaclab", editable = "source/isaaclab" }]
 
 [[package]]
 name = "isaaclab-visualizers"
-version = "1.10.4"
+version = "1.10.5"
 source = { editable = "source/isaaclab_visualizers" }
 dependencies = [
     { name = "isaaclab" },
@@ -3354,13 +3354,10 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.6.0rc1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.6.0"
+source = { git = "https://github.com/newton-physics/newton.git?rev=release-1.6#c2ca70bec5998062b0b2d35869865cbe3a49feee" }
 dependencies = [
     { name = "warp-lang" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/28/1a88699e9e4a5cbe5408e4f5ffb24355cd5854b3f549c59d83679d6c88cc/newton-1.6.0rc1-py3-none-any.whl", hash = "sha256:7ed998bba97167534194c53119c68bd116c8266661c3a339e5a2e4d503701f20", size = 6072745, upload-time = "2026-09-03T04:17:09.936Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# Description

`develop` currently pins the published `newton[sim]==1.6.0rc1` package. Newton's `release-1.6` branch now reports version 1.6.0 and points to `c2ca70bec5998062b0b2d35869865cbe3a49feee`, the commit that finalized the Newton 1.6.0 release.

This changes source/uv installs to follow `release-1.6`, refreshes `uv.lock` to that commit, and keeps the generated wheel-builder and install-CI override files synchronized. The wheel dependency returns to its compatible lower bound now that Newton 1.6.0 final is available, while install CI applies the release-branch override explicitly.

The `release/3.0.0` line remains on Newton 1.5.2 via #7743; this PR is only for `develop`.

## Type of change

- Workflow/dependency update (non-breaking)

## Release backport

- [ ] <!-- backport-active-release --> Not applicable; `release/3.0.0` remains on the Newton 1.5 release line.

## Screenshots

Not applicable.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation is not affected; a changelog fragment is included
- [x] My changes generate no new warnings
- [x] I have updated the pin-consistency and install-CI coverage
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] My name already exists in `CONTRIBUTORS.md`

## Validation

- `uv run --extra test python -m pytest source/isaaclab/test/cli/test_install.py source/isaaclab/test/cli/test_uv_run_pyproject.py source/isaaclab/test/cli/test_wheel_builder_metadata.py` (45 passed, 1 skipped)
- Modified install-CI tests collect successfully with the release-branch override fixture
- `uv lock --check`
- Installed metadata reports Newton 1.6.0 from commit `c2ca70be`
- The locked Newton commit matches the current `release-1.6` branch tip
- `uv run python tools/changelog/cli.py check --include-worktree`
- `uv run isaaclab -f`
