### PR TITLE
Fixed hdf5 to mp4 opencv5

### DIFF
--- a/scripts/tools/hdf5_to_mp4.py
+++ b/scripts/tools/hdf5_to_mp4.py
@@ -48,6 +48,19 @@ MIN_DEPTH = 0.0
 MAX_DEPTH = 1.5
 
 
+def _convert_frame_to_uint8(frame: np.ndarray) -> np.ndarray:
+    """Convert a video frame to the uint8 format expected by MP4 encoders."""
+    if frame.dtype == np.uint8:
+        return frame
+
+    if np.issubdtype(frame.dtype, np.floating):
+        frame = np.nan_to_num(frame, nan=0.0, posinf=1.0, neginf=0.0)
+        if frame.size > 0 and frame.max() <= 1.0:
+            frame = frame * 255.0
+
+    return np.clip(frame, 0, 255).astype(np.uint8)
+
+
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Convert HDF5 demonstration files to MP4 videos.")
@@ -147,12 +160,13 @@ def write_demo_to_mp4(
 
             # Process shaded segmentation frames
             elif "shaded_segmentation" in input_key:
-                seg = frame[..., :-1]
+                segmentation_frame = _convert_frame_to_uint8(frame)
+                seg = segmentation_frame[..., :-1]
                 normals_key = input_key.replace("shaded_segmentation", "normals")
                 normals = f[f"data/demo_{demo_id}/obs/{normals_key}"][ix]
                 shade = 0.5 + (normals * LIGHT_SOURCE[None, None, :]).sum(axis=-1) * 0.5
-                shaded_seg = (shade[..., None] * seg).astype(np.uint8)
-                frame = np.concatenate((shaded_seg, frame[..., -1:]), axis=-1)
+                shaded_seg = np.clip(shade[..., None] * seg, 0, 255).astype(np.uint8)
+                frame = np.concatenate((shaded_seg, segmentation_frame[..., -1:]), axis=-1)
 
             # Convert RGB to BGR
             if "depth" not in input_key:
@@ -165,6 +179,7 @@ def write_demo_to_mp4(
 
             # Resize to video resolution
             frame = cv2.resize(frame, (video_width, video_height), interpolation=cv2.INTER_CUBIC)
+            frame = _convert_frame_to_uint8(frame)
             video.write(frame)
 
         video.release()

--- a/scripts/tools/test/test_hdf5_to_mp4.py
+++ b/scripts/tools/test/test_hdf5_to_mp4.py
@@ -28,6 +28,10 @@ def temp_hdf5_file():
             rgb_data = np.random.randint(0, 255, (2, 704, 1280, 3), dtype=np.uint8)
             demo_group.create_dataset("table_cam", data=rgb_data)
 
+            # Create RGB frames stored as floats in [0, 1]
+            rgb_float_data = np.random.rand(2, 16, 16, 3).astype(np.float32)
+            demo_group.create_dataset("table_cam_float", data=rgb_float_data)
+
             # Create segmentation frames
             seg_data = np.random.randint(0, 255, (2, 704, 1280, 4), dtype=np.uint8)
             demo_group.create_dataset("table_cam_segmentation", data=seg_data)
@@ -69,6 +73,14 @@ class TestHDF5ToMP4:
         write_demo_to_mp4(temp_hdf5_file, 0, "data/demo_0/obs", "table_cam", temp_output_dir, 704, 1280)
 
         output_file = os.path.join(temp_output_dir, "demo_0_table_cam.mp4")
+        assert os.path.exists(output_file)
+        assert os.path.getsize(output_file) > 0
+
+    def test_write_demo_to_mp4_float_rgb(self, temp_hdf5_file, temp_output_dir):
+        """Test writing float RGB frames to MP4."""
+        write_demo_to_mp4(temp_hdf5_file, 0, "data/demo_0/obs", "table_cam_float", temp_output_dir, 16, 16)
+
+        output_file = os.path.join(temp_output_dir, "demo_0_table_cam_float.mp4")
         assert os.path.exists(output_file)
         assert os.path.getsize(output_file) > 0
 


### PR DESCRIPTION
# Fixed hdf5 to mp4 opencv5

The generated HDF5 dataset can store camera frames as float32, commonly in the [0, 1] range. hdf5_to_mp4.py passed those frames directly to cv2.VideoWriter.write() after color conversion and resize. After installing opencv-python==5.0.0.93, OpenCV’s FFmpeg writer rejects float images and requires frame depth to be CV_8U or CV_16U, which causes the error.

This change fixed the issue by converting float frames in [0, 1] to [0, 255]

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
