### PR TITLE
Fixed HDF5 to MP4 frame dtype conversion

### DIFF
--- a/scripts/tools/hdf5_to_mp4.py
+++ b/scripts/tools/hdf5_to_mp4.py
@@ -48,6 +48,18 @@ MIN_DEPTH = 0.0
 MAX_DEPTH = 1.5
 
 
+def _convert_frame_to_uint8(frame: np.ndarray) -> np.ndarray:
+    """Convert a video frame to the uint8 format expected by MP4 encoders."""
+    if frame.dtype == np.uint8:
+        return frame
+
+    if np.issubdtype(frame.dtype, np.floating):
+        frame = np.nan_to_num(frame, nan=0.0, posinf=1.0, neginf=0.0)
+        return np.clip(frame * 255.0, 0, 255).astype(np.uint8)
+
+    return np.clip(frame, 0, 255).astype(np.uint8)
+
+
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Convert HDF5 demonstration files to MP4 videos.")
@@ -147,15 +159,17 @@ def write_demo_to_mp4(
 
             # Process shaded segmentation frames
             elif "shaded_segmentation" in input_key:
-                seg = frame[..., :-1]
+                segmentation_frame = _convert_frame_to_uint8(frame)
+                seg = segmentation_frame[..., :-1]
                 normals_key = input_key.replace("shaded_segmentation", "normals")
                 normals = f[f"data/demo_{demo_id}/obs/{normals_key}"][ix]
                 shade = 0.5 + (normals * LIGHT_SOURCE[None, None, :]).sum(axis=-1) * 0.5
-                shaded_seg = (shade[..., None] * seg).astype(np.uint8)
-                frame = np.concatenate((shaded_seg, frame[..., -1:]), axis=-1)
+                shaded_seg = np.clip(shade[..., None] * seg, 0, 255).astype(np.uint8)
+                frame = np.concatenate((shaded_seg, segmentation_frame[..., -1:]), axis=-1)
 
             # Convert RGB to BGR
             if "depth" not in input_key:
+                frame = _convert_frame_to_uint8(frame)
                 frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
             else:
                 frame = (frame[..., 0] - MIN_DEPTH) / (MAX_DEPTH - MIN_DEPTH)

--- a/scripts/tools/test/test_hdf5_to_mp4.py
+++ b/scripts/tools/test/test_hdf5_to_mp4.py
@@ -8,6 +8,7 @@
 import os
 import tempfile
 
+import cv2
 import h5py
 import numpy as np
 import pytest
@@ -27,6 +28,12 @@ def temp_hdf5_file():
             # Create RGB frames (2 frames per demo)
             rgb_data = np.random.randint(0, 255, (2, 704, 1280, 3), dtype=np.uint8)
             demo_group.create_dataset("table_cam", data=rgb_data)
+
+            # Create RGB frames stored as floats in [0, 1]
+            checkerboard = (np.indices((16, 16)).sum(axis=0) % 2).astype(np.float32)
+            rgb_float_data = np.stack([checkerboard, 1.0 - checkerboard], axis=0)
+            rgb_float_data = np.repeat(rgb_float_data[..., None], 3, axis=-1)
+            demo_group.create_dataset("table_cam_float", data=rgb_float_data)
 
             # Create segmentation frames
             seg_data = np.random.randint(0, 255, (2, 704, 1280, 4), dtype=np.uint8)
@@ -71,6 +78,28 @@ class TestHDF5ToMP4:
         output_file = os.path.join(temp_output_dir, "demo_0_table_cam.mp4")
         assert os.path.exists(output_file)
         assert os.path.getsize(output_file) > 0
+
+    def test_write_demo_to_mp4_float_rgb(self, temp_hdf5_file, temp_output_dir):
+        """Test writing float RGB frames to MP4."""
+        write_demo_to_mp4(temp_hdf5_file, 0, "data/demo_0/obs", "table_cam_float", temp_output_dir, 12, 20)
+
+        output_file = os.path.join(temp_output_dir, "demo_0_table_cam_float.mp4")
+        assert os.path.exists(output_file)
+        assert os.path.getsize(output_file) > 0
+
+        video = cv2.VideoCapture(output_file)
+        decoded_frames = []
+        while True:
+            success, frame = video.read()
+            if not success:
+                break
+            decoded_frames.append(frame)
+        video.release()
+
+        assert len(decoded_frames) == 2
+        decoded_frames = np.stack(decoded_frames)
+        assert decoded_frames.shape[1:3] == (12, 20)
+        assert 60.0 < decoded_frames.mean() < 195.0
 
     def test_write_demo_to_mp4_segmentation(self, temp_hdf5_file, temp_output_dir):
         """Test writing segmentation frames to MP4."""


### PR DESCRIPTION
# Fixed HDF5 to MP4 frame dtype conversion

The generated HDF5 dataset stores camera frames as float32. After installing opencv-python==5.0.0.93, OpenCV’s FFmpeg writer rejects float images and requires frame depth to be CV_8U or CV_16U, which causes the error.

This change fixed the issue by converting float frames in [0, 1] to [0, 255]

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
