### PR TITLE
Fix LEAPP RSL-RL exports on Isaac Sim 6.1

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-leapp-physx-launch.rst
+++ b/source/isaaclab_rl/changelog.d/fix-leapp-physx-launch.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Restored launch-safe lazy imports for RSL-RL LEAPP exports, preventing Isaac Sim 6.1 PhysX exports from exiting
+  without producing ONNX artifacts.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
@@ -15,11 +15,20 @@ import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import torch
+
+# TorchScript must be disabled before importing task or environment modules because
+# ``@torch.jit.script`` compiles at decoration time.
+torch.jit._state.disable()
+
 if TYPE_CHECKING:
-    import torch
     from leapp import GraphConfigs
 
     from isaaclab.envs import DirectRLEnvCfg, ManagerBasedEnvCfg
+
+from isaaclab.app import AppLauncher
+
+from isaaclab_tasks.utils import setup_preset_cli
 
 
 def add_common_export_args(parser: argparse.ArgumentParser, *, agent_default: str) -> None:
@@ -29,8 +38,6 @@ def add_common_export_args(parser: argparse.ArgumentParser, *, agent_default: st
         parser: Argument parser to extend.
         agent_default: Default Hydra agent configuration entry point for the backend.
     """
-
-    from isaaclab.app import AppLauncher
 
     parser.add_argument("--task", type=str, default=None, help="Name of the task.")
     parser.add_argument(
@@ -88,29 +95,9 @@ def finalize_export_args(
     parser: argparse.ArgumentParser, argv: list[str] | None = None
 ) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments with preset support and force headless mode."""
-    from isaaclab_tasks.utils import setup_preset_cli
-
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     args_cli.headless = True
     return args_cli, hydra_args
-
-
-def disable_torchscript_for_export() -> None:
-    """Disable TorchScript compilation so ``@torch.jit.script`` helpers stay traceable.
-
-    LEAPP traces the observation and action pipeline in Python. A compiled
-    :class:`torch.jit.ScriptFunction` is opaque to the tracer, so any environment
-    quantity flowing through one (for example the quaternion helpers in
-    ``isaaclab.utils.math``) is folded into the graph as a constant and the exported
-    policy fails validation once that quantity changes.
-
-    Call this before importing task or environment modules: :func:`torch.jit.script`
-    compiles at decoration time, so disabling afterwards has no effect on helpers that
-    were already imported.
-    """
-    import torch
-
-    torch.jit._state.disable()
 
 
 def get_checkpoint_path(
@@ -187,8 +174,6 @@ def create_graph_configs(env_cfg: ManagerBasedEnvCfg | DirectRLEnvCfg) -> GraphC
 
 def is_two_tensor_lstm_state(states: object) -> bool:
     """Return whether *states* looks like an LSTM ``[hidden, cell]`` state."""
-    import torch
-
     return (
         isinstance(states, (list, tuple))
         and len(states) == 2

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
@@ -13,18 +13,13 @@ import argparse
 import os
 import re
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-import torch
-from leapp import GraphConfigs
+if TYPE_CHECKING:
+    import torch
+    from leapp import GraphConfigs
 
-# TorchScript must be disabled before importing task or environment modules because
-# ``@torch.jit.script`` compiles at decoration time.
-torch.jit._state.disable()
-
-from isaaclab.app import AppLauncher
-from isaaclab.envs import DirectRLEnvCfg, ManagerBasedEnvCfg
-
-from isaaclab_tasks.utils import setup_preset_cli
+    from isaaclab.envs import DirectRLEnvCfg, ManagerBasedEnvCfg
 
 
 def add_common_export_args(parser: argparse.ArgumentParser, *, agent_default: str) -> None:
@@ -34,6 +29,8 @@ def add_common_export_args(parser: argparse.ArgumentParser, *, agent_default: st
         parser: Argument parser to extend.
         agent_default: Default Hydra agent configuration entry point for the backend.
     """
+
+    from isaaclab.app import AppLauncher
 
     parser.add_argument("--task", type=str, default=None, help="Name of the task.")
     parser.add_argument(
@@ -91,10 +88,29 @@ def finalize_export_args(
     parser: argparse.ArgumentParser, argv: list[str] | None = None
 ) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments with preset support and force headless mode."""
+    from isaaclab_tasks.utils import setup_preset_cli
 
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     args_cli.headless = True
     return args_cli, hydra_args
+
+
+def disable_torchscript_for_export() -> None:
+    """Disable TorchScript compilation so ``@torch.jit.script`` helpers stay traceable.
+
+    LEAPP traces the observation and action pipeline in Python. A compiled
+    :class:`torch.jit.ScriptFunction` is opaque to the tracer, so any environment
+    quantity flowing through one (for example the quaternion helpers in
+    ``isaaclab.utils.math``) is folded into the graph as a constant and the exported
+    policy fails validation once that quantity changes.
+
+    Call this before importing task or environment modules: :func:`torch.jit.script`
+    compiles at decoration time, so disabling afterwards has no effect on helpers that
+    were already imported.
+    """
+    import torch
+
+    torch.jit._state.disable()
 
 
 def get_checkpoint_path(
@@ -163,12 +179,15 @@ def create_graph_configs(env_cfg: ManagerBasedEnvCfg | DirectRLEnvCfg) -> GraphC
         Graph metadata containing the policy frequency [Hz].
     """
 
+    from leapp import GraphConfigs
+
     policy_frequency = 1.0 / (env_cfg.sim.dt * env_cfg.decimation)
     return GraphConfigs(frequency=policy_frequency)
 
 
 def is_two_tensor_lstm_state(states: object) -> bool:
     """Return whether *states* looks like an LSTM ``[hidden, cell]`` state."""
+    import torch
 
     return (
         isinstance(states, (list, tuple))

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
@@ -5,8 +5,6 @@
 
 """Script to export a checkpoint if an RL agent from RSL-RL."""
 
-# ruff: noqa: E402, I001
-
 from __future__ import annotations
 
 import argparse
@@ -18,42 +16,36 @@ import sys
 import time
 from collections.abc import Mapping
 
-import torch
-
-# LEAPP traces Isaac Lab's Python tensor operations, so disable TorchScript before
-# importing task or environment modules that compile decorated helpers.
-torch.jit._state.disable()
-
-import gymnasium as gym
-import leapp
-from leapp import annotate
-from packaging import version
-from rsl_rl.runners import DistillationRunner, OnPolicyRunner
-
-from isaaclab.app import launch_simulation
-from isaaclab.utils.assets import retrieve_file_path
-from isaaclab.utils.leapp import patch_env_for_export
-from isaaclab.utils.leapp.utils import ensure_env_spec_id
-
-from isaaclab_rl.entrypoints.backends.export_common import (
-    add_common_export_args,
-    create_graph_configs,
-    finalize_export_args,
-    get_checkpoint_path,
-)
-from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
-from isaaclab_rl.utils.pretrained_checkpoint import (
-    get_pretrained_checkpoint_backend_names,
-    get_published_pretrained_checkpoint,
-)
-
-from isaaclab_tasks.utils.hydra import hydra_task_config
-
 RSL_RL_MIN_VERSION = "5.0.1"
+_RUNTIME_IMPORTS_LOADED = False
+
+# Keep heavy/runtime-sensitive imports out of module import time. The CLI needs
+# to parse launcher arguments and start Isaac Sim/Kit before importing torch,
+# LEAPP, RSL-RL, and task modules; importing them earlier causes launcher
+# import-order failures in the Isaac Sim 6.1 runtime.
+torch = None
+leapp = None
+annotate = None
+gym = None
+DistillationRunner = None
+OnPolicyRunner = None
+ManagerBasedRLEnv = None
+RslRlVecEnvWrapper = None
+handle_deprecated_rsl_rl_cfg = None
+retrieve_file_path = None
+patch_env_for_export = None
+ensure_env_spec_id = None
+get_published_pretrained_checkpoint = None
+get_pretrained_checkpoint_backend_names = None
+get_checkpoint_path = None
+installed_version = None
+create_graph_configs = None
 
 
 def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments and return remaining Hydra overrides."""
+    from isaaclab_rl.entrypoints.backends.export_common import add_common_export_args, finalize_export_args
+
     parser = argparse.ArgumentParser(description="Export an RL agent with RSL-RL.")
     add_common_export_args(parser, agent_default="rsl_rl_cfg_entry_point")
     parser.add_argument("--seed", type=int, default=None, help="Seed used for the environment.")
@@ -64,6 +56,75 @@ def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace
     # remainder still carries typed selectors (physics=/renderer=/presets=)
     # verbatim for run_export_with_hydra to fold before invoking Hydra.
     return finalize_export_args(parser, argv)
+
+
+def _load_runtime_dependencies() -> None:
+    """Import runtime dependencies after Isaac Sim has been launched."""
+    global _RUNTIME_IMPORTS_LOADED
+    global annotate, leapp, torch
+    global DistillationRunner, ManagerBasedRLEnv, OnPolicyRunner, RslRlVecEnvWrapper, get_checkpoint_path, gym
+    global ensure_env_spec_id, get_pretrained_checkpoint_backend_names, get_published_pretrained_checkpoint
+    global handle_deprecated_rsl_rl_cfg
+    global installed_version
+    global patch_env_for_export, retrieve_file_path
+    global create_graph_configs
+
+    if _RUNTIME_IMPORTS_LOADED:
+        return
+
+    try:
+        import leapp as leapp_module
+    except ImportError as e:
+        raise ImportError("LEAPP package is required for policy export. Install with: pip install leapp") from e
+    annotate_module = getattr(leapp_module, "annotate")
+
+    import gymnasium as gym_module
+    import torch as torch_module
+    from packaging import version as packaging_version_module
+    from rsl_rl.runners import DistillationRunner as DistillationRunnerCls
+    from rsl_rl.runners import OnPolicyRunner as OnPolicyRunnerCls
+
+    from isaaclab.envs import ManagerBasedRLEnv as ManagerBasedRLEnvCls
+    from isaaclab.utils.assets import retrieve_file_path as retrieve_file_path_fn
+    from isaaclab.utils.leapp import patch_env_for_export as patch_env_for_export_fn
+    from isaaclab.utils.leapp.utils import ensure_env_spec_id as ensure_env_spec_id_fn
+
+    from isaaclab_rl.entrypoints.backends.export_common import create_graph_configs as create_graph_configs_fn
+    from isaaclab_rl.entrypoints.backends.export_common import get_checkpoint_path as get_checkpoint_path_fn
+    from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper as RslRlVecEnvWrapperCls
+    from isaaclab_rl.rsl_rl import handle_deprecated_rsl_rl_cfg as handle_deprecated_rsl_rl_cfg_fn
+    from isaaclab_rl.utils.pretrained_checkpoint import (
+        get_pretrained_checkpoint_backend_names as get_pretrained_checkpoint_backend_names_fn,
+    )
+    from isaaclab_rl.utils.pretrained_checkpoint import (
+        get_published_pretrained_checkpoint as get_published_pretrained_checkpoint_fn,
+    )
+
+    __import__("isaaclab_tasks")
+    installed_version = metadata.version("rsl-rl-lib")
+    if packaging_version_module.parse(installed_version) < packaging_version_module.parse(RSL_RL_MIN_VERSION):
+        print(
+            f"[WARNING] LEAPP RSL-RL export is validated with rsl-rl-lib {RSL_RL_MIN_VERSION} or newer. "
+            f"Installed version is '{installed_version}'."
+        )
+
+    torch = torch_module
+    leapp = leapp_module
+    annotate = annotate_module
+    gym = gym_module
+    DistillationRunner = DistillationRunnerCls
+    OnPolicyRunner = OnPolicyRunnerCls
+    ManagerBasedRLEnv = ManagerBasedRLEnvCls
+    RslRlVecEnvWrapper = RslRlVecEnvWrapperCls
+    handle_deprecated_rsl_rl_cfg = handle_deprecated_rsl_rl_cfg_fn
+    retrieve_file_path = retrieve_file_path_fn
+    patch_env_for_export = patch_env_for_export_fn
+    ensure_env_spec_id = ensure_env_spec_id_fn
+    get_pretrained_checkpoint_backend_names = get_pretrained_checkpoint_backend_names_fn
+    get_published_pretrained_checkpoint = get_published_pretrained_checkpoint_fn
+    get_checkpoint_path = get_checkpoint_path_fn
+    create_graph_configs = create_graph_configs_fn
+    _RUNTIME_IMPORTS_LOADED = True
 
 
 def get_actor_memory_module(policy):
@@ -95,6 +156,7 @@ def set_actor_hidden_state(policy, actor_hidden) -> None:
 
 def ensure_actor_hidden_state_initialized(policy, batch_size: int, device, dtype):
     """Initialize and return the actor hidden state when a recurrent policy has not created it yet."""
+    import torch as torch_module
 
     actor_state = get_actor_hidden_state(policy)
     if actor_state is not None:
@@ -106,8 +168,8 @@ def ensure_actor_hidden_state_initialized(policy, batch_size: int, device, dtype
 
     num_layers = memory.rnn.num_layers
     hidden_size = memory.rnn.hidden_size
-    zeros = torch.zeros(num_layers, batch_size, hidden_size, device=device, dtype=dtype)
-    if isinstance(memory.rnn, torch.nn.LSTM):
+    zeros = torch_module.zeros(num_layers, batch_size, hidden_size, device=device, dtype=dtype)
+    if isinstance(memory.rnn, torch_module.nn.LSTM):
         actor_state = (zeros.clone(), zeros.clone())
     else:
         actor_state = zeros
@@ -153,16 +215,7 @@ def export_rsl_rl_agent(
     simulation_app=None,
 ) -> bool:
     """Export a RSL-RL agent."""
-    # Concrete environment classes load simulation modules, so import them
-    # only after launch_simulation has initialized the selected backend.
-    from isaaclab.envs import ManagerBasedRLEnv
-
-    installed_version = metadata.version("rsl-rl-lib")
-    if version.parse(installed_version) < version.parse(RSL_RL_MIN_VERSION):
-        print(
-            f"[WARNING] LEAPP RSL-RL export is validated with rsl-rl-lib {RSL_RL_MIN_VERSION} or newer. "
-            f"Installed version is '{installed_version}'."
-        )
+    _load_runtime_dependencies()
 
     task_name = args_cli.task.split(":")[-1]
     checkpoint_task_name = task_name.replace("-Play", "")
@@ -304,6 +357,14 @@ def export_rsl_rl_agent(
 
 def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -> bool:
     """Resolve Hydra task configuration and export one RSL-RL policy."""
+    from isaaclab.app import launch_simulation
+
+    from isaaclab_rl.entrypoints.backends.export_common import disable_torchscript_for_export
+
+    from isaaclab_tasks.utils.hydra import hydra_task_config
+
+    # Must run before task modules are imported during Hydra config resolution.
+    disable_torchscript_for_export()
 
     original_argv = sys.argv
     # Hydra reads the preset tokens (physics=/renderer=/presets=) from sys.argv directly.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
@@ -17,29 +17,6 @@ import time
 from collections.abc import Mapping
 
 RSL_RL_MIN_VERSION = "5.0.1"
-_RUNTIME_IMPORTS_LOADED = False
-
-# Keep heavy/runtime-sensitive imports out of module import time. The CLI needs
-# to parse launcher arguments and start Isaac Sim/Kit before importing torch,
-# LEAPP, RSL-RL, and task modules; importing them earlier causes launcher
-# import-order failures in the Isaac Sim 6.1 runtime.
-torch = None
-leapp = None
-annotate = None
-gym = None
-DistillationRunner = None
-OnPolicyRunner = None
-ManagerBasedRLEnv = None
-RslRlVecEnvWrapper = None
-handle_deprecated_rsl_rl_cfg = None
-retrieve_file_path = None
-patch_env_for_export = None
-ensure_env_spec_id = None
-get_published_pretrained_checkpoint = None
-get_pretrained_checkpoint_backend_names = None
-get_checkpoint_path = None
-installed_version = None
-create_graph_configs = None
 
 
 def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
@@ -56,75 +33,6 @@ def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace
     # remainder still carries typed selectors (physics=/renderer=/presets=)
     # verbatim for run_export_with_hydra to fold before invoking Hydra.
     return finalize_export_args(parser, argv)
-
-
-def _load_runtime_dependencies() -> None:
-    """Import runtime dependencies after Isaac Sim has been launched."""
-    global _RUNTIME_IMPORTS_LOADED
-    global annotate, leapp, torch
-    global DistillationRunner, ManagerBasedRLEnv, OnPolicyRunner, RslRlVecEnvWrapper, get_checkpoint_path, gym
-    global ensure_env_spec_id, get_pretrained_checkpoint_backend_names, get_published_pretrained_checkpoint
-    global handle_deprecated_rsl_rl_cfg
-    global installed_version
-    global patch_env_for_export, retrieve_file_path
-    global create_graph_configs
-
-    if _RUNTIME_IMPORTS_LOADED:
-        return
-
-    try:
-        import leapp as leapp_module
-    except ImportError as e:
-        raise ImportError("LEAPP package is required for policy export. Install with: pip install leapp") from e
-    annotate_module = getattr(leapp_module, "annotate")
-
-    import gymnasium as gym_module
-    import torch as torch_module
-    from packaging import version as packaging_version_module
-    from rsl_rl.runners import DistillationRunner as DistillationRunnerCls
-    from rsl_rl.runners import OnPolicyRunner as OnPolicyRunnerCls
-
-    from isaaclab.envs import ManagerBasedRLEnv as ManagerBasedRLEnvCls
-    from isaaclab.utils.assets import retrieve_file_path as retrieve_file_path_fn
-    from isaaclab.utils.leapp import patch_env_for_export as patch_env_for_export_fn
-    from isaaclab.utils.leapp.utils import ensure_env_spec_id as ensure_env_spec_id_fn
-
-    from isaaclab_rl.entrypoints.backends.export_common import create_graph_configs as create_graph_configs_fn
-    from isaaclab_rl.entrypoints.backends.export_common import get_checkpoint_path as get_checkpoint_path_fn
-    from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper as RslRlVecEnvWrapperCls
-    from isaaclab_rl.rsl_rl import handle_deprecated_rsl_rl_cfg as handle_deprecated_rsl_rl_cfg_fn
-    from isaaclab_rl.utils.pretrained_checkpoint import (
-        get_pretrained_checkpoint_backend_names as get_pretrained_checkpoint_backend_names_fn,
-    )
-    from isaaclab_rl.utils.pretrained_checkpoint import (
-        get_published_pretrained_checkpoint as get_published_pretrained_checkpoint_fn,
-    )
-
-    __import__("isaaclab_tasks")
-    installed_version = metadata.version("rsl-rl-lib")
-    if packaging_version_module.parse(installed_version) < packaging_version_module.parse(RSL_RL_MIN_VERSION):
-        print(
-            f"[WARNING] LEAPP RSL-RL export is validated with rsl-rl-lib {RSL_RL_MIN_VERSION} or newer. "
-            f"Installed version is '{installed_version}'."
-        )
-
-    torch = torch_module
-    leapp = leapp_module
-    annotate = annotate_module
-    gym = gym_module
-    DistillationRunner = DistillationRunnerCls
-    OnPolicyRunner = OnPolicyRunnerCls
-    ManagerBasedRLEnv = ManagerBasedRLEnvCls
-    RslRlVecEnvWrapper = RslRlVecEnvWrapperCls
-    handle_deprecated_rsl_rl_cfg = handle_deprecated_rsl_rl_cfg_fn
-    retrieve_file_path = retrieve_file_path_fn
-    patch_env_for_export = patch_env_for_export_fn
-    ensure_env_spec_id = ensure_env_spec_id_fn
-    get_pretrained_checkpoint_backend_names = get_pretrained_checkpoint_backend_names_fn
-    get_published_pretrained_checkpoint = get_published_pretrained_checkpoint_fn
-    get_checkpoint_path = get_checkpoint_path_fn
-    create_graph_configs = create_graph_configs_fn
-    _RUNTIME_IMPORTS_LOADED = True
 
 
 def get_actor_memory_module(policy):
@@ -215,7 +123,33 @@ def export_rsl_rl_agent(
     simulation_app=None,
 ) -> bool:
     """Export a RSL-RL agent."""
-    _load_runtime_dependencies()
+    import gymnasium as gym
+    import leapp
+    import torch
+    from leapp import annotate
+    from packaging import version
+    from rsl_rl.runners import DistillationRunner, OnPolicyRunner
+
+    from isaaclab.envs import ManagerBasedRLEnv
+    from isaaclab.utils.assets import retrieve_file_path
+    from isaaclab.utils.leapp import patch_env_for_export
+    from isaaclab.utils.leapp.utils import ensure_env_spec_id
+
+    from isaaclab_rl.entrypoints.backends.export_common import create_graph_configs, get_checkpoint_path
+    from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
+    from isaaclab_rl.utils.pretrained_checkpoint import (
+        get_pretrained_checkpoint_backend_names,
+        get_published_pretrained_checkpoint,
+    )
+
+    import isaaclab_tasks  # noqa: F401
+
+    installed_version = metadata.version("rsl-rl-lib")
+    if version.parse(installed_version) < version.parse(RSL_RL_MIN_VERSION):
+        print(
+            f"[WARNING] LEAPP RSL-RL export is validated with rsl-rl-lib {RSL_RL_MIN_VERSION} or newer. "
+            f"Installed version is '{installed_version}'."
+        )
 
     task_name = args_cli.task.split(":")[-1]
     checkpoint_task_name = task_name.replace("-Play", "")
@@ -359,12 +293,7 @@ def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -
     """Resolve Hydra task configuration and export one RSL-RL policy."""
     from isaaclab.app import launch_simulation
 
-    from isaaclab_rl.entrypoints.backends.export_common import disable_torchscript_for_export
-
     from isaaclab_tasks.utils.hydra import hydra_task_config
-
-    # Must run before task modules are imported during Hydra config resolution.
-    disable_torchscript_for_export()
 
     original_argv = sys.argv
     # Hydra reads the preset tokens (physics=/renderer=/presets=) from sys.argv directly.

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -31,6 +31,10 @@ from isaaclab_rl.entrypoints.simple_agents import _create_zero_action_policy
         ("import isaaclab_rl", ["isaaclab_rl.entrypoints", "torch"]),
         ("import isaaclab_rl.entrypoints", ["isaaclab_rl.entrypoints.multigpu", "torch"]),
         ("import isaaclab_rl.entrypoints.backends", ["torch"]),
+        (
+            "import isaaclab_rl.entrypoints.backends.export_rsl_rl",
+            ["torch", "leapp", "rsl_rl", "isaaclab.envs", "isaaclab_tasks"],
+        ),
         ("import isaaclab_rl.rl_games", ["isaaclab_rl.rl_games.rl_games", "rl_games", "torch"]),
         ("import isaaclab_rl.rl_games.pbt", ["isaaclab_rl.rl_games.pbt.pbt", "rl_games", "torch"]),
         ("import isaaclab_rl.rsl_rl", ["isaaclab_rl.rsl_rl.vecenv_wrapper", "rsl_rl", "torch"]),


### PR DESCRIPTION
# Description

The RSL-RL LEAPP tests on `release/3.0.0` report missing ONNX files because the export subprocess exits during Isaac Sim 6.1 startup, before LEAPP compiles the graph. The actionable error is `AttributeError: module 'omni.usd' has no attribute 'get_context'`; the later "Missing .onnx export" assertion is only the downstream symptom.

This regressed when #7427 moved the exporter to the installed entrypoint and made Torch, LEAPP, RSL-RL, environment, and task imports eager. That import order works in the current `latest-develop` venv image, but it is not launch-safe with the Isaac Sim 6.1 Python launcher used by the release branch.

This change:

- defers only the RSL-RL exporter's runtime-sensitive imports until after the selected simulation backend launches;
- keeps the shared LEAPP argument parsing and TorchScript setup unchanged for the other export backends; and
- adds a clean-subprocess regression check that prevents the exporter module from eagerly importing its runtime stack.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Validation

- `uv run isaaclab -f`
- Clean-import regression: fails on the unmodified release tip and passes with this change.
- `source/isaaclab_rl/test/test_entrypoints.py`: 10 focused tests passed.
- `source/isaaclab_rl/test/export/test_leapp_recurrent_state.py`: 4 focused tests passed.
- `source/isaaclab_rl/test/export/test_rsl_rl_export_flow.py`: 1 focused test passed.
- SB3 shared export-argument regression: 1 focused test passed.
- Direct PhysX LEAPP export flow: 1 test passed with Isaac Sim 6.1 and LEAPP 0.6.1.
- Reproduced the two manager-based CI cases locally; `Isaac-Humanoid` with `isaacsim_physx` and `IsaacContrib-Lift-Cube-Franka` both generated ONNX, YAML, initial-value, and log artifacts.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
