### PR TITLE
Fix LEAPP RSL-RL export startup ordering

### DIFF
--- a/source/isaaclab_rl/changelog.d/fix-leapp-physx-launch.rst
+++ b/source/isaaclab_rl/changelog.d/fix-leapp-physx-launch.rst
@@ -1,0 +1,5 @@
+Fixed
+^^^^^
+
+* Restored launch-safe lazy imports for RSL-RL LEAPP exports, preventing Isaac Sim 6.1 PhysX exports from exiting
+  without producing ONNX artifacts.

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_common.py
@@ -13,16 +13,20 @@ import argparse
 import os
 import re
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import torch
-from leapp import GraphConfigs
 
 # TorchScript must be disabled before importing task or environment modules because
 # ``@torch.jit.script`` compiles at decoration time.
 torch.jit._state.disable()
 
+if TYPE_CHECKING:
+    from leapp import GraphConfigs
+
+    from isaaclab.envs import DirectRLEnvCfg, ManagerBasedEnvCfg
+
 from isaaclab.app import AppLauncher
-from isaaclab.envs import DirectRLEnvCfg, ManagerBasedEnvCfg
 
 from isaaclab_tasks.utils import setup_preset_cli
 
@@ -91,7 +95,6 @@ def finalize_export_args(
     parser: argparse.ArgumentParser, argv: list[str] | None = None
 ) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments with preset support and force headless mode."""
-
     args_cli, hydra_args = setup_preset_cli(parser, argv)
     args_cli.headless = True
     return args_cli, hydra_args
@@ -163,13 +166,14 @@ def create_graph_configs(env_cfg: ManagerBasedEnvCfg | DirectRLEnvCfg) -> GraphC
         Graph metadata containing the policy frequency [Hz].
     """
 
+    from leapp import GraphConfigs
+
     policy_frequency = 1.0 / (env_cfg.sim.dt * env_cfg.decimation)
     return GraphConfigs(frequency=policy_frequency)
 
 
 def is_two_tensor_lstm_state(states: object) -> bool:
     """Return whether *states* looks like an LSTM ``[hidden, cell]`` state."""
-
     return (
         isinstance(states, (list, tuple))
         and len(states) == 2

--- a/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
+++ b/source/isaaclab_rl/isaaclab_rl/entrypoints/backends/export_rsl_rl.py
@@ -5,8 +5,6 @@
 
 """Script to export a checkpoint if an RL agent from RSL-RL."""
 
-# ruff: noqa: E402, I001
-
 from __future__ import annotations
 
 import argparse
@@ -18,42 +16,13 @@ import sys
 import time
 from collections.abc import Mapping
 
-import torch
-
-# LEAPP traces Isaac Lab's Python tensor operations, so disable TorchScript before
-# importing task or environment modules that compile decorated helpers.
-torch.jit._state.disable()
-
-import gymnasium as gym
-import leapp
-from leapp import annotate
-from packaging import version
-from rsl_rl.runners import DistillationRunner, OnPolicyRunner
-
-from isaaclab.app import launch_simulation
-from isaaclab.utils.assets import retrieve_file_path
-from isaaclab.utils.leapp import patch_env_for_export
-from isaaclab.utils.leapp.utils import ensure_env_spec_id
-
-from isaaclab_rl.entrypoints.backends.export_common import (
-    add_common_export_args,
-    create_graph_configs,
-    finalize_export_args,
-    get_checkpoint_path,
-)
-from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
-from isaaclab_rl.utils.pretrained_checkpoint import (
-    get_pretrained_checkpoint_backend_names,
-    get_published_pretrained_checkpoint,
-)
-
-from isaaclab_tasks.utils.hydra import hydra_task_config
-
 RSL_RL_MIN_VERSION = "5.0.1"
 
 
 def parse_export_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
     """Parse export arguments and return remaining Hydra overrides."""
+    from isaaclab_rl.entrypoints.backends.export_common import add_common_export_args, finalize_export_args
+
     parser = argparse.ArgumentParser(description="Export an RL agent with RSL-RL.")
     add_common_export_args(parser, agent_default="rsl_rl_cfg_entry_point")
     parser.add_argument("--seed", type=int, default=None, help="Seed used for the environment.")
@@ -95,6 +64,7 @@ def set_actor_hidden_state(policy, actor_hidden) -> None:
 
 def ensure_actor_hidden_state_initialized(policy, batch_size: int, device, dtype):
     """Initialize and return the actor hidden state when a recurrent policy has not created it yet."""
+    import torch as torch_module
 
     actor_state = get_actor_hidden_state(policy)
     if actor_state is not None:
@@ -106,8 +76,8 @@ def ensure_actor_hidden_state_initialized(policy, batch_size: int, device, dtype
 
     num_layers = memory.rnn.num_layers
     hidden_size = memory.rnn.hidden_size
-    zeros = torch.zeros(num_layers, batch_size, hidden_size, device=device, dtype=dtype)
-    if isinstance(memory.rnn, torch.nn.LSTM):
+    zeros = torch_module.zeros(num_layers, batch_size, hidden_size, device=device, dtype=dtype)
+    if isinstance(memory.rnn, torch_module.nn.LSTM):
         actor_state = (zeros.clone(), zeros.clone())
     else:
         actor_state = zeros
@@ -153,9 +123,26 @@ def export_rsl_rl_agent(
     simulation_app=None,
 ) -> bool:
     """Export a RSL-RL agent."""
-    # Concrete environment classes load simulation modules, so import them
-    # only after launch_simulation has initialized the selected backend.
+    import gymnasium as gym
+    import leapp
+    import torch
+    from leapp import annotate
+    from packaging import version
+    from rsl_rl.runners import DistillationRunner, OnPolicyRunner
+
     from isaaclab.envs import ManagerBasedRLEnv
+    from isaaclab.utils.assets import retrieve_file_path
+    from isaaclab.utils.leapp import patch_env_for_export
+    from isaaclab.utils.leapp.utils import ensure_env_spec_id
+
+    from isaaclab_rl.entrypoints.backends.export_common import create_graph_configs, get_checkpoint_path
+    from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper, handle_deprecated_rsl_rl_cfg
+    from isaaclab_rl.utils.pretrained_checkpoint import (
+        get_pretrained_checkpoint_backend_names,
+        get_published_pretrained_checkpoint,
+    )
+
+    import isaaclab_tasks  # noqa: F401
 
     installed_version = metadata.version("rsl-rl-lib")
     if version.parse(installed_version) < version.parse(RSL_RL_MIN_VERSION):
@@ -304,6 +291,9 @@ def export_rsl_rl_agent(
 
 def run_export_with_hydra(args_cli: argparse.Namespace, hydra_args: list[str]) -> bool:
     """Resolve Hydra task configuration and export one RSL-RL policy."""
+    from isaaclab.app import launch_simulation
+
+    from isaaclab_tasks.utils.hydra import hydra_task_config
 
     original_argv = sys.argv
     # Hydra reads the preset tokens (physics=/renderer=/presets=) from sys.argv directly.

--- a/source/isaaclab_rl/test/test_entrypoints.py
+++ b/source/isaaclab_rl/test/test_entrypoints.py
@@ -31,6 +31,10 @@ from isaaclab_rl.entrypoints.simple_agents import _create_zero_action_policy
         ("import isaaclab_rl", ["isaaclab_rl.entrypoints", "torch"]),
         ("import isaaclab_rl.entrypoints", ["isaaclab_rl.entrypoints.multigpu", "torch"]),
         ("import isaaclab_rl.entrypoints.backends", ["torch"]),
+        (
+            "import isaaclab_rl.entrypoints.backends.export_rsl_rl",
+            ["torch", "leapp", "rsl_rl", "isaaclab.envs", "isaaclab_tasks"],
+        ),
         ("import isaaclab_rl.rl_games", ["isaaclab_rl.rl_games.rl_games", "rl_games", "torch"]),
         ("import isaaclab_rl.rl_games.pbt", ["isaaclab_rl.rl_games.pbt.pbt", "rl_games", "torch"]),
         ("import isaaclab_rl.rsl_rl", ["isaaclab_rl.rsl_rl.vecenv_wrapper", "rsl_rl", "torch"]),


### PR DESCRIPTION
# Description

The RSL-RL LEAPP exporter imports Torch, LEAPP, RSL-RL, Isaac Lab environment modules, and task modules before `launch_simulation` initializes the selected backend. That order is not launch-safe. On the Isaac Sim 6.1 release runtime, startup exits at `omni.usd.get_context()` and the LEAPP tests later report the downstream symptom: a missing ONNX artifact.

The current develop CI runtime masks the problem, but the same eager-import source is present on `develop`. This fixes the source branch first so the change can be backported normally.

This change:

- defers only the RSL-RL LEAPP runtime imports until the simulation context is active;
- keeps shared behavior for the other LEAPP export backends unchanged; and
- adds a clean-subprocess regression check that prevents the RSL-RL exporter module from eagerly importing its runtime stack.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- `uv run isaaclab -f`
- `uv run python tools/changelog/cli.py check develop`
- Baseline import probe failed on unmodified `upstream/develop`, loading `torch`, `leapp`, `rsl_rl`, `isaaclab.envs`, and `isaaclab_tasks`; the new clean-import regression passes with this change.
- Clean entrypoint coverage: 10 passed.
- LEAPP shared and RSL-RL recurrent-state coverage: 5 passed, 4 skipped optional backends.
- SB3 shared export-argument regression: 1 passed.
- Direct PhysX LEAPP export flow: 1 passed with Isaac Sim 6.1 and LEAPP 0.6.1.
- The equivalent patch also generated ONNX, YAML, initial-value, and log artifacts for the two manager-based release CI cases: `Isaac-Humanoid` with `isaacsim_physx` and `IsaacContrib-Lift-Cube-Franka`.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] Documentation changes are not required because this fixes internal startup ordering without changing a public API
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package
- [x] My name already exists in `CONTRIBUTORS.md`
