### PR TITLE
Fixed locomanipulation NuRec SDG generation

### DIFF
--- a/docs/source/features/imitation-learning/humanoids_imitation.rst
+++ b/docs/source/features/imitation-learning/humanoids_imitation.rst
@@ -774,12 +774,11 @@ Integrating 3D Gaussian Splatting into SDG
 
 This section extends
 :ref:`locomanipulation SDG <generate-the-dataset-with-manipulation-and-point-to-point-navigation>`
-by replacing the synthetic background with a 3D Gaussian Splatting (NuRec) scene. As in the
-base pipeline, the workflow takes a manipulation dataset as input and produces a combined
-navigation and manipulation dataset as an HDF5 file — but here the robot navigates and
-manipulates objects inside a neurally-rendered environment, and an ego-centric camera
-captures the result, producing more realistic training data than a purely synthetic scene.
-NVIDIA Isaac Sim renders 3DGS models stored as USD assets; see
+by replacing the synthetic background with a 3D Gaussian Splatting (NuRec) scene. The workflow
+takes a manipulation dataset as input and produces a combined navigation and manipulation
+dataset as an HDF5 file. The navigation replay happens in a neurally-reconstructed environment,
+and an ego-centric camera captures the result, producing more realistic training data.
+For more info on NuRec rendering in Isaac Sim, see
 `Neural Volume Rendering <https://docs.isaacsim.omniverse.nvidia.com/latest/assets/usd_assets_nurec.html>`__
 for details.
 
@@ -805,20 +804,16 @@ Log in to Hugging Face:
 
    hf auth login --token <your_huggingface_access_token>
 
-Download the required USDZ stage files and occupancy maps:
+Download the required USDZ stage file and occupancy maps:
 
 .. code:: bash
 
    hf download nvidia/PhysicalAI-Robotics-NuRec \
-      hand_hold-voyager-babyboom/stage_volume.usdz \
-      hand_hold-voyager-babyboom/stage_particle.usdz \
+      hand_hold-voyager-babyboom/particle_sh_optimized.usdz \
       hand_hold-voyager-babyboom/occupancy_map.png \
       hand_hold-voyager-babyboom/occupancy_map.yaml \
       --repo-type dataset \
       --local-dir <PATH_TO_USD_ASSET>
-
-The sample includes both a volume-based USD (``stage_volume.usdz``) and a particle-field USD
-(``stage_particle.usdz``). Either can be used as the background asset.
 
 Asset requirements
 """"""""""""""""""
@@ -831,11 +826,6 @@ compatible with the SDG pipeline:
   object placement.
 - An occupancy map is required for path planning.
 
-  - If your scene was reconstructed using the `Stereo Workflow <https://docs.nvidia.com/nurec/robotics/neural_reconstruction_stereo.html>`__,
-    the occupancy map is generated via ``nvblox``.
-  - If your background includes a mesh, use the `Occupancy Map Generator <https://docs.isaacsim.omniverse.nvidia.com/latest/digital_twin/ext_isaacsim_asset_generator_occupancy_map.html>`__
-    to create a map via physical simulation.
-
 Generating the dataset
 """"""""""""""""""""""
 
@@ -843,13 +833,7 @@ Before proceeding, ensure you have generated a manipulation dataset or downloade
 dataset provided in the
 :ref:`Generate the manipulation dataset <generate-the-manipulation-dataset>` section.
 
-Once you have gathered:
-
-- A manipulation dataset
-- A background USD asset
-- A matched occupancy map
-
-you can run the generation command. At runtime, the script adds a ground plane at ``z=0`` to
+At runtime, the script adds a ground plane at ``z=0`` to
 the scene. It then proceeds through four stages:
 
 1. **Pick**: The robot picks up an object at the start location by replaying the manipulation
@@ -873,18 +857,20 @@ Run the generation command:
        --num_runs 1 \
        --lift_step 60 \
        --navigate_step 130 \
-       --output_file <DATASET_FOLDER>/generated_dataset_g1_locomanipulation_sdg_gaussian_background.hdf5 \
-       --visualizer kit \
-       --background_usd_path <PATH_TO_USD_ASSET>/stage_particle.usdz \
-       --background_occupancy_yaml_file <PATH_TO_USD_ASSET>/occupancy_map.yaml \
-       --randomize_placement \
+       --output_file <DATASET_FOLDER>/generated_dataset_g1_locomanipulation_sdg_nurec.hdf5 \
+       --background_usd_path <PATH_TO_USD_ASSET>/hand_hold-voyager-babyboom/particle_sh_optimized.usdz \
+       --background_occupancy_yaml_file <PATH_TO_USD_ASSET>/hand_hold-voyager-babyboom/occupancy_map.yaml \
        --high_res_video
+
+To inspect the run in the GUI, add ``--viz kit``; adjust the perspective camera, or switch
+the viewport to the robot camera view for clearer visualization.
 
 The key parameters are:
 
-- ``--background_usd_path``: Path to the 3D Gaussian background USD asset.
-- ``--background_occupancy_yaml_file``: Path to the occupancy map file.
-- ``--high_res_video``: Capture the ego-centric camera at 960×540 instead of the default
+- ``--background_usd_path``: Path to the 3D Gaussian NuRec USD asset.
+- ``--background_occupancy_yaml_file``: Path to the NuRec occupancy map file.
+- Placement randomization is enabled automatically when a NuRec scene is used.
+- ``--high_res_video``: Capture the ego-centric camera at 512×320 instead of the default
   256×160.
 
 When the run completes successfully, an HDF5 dataset is generated containing camera
@@ -892,23 +878,15 @@ observations. You can convert the ego-centric camera view to MP4:
 
 .. code:: bash
 
-   uv run python scripts/tools/hdf5_to_mp4.py \
-      --input_file <DATASET_FOLDER>/generated_dataset_g1_locomanipulation_sdg_gaussian_background.hdf5 \
+   uv run --extra mimic python scripts/tools/hdf5_to_mp4.py \
+      --input_file <DATASET_FOLDER>/generated_dataset_g1_locomanipulation_sdg_nurec.hdf5 \
       --output_dir <DATASET_FOLDER>/ \
       --input_keys robot_pov_cam \
-      --video_width 960 \
-      --video_height 540
+      --video_width 512 \
+      --video_height 320
 
 Set ``--video_width`` and ``--video_height`` to match the resolution captured during
-generation: 960×540 with ``--high_res_video``, or 256×160 without it.
-
-To play the generated MP4 video on Ubuntu, install the following multimedia packages:
-
-.. code:: bash
-
-   sudo apt update
-   sudo apt install libavcodec-extra gstreamer1.0-libav gstreamer1.0-plugins-ugly
-
+generation: 512×320 with ``--high_res_video``, or 256×160 without it.
 
 .. figure:: https://download.isaacsim.omniverse.nvidia.com/isaaclab/images/locomanipulation_sdg_gaussian_background_2x.webp
    :width: 100%

--- a/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
+++ b/scripts/imitation_learning/locomanipulation_sdg/generate_data.py
@@ -95,13 +95,13 @@ parser.add_argument(
     "--background_usd_path",
     type=str,
     default=None,
-    help="Path to the USD file for the background asset",
+    help="Path to the NuRec USD file.",
 )
 parser.add_argument(
     "--background_occupancy_yaml_file",
     type=str,
     default=None,
-    help="Path to the occupancy map YAML file for the background asset",
+    help="Path to the NuRec occupancy map YAML file.",
 )
 parser.add_argument(
     "--high_res_video",
@@ -126,7 +126,7 @@ AppLauncher.add_app_launcher_args(parser)
 # forward unrecognized args as Hydra-style task config overrides
 args_cli, hydra_overrides = parser.parse_known_args()
 
-app_launcher = AppLauncher(args_cli)
+app_launcher = AppLauncher(args_cli, enable_cameras=True)
 simulation_app = app_launcher.app
 
 import enum
@@ -358,7 +358,9 @@ def project_robot_state_into_env(env: LocomanipulationSDGEnv, input_episode_data
     )
     default_vel = env.scene["robot"].data.default_root_vel.torch.clone()
     default_vel[0] = torch.zeros(6, device=env.device)
-    env.scene["robot"].data.default_root_vel.warp.assign(wp.from_torch(default_vel.to(env.device).contiguous()))
+    env.scene["robot"].data.default_root_vel.warp.assign(
+        wp.from_torch(default_vel.to(env.device).contiguous()).view(wp.spatial_vectorf)
+    )
 
     robot_state = recording_initial_state["articulation"]["robot"]
     joint_position = robot_state["joint_position"][0].to(env.device)
@@ -409,7 +411,9 @@ def project_object_state_into_env(env: LocomanipulationSDGEnv, input_episode_dat
     )
     default_vel = env.scene["object"].data.default_root_vel.torch.clone()
     default_vel[0] = torch.zeros(6, device=env.device)
-    env.scene["object"].data.default_root_vel.warp.assign(wp.from_torch(default_vel.to(env.device).contiguous()))
+    env.scene["object"].data.default_root_vel.warp.assign(
+        wp.from_torch(default_vel.to(env.device).contiguous()).view(wp.spatial_vectorf)
+    )
 
     return new_object_pose
 
@@ -438,8 +442,7 @@ def setup_navigation_scene(
     if background_fixture is not None:
         occupancy_map = background_fixture.get_occupancy_map()
         fixtures = [env.get_start_fixture(), env.get_end_fixture()] + env.get_obstacle_fixtures()
-        if not randomize_placement:
-            raise ValueError("randomize_placement needs to be True when background_usd_path is provided")
+        randomize_placement = True
     else:
         occupancy_map = merge_occupancy_maps(
             [
@@ -484,17 +487,20 @@ def setup_navigation_scene(
     env.obs_buf = env.observation_manager.compute(update_history=True)
 
     nav_map = occupancy_map.buffered_meters(0.15)
-    nav_fs = nav_map.freespace_mask()
-    start_pos = env.get_base().get_pose()[0, :2].detach().cpu().numpy()
-    start_px = nav_map.world_to_pixel_numpy(start_pos[None])[0].astype(int)
-    sx, sy = int(start_px[0]), int(start_px[1])
 
-    # Clear the buffer zone around the robot's start pixel if it falls inside it.
-    # The robot stands adjacent to the start table so its position sits within the 0.15m buffer.
-    if 0 <= sy < nav_fs.shape[0] and 0 <= sx < nav_fs.shape[1] and not nav_fs[sy, sx]:
+    def clear_nav_map_buffer(world_xy: torch.Tensor | np.ndarray):
+        nav_fs = nav_map.freespace_mask()
+        pixel_xy = nav_map.world_to_pixel_numpy(np.asarray(world_xy)[None])[0].astype(int)
+        x_px, y_px = int(pixel_xy[0]), int(pixel_xy[1])
+        if not (0 <= y_px < nav_fs.shape[0] and 0 <= x_px < nav_fs.shape[1]) or nav_fs[y_px, x_px]:
+            return
         clear_r = int(0.15 / nav_map.resolution)
         yy, xx = np.ogrid[: nav_map.data.shape[0], : nav_map.data.shape[1]]
-        nav_map.data[(xx - sx) ** 2 + (yy - sy) ** 2 <= clear_r**2] = OccupancyMapDataValue.FREESPACE
+        nav_map.data[(xx - x_px) ** 2 + (yy - y_px) ** 2 <= clear_r**2] = OccupancyMapDataValue.FREESPACE
+
+    # The robot start and approach goal can sit adjacent to their tables, inside the 0.15 m buffer.
+    clear_nav_map_buffer(env.get_base().get_pose()[0, :2].detach().cpu().numpy())
+    clear_nav_map_buffer(base_goal_approach.get_pose()[0, :2].detach().cpu().numpy())
 
     base_path = plan_path(start=env.get_base(), end=base_goal_approach, occupancy_map=nav_map)
 
@@ -899,6 +905,11 @@ def replay(
         print("Failed to setup navigation scene", flush=True)
         return False
 
+    # Background placement can move fixtures and re-project robot/object root poses
+    # after reset_to records initial_state. Re-record from the projected scene.
+    env.recorder_manager.reset(env_ids=[0])
+    env.recorder_manager.record_post_reset(env_ids=[0])
+
     if sensor_camera_view:
         _set_sensor_camera_view()
 
@@ -1001,7 +1012,17 @@ if __name__ == "__main__":
         env_cfg.recorders.dataset_export_mode = DatasetExportMode.EXPORT_SUCCEEDED_ONLY
         env_cfg.recorders.export_in_record_pre_reset = True
 
-        if args_cli.background_usd_path is not None and args_cli.background_occupancy_yaml_file is not None:
+        nurec_scene_used = (
+            args_cli.background_usd_path is not None or args_cli.background_occupancy_yaml_file is not None
+        )
+        if nurec_scene_used and (
+            args_cli.background_usd_path is None or args_cli.background_occupancy_yaml_file is None
+        ):
+            raise ValueError(
+                "Both --background_usd_path and --background_occupancy_yaml_file must be provided for NuRec scenes."
+            )
+
+        if nurec_scene_used:
             env_cfg.background_usd_path = args_cli.background_usd_path
             env_cfg.background_occupancy_yaml_file = args_cli.background_occupancy_yaml_file
 
@@ -1048,7 +1069,7 @@ if __name__ == "__main__":
                 following_offset=args_cli.following_offset,
                 angle_threshold=args_cli.angle_threshold,
                 approach_distance=args_cli.approach_distance,
-                randomize_placement=args_cli.randomize_placement,
+                randomize_placement=args_cli.randomize_placement or nurec_scene_used,
                 sensor_camera_view=args_cli.sensor_camera_view,
             )
 

--- a/source/isaaclab_mimic/changelog.d/locomanip-nurec-sdg.rst
+++ b/source/isaaclab_mimic/changelog.d/locomanip-nurec-sdg.rst
@@ -1,0 +1,7 @@
+Fixed
+^^^^^
+
+* Fixed locomanipulation SDG generation with NuRec backgrounds by enabling camera capture, applying Isaac RTX
+  Gaussian renderer settings, syncing randomized fixture poses, and recording the projected scene state after
+  placement. ``--high_res_video`` now records RGB observations at 512x320 instead of 960x540; update MP4
+  conversion dimensions and model input shapes accordingly.

--- a/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/envs/g1_locomanipulation_sdg_env.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import torch
+from isaaclab_physx.renderers import IsaacRtxRendererCfg, IsaacRtxRendererGlobalSettingsCfg
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import AssetBaseCfg
@@ -35,6 +36,11 @@ from .locomanipulation_sdg_env_cfg import LocomanipulationSDGEnvCfg, Locomanipul
 
 NUM_FORKLIFTS = 0
 NUM_BOXES = 0
+ISAAC_RTX_GAUSSIAN_CAMERA_RENDERER_CARB_SETTINGS = {
+    "/rtx/rtpt/gaussian/accumulatedDepth/allHits/enabled": True,
+    "/rtx/rtpt/gaussian/accumulatedAlbedo/enabled": True,
+    "/rtx/rtpt/gaussian/maxGaussiansToAccumulate": 360,
+}
 
 
 @configclass
@@ -52,7 +58,17 @@ class G1LocomanipulationSDGSceneCfg(LocomanipulationG1SceneCfg):
         ),
     )
 
-    def add_robot_pov_cam(self, height, width):
+    def add_robot_pov_cam(self, height, width, use_nurec_renderer_settings: bool = False):
+        camera_kwargs = {}
+        if use_nurec_renderer_settings:
+            camera_kwargs["renderer_cfg"] = IsaacRtxRendererCfg(
+                global_settings=IsaacRtxRendererGlobalSettingsCfg(
+                    enable_dl_denoiser=True,
+                    antialiasing_mode="DLSS",
+                    carb_settings=ISAAC_RTX_GAUSSIAN_CAMERA_RENDERER_CARB_SETTINGS,
+                )
+            )
+
         robot_pov_cam = CameraCfg(
             prim_path="{ENV_REGEX_NS}/Robot/torso_link/d435_link/camera",
             update_period=0.0,
@@ -61,6 +77,7 @@ class G1LocomanipulationSDGSceneCfg(LocomanipulationG1SceneCfg):
             data_types=["rgb"],
             spawn=sim_utils.PinholeCameraCfg(focal_length=8.0, clipping_range=(0.1, 20.0)),
             offset=CameraCfg.OffsetCfg(pos=(0.0, 0.0, 0.0), rot=(0.0, -0.1736482, 0.0, 0.9848078), convention="world"),
+            **camera_kwargs,
         )
         setattr(self, "robot_pov_cam", robot_pov_cam)
 
@@ -176,10 +193,10 @@ class G1LocomanipulationSDGEnv(LocomanipulationSDGEnv):
             self._num_boxes = NUM_BOXES
             set_ground_invisible = False
 
-        if cfg.high_res_video:
-            cfg.scene.add_robot_pov_cam(540, 960)
-        else:
-            cfg.scene.add_robot_pov_cam(160, 256)
+        camera_height, camera_width = (320, 512) if cfg.high_res_video else (160, 256)
+        cfg.scene.add_robot_pov_cam(
+            camera_height, camera_width, use_nurec_renderer_settings=cfg.background_usd_path is not None
+        )
 
         cfg.scene.add_forklifts(self._num_forklifts)
         cfg.scene.add_boxes(self._num_boxes)

--- a/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/scene_utils.py
+++ b/source/isaaclab_mimic/isaaclab_mimic/locomanipulation_sdg/scene_utils.py
@@ -11,7 +11,7 @@ import warp as wp
 
 import isaaclab.utils.math as math_utils
 from isaaclab.assets import AssetBaseCfg
-from isaaclab.sim.views import FrameView
+from isaaclab.sim.views import UsdFrameView
 
 from .occupancy_map_utils import OccupancyMap, intersect_occupancy_maps
 from .transform_utils import transform_mul
@@ -101,10 +101,11 @@ class SceneAsset(HasPose):
     def __init__(self, scene, entity_name: str):
         self.scene = scene
         self.entity_name = entity_name
-        self._xform_view: FrameView | None = None
+        self._xform_view: UsdFrameView | None = None
+        self._cached_pose: torch.Tensor | None = None
 
-    def _get_xform_view(self) -> FrameView:
-        """Return the FrameView for this asset, building it on demand.
+    def _get_xform_view(self) -> UsdFrameView:
+        """Return the USD transform view for this asset, building it on demand.
 
         Static scene assets carry no runtime view (``scene[name]`` returns the spawned
         configuration), so the pose view is created lazily here and cached on this
@@ -114,23 +115,27 @@ class SceneAsset(HasPose):
         if self._xform_view is None or self._xform_view.count == 0:
             if self._xform_view is not None:
                 self._xform_view.close()
+            self._cached_pose = None
             entity = self.scene[self.entity_name]
             prim_path = (
                 entity.prim_path
                 if isinstance(entity, AssetBaseCfg)
                 else getattr(entity, "_usd_view", entity)._prim_path
             )
-            self._xform_view = FrameView(prim_path, device=self.scene.device)
+            self._xform_view = UsdFrameView(prim_path, device=self.scene.device)
         return self._xform_view
 
     def get_pose(self):
         """Get the 3D pose of the entity."""
+        if self._cached_pose is not None:
+            return self._cached_pose.clone()
         xform_prim = self._get_xform_view()
         pos_w, quat_w = xform_prim.get_world_poses()
         position = pos_w.torch
         orientation = quat_w.torch
         pose = torch.cat([position, orientation], dim=-1)
-        return pose
+        self._cached_pose = pose.detach().clone()
+        return self._cached_pose.clone()
 
     def set_pose(self, pose: torch.Tensor):
         """Set the 3D pose of the entity."""
@@ -139,6 +144,16 @@ class SceneAsset(HasPose):
         orientation = pose[..., 3:]
         with xform_prim.xform_world_space_writer() as writer:
             writer.set_poses(wp.from_torch(position.contiguous()), wp.from_torch(orientation.contiguous()), None)
+        self._cached_pose = pose.detach().clone()
+        entity = self.scene[self.entity_name]
+        if isinstance(entity, AssetBaseCfg):
+            # Static assets have no runtime data object, so keep their config pose aligned.
+            pose_cfg = pose[0] if pose.ndim > 1 else pose
+            env_origin = self.scene.env_origins[0].to(pose_cfg.device)
+            pos = (pose_cfg[:3] - env_origin).detach().cpu().tolist()
+            rot = pose_cfg[3:].detach().cpu().tolist()
+            entity.init_state.pos = tuple(float(value) for value in pos)
+            entity.init_state.rot = tuple(float(value) for value in rot)
 
 
 class RelativePose(HasPose):


### PR DESCRIPTION
# Fixed locomanipulation NuRec SDG generation

Hugging Face NuRec assets were updated to v0.2. This PR updates locomanip_sdg to use the v0.2 assets and fixes several issues in the NuRec SDG workflow:

  - Fixed navigation pose projection and recorder initial-state capture after placement.
  - Synced randomized static fixture poses so downstream success checks use the placed table pose
  - Applied Isaac RTX Gaussian camera settings for NuRec camera capture.
  - Automatically enabled placement randomization when a NuRec scene is used.
 
## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Screenshots

<img width="692" height="437" alt="image" src="https://github.com/user-attachments/assets/5491a85a-cd94-4fa0-818e-66e4983cdd6c" />


## Checklist

Docker and GPU tests run on demand. Push the commits you want tested, then
comment `run-ci` on the pull request.

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a changelog fragment under `source/<pkg>/changelog.d/` for every touched package (do **not** edit `CHANGELOG.rst` or bump `extension.toml` — CI handles that)
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
