### PR TITLE
[Fix] Cache static joint limits across in-hand task resets

### DIFF
--- a/source/isaaclab_tasks/changelog.d/reorient-handover-joint-limit-cache.rst
+++ b/source/isaaclab_tasks/changelog.d/reorient-handover-joint-limit-cache.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Removed a redundant ``joint_limits`` read from every reorientation and handover reset. The limits are a
+  static model property already available from initialization; re-reading them per reset cost a
+  pinned-host staging read and a host-to-device copy on backends that keep the property on the CPU.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env.py
@@ -79,9 +79,14 @@ class HandoverEnv(DirectMARLEnv):
         self.num_fingertips = len(self.finger_bodies)
 
         # joint limits
-        joint_pos_limits = self.right_hand.data.joint_limits.torch
-        self.hand_dof_lower_limits = joint_pos_limits[..., 0]
-        self.hand_dof_upper_limits = joint_pos_limits[..., 1]
+        # Static model properties, so read them once per hand: on backends that keep them
+        # host-side (OvPhysX) each read stages through a pinned buffer and copies to device.
+        # Cached for the episode: limits written after setup (e.g. ``randomize_joint_parameters``)
+        # are NOT picked up here.
+        self.right_hand_dof_limits = self.right_hand.data.joint_limits.torch
+        self.left_hand_dof_limits = self.left_hand.data.joint_limits.torch
+        self.hand_dof_lower_limits = self.right_hand_dof_limits[..., 0]
+        self.hand_dof_upper_limits = self.right_hand_dof_limits[..., 1]
 
         # default goal positions
         self.goal_rot = torch.zeros((self.num_envs, 4), dtype=torch.float, device=self.device)
@@ -299,7 +304,7 @@ class HandoverEnv(DirectMARLEnv):
 
         # reset right hand
         default_dof_pos = self.right_hand.data.default_joint_pos.torch[env_ids]
-        dof_limits = self.right_hand.data.joint_limits.torch[env_ids]
+        dof_limits = self.right_hand_dof_limits[env_ids]
         dof_pos = sample_joint_positions_within_limits(default_dof_pos, dof_limits, self.cfg.reset_dof_pos_noise)
 
         dof_vel_noise = sample_uniform(-1.0, 1.0, (len(env_ids), self.num_hand_dofs), device=self.device)
@@ -314,7 +319,7 @@ class HandoverEnv(DirectMARLEnv):
 
         # reset left hand
         default_dof_pos = self.left_hand.data.default_joint_pos.torch[env_ids]
-        dof_limits = self.left_hand.data.joint_limits.torch[env_ids]
+        dof_limits = self.left_hand_dof_limits[env_ids]
         dof_pos = sample_joint_positions_within_limits(default_dof_pos, dof_limits, self.cfg.reset_dof_pos_noise)
 
         dof_vel_noise = sample_uniform(-1.0, 1.0, (len(env_ids), self.num_hand_dofs), device=self.device)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/mdp/events.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/mdp/events.py
@@ -11,41 +11,66 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import isaaclab.utils.math as math_utils
-from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import ManagerTermBase, SceneEntityCfg
 
 from isaaclab_tasks.core.reorient.utils import sample_joint_positions_within_limits
 
 if TYPE_CHECKING:
     from isaaclab.assets import Articulation
     from isaaclab.envs import ManagerBasedRLEnv
+    from isaaclab.managers import EventTermCfg
 
 
-def reset_reorient_hand(
-    env: ManagerBasedRLEnv,
-    env_ids: Sequence[int],
-    joint_position_noise: float,
-    joint_velocity_noise: float,
-    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
-) -> None:
+class reset_reorient_hand(ManagerTermBase):
     """Reset the hand's joints and the position targets tracking them.
 
     Task-local rather than :func:`~isaaclab.envs.mdp.reset_joints_by_offset`: the
     hand's PD targets must be re-seeded alongside the joint state, and the framework
     terms write joint state only.
 
-    Args:
-        env: Environment containing the robot.
-        env_ids: Environment indices to reset.
-        joint_position_noise: Scale applied to sampled joint-position deltas.
-        joint_velocity_noise: Joint-velocity noise half-width [rad/s].
-        robot_cfg: Robot scene entity.
+    A term rather than a plain function so the joint limits are read once. They are a static
+    model property, and on backends that keep them host-side (OvPhysX) every read stages
+    through a pinned buffer and copies to the device -- a cost paid on each reset otherwise.
+
+    The limits are cached at term construction, so limits written later in the run (for example by
+    :func:`~isaaclab.envs.mdp.events.randomize_joint_parameters`) are NOT reflected here.
     """
-    robot: Articulation = env.scene[robot_cfg.name]
-    default_position = robot.data.default_joint_pos.torch[env_ids]
-    limits = robot.data.joint_limits.torch[env_ids]
-    joint_position = sample_joint_positions_within_limits(default_position, limits, joint_position_noise)
-    velocity_sample = math_utils.sample_uniform(-1.0, 1.0, (len(env_ids), robot.num_joints), device=env.device)
-    joint_velocity = robot.data.default_joint_vel.torch[env_ids] + joint_velocity_noise * velocity_sample
-    robot.set_joint_position_target_index(target=joint_position, env_ids=env_ids)
-    robot.write_joint_position_to_sim_index(position=joint_position, env_ids=env_ids)
-    robot.write_joint_velocity_to_sim_index(velocity=joint_velocity, env_ids=env_ids)
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        """Initialize the term and cache the robot's joint limits.
+
+        Args:
+            cfg: The configuration of the event term.
+            env: The environment instance.
+        """
+        super().__init__(cfg, env)
+        robot_cfg: SceneEntityCfg = cfg.params.get("robot_cfg", SceneEntityCfg("robot"))
+        self.robot: Articulation = env.scene[robot_cfg.name]
+        self.joint_limits = self.robot.data.joint_limits.torch
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],
+        joint_position_noise: float,
+        joint_velocity_noise: float,
+        robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    ) -> None:
+        """Reset the selected environments.
+
+        Args:
+            env: Environment containing the robot.
+            env_ids: Environment indices to reset.
+            joint_position_noise: Scale applied to sampled joint-position deltas.
+            joint_velocity_noise: Joint-velocity noise half-width [rad/s].
+            robot_cfg: Robot scene entity.
+        """
+        robot = self.robot
+        default_position = robot.data.default_joint_pos.torch[env_ids]
+        limits = self.joint_limits[env_ids]
+        joint_position = sample_joint_positions_within_limits(default_position, limits, joint_position_noise)
+        velocity_sample = math_utils.sample_uniform(-1.0, 1.0, (len(env_ids), robot.num_joints), device=env.device)
+        joint_velocity = robot.data.default_joint_vel.torch[env_ids] + joint_velocity_noise * velocity_sample
+        robot.set_joint_position_target_index(target=joint_position, env_ids=env_ids)
+        robot.write_joint_position_to_sim_index(position=joint_position, env_ids=env_ids)
+        robot.write_joint_velocity_to_sim_index(velocity=joint_velocity, env_ids=env_ids)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_direct_env.py
@@ -136,9 +136,13 @@ class ReorientDirectEnv(DirectRLEnv):
             for body_name in fingertip_body_names:
                 self.finger_wrench_bodies.append(self._joint_wrench_sensor.body_names.index(body_name))
             self.finger_wrench_bodies.sort()
-        joint_pos_limits = self.hand.data.joint_limits.torch.to(self.device)
-        self.hand_dof_lower_limits = joint_pos_limits[..., 0]
-        self.hand_dof_upper_limits = joint_pos_limits[..., 1]
+        # Joint limits are a static model property, so read them once: on backends that keep
+        # them host-side (OvPhysX) each read stages through a pinned buffer and copies to device.
+        # Cached for the episode: limits written after setup (e.g. ``randomize_joint_parameters``)
+        # are NOT picked up here.
+        self.hand_dof_limits = self.hand.data.joint_limits.torch.to(self.device)
+        self.hand_dof_lower_limits = self.hand_dof_limits[..., 0]
+        self.hand_dof_upper_limits = self.hand_dof_limits[..., 1]
 
         # -- actuation targets (EMA-smoothed joint position targets) --
         self.prev_targets = torch.zeros((self.num_envs, self.num_hand_dofs), dtype=torch.float, device=self.device)
@@ -368,7 +372,7 @@ class ReorientDirectEnv(DirectRLEnv):
 
         # reset hand
         default_dof_pos = self.hand.data.default_joint_pos.torch[env_ids]
-        dof_limits = self.hand.data.joint_limits.torch[env_ids]
+        dof_limits = self.hand_dof_limits[env_ids]
         dof_pos = sample_joint_positions_within_limits(default_dof_pos, dof_limits, self.cfg.reset_dof_pos_noise)
 
         dof_vel_noise = sample_uniform(-1.0, 1.0, (len(env_ids), self.num_hand_dofs), device=self.device)


### PR DESCRIPTION
# Description

The reorientation and handover tasks read `joint_limits` from the asset on **every reset**. The
limits are a static model property that setup has already read, and on backends that keep such
properties host-side (OvPhysX) each read stages through a pinned host buffer and copies to the
simulation device. PhysX serves the same property from device memory, so the cost is invisible
there and shows up only on OvPhysX.

This reuses the value captured at initialization, in **both workflows of both tasks**:

| task | workflow | site |
|---|---|---|
| Reorient | Direct | `reorient_direct_env.py` — `_reset_idx` reuses the `__init__` value |
| Reorient | Manager | `mdp/events.py` — `reset_reorient_hand` becomes a `ManagerTermBase` |
| Handover | Direct | `handover_env.py` — both hands cached (only the right one was) |
| Handover | Manager | reuses `reorient_mdp.reset_reorient_hand`, one instance per hand |

`reset_reorient_hand` keeps its name, so `func=mdp.reset_reorient_hand` in the Allegro, Shadow and
handover configurations is unchanged. Snake-case `ManagerTermBase` classes match the convention
already used by `randomize_rigid_body_mass`, `randomize_joint_parameters` and friends.

## Measurement

`Isaac-Reorient-Cube-Shadow`, OvPhysX, 8 GPU box, one job at a time on an idle machine:

| | throughput |
|---|---|
| before | 117,191 ± 3,122 fps |
| after | 188,776 ± 2,346 fps |

**+61%.** PhysX is unchanged, as expected: the same property is served from device memory there,
so the redundant read costs nothing.

| backend | before | after |
|---|---|---|
| `isaacsim_physx` | 245,469 +- 383 fps | 245,469 +- 383 fps (untouched) |
| `ovphysx` | 117,191 +- 3,122 fps | 188,776 +- 2,346 fps |

In end-to-end training (`isaaclab train`, sequential on an idle box) the same fix leaves
`isaacsim_physx` at 0.82 s/iter and brings `ovphysx` to 0.94 s/iter.

### Why this shows up on these tasks

The cost is per-reset and per-articulation, so it scales with articulation complexity. Measured
across tasks (single run per cell, so read the ratios rather than the absolute numbers):

| task | ~DOF | `ovphysx` vs `isaacsim_physx` |
|---|---|---|
| `Isaac-Cartpole` | 2 | 1.43x faster |
| `Isaac-Ant` | 8 | 1.05x faster |
| `Isaac-Humanoid` | 21 | 0.92x |
| `Isaac-Reorient-Cube-Shadow` | 24 + object | 0.48x, and 0.77x with this fix |

The in-hand tasks sit at the far end of that curve -- many joints, frequent resets -- which is why
a property read that is free elsewhere dominates here.

## Note on cached limits

The cached value is not refreshed, so a term that writes joint limits during the run — notably
`isaaclab.envs.mdp.events.randomize_joint_parameters`, which writes them through
`write_joint_position_limit_to_sim_index` — would not be reflected. Neither task enables such a
term today; the caveat is documented at each call site.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have added a changelog fragment
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works

