### PR TITLE
Add task-owned recording cameras with heading tracking

### DIFF
--- a/docs/source/features/record_video.rst
+++ b/docs/source/features/record_video.rst
@@ -51,6 +51,51 @@ the environment config:
 See `Source types`_ for the full list of recordable sources and `Clip control`_ for length and
 interval options.
 
+Task-owned Camera Views
+-----------------------
+
+Set ``sim.default_visualizer_cfg`` in a task to share its recording view across Kit,
+Newton GL/RTX, Rerun, and Viser. Explicit backend customizations take precedence;
+policy camera sensors are unaffected. For example, follow a robot's position and yaw:
+
+.. code-block:: python
+
+    from isaaclab.visualizers import VisualizerCfg
+
+    self.sim.default_visualizer_cfg = VisualizerCfg(
+        origin_type="asset",
+        origin_env_index="center",
+        origin_track_path="robot",
+        origin_follow_heading=True,
+        origin_heading_smoothing_time_constant=0.2,
+        eye=(-3.0, -3.0, 2.0),
+        lookat=(0.5, 0.0, 0.0),
+    )
+
+``eye`` and ``lookat`` are offsets in meters. Use ``origin_type="env"`` for a fixed view,
+``"asset"`` to track an asset (or a body such as ``"robot/base"``), or ``"world"`` for
+absolute coordinates. Heading following rotates offsets with yaw only, keeping the horizon
+level; disabling it follows position with world-aligned offsets. The smoothing time constant
+is in seconds; zero disables filtering. Core locomotion views use 0.2 seconds, or 0.5 for
+Ant and Humanoid. Position tracking remains immediate.
+
+``origin_env_index="center"`` selects the visible environment nearest the horizontal bounding-box
+center of all environment origins, breaking ties by lowest index (27 for a standard 64-env grid).
+The selection survives resets and terrain relocation; ``visualizer.camera_env_index`` exposes it.
+An explicit index must be in range and visible. Existing Kit camera settings remain compatible.
+
+Record through the normal play command, using the task's camera automatically:
+
+.. code-block:: bash
+
+    uv run --extra video isaaclab play --rl_library rsl_rl --task Isaac-Ant \
+        --checkpoint /path/to/checkpoint.pt --num_envs 1 \
+        --viz newton_rtx --video --video_length 600
+
+Clips go to ``videos/play/`` beside the resolved checkpoint. Length is in environment steps
+(600 is 10 seconds for Ant). On Linux, prefix with ``env -u DISPLAY`` for headless OVRTX.
+See :ref:`reinforcement-learning` for checkpoint selection.
+
 
 Overview
 --------

--- a/docs/source/features/record_video.rst
+++ b/docs/source/features/record_video.rst
@@ -78,6 +78,8 @@ absolute coordinates. Heading following rotates offsets with yaw only, keeping t
 level; disabling it follows position with world-aligned offsets. The smoothing time constant
 is in seconds; zero disables filtering. Core locomotion views use 0.2 seconds, or 0.5 for
 Ant and Humanoid. Position tracking remains immediate.
+``visualizer.set_camera_view(eye, target)`` accepts world coordinates and preserves the edit
+as offsets for subsequent tracking.
 
 ``origin_env_index="center"`` selects the visible environment nearest the horizontal bounding-box
 center of all environment origins, breaking ties by lowest index (27 for a standard 64-env grid).

--- a/source/isaaclab/changelog.d/task-camera-tracking.minor.rst
+++ b/source/isaaclab/changelog.d/task-camera-tracking.minor.rst
@@ -1,0 +1,5 @@
+Added
+^^^^^
+
+* Added task-owned fixed and tracking cameras through ``VisualizerCfg``, with spatial-center
+  selection, optional yaw following and smoothing, and ``BaseVisualizer.camera_env_index``.

--- a/source/isaaclab/isaaclab/envs/ui/base_env_window.py
+++ b/source/isaaclab/isaaclab/envs/ui/base_env_window.py
@@ -445,9 +445,6 @@ class BaseEnvWindow:
         lookat = [self.ui_window_elements["viewer_lookat"][i].get_value_as_float() for i in range(3)]
         viz.set_camera_view(eye, lookat)
 
-        # Preserve world-space slider edits in the camera's configured tracking frame.
-        viz._set_camera_pose_cfg(tuple(eye), tuple(lookat))
-
     def _set_viewer_env_index_fn(self, model: omni.ui.SimpleIntModel):
         """Sets the environment index and updates the camera if in 'env' origin mode."""
         viz = self._get_kit_visualizer()

--- a/source/isaaclab/isaaclab/envs/ui/base_env_window.py
+++ b/source/isaaclab/isaaclab/envs/ui/base_env_window.py
@@ -212,7 +212,7 @@ class BaseEnvWindow:
                 viewport_origin_cfg = {
                     "label": "Environment Index",
                     "type": "button",
-                    "default_val": (_viz.cfg.origin_env_index if _viz is not None else 0) + 1,
+                    "default_val": ((_viz.camera_env_index or 0) if _viz is not None else 0) + 1,
                     "min": 1,
                     "max": self.env.num_envs,
                     "tooltip": "The environment index to follow. Only effective if follow mode is not 'World'.",
@@ -445,16 +445,8 @@ class BaseEnvWindow:
         lookat = [self.ui_window_elements["viewer_lookat"][i].get_value_as_float() for i in range(3)]
         viz.set_camera_view(eye, lookat)
 
-        # Persist the slider values back to cfg so that asset-tracking steps do not
-        # snap the camera back to the previously configured offsets.
-        origin = viz.viewer_origin
-        if origin is not None:
-            origin_np = origin.detach().cpu().numpy()
-            viz.cfg.eye = tuple(float(e - o) for e, o in zip(eye, origin_np))
-            viz.cfg.lookat = tuple(float(lk - o) for lk, o in zip(lookat, origin_np))
-        else:
-            viz.cfg.eye = tuple(float(v) for v in eye)
-            viz.cfg.lookat = tuple(float(v) for v in lookat)
+        # Preserve world-space slider edits in the camera's configured tracking frame.
+        viz._set_camera_pose_cfg(tuple(eye), tuple(lookat))
 
     def _set_viewer_env_index_fn(self, model: omni.ui.SimpleIntModel):
         """Sets the environment index and updates the camera if in 'env' origin mode."""

--- a/source/isaaclab/isaaclab/visualizers/base_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/base_visualizer.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from isaaclab.renderers.base_renderer import VisualMaterialBatch
     from isaaclab.scene_data import SceneDataProvider
 
+    from .camera_controller import _CameraController
     from .visualizer_cfg import VisualizerCfg
 
 
@@ -52,6 +53,9 @@ class BaseVisualizer(ABC):
         self._live_plot_env_idx: int = 0
         self._live_plots_step_counter: int = 0
         self._reset_requested: bool = False
+        self._camera_controller: _CameraController | None = None
+        self._camera_origin_spec: tuple | None = None
+        self._pending_world_camera_pose: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None
 
     @property
     def visual_material_writer(self) -> Callable[[tuple[VisualMaterialBatch, ...]], Any] | None:
@@ -144,6 +148,14 @@ class BaseVisualizer(ABC):
     def is_closed(self) -> bool:
         """Check if close() has been called."""
         return self._is_closed
+
+    @property
+    def camera_env_index(self) -> int | None:
+        """Resolved camera environment, or ``None`` while automatic selection is pending."""
+        if self._camera_controller is not None:
+            return self._camera_controller.env_index
+        index = self.cfg.origin_env_index
+        return index if isinstance(index, int) else None
 
     @property
     def physics_backend(self) -> str | None:
@@ -304,6 +316,60 @@ class BaseVisualizer(ABC):
             target: Camera target position.
         """
         pass
+
+    def _update_camera_tracking(self, dt: float = 0.0) -> None:
+        """Apply the task camera before rendering, without rewriting configured offsets."""
+        origin_spec = (self.cfg.origin_type, self.cfg.origin_env_index, self.cfg.origin_track_path)
+        if origin_spec != self._camera_origin_spec:
+            self._camera_controller = None
+            self._camera_origin_spec = origin_spec
+        if self.cfg.origin_type == "world":
+            if self._pending_world_camera_pose is not None:
+                pose = self._pending_world_camera_pose
+                self._set_camera_pose_cfg(*pose)
+                self._apply_camera_pose(pose)
+            return
+        if self._camera_controller is None:
+            # Visualizers may initialize before the interactive scene and asset state exist.
+            from isaaclab.sim import SimulationContext
+
+            from .camera_controller import _CameraController
+
+            scene = getattr(SimulationContext.instance(), "_interactive_scene", None)
+            if scene is None:
+                return
+            self._camera_controller = _CameraController(
+                self.cfg, scene, getattr(self, "_resolved_visible_env_ids", None)
+            )
+        pose = self._camera_controller.update(dt)
+        if pose is not None:
+            if self._pending_world_camera_pose is not None:
+                pose = self._pending_world_camera_pose
+                self._set_camera_pose_cfg(*pose)
+            self._apply_camera_pose(pose)
+
+    def _set_camera_pose_cfg(self, eye: tuple[float, float, float], target: tuple[float, float, float]) -> None:
+        """Persist a world-space camera edit as offsets in the configured origin frame."""
+        eye = tuple(float(v) for v in eye)
+        target = tuple(float(v) for v in target)
+        if self.cfg.origin_type != "world":
+            origin_spec = (self.cfg.origin_type, self.cfg.origin_env_index, self.cfg.origin_track_path)
+            if (
+                self._camera_controller is None
+                or not self._camera_controller.has_pose
+                or origin_spec != self._camera_origin_spec
+            ):
+                # A queued world-space edit must wait for the first valid origin and heading.
+                self._pending_world_camera_pose = (eye, target)
+                return
+            eye, target = self._camera_controller.world_to_offsets(eye, target)
+        self.cfg.eye = eye
+        self.cfg.lookat = target
+        self._pending_world_camera_pose = None
+
+    def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
+        """Apply a world-space pose; backends must preserve the configured camera offsets."""
+        self.set_camera_view(*pose)
 
     def _resolve_cfg_camera_pose(
         self, _visualizer_name: str

--- a/source/isaaclab/isaaclab/visualizers/base_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/base_visualizer.py
@@ -324,24 +324,21 @@ class BaseVisualizer(ABC):
             self._camera_controller = None
             self._camera_origin_spec = origin_spec
         if self.cfg.origin_type == "world":
-            if self._pending_world_camera_pose is not None:
-                pose = self._pending_world_camera_pose
-                self._set_camera_pose_cfg(*pose)
-                self._apply_camera_pose(pose)
-            return
-        if self._camera_controller is None:
-            # Visualizers may initialize before the interactive scene and asset state exist.
-            from isaaclab.sim import SimulationContext
+            pose = self._pending_world_camera_pose
+        else:
+            if self._camera_controller is None:
+                # The scene and asset state may become available after visualizer initialization.
+                from .camera_controller import _CameraController
 
-            from .camera_controller import _CameraController
-
-            scene = getattr(SimulationContext.instance(), "_interactive_scene", None)
-            if scene is None:
-                return
-            self._camera_controller = _CameraController(
-                self.cfg, scene, getattr(self, "_resolved_visible_env_ids", None)
-            )
-        pose = self._camera_controller.update(dt)
+                if self._scene_data_provider is None:
+                    return
+                scene = self._scene_data_provider.get_interactive_scene()
+                if scene is None:
+                    return
+                self._camera_controller = _CameraController(
+                    self.cfg, scene, getattr(self, "_resolved_visible_env_ids", None)
+                )
+            pose = self._camera_controller.update(dt)
         if pose is not None:
             if self._pending_world_camera_pose is not None:
                 pose = self._pending_world_camera_pose

--- a/source/isaaclab/isaaclab/visualizers/base_visualizer.py
+++ b/source/isaaclab/isaaclab/visualizers/base_visualizer.py
@@ -308,14 +308,19 @@ class BaseVisualizer(ABC):
         """
         return None
 
-    def set_camera_view(self, eye: tuple, target: tuple) -> None:
-        """Set camera view position.
+    def set_camera_view(
+        self, eye: tuple[float, float, float] | list[float], target: tuple[float, float, float] | list[float]
+    ) -> None:
+        """Set a world-space camera view and preserve it as offsets for subsequent tracking.
 
         Args:
-            eye: Camera eye position.
-            target: Camera target position.
+            eye: Camera eye position in world coordinates [m].
+            target: Camera look-at target in world coordinates [m].
         """
-        pass
+        eye = tuple(float(v) for v in eye)
+        target = tuple(float(v) for v in target)
+        self._set_camera_pose_cfg(eye, target)
+        self._apply_camera_pose((eye, target))
 
     def _update_camera_tracking(self, dt: float = 0.0) -> None:
         """Apply the task camera before rendering, without rewriting configured offsets."""
@@ -366,7 +371,7 @@ class BaseVisualizer(ABC):
 
     def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
         """Apply a world-space pose; backends must preserve the configured camera offsets."""
-        self.set_camera_view(*pose)
+        pass
 
     def _resolve_cfg_camera_pose(
         self, _visualizer_name: str

--- a/source/isaaclab/isaaclab/visualizers/camera_controller.py
+++ b/source/isaaclab/isaaclab/visualizers/camera_controller.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Shared environment-relative and asset-tracking visualizer cameras."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.utils.math import quat_apply, quat_apply_inverse, quat_slerp, yaw_quat
+
+if TYPE_CHECKING:
+    from isaaclab.scene import InteractiveScene
+
+    from .visualizer_cfg import VisualizerCfg
+
+
+class _CameraController:
+    """Resolve one camera's origin and retain its selected environment across resets."""
+
+    def __init__(self, cfg: VisualizerCfg, scene: InteractiveScene, visible_env_ids: list[int] | None) -> None:
+        self.cfg = cfg
+        self.scene = scene
+        self.env_index = self._resolve_env_index(visible_env_ids)
+        self.origin = scene.env_origins[self.env_index].detach().clone()
+        self.has_pose = False
+        self._heading: torch.Tensor | None = None
+        self._body_index: int | None = None
+        self._asset = None
+        self._body_name = ""
+        if cfg.origin_type == "asset":
+            if not cfg.origin_track_path:
+                raise ValueError("origin_type='asset' requires origin_track_path to be set.")
+            asset_name, _, self._body_name = cfg.origin_track_path.partition("/")
+            try:
+                self._asset = scene[asset_name]
+            except KeyError as exc:
+                raise ValueError(f"Camera origin_track_path refers to an unknown scene asset: {asset_name!r}.") from exc
+        elif cfg.origin_type != "env":
+            raise ValueError(f"Unknown camera origin_type: {cfg.origin_type!r}.")
+
+    def update(self, dt: float = 0.0) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+        """Return a world-space eye/target pose after elapsed time ``dt`` [s], or defer until ready."""
+        orientation = None
+        if self._asset is None:
+            if self.has_pose:
+                return None
+        else:
+            if not self._asset.is_initialized:
+                return None
+            if self._body_name:
+                if self._body_index is None:
+                    body_ids, _ = self._asset.find_bodies(self._body_name)
+                    if len(body_ids) != 1:
+                        raise ValueError(
+                            f"Camera origin_track_path must match exactly one body: {self.cfg.origin_track_path!r}."
+                        )
+                    self._body_index = body_ids[0]
+                self.origin = self._asset.data.body_pos_w.torch[self.env_index, self._body_index]
+                if self.cfg.origin_follow_heading:
+                    orientation = self._asset.data.body_quat_w.torch[self.env_index, self._body_index]
+            else:
+                self.origin = self._asset.data.root_pos_w.torch[self.env_index]
+                if self.cfg.origin_follow_heading:
+                    orientation = self._asset.data.root_quat_w.torch[self.env_index]
+        offsets = self.origin.new_tensor((self.cfg.eye, self.cfg.lookat))
+        heading = yaw_quat(orientation) if orientation is not None else None
+        time_constant = self.cfg.origin_heading_smoothing_time_constant
+        if heading is not None and self._heading is not None and time_constant > 0.0:
+            # Interpolate yaw only; slerp handles the shortest path across the +/-pi boundary.
+            weight = -math.expm1(-max(dt, 0.0) / time_constant)
+            heading = quat_slerp(self._heading, heading, weight)
+        self._heading = heading
+        if self._heading is not None:
+            offsets = quat_apply(self._heading.expand(2, -1), offsets)
+        eye, target = (offsets + self.origin).detach().cpu().tolist()
+        self.has_pose = True
+        return tuple(eye), tuple(target)
+
+    def world_to_offsets(
+        self, eye: tuple[float, float, float], target: tuple[float, float, float]
+    ) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+        """Convert a world-space camera edit back into the last rendered tracking frame."""
+        offsets = self.origin.new_tensor((eye, target)) - self.origin
+        if self._heading is not None:
+            offsets = quat_apply_inverse(self._heading.expand(2, -1), offsets)
+        eye_offset, target_offset = offsets.detach().cpu().tolist()
+        return tuple(eye_offset), tuple(target_offset)
+
+    def _resolve_env_index(self, visible_env_ids: list[int] | None) -> int:
+        """Choose a visible environment using physical layout rather than array ordering."""
+        num_envs = self.scene.num_envs
+        candidates = sorted(set(visible_env_ids)) if visible_env_ids is not None else list(range(num_envs))
+        if not candidates:
+            raise ValueError("Camera origin requires at least one visible environment.")
+        if self.cfg.origin_env_index == "center":
+            xy = self.scene.env_origins[:, :2]
+            center = (xy.amin(dim=0) + xy.amax(dim=0)) / 2
+            distances = (xy[candidates] - center).square().sum(dim=-1)
+            return candidates[int(distances.argmin().item())]
+        index = self.cfg.origin_env_index
+        if not isinstance(index, int) or not 0 <= index < num_envs:
+            raise ValueError(f"Camera origin_env_index {index!r} is outside the environment range [0, {num_envs - 1}].")
+        if index not in candidates:
+            raise ValueError(f"Camera origin_env_index {index} is not a visible environment.")
+        return index

--- a/source/isaaclab/isaaclab/visualizers/visualizer_cfg.py
+++ b/source/isaaclab/isaaclab/visualizers/visualizer_cfg.py
@@ -7,7 +7,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import math
+from typing import TYPE_CHECKING, Literal
 
 from isaaclab.utils import configclass
 
@@ -46,10 +47,10 @@ class VisualizerCfg:
 
     # Primary interactive camera settings
     eye: tuple[float, float, float] = (4.0, -4.0, 3.0)
-    """Interactive visualizer camera eye position in world coordinates."""
+    """Camera eye offset [m] relative to :attr:`origin_type`."""
 
     lookat: tuple[float, float, float] = (0.0, 0.0, 0.0)
-    """Interactive visualizer camera look-at target in world coordinates."""
+    """Camera look-at offset [m] relative to :attr:`origin_type`."""
 
     focal_length: float = 12.0
     """Camera focal length in millimeters for visualizer camera views."""
@@ -59,6 +60,45 @@ class VisualizerCfg:
 
     Kit, Newton GL, and Newton RTX honor this field. Set it to ``None`` to preserve the
     backend's native background. Scene lighting remains independent of the visible background.
+    """
+
+    origin_type: Literal["world", "env", "asset"] = "world"
+    """Origin for :attr:`eye` and :attr:`lookat`.
+
+    ``"world"`` uses world coordinates. ``"env"`` fixes the camera relative to the selected
+    environment's initial origin. ``"asset"`` follows the asset root or body specified by
+    :attr:`origin_track_path`. These settings affect the interactive camera, not sensor streams.
+    """
+
+    origin_env_index: int | Literal["center"] = 0
+    """Environment used by ``"env"`` and ``"asset"`` origins.
+
+    ``"center"`` selects the visible environment nearest the horizontal bounding-box center
+    of all environment origins, with the lowest index breaking ties. Selection happens once
+    when the scene becomes available and is retained across episode resets. Explicit indices
+    must be in range and visible. The default preserves environment zero.
+    """
+
+    origin_track_path: str | None = None
+    """Scene asset to follow when :attr:`origin_type` is ``"asset"``.
+
+    Use ``"robot"`` for an asset root or ``"robot/base"`` for a named body. A body path must
+    match exactly one body on the asset.
+    """
+
+    origin_follow_heading: bool = False
+    """Rotate :attr:`eye` and :attr:`lookat` offsets with the tracked asset's yaw.
+
+    Only used with ``origin_type="asset"``. Roll and pitch are ignored to keep the horizon
+    level. The default follows position only, with offsets aligned to the world axes.
+    """
+
+    origin_heading_smoothing_time_constant: float = 0.0
+    """Exponential heading-filter time constant [s]. Zero disables smoothing.
+
+    Only used with ``origin_type="asset"`` and ``origin_follow_heading=True``. Positive values
+    smooth yaw along the shortest rotation while position follows immediately. Larger values
+    reduce rapid rotation more, with more lag. The first valid heading is applied immediately.
     """
 
     # ── Streaming view ────────────────────────────────────────────────────────
@@ -191,6 +231,12 @@ class VisualizerCfg:
             if len(self.background_color) != 3 or any(not 0.0 <= value <= 1.0 for value in self.background_color):
                 raise ValueError("background_color must contain three normalized RGB values in [0, 1].")
             self.background_color = tuple(float(value) for value in self.background_color)
+
+        if (
+            not math.isfinite(self.origin_heading_smoothing_time_constant)
+            or self.origin_heading_smoothing_time_constant < 0.0
+        ):
+            raise ValueError("origin_heading_smoothing_time_constant must be finite and non-negative.")
 
         _simple = [
             ("tiled_cam_view", "streaming_view"),

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -886,10 +886,6 @@ def test_default_visualizer_cfg_applies_to_explicit_visualizer_cfgs():
         eye=(8.0, 0.0, 5.0),
         lookat=(0.0, 0.0, 0.5),
         streaming_cam_target_prim_path="/World/envs/*/Object",
-        origin_type="asset",
-        origin_env_index="center",
-        origin_track_path="robot",
-        origin_follow_heading=True,
     )
     # Explicit Newton cfg with only window_width customized; eye/lookat at class defaults.
     explicit_cfg = NewtonGLVisualizerCfg(window_width=320, window_height=240)
@@ -902,10 +898,6 @@ def test_default_visualizer_cfg_applies_to_explicit_visualizer_cfgs():
     assert cfgs[0].eye == (8.0, 0.0, 5.0)
     assert cfgs[0].lookat == (0.0, 0.0, 0.5)
     assert cfgs[0].streaming_cam_target_prim_path == "/World/envs/*/Object"
-    assert cfgs[0].origin_type == "asset"
-    assert cfgs[0].origin_env_index == "center"
-    assert cfgs[0].origin_track_path == "robot"
-    assert cfgs[0].origin_follow_heading is True
     # user-customized fields preserved
     assert cfgs[0].window_width == 320
     assert cfgs[0].window_height == 240
@@ -1267,64 +1259,6 @@ def test_tracking_camera_updates_before_backend_frame(monkeypatch, backend):
     assert poses == [((12.0, 20.0, 1.0), (10.0, 20.0, 0.0))]
     assert viz.cfg.eye == (2, 0, 1)
     assert viz.cfg.lookat == (0, 0, 0)
-
-
-def test_newton_tracking_pose_does_not_rewrite_relative_offsets(monkeypatch):
-    from types import SimpleNamespace
-
-    import torch
-    from isaaclab_newton.physics import NewtonManager
-    from isaaclab_visualizers.newton.newton_visualizer import NewtonGLVisualizer
-
-    cfg = NewtonGLVisualizerCfg(
-        origin_type="asset",
-        origin_track_path="robot",
-        origin_follow_heading=True,
-        eye=(2, 0, 1),
-        lookat=(1, 0, 0),
-    )
-    positions = torch.tensor([[10.0, 20.0, 0.0]])
-    # A 90-degree yaw, represented in xyzw order.
-    orientations = torch.tensor([[0.0, 0.0, 2**-0.5, 2**-0.5]])
-    asset = SimpleNamespace(
-        is_initialized=True,
-        data=SimpleNamespace(
-            root_pos_w=SimpleNamespace(torch=positions),
-            root_quat_w=SimpleNamespace(torch=orientations),
-        ),
-    )
-
-    class Scene:
-        num_envs = 1
-        env_origins = torch.zeros(1, 3)
-
-        def __getitem__(self, name):
-            assert name == "robot"
-            return asset
-
-    class Camera:
-        def look_at(self, target):
-            self.target = target
-
-    viz = NewtonGLVisualizer(cfg)
-    camera = Camera()
-    viz._viewer = SimpleNamespace(camera=camera)
-    viz._runtime_headless = True
-    viz._is_initialized = True
-    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=Scene()))
-    monkeypatch.setattr(NewtonManager, "get_state", lambda *args: None)
-    for x in (10.0, 30.0, -5.0):
-        positions[0, 0] = x
-        viz.step(0.1)
-        assert tuple(camera.pos) == pytest.approx((x, 22.0, 1.0))
-        assert camera.target == pytest.approx((x, 21.0, 0.0))
-        assert viz.cfg.eye == (2, 0, 1)
-        assert viz.cfg.lookat == (1, 0, 0)
-    # Public world-space camera edits must survive the next tracking update.
-    viz.set_camera_view((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
-    viz.step(0.1)
-    assert tuple(camera.pos) == pytest.approx((7.0, 12.0, 3.0), abs=1e-5)
-    assert camera.target == pytest.approx((4.0, 9.0, 1.0), abs=1e-5)
 
 
 def test_rerun_tracking_preserves_live_plot_panels(monkeypatch):

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -1233,7 +1233,6 @@ def test_tracking_camera_updates_before_backend_frame(monkeypatch, backend):
     cfg = cfg_type(origin_type="env", origin_env_index=0, eye=(2, 0, 1), lookat=(0, 0, 0), enable_markers=False)
     viz = viz_type(cfg)
     scene = SimpleNamespace(num_envs=1, env_origins=torch.tensor([[10.0, 20, 0]]))
-    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
     monkeypatch.setattr(NewtonManager, "get_state", lambda *args: None)
     monkeypatch.setattr(NewtonManager, "get_num_envs", lambda: 1)
     poses = []
@@ -1250,6 +1249,7 @@ def test_tracking_camera_updates_before_backend_frame(monkeypatch, backend):
 
     viz._viewer = Viewer()
     viz._scene_data_provider = _FakeProvider(1)
+    viz._scene_data_provider.get_interactive_scene = lambda: scene
     viz._is_initialized = True
     if backend in ("kit", "newton_gl", "newton_rtx"):
         viz._runtime_headless = True

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -445,7 +445,7 @@ def test_viser_visualizer_create_viewer_applies_visible_worlds(
         "_resolve_initial_camera_pose",
         lambda self: ((1.0, 2.0, 3.0), (0.0, 0.0, 0.0)),
     )
-    monkeypatch.setattr(viser_visualizer.ViserVisualizer, "_set_viser_camera_view", lambda self, pose: None)
+    monkeypatch.setattr(viser_visualizer.ViserVisualizer, "_apply_camera_pose", lambda self, pose: None)
 
     cfg = ViserVisualizerCfg(
         max_visible_envs=cfg_max_visible_envs,
@@ -1259,9 +1259,15 @@ def test_tracking_camera_updates_before_backend_frame(monkeypatch, backend):
     assert poses == [((12.0, 20.0, 1.0), (10.0, 20.0, 0.0))]
     assert viz.cfg.eye == (2, 0, 1)
     assert viz.cfg.lookat == (0, 0, 0)
+    viz.set_camera_view((15, 22, 3), (10, 21, 0))
+    viz._update_camera_tracking(0.0)
+    assert poses[-1] == ((15.0, 22.0, 3.0), (10.0, 21.0, 0.0))
+    assert viz.cfg.eye == (5, 2, 3)
+    assert viz.cfg.lookat == (0, 1, 0)
 
 
 def test_rerun_tracking_preserves_live_plot_panels(monkeypatch):
+    import numpy as np
     import rerun.blueprint as rrb
 
     viewer = object.__new__(rerun_visualizer.NewtonViewerRerun)
@@ -1272,6 +1278,8 @@ def test_rerun_tracking_preserves_live_plot_panels(monkeypatch):
     viz = rerun_visualizer.RerunVisualizer(RerunVisualizerCfg())
     viz._viewer = viewer
     blueprints = []
+    camera_updates = []
+    monkeypatch.setattr(rerun_visualizer.rr, "log", lambda path, data, **kwargs: camera_updates.append((path, data)))
     monkeypatch.setattr(rerun_visualizer.rr, "send_blueprint", blueprints.append)
     for eye in ((1.0, 2.0, 3.0), (4.0, 5.0, 6.0)):
         viz._apply_camera_pose((eye, (0.0, 0.0, 0.0)))
@@ -1285,6 +1293,14 @@ def test_rerun_tracking_preserves_live_plot_panels(monkeypatch):
         if root is not None:
             yield from views(root)
 
-    assert len(blueprints) == 2
+    assert len(blueprints) == 1
+    assert len(camera_updates) == 2
+    for (path, transform), eye in zip(camera_updates, ((1, 2, 3), (4, 5, 6))):
+        assert path == "viewer/camera"
+        assert transform.translation.as_arrow_array().to_pylist() == [list(eye)]
+        rotation = np.array(transform.mat3x3.as_arrow_array().to_pylist()[0]).reshape(3, 3).T
+        assert rotation @ [0, 0, -1] == pytest.approx(-np.array(eye) / np.linalg.norm(eye))
     for blueprint in blueprints:
         assert {view.name for view in views(blueprint)} >= {"reward", "termination"}
+        camera_view = next(view for view in views(blueprint) if isinstance(view, rrb.Spatial3DView))
+        assert camera_view.origin == "viewer/camera"

--- a/source/isaaclab/test/sim/test_simulation_context_visualizers.py
+++ b/source/isaaclab/test/sim/test_simulation_context_visualizers.py
@@ -819,6 +819,10 @@ def test_default_visualizer_cfg_applies_to_cli_created_configs():
     default_cfg = VisualizerCfg(
         background_color=(0.1, 0.2, 0.3),
         streaming_cam_target_prim_path="/World/envs/*/Object",
+        origin_type="asset",
+        origin_env_index="center",
+        origin_track_path="robot",
+        origin_follow_heading=True,
         streaming_cam_eye=(1.0, -1.0, 0.5),
     )
     ctx = _make_context_with_settings(settings, default_visualizer_cfg=default_cfg)
@@ -829,6 +833,10 @@ def test_default_visualizer_cfg_applies_to_cli_created_configs():
     assert isinstance(cfgs[0], NewtonVisualizerCfg)
     assert cfgs[0].background_color == (0.1, 0.2, 0.3)
     assert cfgs[0].streaming_cam_target_prim_path == "/World/envs/*/Object"
+    assert cfgs[0].origin_type == "asset"
+    assert cfgs[0].origin_env_index == "center"
+    assert cfgs[0].origin_track_path == "robot"
+    assert cfgs[0].origin_follow_heading is True
     assert cfgs[0].streaming_cam_eye == (1.0, -1.0, 0.5)
 
 
@@ -878,6 +886,10 @@ def test_default_visualizer_cfg_applies_to_explicit_visualizer_cfgs():
         eye=(8.0, 0.0, 5.0),
         lookat=(0.0, 0.0, 0.5),
         streaming_cam_target_prim_path="/World/envs/*/Object",
+        origin_type="asset",
+        origin_env_index="center",
+        origin_track_path="robot",
+        origin_follow_heading=True,
     )
     # Explicit Newton cfg with only window_width customized; eye/lookat at class defaults.
     explicit_cfg = NewtonGLVisualizerCfg(window_width=320, window_height=240)
@@ -890,6 +902,10 @@ def test_default_visualizer_cfg_applies_to_explicit_visualizer_cfgs():
     assert cfgs[0].eye == (8.0, 0.0, 5.0)
     assert cfgs[0].lookat == (0.0, 0.0, 0.5)
     assert cfgs[0].streaming_cam_target_prim_path == "/World/envs/*/Object"
+    assert cfgs[0].origin_type == "asset"
+    assert cfgs[0].origin_env_index == "center"
+    assert cfgs[0].origin_track_path == "robot"
+    assert cfgs[0].origin_follow_heading is True
     # user-customized fields preserved
     assert cfgs[0].window_width == 320
     assert cfgs[0].window_height == 240
@@ -1204,3 +1220,137 @@ def test_rerun_visualizer_setup_streaming_view_sets_flag_and_blueprint_includes_
     assert any(isinstance(item, rrb.Spatial2DView) for item in flat), (
         "_get_blueprint with streaming_view_active=True must include a Spatial2DView panel"
     )
+
+
+@pytest.mark.parametrize("backend", ["kit", "newton_gl", "newton_rtx", "viser", "rerun"])
+def test_tracking_camera_updates_before_backend_frame(monkeypatch, backend):
+    from types import SimpleNamespace
+
+    import torch
+    from isaaclab_newton.physics import NewtonManager
+    from isaaclab_visualizers.newton.newton_visualizer import NewtonGLVisualizer, NewtonRTXVisualizer
+
+    classes = {
+        "kit": (kit_visualizer.KitVisualizer, KitVisualizerCfg),
+        "newton_gl": (NewtonGLVisualizer, NewtonGLVisualizerCfg),
+        "newton_rtx": (NewtonRTXVisualizer, NewtonRTXVisualizerCfg),
+        "viser": (viser_visualizer.ViserVisualizer, ViserVisualizerCfg),
+        "rerun": (rerun_visualizer.RerunVisualizer, RerunVisualizerCfg),
+    }
+    viz_type, cfg_type = classes[backend]
+    cfg = cfg_type(origin_type="env", origin_env_index=0, eye=(2, 0, 1), lookat=(0, 0, 0), enable_markers=False)
+    viz = viz_type(cfg)
+    scene = SimpleNamespace(num_envs=1, env_origins=torch.tensor([[10.0, 20, 0]]))
+    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
+    monkeypatch.setattr(NewtonManager, "get_state", lambda *args: None)
+    monkeypatch.setattr(NewtonManager, "get_num_envs", lambda: 1)
+    poses = []
+    # Capture the output boundary; the real step and camera controller run unchanged.
+    monkeypatch.setattr(viz, "_apply_camera_pose", lambda pose: poses.append(pose))
+
+    class Viewer(_DummyViserViewer):
+        def is_paused(self):
+            return False
+
+        def begin_frame(self, sim_time):
+            assert poses == [((12.0, 20.0, 1.0), (10.0, 20.0, 0.0))]
+            super().begin_frame(sim_time)
+
+    viz._viewer = Viewer()
+    viz._scene_data_provider = _FakeProvider(1)
+    viz._is_initialized = True
+    if backend in ("kit", "newton_gl", "newton_rtx"):
+        viz._runtime_headless = True
+    if backend in ("viser", "rerun"):
+        monkeypatch.setattr(viz, "_push_streaming_frame", lambda: None)
+    viz.step(0.1)
+    assert poses == [((12.0, 20.0, 1.0), (10.0, 20.0, 0.0))]
+    assert viz.cfg.eye == (2, 0, 1)
+    assert viz.cfg.lookat == (0, 0, 0)
+
+
+def test_newton_tracking_pose_does_not_rewrite_relative_offsets(monkeypatch):
+    from types import SimpleNamespace
+
+    import torch
+    from isaaclab_newton.physics import NewtonManager
+    from isaaclab_visualizers.newton.newton_visualizer import NewtonGLVisualizer
+
+    cfg = NewtonGLVisualizerCfg(
+        origin_type="asset",
+        origin_track_path="robot",
+        origin_follow_heading=True,
+        eye=(2, 0, 1),
+        lookat=(1, 0, 0),
+    )
+    positions = torch.tensor([[10.0, 20.0, 0.0]])
+    # A 90-degree yaw, represented in xyzw order.
+    orientations = torch.tensor([[0.0, 0.0, 2**-0.5, 2**-0.5]])
+    asset = SimpleNamespace(
+        is_initialized=True,
+        data=SimpleNamespace(
+            root_pos_w=SimpleNamespace(torch=positions),
+            root_quat_w=SimpleNamespace(torch=orientations),
+        ),
+    )
+
+    class Scene:
+        num_envs = 1
+        env_origins = torch.zeros(1, 3)
+
+        def __getitem__(self, name):
+            assert name == "robot"
+            return asset
+
+    class Camera:
+        def look_at(self, target):
+            self.target = target
+
+    viz = NewtonGLVisualizer(cfg)
+    camera = Camera()
+    viz._viewer = SimpleNamespace(camera=camera)
+    viz._runtime_headless = True
+    viz._is_initialized = True
+    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=Scene()))
+    monkeypatch.setattr(NewtonManager, "get_state", lambda *args: None)
+    for x in (10.0, 30.0, -5.0):
+        positions[0, 0] = x
+        viz.step(0.1)
+        assert tuple(camera.pos) == pytest.approx((x, 22.0, 1.0))
+        assert camera.target == pytest.approx((x, 21.0, 0.0))
+        assert viz.cfg.eye == (2, 0, 1)
+        assert viz.cfg.lookat == (1, 0, 0)
+    # Public world-space camera edits must survive the next tracking update.
+    viz.set_camera_view((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    viz.step(0.1)
+    assert tuple(camera.pos) == pytest.approx((7.0, 12.0, 3.0), abs=1e-5)
+    assert camera.target == pytest.approx((4.0, 9.0, 1.0), abs=1e-5)
+
+
+def test_rerun_tracking_preserves_live_plot_panels(monkeypatch):
+    import rerun.blueprint as rrb
+
+    viewer = object.__new__(rerun_visualizer.NewtonViewerRerun)
+    viewer._live_plot_manager_names = ["reward", "termination"]
+    viewer._streaming_view_active = False
+    viewer._camera_pose = None
+    viewer._has_scalars = True
+    viz = rerun_visualizer.RerunVisualizer(RerunVisualizerCfg())
+    viz._viewer = viewer
+    blueprints = []
+    monkeypatch.setattr(rerun_visualizer.rr, "send_blueprint", blueprints.append)
+    for eye in ((1.0, 2.0, 3.0), (4.0, 5.0, 6.0)):
+        viz._apply_camera_pose((eye, (0.0, 0.0, 0.0)))
+
+    def views(node):
+        if isinstance(node, rrb.View):
+            yield node
+        for child in getattr(node, "contents", []):
+            yield from views(child)
+        root = getattr(node, "root_container", None)
+        if root is not None:
+            yield from views(root)
+
+    assert len(blueprints) == 2
+    for blueprint in blueprints:
+        assert {view.name for view in views(blueprint)} >= {"reward", "termination"}

--- a/source/isaaclab/test/visualizers/test_visualizer.py
+++ b/source/isaaclab/test/visualizers/test_visualizer.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import math
 from types import SimpleNamespace
 
 import pytest
@@ -84,7 +85,10 @@ class _DummyVisualizer(BaseVisualizer):
         self._is_initialized = True
 
     def step(self, dt: float) -> None:
-        return
+        self._update_camera_tracking(dt)
+
+    def set_camera_view(self, eye, target) -> None:
+        self.camera_pose = (eye, target)
 
     def close(self) -> None:
         self._is_closed = True
@@ -254,3 +258,211 @@ def test_physics_backend_returns_none_without_simulation_context():
     """physics_backend is None when no SimulationContext is active."""
     viz = _DummyVisualizer(_make_cfg())
     assert viz.physics_backend is None
+
+
+class _CameraScene(dict):
+    def __init__(self, origins):
+        super().__init__()
+        self.env_origins = torch.as_tensor(origins, dtype=torch.float32)
+        self.num_envs = len(origins)
+
+
+def _camera_asset(**state):
+    return SimpleNamespace(
+        is_initialized=True,
+        data=SimpleNamespace(**{name: SimpleNamespace(torch=value) for name, value in state.items()}),
+    )
+
+
+def _camera_visualizer(monkeypatch, scene, **kwargs):
+    from isaaclab.sim import SimulationContext
+
+    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
+    cfg = VisualizerCfg(eye=(2.0, 0.0, 1.0), lookat=(1.0, 0.0, 0.0), **kwargs)
+    viz = _DummyVisualizer(cfg)
+    viz.initialize(_FakeProvider(scene.num_envs))
+    return viz
+
+
+@pytest.mark.parametrize("num_envs", [1, 5, 9, 64])
+def test_camera_selects_spatial_center_once(monkeypatch, num_envs):
+    from isaaclab.cloner.clone_plan import grid_transforms
+
+    origins, _ = grid_transforms(num_envs)
+    scene = _CameraScene(origins)
+    viz = _camera_visualizer(monkeypatch, scene, origin_type="env", origin_env_index="center")
+    viz.step(0.1)
+
+    # Independently compare horizontal distances to the layout's bounding-box center.
+    points = scene.env_origins.tolist()
+    center = [(min(p[i] for p in points) + max(p[i] for p in points)) / 2 for i in (0, 1)]
+    index = min(range(num_envs), key=lambda j: sum((points[j][i] - center[i]) ** 2 for i in (0, 1)))
+    origin = scene.env_origins[index]
+    assert viz.camera_env_index == index
+    assert viz.camera_pose[0] == pytest.approx((origin + torch.tensor(viz.cfg.eye)).tolist())
+    assert viz.camera_pose[1] == pytest.approx((origin + torch.tensor(viz.cfg.lookat)).tolist())
+    if num_envs == 64:
+        assert index == 27
+
+    # Fixed cameras must not move when a terrain curriculum relocates environment origins.
+    first_pose = viz.camera_pose
+    scene.env_origins.add_(100.0)
+    viz.step(0.1)
+    assert viz.camera_pose == first_pose
+
+
+def test_camera_center_uses_visible_envs_and_ignores_height(monkeypatch):
+    scene = _CameraScene([[-4, 0, 0], [0, 0, 100], [1, 0, 0], [4, 0, 0]])
+    viz = _camera_visualizer(monkeypatch, scene, origin_type="env", origin_env_index="center")
+    viz._resolved_visible_env_ids = [3, 1]
+    viz.step(0.1)
+    assert viz.camera_pose == ((2.0, 0.0, 101.0), (1.0, 0.0, 100.0))
+
+
+@pytest.mark.parametrize("follow_heading", [False, True])
+@pytest.mark.parametrize("track_path", ["robot", "robot/base"])
+def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatch, follow_heading, track_path):
+    from isaaclab.utils.math import quat_from_euler_xyz
+
+    scene = _CameraScene([[0, 0, 0], [20, 0, 0], [10, 0, 0]])
+    positions = torch.tensor([[100.0, 0, 0], [200.0, 0, 0], [10.0, 2, 3]])
+    # Rz(90 degrees) * Ry(30 degrees) * Rx(60 degrees), xyzw quaternion.
+    orientations = quat_from_euler_xyz(
+        torch.full((3,), math.pi / 3), torch.full((3,), math.pi / 6), torch.full((3,), math.pi / 2)
+    )
+    body_positions = torch.stack((positions + 100, positions + torch.tensor([0, 0, 0.5])), dim=1)
+    body_orientation = quat_from_euler_xyz(
+        torch.full((3,), math.pi / 3), torch.full((3,), math.pi / 6), torch.full((3,), -math.pi / 2)
+    )
+    body_orientations = torch.stack((orientations, body_orientation), dim=1)
+    scene["robot"] = _camera_asset(
+        root_pos_w=positions, root_quat_w=orientations, body_pos_w=body_positions, body_quat_w=body_orientations
+    )
+    scene["robot"].find_bodies = lambda name: ([1], ["base"]) if name == "base" else ([], [])
+    viz = _camera_visualizer(
+        monkeypatch,
+        scene,
+        origin_type="asset",
+        origin_env_index="center",
+        origin_track_path=track_path,
+        origin_follow_heading=follow_heading,
+    )
+    viz.step(0.1)
+    for origin in ([10.0, 2, 3], [20.0, -5, 2], [-10.0, 8, 1]):
+        positions[2] = torch.tensor(origin)
+        body_positions[2, 1] = positions[2] + torch.tensor([0, 0, 0.5])
+        scene.env_origins[2] += 100  # Reset/terrain movement must not change the selected robot.
+        viz.step(0.1)
+        direction = -1 if track_path == "robot/base" else 1
+        height = 0.5 if track_path == "robot/base" else 0
+        eye_offset = [0, direction * 2, 1 + height] if follow_heading else [2, 0, 1 + height]
+        target_offset = [0, direction, height] if follow_heading else [1, 0, height]
+        assert viz.camera_pose[0] == pytest.approx([a + b for a, b in zip(origin, eye_offset)], abs=1e-5)
+        assert viz.camera_pose[1] == pytest.approx([a + b for a, b in zip(origin, target_offset)], abs=1e-5)
+        assert viz.cfg.eye == (2.0, 0.0, 1.0)
+        assert viz.cfg.lookat == (1.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("env_index,visible", [(3, None), (-1, None), (1, [0]), ("center", [])])
+def test_camera_rejects_unavailable_environment(monkeypatch, env_index, visible):
+    viz = _camera_visualizer(
+        monkeypatch, _CameraScene([[0, 0, 0], [1, 0, 0]]), origin_type="env", origin_env_index=env_index
+    )
+    viz._resolved_visible_env_ids = visible
+    with pytest.raises(ValueError, match="environment|origin_env_index"):
+        viz.step(0.1)
+
+
+@pytest.mark.parametrize("path", [None, "missing", "robot/missing", "robot/.*"])
+def test_camera_rejects_missing_or_ambiguous_asset_target(monkeypatch, path):
+    scene = _CameraScene([[0, 0, 0]])
+    scene["robot"] = SimpleNamespace(is_initialized=True, find_bodies=lambda name: ([], []))
+    if path == "robot/.*":
+        scene["robot"].find_bodies = lambda name: ([0, 1], ["base", "foot"])
+    viz = _camera_visualizer(monkeypatch, scene, origin_type="asset", origin_track_path=path)
+    with pytest.raises(ValueError, match="origin_track_path"):
+        viz.step(0.1)
+
+
+def test_camera_waits_for_asset_state_and_accepts_new_environment_selection(monkeypatch):
+    scene = _CameraScene([[10, 20, 0], [30, 20, 0]])
+    asset = SimpleNamespace(is_initialized=False)
+    scene["robot"] = asset
+    viz = _camera_visualizer(monkeypatch, scene, origin_type="asset", origin_track_path="robot")
+    viz.step(0.1)
+    assert not hasattr(viz, "camera_pose")
+    viz._set_camera_pose_cfg((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    asset.is_initialized = True
+    asset.data = SimpleNamespace(root_pos_w=SimpleNamespace(torch=scene.env_origins))
+    viz.step(0.1)
+    assert viz.camera_pose == ((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    viz.cfg.origin_env_index = 1
+    viz.step(0.1)
+    assert viz.camera_pose == ((27.0, 12.0, 3.0), (24.0, 9.0, 1.0))
+
+
+@pytest.mark.parametrize("substeps", [1, 5, 20])
+def test_camera_heading_filter_uses_elapsed_time_and_keeps_position_tracking(monkeypatch, substeps):
+    scene = _CameraScene([[0, 0, 0]])
+    positions = torch.zeros((1, 3))
+    orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]])
+    scene["robot"] = _camera_asset(root_pos_w=positions, root_quat_w=orientations)
+    viz = _camera_visualizer(
+        monkeypatch,
+        scene,
+        origin_type="asset",
+        origin_track_path="robot",
+        origin_follow_heading=True,
+        origin_heading_smoothing_time_constant=0.2,
+    )
+    viz.step(0.0)
+    orientations[0] = torch.tensor([0.0, 0.0, 2**-0.5, 2**-0.5])
+    positions[0] = torch.tensor([10.0, 20.0, 3.0])
+    # One half-life must produce 45 degrees, regardless of the render cadence.
+    for _ in range(substeps):
+        viz.step(0.2 * math.log(2) / substeps)
+    assert viz.camera_pose[0] == pytest.approx((10 + 2**0.5, 20 + 2**0.5, 4), abs=1e-5)
+    assert viz.camera_pose[1] == pytest.approx((10 + 2**-0.5, 20 + 2**-0.5, 3), abs=1e-5)
+    pose = viz.camera_pose
+    viz.step(0.0)
+    assert viz.camera_pose == pose
+    # UI edits are converted through the filtered heading, without a jump while paused.
+    viz._set_camera_pose_cfg((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    viz.step(0.0)
+    assert viz.camera_pose[0] == pytest.approx((7.0, 12.0, 3.0), abs=1e-5)
+    assert viz.camera_pose[1] == pytest.approx((4.0, 9.0, 1.0), abs=1e-5)
+
+
+def test_camera_heading_filter_takes_short_path_and_reinitializes_on_target_change(monkeypatch):
+    scene = _CameraScene([[0, 0, 0], [0, 0, 0]])
+    orientations = torch.tensor(
+        [
+            [0.0, 0.0, math.sin(math.radians(179) / 2), math.cos(math.radians(179) / 2)],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    scene["robot"] = _camera_asset(root_pos_w=scene.env_origins, root_quat_w=orientations)
+    viz = _camera_visualizer(
+        monkeypatch,
+        scene,
+        origin_type="asset",
+        origin_track_path="robot",
+        origin_follow_heading=True,
+        origin_heading_smoothing_time_constant=0.2,
+    )
+    viz.step(0.0)
+    assert viz.camera_pose[0] == pytest.approx(
+        (2 * math.cos(math.radians(179)), 2 * math.sin(math.radians(179)), 1), abs=1e-5
+    )
+    orientations[0, 2] *= -1
+    viz.step(0.2 * math.log(2))
+    assert viz.camera_pose[0] == pytest.approx((-2.0, 0.0, 1.0), abs=1e-5)
+    viz.cfg.origin_env_index = 1
+    viz.step(0.0)
+    assert viz.camera_pose[0] == pytest.approx((2.0, 0.0, 1.0), abs=1e-5)
+
+
+@pytest.mark.parametrize("time_constant", [-0.1, math.inf, math.nan])
+def test_camera_rejects_invalid_heading_smoothing_time_constant(time_constant):
+    with pytest.raises(ValueError, match="origin_heading_smoothing_time_constant"):
+        VisualizerCfg(origin_heading_smoothing_time_constant=time_constant)

--- a/source/isaaclab/test/visualizers/test_visualizer.py
+++ b/source/isaaclab/test/visualizers/test_visualizer.py
@@ -284,25 +284,19 @@ def _camera_visualizer(monkeypatch, scene, **kwargs):
     return viz
 
 
-@pytest.mark.parametrize("num_envs", [1, 5, 9, 64])
-def test_camera_selects_spatial_center_once(monkeypatch, num_envs):
+def test_camera_selects_spatial_center_once(monkeypatch):
     from isaaclab.cloner.clone_plan import grid_transforms
 
-    origins, _ = grid_transforms(num_envs)
+    origins, _ = grid_transforms(64)
     scene = _CameraScene(origins)
     viz = _camera_visualizer(monkeypatch, scene, origin_type="env", origin_env_index="center")
     viz.step(0.1)
 
-    # Independently compare horizontal distances to the layout's bounding-box center.
-    points = scene.env_origins.tolist()
-    center = [(min(p[i] for p in points) + max(p[i] for p in points)) / 2 for i in (0, 1)]
-    index = min(range(num_envs), key=lambda j: sum((points[j][i] - center[i]) ** 2 for i in (0, 1)))
-    origin = scene.env_origins[index]
-    assert viz.camera_env_index == index
+    # Four environments share the center of the 8x8 grid; select the lowest index.
+    origin = scene.env_origins[27]
+    assert viz.camera_env_index == 27
     assert viz.camera_pose[0] == pytest.approx((origin + torch.tensor(viz.cfg.eye)).tolist())
     assert viz.camera_pose[1] == pytest.approx((origin + torch.tensor(viz.cfg.lookat)).tolist())
-    if num_envs == 64:
-        assert index == 27
 
     # Fixed cameras must not move when a terrain curriculum relocates environment origins.
     first_pose = viz.camera_pose
@@ -322,18 +316,12 @@ def test_camera_center_uses_visible_envs_and_ignores_height(monkeypatch):
 @pytest.mark.parametrize("follow_heading", [False, True])
 @pytest.mark.parametrize("track_path", ["robot", "robot/base"])
 def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatch, follow_heading, track_path):
-    from isaaclab.utils.math import quat_from_euler_xyz
-
     scene = _CameraScene([[0, 0, 0], [20, 0, 0], [10, 0, 0]])
     positions = torch.tensor([[100.0, 0, 0], [200.0, 0, 0], [10.0, 2, 3]])
-    # Rz(90 degrees) * Ry(30 degrees) * Rx(60 degrees), xyzw quaternion.
-    orientations = quat_from_euler_xyz(
-        torch.full((3,), math.pi / 3), torch.full((3,), math.pi / 6), torch.full((3,), math.pi / 2)
-    )
+    # XYZW quaternions: 90-degree roll, with +90-degree root yaw and -90-degree body yaw.
+    orientations = torch.tensor([[0.5, 0.5, 0.5, 0.5]]).expand(3, -1)
     body_positions = torch.stack((positions + 100, positions + torch.tensor([0, 0, 0.5])), dim=1)
-    body_orientation = quat_from_euler_xyz(
-        torch.full((3,), math.pi / 3), torch.full((3,), math.pi / 6), torch.full((3,), -math.pi / 2)
-    )
+    body_orientation = torch.tensor([[0.5, -0.5, -0.5, 0.5]]).expand(3, -1)
     body_orientations = torch.stack((orientations, body_orientation), dim=1)
     scene["robot"] = _camera_asset(
         root_pos_w=positions, root_quat_w=orientations, body_pos_w=body_positions, body_quat_w=body_orientations
@@ -361,27 +349,6 @@ def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatc
         assert viz.camera_pose[1] == pytest.approx([a + b for a, b in zip(origin, target_offset)], abs=1e-5)
         assert viz.cfg.eye == (2.0, 0.0, 1.0)
         assert viz.cfg.lookat == (1.0, 0.0, 0.0)
-
-
-@pytest.mark.parametrize("env_index,visible", [(3, None), (-1, None), (1, [0]), ("center", [])])
-def test_camera_rejects_unavailable_environment(monkeypatch, env_index, visible):
-    viz = _camera_visualizer(
-        monkeypatch, _CameraScene([[0, 0, 0], [1, 0, 0]]), origin_type="env", origin_env_index=env_index
-    )
-    viz._resolved_visible_env_ids = visible
-    with pytest.raises(ValueError, match="environment|origin_env_index"):
-        viz.step(0.1)
-
-
-@pytest.mark.parametrize("path", [None, "missing", "robot/missing", "robot/.*"])
-def test_camera_rejects_missing_or_ambiguous_asset_target(monkeypatch, path):
-    scene = _CameraScene([[0, 0, 0]])
-    scene["robot"] = SimpleNamespace(is_initialized=True, find_bodies=lambda name: ([], []))
-    if path == "robot/.*":
-        scene["robot"].find_bodies = lambda name: ([0, 1], ["base", "foot"])
-    viz = _camera_visualizer(monkeypatch, scene, origin_type="asset", origin_track_path=path)
-    with pytest.raises(ValueError, match="origin_track_path"):
-        viz.step(0.1)
 
 
 def test_camera_waits_for_asset_state_and_accepts_new_environment_selection(monkeypatch):
@@ -460,9 +427,3 @@ def test_camera_heading_filter_takes_short_path_and_reinitializes_on_target_chan
     viz.cfg.origin_env_index = 1
     viz.step(0.0)
     assert viz.camera_pose[0] == pytest.approx((2.0, 0.0, 1.0), abs=1e-5)
-
-
-@pytest.mark.parametrize("time_constant", [-0.1, math.inf, math.nan])
-def test_camera_rejects_invalid_heading_smoothing_time_constant(time_constant):
-    with pytest.raises(ValueError, match="origin_heading_smoothing_time_constant"):
-        VisualizerCfg(origin_heading_smoothing_time_constant=time_constant)

--- a/source/isaaclab/test/visualizers/test_visualizer.py
+++ b/source/isaaclab/test/visualizers/test_visualizer.py
@@ -87,8 +87,8 @@ class _DummyVisualizer(BaseVisualizer):
     def step(self, dt: float) -> None:
         self._update_camera_tracking(dt)
 
-    def set_camera_view(self, eye, target) -> None:
-        self.camera_pose = (eye, target)
+    def _apply_camera_pose(self, pose) -> None:
+        self.camera_pose = pose
 
     def close(self) -> None:
         self._is_closed = True
@@ -354,7 +354,7 @@ def test_camera_waits_for_asset_state_and_accepts_new_environment_selection():
     viz = _camera_visualizer(scene, origin_type="asset", origin_track_path="robot")
     viz.step(0.1)
     assert not hasattr(viz, "camera_pose")
-    viz._set_camera_pose_cfg((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    viz.set_camera_view((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
     asset.is_initialized = True
     asset.data = SimpleNamespace(root_pos_w=SimpleNamespace(torch=scene.env_origins))
     viz.step(0.1)
@@ -389,7 +389,7 @@ def test_camera_heading_filter_uses_elapsed_time_and_keeps_position_tracking(sub
     viz.step(0.0)
     assert viz.camera_pose == pose
     # UI edits are converted through the filtered heading, without a jump while paused.
-    viz._set_camera_pose_cfg((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
+    viz.set_camera_view((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
     viz.step(0.0)
     assert viz.camera_pose[0] == pytest.approx((7.0, 12.0, 3.0), abs=1e-5)
     assert viz.camera_pose[1] == pytest.approx((4.0, 9.0, 1.0), abs=1e-5)

--- a/source/isaaclab/test/visualizers/test_visualizer.py
+++ b/source/isaaclab/test/visualizers/test_visualizer.py
@@ -274,22 +274,19 @@ def _camera_asset(**state):
     )
 
 
-def _camera_visualizer(monkeypatch, scene, **kwargs):
-    from isaaclab.sim import SimulationContext
-
-    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
+def _camera_visualizer(scene, **kwargs):
     cfg = VisualizerCfg(eye=(2.0, 0.0, 1.0), lookat=(1.0, 0.0, 0.0), **kwargs)
     viz = _DummyVisualizer(cfg)
-    viz.initialize(_FakeProvider(scene.num_envs))
+    viz.initialize(SimpleNamespace(get_interactive_scene=lambda: scene))
     return viz
 
 
-def test_camera_selects_spatial_center_once(monkeypatch):
+def test_camera_selects_spatial_center_once():
     from isaaclab.cloner.clone_plan import grid_transforms
 
     origins, _ = grid_transforms(64)
     scene = _CameraScene(origins)
-    viz = _camera_visualizer(monkeypatch, scene, origin_type="env", origin_env_index="center")
+    viz = _camera_visualizer(scene, origin_type="env", origin_env_index="center")
     viz.step(0.1)
 
     # Four environments share the center of the 8x8 grid; select the lowest index.
@@ -305,9 +302,9 @@ def test_camera_selects_spatial_center_once(monkeypatch):
     assert viz.camera_pose == first_pose
 
 
-def test_camera_center_uses_visible_envs_and_ignores_height(monkeypatch):
+def test_camera_center_uses_visible_envs_and_ignores_height():
     scene = _CameraScene([[-4, 0, 0], [0, 0, 100], [1, 0, 0], [4, 0, 0]])
-    viz = _camera_visualizer(monkeypatch, scene, origin_type="env", origin_env_index="center")
+    viz = _camera_visualizer(scene, origin_type="env", origin_env_index="center")
     viz._resolved_visible_env_ids = [3, 1]
     viz.step(0.1)
     assert viz.camera_pose == ((2.0, 0.0, 101.0), (1.0, 0.0, 100.0))
@@ -315,7 +312,7 @@ def test_camera_center_uses_visible_envs_and_ignores_height(monkeypatch):
 
 @pytest.mark.parametrize("follow_heading", [False, True])
 @pytest.mark.parametrize("track_path", ["robot", "robot/base"])
-def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatch, follow_heading, track_path):
+def test_camera_tracks_position_and_optional_yaw_without_offset_drift(follow_heading, track_path):
     scene = _CameraScene([[0, 0, 0], [20, 0, 0], [10, 0, 0]])
     positions = torch.tensor([[100.0, 0, 0], [200.0, 0, 0], [10.0, 2, 3]])
     # XYZW quaternions: 90-degree roll, with +90-degree root yaw and -90-degree body yaw.
@@ -328,7 +325,6 @@ def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatc
     )
     scene["robot"].find_bodies = lambda name: ([1], ["base"]) if name == "base" else ([], [])
     viz = _camera_visualizer(
-        monkeypatch,
         scene,
         origin_type="asset",
         origin_env_index="center",
@@ -351,11 +347,11 @@ def test_camera_tracks_position_and_optional_yaw_without_offset_drift(monkeypatc
         assert viz.cfg.lookat == (1.0, 0.0, 0.0)
 
 
-def test_camera_waits_for_asset_state_and_accepts_new_environment_selection(monkeypatch):
+def test_camera_waits_for_asset_state_and_accepts_new_environment_selection():
     scene = _CameraScene([[10, 20, 0], [30, 20, 0]])
     asset = SimpleNamespace(is_initialized=False)
     scene["robot"] = asset
-    viz = _camera_visualizer(monkeypatch, scene, origin_type="asset", origin_track_path="robot")
+    viz = _camera_visualizer(scene, origin_type="asset", origin_track_path="robot")
     viz.step(0.1)
     assert not hasattr(viz, "camera_pose")
     viz._set_camera_pose_cfg((7.0, 12.0, 3.0), (4.0, 9.0, 1.0))
@@ -369,13 +365,12 @@ def test_camera_waits_for_asset_state_and_accepts_new_environment_selection(monk
 
 
 @pytest.mark.parametrize("substeps", [1, 5, 20])
-def test_camera_heading_filter_uses_elapsed_time_and_keeps_position_tracking(monkeypatch, substeps):
+def test_camera_heading_filter_uses_elapsed_time_and_keeps_position_tracking(substeps):
     scene = _CameraScene([[0, 0, 0]])
     positions = torch.zeros((1, 3))
     orientations = torch.tensor([[0.0, 0.0, 0.0, 1.0]])
     scene["robot"] = _camera_asset(root_pos_w=positions, root_quat_w=orientations)
     viz = _camera_visualizer(
-        monkeypatch,
         scene,
         origin_type="asset",
         origin_track_path="robot",
@@ -400,7 +395,7 @@ def test_camera_heading_filter_uses_elapsed_time_and_keeps_position_tracking(mon
     assert viz.camera_pose[1] == pytest.approx((4.0, 9.0, 1.0), abs=1e-5)
 
 
-def test_camera_heading_filter_takes_short_path_and_reinitializes_on_target_change(monkeypatch):
+def test_camera_heading_filter_takes_short_path_and_reinitializes_on_target_change():
     scene = _CameraScene([[0, 0, 0], [0, 0, 0]])
     orientations = torch.tensor(
         [
@@ -410,7 +405,6 @@ def test_camera_heading_filter_takes_short_path_and_reinitializes_on_target_chan
     )
     scene["robot"] = _camera_asset(root_pos_w=scene.env_origins, root_quat_w=orientations)
     viz = _camera_visualizer(
-        monkeypatch,
         scene,
         origin_type="asset",
         origin_track_path="robot",

--- a/source/isaaclab_tasks/changelog.d/task-camera-views.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/task-camera-views.minor.rst
@@ -1,0 +1,6 @@
+Changed
+^^^^^^^
+
+* Defined fixed recording views for static core tasks and tracking views for locomotion, with
+  heading smoothing of 0.2 seconds (0.5 for Ant and Humanoid). Explicit visualizer settings
+  override task defaults; set ``origin_heading_smoothing_time_constant=0.0`` for immediate yaw.

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -108,16 +108,8 @@ class CabinetSimCfg(PresetCfg):
     physx: SimulationCfg = isaacsim_physx.replace(
         physics=PhysxAutoCfg(isaacsim_physx=isaacsim_physx.physics, ovphysx=ovphysx.physics)
     )
-    newton_mjwarp: SimulationCfg = SimulationCfg(
+    newton_mjwarp: SimulationCfg = isaacsim_physx.replace(
         dt=1 / 600,
-        render_interval=1,
-        default_visualizer_cfg=VisualizerCfg(
-            eye=(-1.8, 2.0, 1.6),
-            lookat=(0.55, 0.0, 0.5),
-            focal_length=28.0,
-            origin_type="env",
-            origin_env_index="center",
-        ),
         physics=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=90,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cabinet/cabinet_env_cfg.py
@@ -96,7 +96,13 @@ class CabinetSimCfg(PresetCfg):
         dt=1 / 60,
         render_interval=1,
         physics=PhysxCfg(bounce_threshold_velocity=0.01, friction_correlation_distance=0.00625),
-        default_visualizer_cfg=VisualizerCfg(eye=(-2.0, 2.0, 2.0), lookat=(0.8, 0.0, 0.5)),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(-1.8, 2.0, 1.6),
+            lookat=(0.55, 0.0, 0.5),
+            focal_length=28.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
     )
     ovphysx: SimulationCfg = isaacsim_physx.replace(physics=OvPhysxCfg())
     physx: SimulationCfg = isaacsim_physx.replace(
@@ -105,7 +111,13 @@ class CabinetSimCfg(PresetCfg):
     newton_mjwarp: SimulationCfg = SimulationCfg(
         dt=1 / 600,
         render_interval=1,
-        default_visualizer_cfg=VisualizerCfg(eye=(-2.0, 2.0, 2.0), lookat=(0.8, 0.0, 0.5)),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(-1.8, 2.0, 1.6),
+            lookat=(0.55, 0.0, 0.5),
+            focal_length=28.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
         physics=NewtonCfg(
             solver_cfg=MJWarpSolverCfg(
                 njmax=90,

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_camera_env_cfg.py
@@ -11,7 +11,6 @@ import isaaclab.sim as sim_utils
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
-from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.core.cartpole.cartpole_direct_env_cfg import CartpoleEnvCfg
 from isaaclab_tasks.utils import PresetCfg
@@ -71,9 +70,6 @@ class CartpoleCameraEnvCfg(PresetCfg):
 
         # reset: smaller initial pole angle than the proprioceptive task
         initial_pole_angle_range = (-0.125 * math.pi, 0.125 * math.pi)  # [rad]
-
-        def __post_init__(self):
-            self.sim.default_visualizer_cfg = VisualizerCfg(eye=(20.0, 20.0, 20.0))
 
     default = BaseCartpoleCameraEnvCfg()
     depth = BaseCartpoleCameraEnvCfg(observation_space=[1, 96, 96])

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_direct_env_cfg.py
@@ -90,4 +90,10 @@ class CartpoleEnvCfg(DirectRLEnvCfg):
     rew_scale_pole_vel = -0.005
 
     def __post_init__(self):
-        self.sim.default_visualizer_cfg = VisualizerCfg(eye=(8.0, 0.0, 5.0))
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(8.0, 0.0, 2.5),
+            lookat=(0.0, 0.0, 2.5),
+            focal_length=24.0,
+            origin_type="env",
+            origin_env_index="center",
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_camera_env_cfg.py
@@ -11,7 +11,6 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
-from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.cartpole.mdp as mdp
 from isaaclab_tasks.core.cartpole.cartpole_manager_env_cfg import CartpoleEnvCfg, CartpoleSceneCfg, ObservationsCfg
@@ -172,8 +171,6 @@ class CartpoleCameraEnvCfg(PresetCfg):
             # remove ground as it obstructs the camera
             self.scene.ground = None
             self.events.reset_pole_position.params["position_range"] = (-0.125 * math.pi, 0.125 * math.pi)
-            # visualizer camera settings
-            self.sim.default_visualizer_cfg = VisualizerCfg(eye=(20.0, 20.0, 20.0), lookat=(0.0, 0.0, 0.0))
 
     rgb = BaseCartpoleCameraEnvCfg(observations=image_observations_cfg("rgb"))
     depth = BaseCartpoleCameraEnvCfg(observations=image_observations_cfg("depth"))

--- a/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/cartpole/cartpole_manager_env_cfg.py
@@ -219,7 +219,13 @@ class CartpoleEnvCfg(ManagerBasedRLEnvCfg):
         self.decimation = 2
         self.episode_length_s = 5
         # visualizer camera settings
-        self.sim.default_visualizer_cfg = VisualizerCfg(eye=(8.0, 0.0, 5.0))
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(8.0, 0.0, 2.5),
+            lookat=(0.0, 0.0, 2.5),
+            focal_length=24.0,
+            origin_type="env",
+            origin_env_index="center",
+        )
         # simulation settings
         self.sim.dt = 1 / 120
         self.sim.render_interval = self.decimation

--- a/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/fourbar_pole_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/fourbar_pole/fourbar_pole_manager_env_cfg.py
@@ -239,7 +239,13 @@ class FourbarPoleSwingupEnvCfg(ManagerBasedRLEnvCfg):
         self.decimation = 2
         self.episode_length_s = 5
         # Match Newton GL / --video camera to the task viewport when --viz newton creates the visualizer.
-        self.sim.default_visualizer_cfg = VisualizerCfg(eye=(12.0, 0.0, 4.0))
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(4.5, 0.0, 1.8),
+            lookat=(0.0, 0.0, 1.8),
+            focal_length=24.0,
+            origin_type="env",
+            origin_env_index="center",
+        )
         # simulation settings
         self.sim.dt = 1 / 120
         self.sim.render_interval = self.decimation

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_env_cfg.py
@@ -177,7 +177,13 @@ class HandoverEnvCfg(DirectMARLEnvCfg):
         physics=PhysicsCfg(),
         # Frame both hands and the object between them. Without this the visualizer looks at the
         # origin from its default 4 m away, which renders the pair a few pixels wide.
-        default_visualizer_cfg=VisualizerCfg(eye=(1.15, -1.65, 1.15), lookat=(0.0, -0.5, 0.55), focal_length=35.0),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(1.15, -1.65, 1.15),
+            lookat=(0.0, -0.5, 0.55),
+            focal_length=35.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
     )
 
     # robot

--- a/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/handover/handover_manager_env_cfg.py
@@ -17,6 +17,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialBaseCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.handover.mdp as mdp
 import isaaclab_tasks.core.reorient.mdp as reorient_mdp
@@ -322,4 +323,10 @@ class HandoverManagerEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.render_interval = self.decimation
         self.sim.physics_material = RigidBodyMaterialBaseCfg(static_friction=1.0, dynamic_friction=1.0)
         self.sim.physics = PhysicsCfg()
-        self.viewer.eye = (2.0, 2.0, 2.0)
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(1.15, -1.65, 1.15),
+            lookat=(0.0, -0.5, 0.55),
+            focal_length=35.0,
+            origin_type="env",
+            origin_env_index="center",
+        )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
@@ -660,11 +660,12 @@ class FrankaSoftEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.render_interval = self.decimation
         self.sim.physics = PhysicsCfg()
 
-        self.viewer.eye = (0.75, 0.25, 0.65)
-        self.viewer.lookat = (0.0, 0.75, 0.4)
         self.sim.default_visualizer_cfg = _FrankaSoftVisualizerCfg(
-            eye=self.viewer.eye,
-            lookat=self.viewer.lookat,
+            eye=(1.8, -1.8, 1.5),
+            lookat=(0.35, 0.0, 0.35),
+            focal_length=28.0,
+            origin_type="env",
+            origin_env_index="center",
         )
 
     def play_mode(self):

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/lift_env_cfg.py
@@ -574,7 +574,13 @@ class ReorientEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.dt = 1 / 120
         self.sim.render_interval = self.decimation
         self.sim.physics = PhysicsCfg()
-        self.sim.default_visualizer_cfg = VisualizerCfg(eye=(-2.25, 0.0, 0.75), lookat=(0.0, 0.0, 0.45))
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(-1.8, -1.8, 1.45),
+            lookat=(-0.3, 0.0, 0.45),
+            focal_length=28.0,
+            origin_type="env",
+            origin_env_index="center",
+        )
 
     def play_mode(self):
         # play-mode overrides of parent

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_direct_env_cfg.py
@@ -22,6 +22,7 @@ from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.utils import PresetCfg
 
@@ -65,7 +66,21 @@ class AntEnvCfg(DirectRLEnvCfg):
     state_space = 0
 
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=AntPhysicsCfg())
+    sim: SimulationCfg = SimulationCfg(
+        dt=1 / 120,
+        render_interval=decimation,
+        physics=AntPhysicsCfg(),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(3.5, -1.0, 2.8),
+            lookat=(0.0, 0.0, 0.0),
+            focal_length=26.0,
+            origin_type="asset",
+            origin_env_index="center",
+            origin_track_path="robot",
+            origin_follow_heading=True,
+            origin_heading_smoothing_time_constant=0.5,
+        ),
+    )
     terrain = TerrainImporterCfg(
         prim_path="/World/ground",
         terrain_type="plane",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/ant/ant_manager_env_cfg.py
@@ -25,6 +25,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.locomotion.mdp as mdp
 from isaaclab_tasks.utils import PresetCfg
@@ -227,6 +228,16 @@ class AntEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 120.0
         self.sim.render_interval = self.decimation
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(3.5, -1.0, 2.8),
+            lookat=(0.0, 0.0, 0.0),
+            focal_length=26.0,
+            origin_type="asset",
+            origin_env_index="center",
+            origin_track_path="robot",
+            origin_follow_heading=True,
+            origin_heading_smoothing_time_constant=0.5,
+        )
         self.sim.physics = AntPhysicsCfg()
         # default friction material
         self.sim.physics_material.static_friction = 1.0

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_direct_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.utils import PresetCfg
 
@@ -57,7 +58,21 @@ class HumanoidEnvCfg(DirectRLEnvCfg):
     state_space = 0
 
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=HumanoidPhysicsCfg())
+    sim: SimulationCfg = SimulationCfg(
+        dt=1 / 120,
+        render_interval=decimation,
+        physics=HumanoidPhysicsCfg(),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(2.5, -3.5, 0.9),
+            lookat=(0.0, 0.0, -0.5),
+            focal_length=26.0,
+            origin_type="asset",
+            origin_env_index="center",
+            origin_track_path="robot",
+            origin_follow_heading=True,
+            origin_heading_smoothing_time_constant=0.5,
+        ),
+    )
     terrain = TerrainImporterCfg(
         prim_path="/World/ground",
         terrain_type="plane",

--- a/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/locomotion/humanoid/humanoid_manager_env_cfg.py
@@ -21,6 +21,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sensors import JointWrenchSensorCfg
 from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.locomotion.mdp as mdp
 from isaaclab_tasks.utils import PresetCfg
@@ -233,6 +234,16 @@ class HumanoidEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 1 / 120.0
         self.sim.render_interval = self.decimation
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(2.5, -3.5, 0.9),
+            lookat=(0.0, 0.0, -0.5),
+            focal_length=26.0,
+            origin_type="asset",
+            origin_env_index="center",
+            origin_track_path="robot",
+            origin_follow_heading=True,
+            origin_heading_smoothing_time_constant=0.5,
+        )
         self.sim.physics = HumanoidPhysicsCfg()
         # default friction material
         self.sim.physics_material.static_friction = 1.0

--- a/source/isaaclab_tasks/isaaclab_tasks/core/pendulum/pendulum_marl_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/pendulum/pendulum_marl_env_cfg.py
@@ -17,6 +17,7 @@ from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.utils import PresetCfg
 
@@ -63,7 +64,18 @@ class PendulumMARLEnvCfg(DirectMARLEnvCfg):
     state_space = -1
 
     # simulation
-    sim: SimulationCfg = SimulationCfg(dt=1 / 120, render_interval=decimation, physics=PendulumPhysicsCfg())
+    sim: SimulationCfg = SimulationCfg(
+        dt=1 / 120,
+        render_interval=decimation,
+        physics=PendulumPhysicsCfg(),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(8.0, 0.0, 2.3),
+            lookat=(0.0, 0.0, 2.3),
+            focal_length=24.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
+    )
 
     # robot
     robot_cfg: ArticulationCfg = CART_DOUBLE_PENDULUM_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/ur_10/joint_pos_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/config/ur_10/joint_pos_env_cfg.py
@@ -26,6 +26,8 @@ class UR10ReachEnvCfg(ReachEnvCfg):
     def __post_init__(self) -> None:
         # post init of parent
         super().__post_init__()
+        self.sim.default_visualizer_cfg.eye = (2.2, -2.2, 1.6)
+        self.sim.default_visualizer_cfg.lookat = (0.3, 0.0, 0.45)
 
         # switch robot to ur10
         self.scene.robot = UR10_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reach/reach_env_cfg.py
@@ -240,7 +240,13 @@ class ReachEnvCfg(ManagerBasedRLEnvCfg):
         self.decimation = 4
         self.sim.render_interval = self.decimation
         self.episode_length_s = 12.0
-        self.sim.default_visualizer_cfg = VisualizerCfg(eye=(3.5, 3.5, 3.5))
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(1.8, -1.8, 1.5),
+            lookat=(0.3, 0.0, 0.4),
+            focal_length=28.0,
+            origin_type="env",
+            origin_env_index="center",
+        )
         # simulation settings
         self.sim.dt = 1.0 / 120.0
         self.sim.physics = ReachPhysicsCfg()

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/allegro_hand/allegro_hand_direct_env_cfg.py
@@ -10,6 +10,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialBaseCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.core.reorient.config.allegro_hand.allegro_hand_common import (
     ALLEGRO_HAND_ROBOT_CFG,
@@ -38,6 +39,13 @@ class AllegroHandEnvCfg(DirectRLEnvCfg):
         render_interval=decimation,
         physics_material=RigidBodyMaterialBaseCfg(static_friction=1.0, dynamic_friction=1.0),
         physics=PhysicsCfg(),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(0.75, -0.95, 0.95),
+            lookat=(-0.05, -0.28, 0.6),
+            focal_length=30.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
     )
     # robot
     robot_cfg: ArticulationCfg = ALLEGRO_HAND_ROBOT_CFG

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/config/shadow_hand/shadow_hand_direct_env_cfg.py
@@ -10,6 +10,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialBaseCfg
 from isaaclab.utils import configclass
+from isaaclab.visualizers import VisualizerCfg
 
 from isaaclab_tasks.core.reorient.config.shadow_hand.shadow_hand_common import (
     CUBE_CFG,
@@ -52,6 +53,13 @@ class ShadowHandEnvCfg(DirectRLEnvCfg):
         render_interval=decimation,
         physics_material=RigidBodyMaterialBaseCfg(static_friction=1.0, dynamic_friction=1.0),
         physics=PhysicsCfg(),
+        default_visualizer_cfg=VisualizerCfg(
+            eye=(0.75, -0.95, 0.95),
+            lookat=(-0.05, -0.28, 0.6),
+            focal_length=30.0,
+            origin_type="env",
+            origin_env_index="center",
+        ),
     )
 
     # robot

--- a/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_manager_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/reorient/reorient_manager_env_cfg.py
@@ -212,8 +212,11 @@ class ReorientManagerEnvBaseCfg(ManagerBasedRLEnvCfg):
         self.commands.object_pose.orientation_success_threshold = self.goal_orientation_threshold
         self.commands.object_pose.goal_pose_visualizer_cfg = self.goal_marker_cfg
         self.sim.render_interval = self.decimation
-        # Frame the hand, which lies horizontal around (0, -0.25, 0.51). Looking at the origin
-        # from 2 m away renders a 20 cm hand a few pixels wide, so a recorded video shows nothing.
+        # Include the hand and the offset reference cube.
         self.sim.default_visualizer_cfg = VisualizerCfg(
-            eye=(0.62, -0.80, 0.85), lookat=(0.0, -0.28, 0.53), focal_length=35.0
+            eye=(0.75, -0.95, 0.95),
+            lookat=(-0.05, -0.28, 0.6),
+            focal_length=30.0,
+            origin_type="env",
+            origin_env_index="center",
         )

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/anymal_d/rough_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab_assets.robots.anymal import ANYMAL_D_CFG  # isort: skip
 class AnymalDRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
+        self.sim.default_visualizer_cfg.eye = (2.0, -3.0, 1.4)
 
         # scene
         self.scene.robot = ANYMAL_D_CFG.replace(

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/cassie/rough_env_cfg.py
@@ -56,6 +56,7 @@ class CassieRoughEnvCfg(LocomotionVelocityRoughEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
+        self.sim.default_visualizer_cfg.lookat = (0.15, 0.0, -0.25)
 
         # scene
         self.scene.robot = CASSIE_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/go2/rough_env_cfg.py
@@ -18,6 +18,7 @@ from isaaclab_assets.robots.unitree import UNITREE_GO2_CFG  # isort: skip
 class UnitreeGo2RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
     def __post_init__(self):
         super().__post_init__()
+        self.sim.default_visualizer_cfg.eye = (1.5, -2.5, 1.1)
 
         # simulation
         # execute the DC motor actuators through the backend-native path

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/config/h1/rough_env_cfg.py
@@ -77,6 +77,7 @@ class H1RoughEnvCfg(LocomotionVelocityRoughEnvCfg):
 
     def __post_init__(self):
         super().__post_init__()
+        self.sim.default_visualizer_cfg.eye = (2.5, -3.5, 1.3)
 
         # scene
         self.scene.robot = H1_MINIMAL_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")

--- a/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/velocity/velocity_env_cfg.py
@@ -34,6 +34,7 @@ from isaaclab.terrains import TerrainImporterCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 from isaaclab.utils.noise import UniformNoiseCfg as Unoise
+from isaaclab.visualizers import VisualizerCfg
 
 import isaaclab_tasks.core.velocity.mdp as mdp
 from isaaclab_tasks.utils import PresetCfg
@@ -362,6 +363,16 @@ class LocomotionVelocityRoughEnvCfg(ManagerBasedRLEnvCfg):
         # simulation settings
         self.sim.dt = 0.005
         self.sim.render_interval = self.decimation
+        self.sim.default_visualizer_cfg = VisualizerCfg(
+            eye=(1.8, -3.0, 1.1),
+            lookat=(0.15, 0.0, 0.0),
+            focal_length=26.0,
+            origin_type="asset",
+            origin_env_index="center",
+            origin_track_path="robot",
+            origin_follow_heading=True,
+            origin_heading_smoothing_time_constant=0.2,
+        )
         self.sim.physics_material = self.scene.terrain.physics_material
         # update sensor update periods
         # we tick all the sensors based on the smallest update period (physics update period)

--- a/source/isaaclab_visualizers/changelog.d/task-camera-tracking.minor.rst
+++ b/source/isaaclab_visualizers/changelog.d/task-camera-tracking.minor.rst
@@ -1,0 +1,5 @@
+Changed
+^^^^^^^
+
+* Shared fixed and tracking cameras, including yaw smoothing, across Kit, Newton, Rerun, and
+  Viser. Existing Kit camera fields and defaults remained compatible; no migration was required.

--- a/source/isaaclab_visualizers/changelog.d/task-camera-tracking.minor.rst
+++ b/source/isaaclab_visualizers/changelog.d/task-camera-tracking.minor.rst
@@ -2,4 +2,5 @@ Changed
 ^^^^^^^
 
 * Shared fixed and tracking cameras, including yaw smoothing, across Kit, Newton, Rerun, and
-  Viser. Existing Kit camera fields and defaults remained compatible; no migration was required.
+  Viser. Preserved runtime camera edits across backends and kept Rerun layouts intact during tracking.
+  Existing Kit camera fields and defaults remained compatible; no migration was required.

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -131,8 +131,8 @@ class KitVisualizer(BaseVisualizer):
         # render_rgb_array() skips its own pump when the step already pumped the app.
         self._app_pumped_this_step: bool = False
         # Camera tracking state (replaces ViewportCameraController)
-        self._interactive_scene = None  # set from SimulationContext._interactive_scene in initialize()
         self._viewer_origin: torch.Tensor | None = None  # world-space origin offset for eye/lookat
+        self._camera_partition_env_index: int | None = None
 
     # ---- Lifecycle ------------------------------------------------------------------------
 
@@ -207,8 +207,7 @@ class KitVisualizer(BaseVisualizer):
         self._sim_time += dt
         self._step_counter += 1
         # Update dynamic asset tracking before the frame renders.
-        if self.cfg.origin_type == "asset":
-            self._update_asset_tracking_camera()
+        self._update_camera_tracking(dt)
         # Headless mode: skip the app update and camera panel refresh; rendering is
         # triggered on demand by render_rgb_array() / render_tiled_rgb_array().
         if self._runtime_headless:
@@ -468,9 +467,8 @@ class KitVisualizer(BaseVisualizer):
         :attr:`cfg.origin_track_path` so the viewport reflects the new origin immediately rather than
         waiting for the next :meth:`step` call.
 
-        For ``"asset"`` origins the camera update is deferred to the
-        next :meth:`step` because asset state is not available until after
-        :meth:`~isaaclab.sim.SimulationContext.reset`.
+        For ``"asset"`` origins the camera update is deferred until asset state becomes
+        available after :meth:`~isaaclab.sim.SimulationContext.reset`.
         """
         self._setup_initial_camera_view()
 
@@ -482,6 +480,8 @@ class KitVisualizer(BaseVisualizer):
         Returns ``None`` before :meth:`initialize` is called or when no valid origin has been
         established yet (e.g. asset-tracking before the first :meth:`step`).
         """
+        if self._camera_controller is not None and self._camera_controller.has_pose:
+            return self._camera_controller.origin
         return self._viewer_origin
 
     # ---- Viewport + camera ----------------------------------------------------------------
@@ -934,7 +934,8 @@ class KitVisualizer(BaseVisualizer):
         ``/World/envs`` and are created by Kit, so they do not inherit the env-root
         primvar authored by the renderer. When the RTX spectator-view setting is
         enabled, leaving the viewport camera unpartitioned shows all environments.
-        Otherwise, the viewport is assigned to the first visible environment.
+        Otherwise, the viewport is assigned to the camera origin environment, falling back
+        to the first visible environment for world-space views.
         """
 
         if num_envs <= 0 or self._controlled_camera_path is None:
@@ -963,6 +964,8 @@ class KitVisualizer(BaseVisualizer):
             return
 
         env_id = self._resolved_visible_env_ids[0] if self._resolved_visible_env_ids else 0
+        if self.cfg.origin_type != "world" and self.camera_env_index is not None:
+            env_id = self.camera_env_index
         logger.debug(
             "[KitVisualizer] Assigning viewport camera '%s' to scene partition env_%d.",
             self._controlled_camera_path,
@@ -1231,72 +1234,31 @@ class KitVisualizer(BaseVisualizer):
         self._point_instancer_invisible_ids_backup.clear()
 
     def _setup_initial_camera_view(self) -> None:
-        """Position the viewport camera according to :attr:`KitVisualizerCfg.origin_type`.
-
-        Called once at the end of :meth:`initialize`. For ``"world"`` and ``"env"`` origins the
-        camera is positioned immediately. For asset-tracking origins the first update is deferred
-        to :meth:`step` because asset state is not yet available at initialization time.
-        """
-        from isaaclab.sim import SimulationContext  # noqa: PLC0415
-
-        self._interactive_scene = getattr(SimulationContext.instance(), "_interactive_scene", None)
-
+        """Reset camera selection, deferring asset tracking until state is available."""
+        self._camera_controller = None
+        self._viewer_origin = None
         if self.cfg.origin_type == "world":
             self._viewer_origin = torch.zeros(3)
+            self._apply_camera_pose(self._resolve_cfg_camera_pose("KitVisualizer"))
         elif self.cfg.origin_type == "env":
-            scene = self._interactive_scene
-            if scene is None:
-                logger.warning("[KitVisualizer] origin_type='env' requested but no scene is registered yet.")
-                self._viewer_origin = torch.zeros(3)
-            else:
-                num_envs = scene.num_envs
-                if not (0 <= self.cfg.origin_env_index < num_envs):
-                    raise ValueError(
-                        f"[KitVisualizer] origin_env_index {self.cfg.origin_env_index} is out of range "
-                        f"[0, {num_envs - 1}] for origin_type='env'."
-                    )
-                self._viewer_origin = scene.env_origins[self.cfg.origin_env_index]
+            self._update_camera_tracking()
         elif self.cfg.origin_type == "asset":
-            if self.cfg.origin_track_path is None:
-                raise ValueError("[KitVisualizer] origin_type='asset' requires origin_track_path to be set.")
-            # Asset data is not available until after sim.reset(); defer to step().
-            return
+            if not self.cfg.origin_track_path:
+                raise ValueError("origin_type='asset' requires origin_track_path to be set.")
+            self._update_camera_tracking()
         else:
-            logger.warning("[KitVisualizer] Unknown origin_type '%s'; defaulting to world.", self.cfg.origin_type)
-            self._viewer_origin = torch.zeros(3)
+            raise ValueError(f"Unknown camera origin_type: {self.cfg.origin_type!r}.")
 
-        self._apply_viewer_origin_to_camera()
-
-    def _update_asset_tracking_camera(self) -> None:
-        """Update the viewport camera to track an asset root or body.
-
-        Called every :meth:`step` when :attr:`KitVisualizerCfg.origin_type` is ``"asset"``.
-        Parses :attr:`~KitVisualizerCfg.origin_track_path`: ``"asset_name"`` tracks the root,
-        ``"asset_name/body_name"`` tracks a specific body.
-        """
-        scene = self._interactive_scene
-        if scene is None or self.cfg.origin_track_path is None:
-            return
-        asset_name, _, body_name = self.cfg.origin_track_path.partition("/")
-        try:
-            asset = scene[asset_name]
-        except KeyError:
-            return
-        if body_name:
-            body_ids, _ = asset.find_bodies(body_name)
-            self._viewer_origin = asset.data.body_pos_w.torch[self.cfg.origin_env_index, body_ids[0]]
-        else:
-            self._viewer_origin = asset.data.root_pos_w.torch[self.cfg.origin_env_index]
-        self._apply_viewer_origin_to_camera()
-
-    def _apply_viewer_origin_to_camera(self) -> None:
-        """Compute absolute eye/target from :attr:`_viewer_origin` and push to the viewport."""
-        if self._viewer_origin is None:
-            return
-        origin = self._viewer_origin.detach().cpu().numpy()
-        eye = np.array(self.cfg.eye, dtype=float) + origin
-        target = np.array(self.cfg.lookat, dtype=float) + origin
-        self.set_camera_view(tuple(float(v) for v in eye), tuple(float(v) for v in target))
+    def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
+        """Apply a world-space pose to both the viewport and the recording renderer."""
+        eye, target = pose
+        env_index = self.camera_env_index if self.cfg.origin_type != "world" else None
+        if env_index != self._camera_partition_env_index:
+            stage = getattr(self._scene_data_provider, "usd_stage", None)
+            if stage is not None:
+                self._apply_viewport_camera_scene_partition(stage, self._scene_data_provider.num_envs)
+                self._camera_partition_env_index = env_index
+        self.set_camera_view(eye, target)
         # Keep the Isaac RTX renderer camera in sync (no-op if isaaclab_physx is not installed).
         try:
             from isaaclab_physx.renderers.kit_viewport_utils import set_kit_renderer_camera_view  # noqa: PLC0415

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -419,20 +419,6 @@ class KitVisualizer(BaseVisualizer):
         """KitVisualizer calls app.update() in step(), so render() should not do it again."""
         return True
 
-    def set_camera_view(
-        self, eye: tuple[float, float, float] | list[float], target: tuple[float, float, float] | list[float]
-    ) -> None:
-        """Set active viewport camera eye/target.
-
-        Args:
-            eye: Camera eye position.
-            target: Camera look-at target.
-        """
-        if not self._is_initialized:
-            logger.debug("[KitVisualizer] set_camera_view() ignored because visualizer is not initialized.")
-            return
-        self._set_viewport_camera(tuple(eye), tuple(target))
-
     def render_tiled_rgb_array(self) -> np.ndarray | None:
         """Return the last composited streaming frame (all GT types side-by-side).
 
@@ -1245,6 +1231,8 @@ class KitVisualizer(BaseVisualizer):
 
     def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
         """Apply a world-space pose to both the viewport and the recording renderer."""
+        if not self._is_initialized:
+            return
         eye, target = pose
         env_index = self.camera_env_index if self.cfg.origin_type != "world" else None
         if env_index != self._camera_partition_env_index:
@@ -1252,7 +1240,7 @@ class KitVisualizer(BaseVisualizer):
             if stage is not None:
                 self._apply_viewport_camera_scene_partition(stage, self._scene_data_provider.num_envs)
                 self._camera_partition_env_index = env_index
-        self.set_camera_view(eye, target)
+        self._set_viewport_camera(eye, target)
         # Keep the Isaac RTX renderer camera in sync (no-op if isaaclab_physx is not installed).
         try:
             from isaaclab_physx.renderers.kit_viewport_utils import set_kit_renderer_camera_view  # noqa: PLC0415

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer.py
@@ -1240,14 +1240,8 @@ class KitVisualizer(BaseVisualizer):
         if self.cfg.origin_type == "world":
             self._viewer_origin = torch.zeros(3)
             self._apply_camera_pose(self._resolve_cfg_camera_pose("KitVisualizer"))
-        elif self.cfg.origin_type == "env":
-            self._update_camera_tracking()
-        elif self.cfg.origin_type == "asset":
-            if not self.cfg.origin_track_path:
-                raise ValueError("origin_type='asset' requires origin_track_path to be set.")
-            self._update_camera_tracking()
         else:
-            raise ValueError(f"Unknown camera origin_type: {self.cfg.origin_type!r}.")
+            self._update_camera_tracking()
 
     def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
         """Apply a world-space pose to both the viewport and the recording renderer."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer_cfg.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/kit/kit_visualizer_cfg.py
@@ -62,32 +62,3 @@ class KitVisualizerCfg(VisualizerCfg):
 
     window_height: int = 720
     """Viewport height in pixels (when :attr:`create_viewport` is ``True``)."""
-
-    origin_type: str = "world"
-    """Frame in which :attr:`~isaaclab.visualizers.VisualizerCfg.eye` and
-    :attr:`~isaaclab.visualizers.VisualizerCfg.lookat` are interpreted.
-
-    Options:
-
-    * ``"world"``: global origin.
-    * ``"env"``: origin of the environment at :attr:`origin_env_index`.
-    * ``"asset"``: a scene asset (or body) specified by :attr:`origin_track_path`.
-    """
-
-    origin_env_index: int = 0
-    """Index of the environment used as the viewport camera origin.
-
-    Only meaningful when :attr:`origin_type` is ``"env"`` or ``"asset"``.
-    """
-
-    origin_track_path: str | None = None
-    """Asset tracking path for the viewport camera origin.
-
-    Format: ``"<asset_name>"`` to track the asset root, or ``"<asset_name>/<body_name>"``
-    to track a specific body on the asset.  Required when :attr:`origin_type` is ``"asset"``.
-
-    Examples::
-
-        origin_track_path = "robot"             # track robot root
-        origin_track_path = "robot/panda_hand"  # track panda_hand body on robot
-    """

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1157,6 +1157,7 @@ class NewtonVisualizer(BaseVisualizer):
                 " rigid-body force input."
             )
         self._is_initialized = True
+        self._update_camera_tracking()
         # Inform the viewer whether contact data is available so the UI can grey
         # out "Show Contacts" when neither native Newton contacts nor a ContactSensor
         # exists in the scene.
@@ -1185,6 +1186,7 @@ class NewtonVisualizer(BaseVisualizer):
         if not self._is_initialized or self._is_closed:
             return
 
+        self._update_camera_tracking(dt)
         self._sim_time += dt
         self._step_counter += 1
 
@@ -1380,8 +1382,7 @@ class NewtonVisualizer(BaseVisualizer):
         """
         eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
         target_t = (float(target[0]), float(target[1]), float(target[2]))
-        self.cfg.eye = eye_t
-        self.cfg.lookat = target_t
+        self._set_camera_pose_cfg(eye_t, target_t)
         self._apply_camera_pose((eye_t, target_t))
 
     def log_mesh(

--- a/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/newton/newton_visualizer.py
@@ -1371,20 +1371,6 @@ class NewtonVisualizer(BaseVisualizer):
             return False
         return self._viewer.is_rendering_paused()
 
-    def set_camera_view(
-        self, eye: tuple[float, float, float] | list[float], target: tuple[float, float, float] | list[float]
-    ) -> None:
-        """Set active viewer camera eye/target.
-
-        Args:
-            eye: Camera eye position.
-            target: Camera look-at target.
-        """
-        eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
-        target_t = (float(target[0]), float(target[1]), float(target[2]))
-        self._set_camera_pose_cfg(eye_t, target_t)
-        self._apply_camera_pose((eye_t, target_t))
-
     def log_mesh(
         self,
         name: str,

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
@@ -428,6 +428,7 @@ class RerunVisualizer(BaseVisualizer):
 
         self._setup_streaming_view(num_envs)
         self._is_initialized = True
+        self._update_camera_tracking()
         atexit.register(self.close)
 
     def step(self, dt: float) -> None:
@@ -441,6 +442,7 @@ class RerunVisualizer(BaseVisualizer):
         if not self._is_initialized or self._is_closed or self._viewer is None:
             return
 
+        self._update_camera_tracking(dt)
         self._sim_time += dt
         self._step_counter += 1
 
@@ -688,6 +690,10 @@ class RerunVisualizer(BaseVisualizer):
         # the streaming blueprint (Spatial2DView) from _get_blueprint() would be replaced
         # by a 3D view, hiding the streaming composite panel entirely.
         if self._streaming_view_active:
+            return
+        if self._viewer._live_plot_manager_names:
+            rr.send_blueprint(self._viewer._get_blueprint())
+            self._last_camera_pose = pose
             return
         panel_states = [rrb.TimePanel(state="hidden")]
         rr.send_blueprint(

--- a/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/rerun/rerun_visualizer.py
@@ -20,8 +20,10 @@ import newton
 import numpy as np
 import rerun as rr
 import rerun.blueprint as rrb
+import torch
 from newton.viewer import ViewerRerun
 
+from isaaclab.utils.math import create_rotation_matrix_from_view
 from isaaclab.visualizers.base_visualizer import BaseVisualizer
 
 from isaaclab_visualizers.newton.newton_visualization_markers import render_newton_visualization_markers
@@ -195,8 +197,7 @@ class NewtonViewerRerun(ViewerRerun):
         When streaming is **not** active the standard 3D Newton view is used,
         with live-plot time-series views appended when registered.
 
-        The stored :attr:`_camera_pose` is forwarded to
-        :class:`~rerun.blueprint.EyeControls3D` when the 3D view is included.
+        The 3D view follows a logged camera frame so pose updates preserve the viewer layout.
         """
         manager_views = (
             [rrb.TimeSeriesView(name=name, origin=f"/{name}") for name in self._live_plot_manager_names]
@@ -226,15 +227,11 @@ class NewtonViewerRerun(ViewerRerun):
             )
 
         # Standard 3D blueprint (no streaming).
-        eye_controls = (
-            rrb.EyeControls3D(position=self._camera_pose[0], look_target=self._camera_pose[1])
-            if self._camera_pose
-            else None
-        )
-        view_3d = (
-            rrb.Spatial3DView(name="3D View", origin="/", eye_controls=eye_controls)
-            if eye_controls
-            else rrb.Spatial3DView(name="3D View", origin="/")
+        view_3d = rrb.Spatial3DView(
+            name="3D View",
+            origin="viewer/camera",
+            contents=["+ /**", "- /viewer/**"],
+            eye_controls=rrb.EyeControls3D(position=(0, 0, 0), look_target=(0, 0, -1), eye_up=(0, 1, 0)),
         )
         if manager_views:
             return rrb.Blueprint(
@@ -247,7 +244,13 @@ class NewtonViewerRerun(ViewerRerun):
                 collapse_panels=True,
             )
         return rrb.Blueprint(
-            view_3d,
+            rrb.Vertical(
+                view_3d,
+                rrb.TextDocumentView(
+                    name=f"Physics: {getattr(self, '_backend_display', 'unknown')}", origin="info/physics_backend"
+                ),
+                row_shares=[20, 1],
+            ),
             *panel_states,
             collapse_panels=True,
         )
@@ -396,6 +399,7 @@ class RerunVisualizer(BaseVisualizer):
         self._viewer.set_world_offsets((0.0, 0.0, 0.0))
         backend = self.physics_backend or "unknown"
         self._backend_display = _BACKEND_DISPLAY_NAMES.get(backend, backend)
+        self._viewer._backend_display = self._backend_display
         initial_pose = self._resolve_initial_camera_pose()
         self._apply_camera_pose(initial_pose)
         self._viewer.up_axis = 2
@@ -686,51 +690,17 @@ class RerunVisualizer(BaseVisualizer):
             return
         cam_pos, cam_target = pose
         self._viewer._camera_pose = pose
-        # Do not send a Spatial3DView blueprint when the streaming composite is active:
-        # the streaming blueprint (Spatial2DView) from _get_blueprint() would be replaced
-        # by a 3D view, hiding the streaming composite panel entirely.
+        # Preserve the sensor-composite view when streaming is active.
         if self._streaming_view_active:
             return
-        if self._viewer._live_plot_manager_names:
+        rotation = create_rotation_matrix_from_view(
+            torch.tensor([cam_pos], dtype=torch.float32), torch.tensor([cam_target], dtype=torch.float32)
+        )[0].numpy()
+        # The view stays in this moving frame; only camera data changes on tracking frames.
+        rr.log("viewer/camera", rr.Transform3D(translation=cam_pos, mat3x3=rotation), static=True)
+        if self._last_camera_pose is None:
             rr.send_blueprint(self._viewer._get_blueprint())
-            self._last_camera_pose = pose
-            return
-        panel_states = [rrb.TimePanel(state="hidden")]
-        rr.send_blueprint(
-            rrb.Blueprint(
-                rrb.Vertical(
-                    rrb.Spatial3DView(
-                        name="3D View",
-                        origin="/",
-                        eye_controls=rrb.EyeControls3D(
-                            position=cam_pos,
-                            look_target=cam_target,
-                        ),
-                    ),
-                    rrb.TextDocumentView(
-                        name=f"Physics: {self._backend_display or 'unknown'}",
-                        origin="info/physics_backend",
-                    ),
-                    row_shares=[20, 1],
-                ),
-                *panel_states,
-                collapse_panels=True,
-            )
-        )
-        self._last_camera_pose = (cam_pos, cam_target)
-
-    def set_camera_view(
-        self, eye: tuple[float, float, float] | list[float], target: tuple[float, float, float] | list[float]
-    ) -> None:
-        """Set the 3D view's camera eye/target.
-
-        Args:
-            eye: Camera eye position.
-            target: Camera look-at target.
-        """
-        eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
-        target_t = (float(target[0]), float(target[1]), float(target[2]))
-        self._apply_camera_pose((eye_t, target_t))
+        self._last_camera_pose = pose
 
     def supports_markers(self) -> bool:
         """Rerun backend supports Isaac Lab markers through Newton viewer primitives."""

--- a/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
@@ -440,6 +440,7 @@ class ViserVisualizer(BaseVisualizer):
         )
         self._setup_streaming_view(num_envs)
         self._is_initialized = True
+        self._update_camera_tracking()
 
     def step(self, dt: float) -> None:
         """Advance visualization by one simulation step.
@@ -452,6 +453,7 @@ class ViserVisualizer(BaseVisualizer):
         if not self._is_initialized or self._viewer is None or self._scene_data_provider is None:
             return
 
+        self._update_camera_tracking(dt)
         self._apply_pending_camera_pose()
 
         self._state = NewtonManager.get_state(self._scene_data_provider)

--- a/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
+++ b/source/isaaclab_visualizers/isaaclab_visualizers/viser/viser_visualizer.py
@@ -807,7 +807,7 @@ class ViserVisualizer(BaseVisualizer):
         if self.cfg.open_browser:
             _open_viser_web_viewer(viewer_url)
         initial_pose = self._resolve_initial_camera_pose()
-        self._set_viser_camera_view(initial_pose)
+        self._apply_camera_pose(initial_pose)
         self._sim_time = 0.0
 
     def _setup_isaaclab_sidebar(self, server) -> None:
@@ -930,7 +930,7 @@ class ViserVisualizer(BaseVisualizer):
                 continue
         return applied
 
-    def _set_viser_camera_view(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
+    def _apply_camera_pose(self, pose: tuple[tuple[float, float, float], tuple[float, float, float]]) -> None:
         """Apply or defer camera pose update depending on client readiness."""
         if self._try_apply_viser_camera_view(pose):
             self._last_camera_pose = pose
@@ -945,16 +945,3 @@ class ViserVisualizer(BaseVisualizer):
         if self._try_apply_viser_camera_view(self._pending_camera_pose):
             self._last_camera_pose = self._pending_camera_pose
             self._pending_camera_pose = None
-
-    def set_camera_view(
-        self, eye: tuple[float, float, float] | list[float], target: tuple[float, float, float] | list[float]
-    ) -> None:
-        """Set every connected client's camera eye/target.
-
-        Args:
-            eye: Camera eye position.
-            target: Camera look-at target.
-        """
-        eye_t = (float(eye[0]), float(eye[1]), float(eye[2]))
-        target_t = (float(target[0]), float(target[1]), float(target[2]))
-        self._set_viser_camera_view((eye_t, target_t))

--- a/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
+++ b/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
@@ -140,7 +140,8 @@ def test_viewport_partition_updates_after_center_camera_selection(monkeypatch):
     scene = SimpleNamespace(num_envs=3, env_origins=torch.tensor([[-10.0, 0, 0], [10.0, 0, 0], [0.0, 0, 0]]))
     viz._scene_data_provider = SimpleNamespace(usd_stage=stage, num_envs=3, get_interactive_scene=lambda: scene)
     monkeypatch.setattr(kit_visualizer_module, "get_settings_manager", lambda: SimpleNamespace(get=lambda *args: False))
-    monkeypatch.setattr(viz, "set_camera_view", lambda *args: None)
+    viz._is_initialized = True
+    monkeypatch.setattr(viz, "_set_viewport_camera", lambda *args: None)
     viz._update_camera_tracking()
     assert viz.camera_env_index == 2
     assert camera.GetPrim().GetAttribute("omni:scenePartition").Get() == "env_2"

--- a/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
+++ b/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
@@ -129,8 +129,6 @@ def test_marker_environment_ids_are_sticky_until_count_changes() -> None:
 
 
 def test_viewport_partition_updates_after_center_camera_selection(monkeypatch):
-    from isaaclab.sim import SimulationContext
-
     stage = Usd.Stage.CreateInMemory()
     env_prim = stage.DefinePrim("/World/envs/env_0", "Xform")
     env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set("env_0")
@@ -139,9 +137,8 @@ def test_viewport_partition_updates_after_center_camera_selection(monkeypatch):
     viz = KitVisualizer(KitVisualizerCfg(origin_type="env", origin_env_index="center"))
     viz._controlled_camera_path = "/OmniverseKit_Persp"
     viz._resolved_visible_env_ids = [0, 1, 2]
-    viz._scene_data_provider = SimpleNamespace(usd_stage=stage, num_envs=3)
     scene = SimpleNamespace(num_envs=3, env_origins=torch.tensor([[-10.0, 0, 0], [10.0, 0, 0], [0.0, 0, 0]]))
-    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
+    viz._scene_data_provider = SimpleNamespace(usd_stage=stage, num_envs=3, get_interactive_scene=lambda: scene)
     monkeypatch.setattr(kit_visualizer_module, "get_settings_manager", lambda: SimpleNamespace(get=lambda *args: False))
     monkeypatch.setattr(viz, "set_camera_view", lambda *args: None)
     viz._update_camera_tracking()

--- a/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
+++ b/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock
 import isaaclab_visualizers.kit.kit_visualizer as kit_visualizer_module
 import pytest
 import torch
-from isaaclab_visualizers.kit import KitVisualizerCfg
 from isaaclab_visualizers.kit.kit_visualization_markers import KitVisualizationMarkers
 from isaaclab_visualizers.kit.kit_visualizer import KitVisualizer
 from isaaclab_visualizers.kit.kit_visualizer_cfg import KitVisualizerCfg

--- a/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
+++ b/source/isaaclab_visualizers/test/test_kit_visualizer_scene_partitioning.py
@@ -5,11 +5,13 @@
 
 """Tests for Kit visualizer scene-partition behavior."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import isaaclab_visualizers.kit.kit_visualizer as kit_visualizer_module
 import pytest
 import torch
+from isaaclab_visualizers.kit import KitVisualizerCfg
 from isaaclab_visualizers.kit.kit_visualization_markers import KitVisualizationMarkers
 from isaaclab_visualizers.kit.kit_visualizer import KitVisualizer
 from isaaclab_visualizers.kit.kit_visualizer_cfg import KitVisualizerCfg
@@ -52,7 +54,7 @@ def test_viewport_camera_partition_follows_global_view_setting(
     camera = UsdGeom.Camera.Define(stage, "/OmniverseKit_Persp")
     camera.GetPrim().CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set("env_0")
 
-    visualizer = object.__new__(KitVisualizer)
+    visualizer = KitVisualizer(KitVisualizerCfg())
     visualizer._controlled_camera_path = "/OmniverseKit_Persp"
     visualizer._resolved_visible_env_ids = [2]
     settings = MagicMock()
@@ -125,3 +127,24 @@ def test_marker_environment_ids_are_sticky_until_count_changes() -> None:
     )
 
     assert not primvar.GetAttr().HasAuthoredValueOpinion()
+
+
+def test_viewport_partition_updates_after_center_camera_selection(monkeypatch):
+    from isaaclab.sim import SimulationContext
+
+    stage = Usd.Stage.CreateInMemory()
+    env_prim = stage.DefinePrim("/World/envs/env_0", "Xform")
+    env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set("env_0")
+    camera = UsdGeom.Camera.Define(stage, "/OmniverseKit_Persp")
+    camera.GetPrim().CreateAttribute("omni:scenePartition", Sdf.ValueTypeNames.Token).Set("env_0")
+    viz = KitVisualizer(KitVisualizerCfg(origin_type="env", origin_env_index="center"))
+    viz._controlled_camera_path = "/OmniverseKit_Persp"
+    viz._resolved_visible_env_ids = [0, 1, 2]
+    viz._scene_data_provider = SimpleNamespace(usd_stage=stage, num_envs=3)
+    scene = SimpleNamespace(num_envs=3, env_origins=torch.tensor([[-10.0, 0, 0], [10.0, 0, 0], [0.0, 0, 0]]))
+    monkeypatch.setattr(SimulationContext, "instance", lambda: SimpleNamespace(_interactive_scene=scene))
+    monkeypatch.setattr(kit_visualizer_module, "get_settings_manager", lambda: SimpleNamespace(get=lambda *args: False))
+    monkeypatch.setattr(viz, "set_camera_view", lambda *args: None)
+    viz._update_camera_tracking()
+    assert viz.camera_env_index == 2
+    assert camera.GetPrim().GetAttribute("omni:scenePartition").Get() == "env_2"

--- a/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
+++ b/source/isaaclab_visualizers/test/test_newton_visualizer_viewer_release.py
@@ -212,6 +212,7 @@ def _arm_for_step_failure(visualizer: NewtonVisualizer, viewer: _SpyRTXViewer) -
     visualizer._state = None
     visualizer._scene_data_provider = None
     visualizer._update_frequency = 1
+    visualizer._update_camera_tracking = lambda dt: None
     viewer._update_frequency = 1
 
     def _unrecoverable() -> bool:


### PR DESCRIPTION
# Description

Core tasks now own their recording camera in `sim.default_visualizer_cfg`, so the existing `isaaclab play --video` command produces a task-specific view. Static tasks use fixed cameras; locomotion cameras follow the selected robot's position and yaw while keeping the horizon level.

- Added shared camera tracking across Kit, Newton GL/RTX, Rerun, and Viser, with spatial-center environment selection retained across resets. Runtime camera edits persist through the shared setter; Rerun updates a camera transform without resending the layout each frame.
- Configured camera views across all 45 core task registrations. Heading smoothing uses 0.2 seconds for velocity tasks and 0.5 seconds for Ant and Humanoid.
- Preserved explicit backend camera overrides and policy camera sensors. Recording needs no separate capture script or new dependencies.

## Type of change

- New feature
- Documentation update

## Release backport

- [ ] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

- 162 unit tests passed across the shared visualizer, simulation context, backend camera, scene-partition, adapter, material, and viewer-release tests. Extended existing tests to reproduce the runtime-edit and repeated-blueprint bugs before fixing them.
- `uv run --no-sync isaaclab -f` passed.
- Confirmed camera tracking through the bound scene provider without a global simulation singleton; all four Cabinet preset values remained unchanged after sharing setup.
- Standard-play Ant and Go2 OVRTX recordings were validated before rebasing: one environment, Nucleus RSL-RL checkpoints, two seconds at 1080p, full decoding and visual inspection. Go2 used forward-command Hydra overrides.
- `uv run --isolated --extra dev -- make -C docs current-docs SPHINXOPTS="-j 2"` passed with warnings treated as errors before the bot-review follow-up.

## Known UI limitation

Kit initializes its camera sliders from configured offsets, but the edit callback interprets
those values as world coordinates. With a translated or heading-tracked camera, editing one
slider can therefore move the other coordinates. This existing initialization mismatch remains
a follow-up; the shared inverse-heading conversion preserves world-space edits once supplied.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the pre-commit checks with `uv run isaaclab -f`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] I have added a changelog fragment for every touched source package
- [x] My name already exists in `CONTRIBUTORS.md`
