### PR TITLE
Move deformable camera tasks to benchmark package

### DIFF
--- a/source/isaaclab_tasks/changelog.d/move-deformable-camera-benchmarks.minor.rst
+++ b/source/isaaclab_tasks/changelog.d/move-deformable-camera-benchmarks.minor.rst
@@ -1,0 +1,7 @@
+Changed
+^^^^^^^
+
+* Moved the ``Isaac-Lift-Cable-Franka-Camera``, ``Isaac-Lift-Cloth-Franka-Camera``, and
+  ``Isaac-Lift-Soft-Franka-Camera`` tasks into ``isaaclab_tasks.benchmark.franka_deformable_camera``.
+  The task ids are unchanged, so registry-based loading needs no changes. Code that imports their environment or
+  RSL-RL configuration classes directly must update to the new benchmark package paths.

--- a/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Camera-equipped Franka deformable tasks used for benchmarking."""
+
+import gymnasium as gym
+
+from . import agents
+
+gym.register(
+    id="Isaac-Lift-Cable-Franka-Camera",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.franka_deformable_camera_env_cfg:FrankaCableCameraEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaCableCameraPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Isaac-Lift-Soft-Franka-Camera",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.franka_deformable_camera_env_cfg:FrankaSoftCameraEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformableCameraPPORunnerCfg",
+        "default_agent": "rsl_rl",
+    },
+)
+
+gym.register(
+    id="Isaac-Lift-Cloth-Franka-Camera",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.franka_deformable_camera_env_cfg:FrankaClothCameraEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformableCameraPPORunnerCfg",
+        "default_agent": "rsl_rl",
+    },
+)

--- a/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/agents/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_rl.rsl_rl import RslRlCNNModelCfg, RslRlMLPModelCfg, RslRlOnPolicyRunnerCfg
+
+from isaaclab_tasks.core.lift.config.franka_soft.agents.rsl_rl_ppo_cfg import ALGO_CFG
+
+
+@configclass
+class FrankaDeformableCameraPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 5000
+    save_interval = 50
+    experiment_name = "franka_deformable_camera"
+    obs_groups = {
+        "actor": ["policy", "proprio", "base_image"],
+        "critic": ["policy", "proprio", "perception"],
+    }
+    actor = RslRlCNNModelCfg(
+        obs_normalization=True,
+        hidden_dims=[512, 256, 128],
+        distribution_cfg=RslRlCNNModelCfg.GaussianDistributionCfg(init_std=1.0),
+        cnn_cfg=RslRlCNNModelCfg.CNNCfg(
+            output_channels=[32, 64, 64],
+            kernel_size=[8, 4, 3],
+            stride=[4, 2, 1],
+            activation="elu",
+        ),
+        activation="elu",
+    )
+    critic = RslRlMLPModelCfg(
+        obs_normalization=True,
+        hidden_dims=[512, 256, 128],
+        activation="elu",
+    )
+    algorithm = ALGO_CFG.replace(num_mini_batches=8)
+
+
+@configclass
+class FrankaCableCameraPPORunnerCfg(FrankaDeformableCameraPPORunnerCfg):
+    experiment_name = "lift_cable_camera"

--- a/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/franka_deformable_camera_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/benchmark/franka_deformable_camera/franka_deformable_camera_env_cfg.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Configurations for the Franka deformable camera benchmark tasks."""
+
+from __future__ import annotations
+
+import isaaclab.sim as sim_utils
+from isaaclab.envs import mdp as env_mdp
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import CameraCfg
+from isaaclab.utils import configclass
+
+from isaaclab_tasks.core.lift import mdp
+from isaaclab_tasks.core.lift.config.franka_soft.franka_cable_env_cfg import FrankaCableEnvCfg, FrankaCableSceneCfg
+from isaaclab_tasks.core.lift.config.franka_soft.franka_cloth_env_cfg import FrankaClothEnvCfg, FrankaClothSceneCfg
+from isaaclab_tasks.core.lift.config.franka_soft.franka_soft_env_cfg import FrankaSoftEnvCfg, _FrankaSoftSceneCfg
+from isaaclab_tasks.utils import PresetCfg
+from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
+
+FRANKA_CAMERA_CFG = CameraCfg(
+    prim_path="{ENV_REGEX_NS}/Camera",
+    offset=CameraCfg.OffsetCfg(
+        pos=(0.85, -0.55, 0.42),
+        rot=(0.5080, 0.2114, 0.318, 0.7720),
+        convention="opengl",
+    ),
+    data_types=["rgb"],
+    spawn=sim_utils.PinholeCameraCfg(clipping_range=(0.01, 3.0)),
+    width=128,
+    height=128,
+    renderer_cfg=MultiBackendRendererCfg(),
+)
+
+
+@configclass
+class _FrankaSoftCameraSceneCfg(_FrankaSoftSceneCfg):
+    """Franka soft scene with a base camera."""
+
+    base_camera: CameraCfg = FRANKA_CAMERA_CFG
+
+
+@configclass
+class FrankaCameraObservationsCfg:
+    """Observation groups for visual deformable lifting."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        target_position = ObsTerm(func=mdp.generated_commands, params={"command_name": "deformable_pose"})
+        actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self) -> None:
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    @configclass
+    class ProprioCfg(ObsGroup):
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
+
+        def __post_init__(self) -> None:
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    @configclass
+    class PerceptionCfg(ObsGroup):
+        deformable_sampled_points = ObsTerm(
+            func=mdp.DeformableSampledPointsInRobotRootFrame,
+            params={"asset_cfg": SceneEntityCfg("deformable"), "num_points": 20},
+        )
+
+        def __post_init__(self) -> None:
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    @configclass
+    class BaseImageCfg(ObsGroup):
+        image = ObsTerm(
+            func=env_mdp.image,
+            params={
+                "sensor_cfg": SceneEntityCfg("base_camera"),
+                "data_type": "rgb",
+                "normalize": True,
+                "permute": True,
+            },
+        )
+
+    policy: PolicyCfg = PolicyCfg()
+    proprio: ProprioCfg = ProprioCfg()
+    perception: PerceptionCfg = PerceptionCfg()
+    base_image: BaseImageCfg = BaseImageCfg()
+
+
+@configclass
+class FrankaSoftCameraSceneCfg(PresetCfg):
+    """Scene presets for visual Franka soft lifting."""
+
+    newton_mjwarp_vbd_proxy: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(
+        num_envs=128, env_spacing=2.0, replicate_physics=True
+    )
+    physx: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(num_envs=128, env_spacing=2.0, replicate_physics=False)
+    isaacsim_physx = physx
+    default = newton_mjwarp_vbd_proxy
+
+
+@configclass
+class FrankaSoftCameraEnvCfg(FrankaSoftEnvCfg):
+    """Visual Franka volume-deformable lifting environment."""
+
+    scene: FrankaSoftCameraSceneCfg = FrankaSoftCameraSceneCfg()
+    observations: FrankaCameraObservationsCfg = FrankaCameraObservationsCfg()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # Warm up the RTX render product/annotator (Newton skips the PhysX assets_loading render loop).
+        self.num_rerenders_on_reset = 2
+
+
+@configclass
+class FrankaClothCameraSceneCfg(FrankaClothSceneCfg):
+    """Franka cloth scene with a base camera."""
+
+    base_camera: CameraCfg = FRANKA_CAMERA_CFG
+
+
+@configclass
+class FrankaClothCameraScenePresetCfg(PresetCfg):
+    """Scene presets for visual Franka cloth lifting."""
+
+    newton_mjwarp_vbd_proxy: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(
+        num_envs=128, env_spacing=2.5, replicate_physics=True
+    )
+    physx: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
+    isaacsim_physx = physx
+    default = newton_mjwarp_vbd_proxy
+
+
+@configclass
+class FrankaClothCameraEnvCfg(FrankaClothEnvCfg):
+    """Visual Franka surface-deformable lifting environment."""
+
+    scene: FrankaClothCameraScenePresetCfg = FrankaClothCameraScenePresetCfg()
+    observations: FrankaCameraObservationsCfg = FrankaCameraObservationsCfg()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # Warm up the RTX render product/annotator (Newton skips the PhysX assets_loading render loop).
+        self.num_rerenders_on_reset = 2
+
+
+@configclass
+class FrankaCableCameraSceneCfg(FrankaCableSceneCfg):
+    """Franka cable scene with a base camera."""
+
+    base_camera: CameraCfg = FRANKA_CAMERA_CFG
+
+
+@configclass
+class FrankaCableCameraObservationsCfg(FrankaCameraObservationsCfg):
+    """Observation groups for visual cable lifting."""
+
+    @configclass
+    class PolicyCfg(FrankaCameraObservationsCfg.PolicyCfg):
+        target_position = ObsTerm(func=mdp.generated_commands, params={"command_name": "cable_pose"})
+
+    @configclass
+    class PerceptionCfg(ObsGroup):
+        cable_segment_positions = ObsTerm(
+            func=mdp.cable_segment_positions_in_robot_root_frame,
+            params={"asset_cfg": SceneEntityCfg("cable")},
+        )
+
+        def __post_init__(self) -> None:
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    policy: PolicyCfg = PolicyCfg()
+    perception: PerceptionCfg = PerceptionCfg()
+
+
+@configclass
+class FrankaCableCameraEnvCfg(FrankaCableEnvCfg):
+    """Visual Franka cable lifting environment."""
+
+    scene: FrankaCableCameraSceneCfg = FrankaCableCameraSceneCfg(num_envs=128, env_spacing=2.0, replicate_physics=True)
+    observations: FrankaCableCameraObservationsCfg = FrankaCableCameraObservationsCfg()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.num_rerenders_on_reset = 2

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/__init__.py
@@ -43,37 +43,3 @@ gym.register(
         "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaCablePPORunnerCfg",
     },
 )
-
-
-gym.register(
-    id="Isaac-Lift-Cable-Franka-Camera",
-    entry_point="isaaclab.envs:ManagerBasedRLEnv",
-    disable_env_checker=True,
-    kwargs={
-        "env_cfg_entry_point": f"{__name__}.franka_cable_env_cfg:FrankaCableCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaCableCameraPPORunnerCfg",
-    },
-)
-
-
-gym.register(
-    id="Isaac-Lift-Soft-Franka-Camera",
-    entry_point="isaaclab.envs:ManagerBasedRLEnv",
-    disable_env_checker=True,
-    kwargs={
-        "env_cfg_entry_point": f"{__name__}.franka_soft_env_cfg:FrankaSoftCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformableCameraPPORunnerCfg",
-        "default_agent": "rsl_rl",
-    },
-)
-
-gym.register(
-    id="Isaac-Lift-Cloth-Franka-Camera",
-    entry_point="isaaclab.envs:ManagerBasedRLEnv",
-    disable_env_checker=True,
-    kwargs={
-        "env_cfg_entry_point": f"{__name__}.franka_cloth_env_cfg:FrankaClothCameraEnvCfg",
-        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:FrankaDeformableCameraPPORunnerCfg",
-        "default_agent": "rsl_rl",
-    },
-)

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/agents/rsl_rl_ppo_cfg.py
@@ -6,7 +6,6 @@
 from isaaclab.utils import configclass
 
 from isaaclab_rl.rsl_rl import (
-    RslRlCNNModelCfg,
     RslRlMLPModelCfg,
     RslRlOnPolicyRunnerCfg,
     RslRlPpoAlgorithmCfg,
@@ -60,38 +59,3 @@ class FrankaClothPPORunnerCfg(FrankaDeformablePPORunnerCfg):
 @configclass
 class FrankaCablePPORunnerCfg(FrankaDeformablePPORunnerCfg):
     experiment_name = "lift_cable"
-
-
-@configclass
-class FrankaDeformableCameraPPORunnerCfg(RslRlOnPolicyRunnerCfg):
-    num_steps_per_env = 24
-    max_iterations = 5000
-    save_interval = 50
-    experiment_name = "franka_deformable_camera"
-    obs_groups = {
-        "actor": ["policy", "proprio", "base_image"],
-        "critic": ["policy", "proprio", "perception"],
-    }
-    actor = RslRlCNNModelCfg(
-        obs_normalization=True,
-        hidden_dims=[512, 256, 128],
-        distribution_cfg=RslRlCNNModelCfg.GaussianDistributionCfg(init_std=1.0),
-        cnn_cfg=RslRlCNNModelCfg.CNNCfg(
-            output_channels=[32, 64, 64],
-            kernel_size=[8, 4, 3],
-            stride=[4, 2, 1],
-            activation="elu",
-        ),
-        activation="elu",
-    )
-    critic = RslRlMLPModelCfg(
-        obs_normalization=True,
-        hidden_dims=[512, 256, 128],
-        activation="elu",
-    )
-    algorithm = ALGO_CFG.replace(num_mini_batches=8)
-
-
-@configclass
-class FrankaCableCameraPPORunnerCfg(FrankaDeformableCameraPPORunnerCfg):
-    experiment_name = "lift_cable_camera"

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cable_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cable_env_cfg.py
@@ -18,7 +18,6 @@ from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.markers import VisualizationMarkersCfg
-from isaaclab.sensors import CameraCfg
 from isaaclab.sim.spawners.materials import RigidBodyMaterialBaseCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled
@@ -29,9 +28,7 @@ from isaaclab_tasks.utils import PresetCfg
 
 from ... import mdp
 from .franka_soft_env_cfg import (
-    FRANKA_CAMERA_CFG,
     TABLE_SPAWN_CFG,
-    FrankaCameraObservationsCfg,
     FrankaSoftEnvCfg,
     _FrankaSoftSceneCfg,
 )
@@ -150,13 +147,6 @@ class FrankaCableSceneCfg(_FrankaSoftSceneCfg):
 
 
 @configclass
-class FrankaCableCameraSceneCfg(FrankaCableSceneCfg):
-    """Franka cable scene with a base camera."""
-
-    base_camera: CameraCfg = FRANKA_CAMERA_CFG
-
-
-@configclass
 class CommandsCfg:
     """Goal position for cable segment 6 in the robot root frame."""
 
@@ -209,29 +199,6 @@ class ObservationsCfg:
             self.concatenate_terms = True
 
     policy: PolicyCfg = PolicyCfg()
-
-
-@configclass
-class FrankaCableCameraObservationsCfg(FrankaCameraObservationsCfg):
-    """Observation groups for visual cable lifting."""
-
-    @configclass
-    class PolicyCfg(FrankaCameraObservationsCfg.PolicyCfg):
-        target_position = ObsTerm(func=mdp.generated_commands, params={"command_name": "cable_pose"})
-
-    @configclass
-    class PerceptionCfg(ObsGroup):
-        cable_segment_positions = ObsTerm(
-            func=mdp.cable_segment_positions_in_robot_root_frame,
-            params={"asset_cfg": SceneEntityCfg("cable")},
-        )
-
-        def __post_init__(self) -> None:
-            self.enable_corruption = True
-            self.concatenate_terms = True
-
-    policy: PolicyCfg = PolicyCfg()
-    perception: PerceptionCfg = PerceptionCfg()
 
 
 @configclass
@@ -348,15 +315,3 @@ class FrankaCableEnvCfg(FrankaSoftEnvCfg):
         if not isaac_rtx_per_env_scene_partition_enabled():
             self.scene.partition_bounds_marker_min = None
             self.scene.partition_bounds_marker_max = None
-
-
-@configclass
-class FrankaCableCameraEnvCfg(FrankaCableEnvCfg):
-    """Visual Franka cable lifting environment."""
-
-    scene: FrankaCableCameraSceneCfg = FrankaCableCameraSceneCfg(num_envs=128, env_spacing=2.0, replicate_physics=True)
-    observations: FrankaCableCameraObservationsCfg = FrankaCableCameraObservationsCfg()
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.num_rerenders_on_reset = 2

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cloth_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_cloth_env_cfg.py
@@ -27,7 +27,6 @@ from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.physics import PhysxAutoCfg
-from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
 
 from isaaclab_contrib.coupling import CouplerEntryCfg, CouplerProxyCfg, CouplerProxyMappingCfg
@@ -36,14 +35,9 @@ from isaaclab_tasks.utils import PresetCfg
 
 from ... import mdp
 from .franka_soft_env_cfg import (
-    FRANKA_CAMERA_CFG,
-    FrankaCameraObservationsCfg,
-    FrankaSoftEnvCfg,
-    _FrankaSoftSceneCfg,
-)
-from .franka_soft_env_cfg import (
     EventCfg as FrankaSoftEventCfg,
 )
+from .franka_soft_env_cfg import FrankaSoftEnvCfg, _FrankaSoftSceneCfg
 from .franka_soft_env_cfg import (
     RewardsCfg as FrankaSoftRewardsCfg,
 )
@@ -209,25 +203,6 @@ class FrankaClothScenePresetCfg(PresetCfg):
 
 
 @configclass
-class FrankaClothCameraSceneCfg(FrankaClothSceneCfg):
-    """Franka cloth scene with a base camera."""
-
-    base_camera: CameraCfg = FRANKA_CAMERA_CFG
-
-
-@configclass
-class FrankaClothCameraScenePresetCfg(PresetCfg):
-    """Scene presets for visual Franka cloth lifting."""
-
-    newton_mjwarp_vbd_proxy: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(
-        num_envs=128, env_spacing=2.5, replicate_physics=True
-    )
-    physx: FrankaClothCameraSceneCfg = FrankaClothCameraSceneCfg(num_envs=128, env_spacing=2.5, replicate_physics=False)
-    isaacsim_physx = physx
-    default = newton_mjwarp_vbd_proxy
-
-
-@configclass
 class FrankaClothEventCfg(FrankaSoftEventCfg):
     """Reset and startup events for the Franka cloth environment."""
 
@@ -279,16 +254,3 @@ class FrankaClothEnvCfg(FrankaSoftEnvCfg):
         self.sim.physics = PhysicsCfg()
         # Fully close the gripper on the thin cloth; the shared beam default only closes to 0.01 m.
         self.actions.ik.gripper_action.close_command_expr = {"panda_finger_joint1": 0.0}
-
-
-@configclass
-class FrankaClothCameraEnvCfg(FrankaClothEnvCfg):
-    """Visual Franka surface-deformable lifting environment."""
-
-    scene: FrankaClothCameraScenePresetCfg = FrankaClothCameraScenePresetCfg()
-    observations: FrankaCameraObservationsCfg = FrankaCameraObservationsCfg()
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        # Warm up the RTX render product/annotator (Newton skips the PhysX assets_loading render loop).
-        self.num_rerenders_on_reset = 2

--- a/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/core/lift/config/franka_soft/franka_soft_env_cfg.py
@@ -26,7 +26,6 @@ from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.assets.deformable_object import DeformableObjectCfg
 from isaaclab.controllers import DifferentialIKControllerCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg
-from isaaclab.envs import mdp as env_mdp
 from isaaclab.managers import CurriculumTermCfg as CurrTerm
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
@@ -37,7 +36,7 @@ from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.markers import VisualizationMarkersCfg
 from isaaclab.physics import PhysxAutoCfg
 from isaaclab.scene import InteractiveSceneCfg
-from isaaclab.sensors import CameraCfg, FrameTransformerCfg
+from isaaclab.sensors import FrameTransformerCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import OffsetCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg
 from isaaclab.utils import configclass
@@ -51,7 +50,6 @@ from isaaclab_contrib.coupling import (
 )
 
 from isaaclab_tasks.utils import PresetCfg
-from isaaclab_tasks.utils.presets import MultiBackendRendererCfg
 
 from ... import mdp
 
@@ -77,21 +75,6 @@ TABLE_SPAWN_CFG = sim_utils.CuboidCfg(
     size=(1.3, 0.9, 1.05),
     collision_props=sim_utils.CollisionPropertiesCfg(),
     visible=False,
-)
-
-
-FRANKA_CAMERA_CFG = CameraCfg(
-    prim_path="{ENV_REGEX_NS}/Camera",
-    offset=CameraCfg.OffsetCfg(
-        pos=(0.85, -0.55, 0.42),
-        rot=(0.5080, 0.2114, 0.318, 0.7720),
-        convention="opengl",
-    ),
-    data_types=["rgb"],
-    spawn=sim_utils.PinholeCameraCfg(clipping_range=(0.01, 3.0)),
-    width=128,
-    height=128,
-    renderer_cfg=MultiBackendRendererCfg(),
 )
 
 
@@ -300,13 +283,6 @@ class _FrankaSoftSceneCfg(InteractiveSceneCfg):
         self.robot.actuators["panda_hand"].damping = 100.0
 
 
-@configclass
-class _FrankaSoftCameraSceneCfg(_FrankaSoftSceneCfg):
-    """Franka soft scene with a base camera."""
-
-    base_camera: CameraCfg = FRANKA_CAMERA_CFG
-
-
 ##
 # MDP settings
 ##
@@ -412,57 +388,6 @@ class ObservationsCfg:
             self.concatenate_terms = True
 
     policy: PolicyCfg = PolicyCfg()
-
-
-@configclass
-class FrankaCameraObservationsCfg:
-    """Observation groups for visual deformable lifting."""
-
-    @configclass
-    class PolicyCfg(ObsGroup):
-        target_position = ObsTerm(func=mdp.generated_commands, params={"command_name": "deformable_pose"})
-        actions = ObsTerm(func=mdp.last_action)
-
-        def __post_init__(self) -> None:
-            self.enable_corruption = True
-            self.concatenate_terms = True
-
-    @configclass
-    class ProprioCfg(ObsGroup):
-        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
-        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
-
-        def __post_init__(self) -> None:
-            self.enable_corruption = True
-            self.concatenate_terms = True
-
-    @configclass
-    class PerceptionCfg(ObsGroup):
-        deformable_sampled_points = ObsTerm(
-            func=mdp.DeformableSampledPointsInRobotRootFrame,
-            params={"asset_cfg": SceneEntityCfg("deformable"), "num_points": 20},
-        )
-
-        def __post_init__(self) -> None:
-            self.enable_corruption = True
-            self.concatenate_terms = True
-
-    @configclass
-    class BaseImageCfg(ObsGroup):
-        image = ObsTerm(
-            func=env_mdp.image,
-            params={
-                "sensor_cfg": SceneEntityCfg("base_camera"),
-                "data_type": "rgb",
-                "normalize": True,
-                "permute": True,
-            },
-        )
-
-    policy: PolicyCfg = PolicyCfg()
-    proprio: ProprioCfg = ProprioCfg()
-    perception: PerceptionCfg = PerceptionCfg()
-    base_image: BaseImageCfg = BaseImageCfg()
 
 
 @configclass
@@ -617,18 +542,6 @@ class FrankaSoftSceneCfg(PresetCfg):
 
 
 @configclass
-class FrankaSoftCameraSceneCfg(PresetCfg):
-    """Scene presets for visual Franka soft lifting."""
-
-    newton_mjwarp_vbd_proxy: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(
-        num_envs=128, env_spacing=2.0, replicate_physics=True
-    )
-    physx: _FrankaSoftCameraSceneCfg = _FrankaSoftCameraSceneCfg(num_envs=128, env_spacing=2.0, replicate_physics=False)
-    isaacsim_physx = physx
-    default = newton_mjwarp_vbd_proxy
-
-
-@configclass
 class _FrankaSoftVisualizerCfg(VisualizerCfg):
     window_width: int = 1920
     window_height: int = 1080
@@ -671,16 +584,3 @@ class FrankaSoftEnvCfg(ManagerBasedRLEnvCfg):
         super().play_mode()
         if self.curriculum is not None:
             self.curriculum.gravity = None
-
-
-@configclass
-class FrankaSoftCameraEnvCfg(FrankaSoftEnvCfg):
-    """Visual Franka volume-deformable lifting environment."""
-
-    scene: FrankaSoftCameraSceneCfg = FrankaSoftCameraSceneCfg()
-    observations: FrankaCameraObservationsCfg = FrankaCameraObservationsCfg()
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        # Warm up the RTX render product/annotator (Newton skips the PhysX assets_loading render loop).
-        self.num_rerenders_on_reset = 2

--- a/source/isaaclab_tasks/test/benchmark/test_franka_deformable_camera_cfg.py
+++ b/source/isaaclab_tasks/test/benchmark/test_franka_deformable_camera_cfg.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for the Franka deformable camera benchmark task registrations."""
+
+import gymnasium as gym
+import pytest
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+_ENV_CFG_MODULE = "isaaclab_tasks.benchmark.franka_deformable_camera.franka_deformable_camera_env_cfg"
+_AGENT_CFG_MODULE = "isaaclab_tasks.benchmark.franka_deformable_camera.agents.rsl_rl_ppo_cfg"
+
+
+@pytest.mark.parametrize(
+    ("task_id", "cfg_name", "agent_name"),
+    [
+        ("Isaac-Lift-Cable-Franka-Camera", "FrankaCableCameraEnvCfg", "FrankaCableCameraPPORunnerCfg"),
+        ("Isaac-Lift-Cloth-Franka-Camera", "FrankaClothCameraEnvCfg", "FrankaDeformableCameraPPORunnerCfg"),
+        ("Isaac-Lift-Soft-Franka-Camera", "FrankaSoftCameraEnvCfg", "FrankaDeformableCameraPPORunnerCfg"),
+    ],
+)
+def test_deformable_camera_task_is_registered_from_benchmark_package(task_id: str, cfg_name: str, agent_name: str):
+    spec = gym.spec(task_id)
+
+    assert spec.kwargs["env_cfg_entry_point"] == f"{_ENV_CFG_MODULE}:{cfg_name}"
+    assert spec.kwargs["rsl_rl_cfg_entry_point"] == f"{_AGENT_CFG_MODULE}:{agent_name}"
+
+    env_cfg = load_cfg_from_registry(task_id, "env_cfg_entry_point")
+    agent_cfg = load_cfg_from_registry(task_id, "rsl_rl_cfg_entry_point")
+    assert type(env_cfg).__module__ == _ENV_CFG_MODULE
+    assert type(agent_cfg).__module__ == _AGENT_CFG_MODULE

--- a/source/isaaclab_tasks/test/core/test_environments_isaacsim_physx.py
+++ b/source/isaaclab_tasks/test/core/test_environments_isaacsim_physx.py
@@ -23,10 +23,8 @@ from env_test_utils import SINGLE_ENVIRONMENT_TASKS, _run_environments, setup_en
 
 _COVERED_TASKS = [
     "Isaac-Cartpole-Camera-Direct",  # Already covered by test_rendering_cartpole.py
-    "Isaac-Lift-Cloth-Franka-Camera",  # Already covered by test_rendering_franka_cloth.py
     "Isaac-Lift-KukaAllegro-Camera",  # Already covered by test_rendering_lift_kuka_hetero.py
     "Isaac-Lift-Soft-Franka",  # Temporarily excluded because it can crash the test process
-    "Isaac-Lift-Soft-Franka-Camera",  # Temporarily excluded because it can crash the test process
     "Isaac-Reorient-Cube-Shadow-Camera-Direct",  # Already covered by test_rendering_shadow_hand.py
     "Isaac-Velocity-Flat-AnymalD",  # Already covered by test_environment_determinism.py
     "Isaac-Velocity-Rough-AnymalD",  # Already covered by test_environment_determinism.py

--- a/source/isaaclab_tasks/test/core/test_rendering_franka_cable_partition_bounds.py
+++ b/source/isaaclab_tasks/test/core/test_rendering_franka_cable_partition_bounds.py
@@ -26,7 +26,7 @@ from isaaclab.envs import ManagerBasedRLEnv  # noqa: E402
 from isaaclab.sensors import Camera  # noqa: E402
 from isaaclab.utils.renderers import isaac_rtx_per_env_scene_partition_enabled  # noqa: E402
 
-from isaaclab_tasks.core.lift.config.franka_soft.franka_cable_env_cfg import (  # noqa: E402
+from isaaclab_tasks.benchmark.franka_deformable_camera.franka_deformable_camera_env_cfg import (  # noqa: E402
     FrankaCableCameraEnvCfg,
 )
 from isaaclab_tasks.utils.hydra import resolve_presets  # noqa: E402

--- a/source/isaaclab_tasks/test/rendering_test_utils.py
+++ b/source/isaaclab_tasks/test/rendering_test_utils.py
@@ -2192,7 +2192,9 @@ def rendering_test_franka_cloth(
 
     from isaaclab.envs import ManagerBasedRLEnv
 
-    from isaaclab_tasks.core.lift.config.franka_soft.franka_cloth_env_cfg import FrankaClothCameraEnvCfg
+    from isaaclab_tasks.benchmark.franka_deformable_camera.franka_deformable_camera_env_cfg import (
+        FrankaClothCameraEnvCfg,
+    )
 
     env_cfg = FrankaClothCameraEnvCfg()
 
@@ -2279,7 +2281,9 @@ def rendering_test_franka_soft(
 
     from isaaclab.envs import ManagerBasedRLEnv
 
-    from isaaclab_tasks.core.lift.config.franka_soft.franka_soft_env_cfg import FrankaSoftCameraEnvCfg
+    from isaaclab_tasks.benchmark.franka_deformable_camera.franka_deformable_camera_env_cfg import (
+        FrankaSoftCameraEnvCfg,
+    )
 
     env_cfg = FrankaSoftCameraEnvCfg()
 
@@ -2477,7 +2481,9 @@ def rendering_test_franka_cable(
 
     from isaaclab.envs import ManagerBasedRLEnv
 
-    from isaaclab_tasks.core.lift.config.franka_soft.franka_cable_env_cfg import FrankaCableCameraEnvCfg
+    from isaaclab_tasks.benchmark.franka_deformable_camera.franka_deformable_camera_env_cfg import (
+        FrankaCableCameraEnvCfg,
+    )
 
     env_cfg = FrankaCableCameraEnvCfg()
 


### PR DESCRIPTION
# Description

Moves the cable, cloth, and soft-body Franka camera benchmark tasks into the `isaaclab_tasks.benchmark` package introduced by #7702.

- Moves the camera task registrations and camera-specific environment, scene, observation, and preset configurations into `benchmark/franka_deformable_camera`.
- Moves the camera-only RSL-RL runner configurations alongside the benchmark tasks.
- Preserves all three environment IDs, presets, default agents, observation settings, and task behavior.
- Updates rendering-test imports and removes the camera benchmarks from core-task smoke-test exclusions.
- Adds focused registry-entrypoint coverage and a changelog migration note for direct Python imports.

No new dependencies are added.

## Type of change

- Code organization change. Registry-based loading is unchanged; direct Python import paths move from `isaaclab_tasks.core` to `isaaclab_tasks.benchmark`.

## Validation

Passed locally:

- `ruff check`
- `ruff format --check`
- Python bytecode compilation for every changed Python file
- Changelog-fragment validation against `upstream/develop`
- Isaac Lab skill validation
- AST equivalence checks for all 12 moved environment and agent definitions

Not run locally because the repository lockfile excludes this macOS host:

- Focused pytest for the new registry-entrypoint test
- `uv run isaaclab -f`
- Generated environment-list and documentation checks

The task IDs and presets are unchanged, so no generated environment-browser rows are expected to change. Linux CI should exercise the deferred checks.

## Checklist

- [x] I have read and followed the contribution guidelines.
- [x] I have added tests that prove the fix is effective or that the feature works.
- [x] I have added the required changelog fragment.
- [x] My contributor entry already exists in `CONTRIBUTORS.md`.
