### PR TITLE
[Docs] Carry v3.0.0 EA default policy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -85,6 +85,8 @@ jobs:
     needs: [doc-build-type]
     # run on deploy branches to create multi-version docs
     if: needs.doc-build-type.outputs.trigger-deploy == 'true'
+    env:
+      DOCS_DEFAULT_REF: v3.0.0-EA
 
     steps:
     - name: Checkout code
@@ -106,7 +108,7 @@ jobs:
       env:
         # "deploy" branches build the full set of versions so every page
         # has a complete version dropdown: main, develop, release/3.0.0, and
-        # tags >= v2.0.0 (including pre-release suffixes like -beta or -rc1).
+        # tags >= v2.0.0 (including pre-release suffixes like -beta, -rc1, or -EA).
         # v1.x tags and other release branches are excluded.
         SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0)$'
         SMV_TAG_WHITELIST: '^v[2-9]\d*\.\d+\.\d+(-[A-Za-z0-9.]+)?$'
@@ -116,18 +118,9 @@ jobs:
         git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
-    - name: Set default docs version
+    - name: Verify default docs version
       working-directory: ./docs
-      env:
-        DOCS_DEFAULT_REF: v3.0.0-beta2
-      run: |
-        test -n "$DOCS_DEFAULT_REF"
-        test -f "_build/$DOCS_DEFAULT_REF/index.html" || {
-          echo "::error::Default docs ref '$DOCS_DEFAULT_REF' was not built"
-          exit 1
-        }
-        sed "s|url=\./[^\"]*/index.html|url=./$DOCS_DEFAULT_REF/index.html|" \
-          _redirect/index.html > _build/index.html
+      run: grep -Fq "url=./$DOCS_DEFAULT_REF/index.html" _build/index.html
 
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@v4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,11 +7,14 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+DOCS_DEFAULT_REF ?= main
 
 .PHONY: multi-docs
 multi-docs:
 	@sphinx-multiversion "$(SOURCEDIR)" "$(BUILDDIR)" --jobs=auto $(SPHINXOPTS)
-	@cp _redirect/index.html $(BUILDDIR)/index.html
+	@test -f "$(BUILDDIR)/$(DOCS_DEFAULT_REF)/index.html" || \
+		(echo "Default docs ref '$(DOCS_DEFAULT_REF)' was not built" && exit 1)
+	@sed 's|__DOCS_DEFAULT_REF__|$(DOCS_DEFAULT_REF)|g' _redirect/index.html > $(BUILDDIR)/index.html
 
 .PHONY: current-docs
 current-docs:

--- a/docs/_redirect/index.html
+++ b/docs/_redirect/index.html
@@ -3,6 +3,6 @@
   <head>
     <title>Redirecting to the latest Isaac Lab documentation</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./main/index.html">
+    <meta http-equiv="refresh" content="0; url=./__DOCS_DEFAULT_REF__/index.html">
   </head>
 </html>

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -6,6 +6,7 @@ REM Command file to build Sphinx documentation
 
 set SOURCEDIR=.
 set BUILDDIR=_build
+if "%DOCS_DEFAULT_REF%" == "" set DOCS_DEFAULT_REF=main
 
 REM Check if a specific target was passed
 if "%1" == "multi-docs" (
@@ -26,10 +27,18 @@ if "%1" == "multi-docs" (
 		exit /b 1
 	)
 	%SPHINXBUILD% %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	if errorlevel 1 exit /b 1
 
-	REM Copy the redirect index.html to the build directory
-	copy _redirect\index.html %BUILDDIR%\index.html
-	goto end
+	if not exist "%BUILDDIR%\%DOCS_DEFAULT_REF%\index.html" (
+		echo Default docs ref '%DOCS_DEFAULT_REF%' was not built
+		exit /b 1
+	)
+
+	REM Render the redirect index.html using the selected default docs ref
+	powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; $template = [System.IO.File]::ReadAllText('_redirect\index.html'); $output = $template.Replace('__DOCS_DEFAULT_REF__', $env:DOCS_DEFAULT_REF); [System.IO.File]::WriteAllText('%BUILDDIR%\index.html', $output); exit 0"
+	if errorlevel 1 exit /b 1
+	popd
+	exit /b 0
 )
 
 if "%1" == "current-docs" (
@@ -63,3 +72,4 @@ echo.
 
 :end
 popd
+exit /b 0


### PR DESCRIPTION
## Summary

- make the multi-version docs landing page render from `DOCS_DEFAULT_REF`
- set `v3.0.0-EA` as the intended documentation default
- fail the build if the selected documentation version was not generated
- keep the Windows documentation build path in sync

## Cutover order

Merge this PR first. The `release/3.0.0` prep PR checks out `develop` for the multi-version documentation build and depends on this redirect behavior.

Do not merge the current-default or future-release prep PRs until the `v3.0.0-EA` tag exists. After all prep PRs are merged, change the repository default branch to `release/3.0.0` and manually dispatch the Docs workflow from that branch.

## Validation

- parsed all workflow YAML files
- exercised redirect generation with `DOCS_DEFAULT_REF=v3.0.0-EA`
- verified a missing default ref fails the build
- ran all applicable formatting, lint, YAML, spelling, and Git LFS checks
- verified the branch is based exactly on `upstream/develop`
- the full project-managed docs/formatter commands cannot resolve on macOS arm64 because the lockfile supports Linux and Windows; Linux PR CI remains the authoritative full build
