### PR TITLE
[Docs] Prepare v3.0.0 EA default on beta2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -80,6 +80,8 @@ jobs:
     needs: [doc-build-type]
     # run on deploy branches to create multi-version docs
     if: needs.doc-build-type.outputs.trigger-deploy == 'true'
+    env:
+      DOCS_DEFAULT_REF: v3.0.0-EA
 
     steps:
     - name: Checkout code
@@ -104,28 +106,19 @@ jobs:
       env:
         # "deploy" branches build the full set of versions so every page
         # has a complete version dropdown: main, develop, release/3.0.0,
-        # stable tags >= v2.0.0, and v3.0.0-beta2. Other release branches and
-        # prerelease tags are excluded.
+        # stable tags >= v2.0.0, v3.0.0-beta2, and v3.0.0-EA. Other release
+        # branches and prerelease tags are excluded.
         SMV_BRANCH_WHITELIST: '^(main|develop|release/3\.0\.0)$'
-        SMV_TAG_WHITELIST: '^v([2-9]\d*\.\d+\.\d+|3\.0\.0-beta2)$'
+        SMV_TAG_WHITELIST: '^v([2-9]\d*\.\d+\.\d+|3\.0\.0-(beta2|EA))$'
       run: |
         git fetch --prune --unshallow --tags
         git checkout --detach HEAD
         git for-each-ref --format="%(refname:short)" refs/heads/ | xargs -r git branch -D
         make multi-docs
 
-    - name: Set default docs version
+    - name: Verify default docs version
       working-directory: ./docs
-      env:
-        DOCS_DEFAULT_REF: v3.0.0-beta2
-      run: |
-        test -n "$DOCS_DEFAULT_REF"
-        test -f "_build/$DOCS_DEFAULT_REF/index.html" || {
-          echo "::error::Default docs ref '$DOCS_DEFAULT_REF' was not built"
-          exit 1
-        }
-        sed "s|url=\./[^\"]*/index.html|url=./$DOCS_DEFAULT_REF/index.html|" \
-          _redirect/index.html > _build/index.html
+      run: grep -Fq "url=./$DOCS_DEFAULT_REF/index.html" _build/index.html
 
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary

- add the exact-case `v3.0.0-EA` tag to the current default branch's multi-version docs set
- make `v3.0.0-EA` the documentation landing-page default
- use the Makefile-owned redirect rendering and verify the generated result before deployment
- continue excluding unrelated prerelease tags from this frozen release branch

## Why this branch is required

`release/3.0.0-beta2` remains the repository default until the cutover, so it currently owns the scheduled Docs workflow. This PR lets that workflow publish and select the EA tag before ownership moves to `release/3.0.0`.

## Cutover order

Merge the companion `develop` prep PR first, then create the exact-case `v3.0.0-EA` tag before merging this PR. Merge the future-release prep PR, change the repository default to `release/3.0.0`, and manually dispatch Docs from the new default branch.

## Validation

- full current-version documentation build passed
- parsed all workflow YAML files
- exercised redirect generation with `DOCS_DEFAULT_REF=v3.0.0-EA`
- verified a missing default ref fails the build
- ran all formatting, lint, YAML, and spelling checks
- verified the branch is based exactly on `upstream/release/3.0.0-beta2`
