### PR TITLE
[Docs] Fix develop README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-yellow.svg)](https://opensource.org/license/apache-2-0)
 
 
-This branch targets Isaac Sim 6.1. For installation instructions, see the
-[Isaac Lab documentation](https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html).
+This branch targets Isaac Sim 6.1. For release installation instructions, see the
+[Isaac Lab v3.0.0 EA documentation](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/installation/index.html).
 
 Note that this branch is currently under active development and may experience breaking changes or error messages.
 Performance issues and regressions may also be observed in some use cases.
@@ -47,13 +47,13 @@ Isaac Lab offers a comprehensive set of tools and environments designed to facil
 
 ### Documentation
 
-Our [documentation page](https://isaac-sim.github.io/IsaacLab) provides everything you need to get started, including
+Our [documentation page](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/) provides everything you need to get started, including
 detailed tutorials and step-by-step guides. Follow these links to learn more about:
 
-- [Installation steps](https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#local-installation)
-- [Reinforcement learning](docs/source/concepts/reinforcement_learning.rst)
-- [Tutorials](https://isaac-sim.github.io/IsaacLab/develop/source/tutorials/index.html)
-- [Available environments](https://isaac-sim.github.io/IsaacLab/develop/source/setup/environments.html)
+- [Installation steps](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/installation/index.html)
+- [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/concepts/reinforcement_learning.html)
+- [Tutorials and how-to guides](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/how-to/index.html)
+- [Available environments](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/environments.html)
 
 ## Performance Dashboard
 
@@ -74,7 +74,8 @@ dependency versions for Isaac Sim.
 | `release/3.0.0-beta2` branch  | Isaac Sim 6.0             |
 | `develop` branch              | Isaac Sim 6.1             |
 | `main` branch                 | Isaac Sim 4.5 / 5.0 / 5.1 |
-| `v3.0.0*`                     | Isaac Sim 6.0             |
+| `v3.0.0-EA` tag               | Isaac Sim 6.1             |
+| `v3.0.0-beta2*` tags          | Isaac Sim 6.0             |
 | `v2.3.X`                      | Isaac Sim 4.5 / 5.0 / 5.1 |
 | `v2.2.X`                      | Isaac Sim 4.5 / 5.0       |
 | `v2.1.X`                      | Isaac Sim 4.5             |
@@ -84,7 +85,7 @@ dependency versions for Isaac Sim.
 
 We wholeheartedly welcome contributions from the community to make this framework mature and useful for everyone.
 These may happen as bug reports, feature requests, or code contributions. For details, please check our
-[contribution guidelines](https://isaac-sim.github.io/IsaacLab/develop/source/refs/contributing.html).
+[contribution guidelines](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/refs/contributing.html).
 
 ## Show & Tell: Share Your Inspiration
 
@@ -101,7 +102,7 @@ innovation in robotics and simulation.
 
 ## Troubleshooting
 
-Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/develop/source/refs/troubleshooting.html) section for
+Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/refs/troubleshooting.html) section for
 common fixes or [submit an issue](https://github.com/isaac-sim/IsaacLab/issues).
 
 For issues related to Isaac Sim, we recommend checking its [documentation](https://docs.isaacsim.omniverse.nvidia.com/latest/index.html)

--- a/README.md
+++ b/README.md
@@ -71,11 +71,10 @@ dependency versions for Isaac Sim.
 | Isaac Lab Version             | Isaac Sim Version         |
 | ----------------------------- | ------------------------- |
 | `release/3.0.0` branch        | Isaac Sim 6.1             |
-| `release/3.0.0-beta2` branch  | Isaac Sim 6.0             |
 | `develop` branch              | Isaac Sim 6.1             |
 | `main` branch                 | Isaac Sim 4.5 / 5.0 / 5.1 |
 | `v3.0.0-EA` tag               | Isaac Sim 6.1             |
-| `v3.0.0-beta2*` tags          | Isaac Sim 6.0             |
+| `v3.0.0-beta2` tag            | Isaac Sim 6.0             |
 | `v2.3.X`                      | Isaac Sim 4.5 / 5.0 / 5.1 |
 | `v2.2.X`                      | Isaac Sim 4.5 / 5.0       |
 | `v2.1.X`                      | Isaac Sim 4.5             |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-yellow.svg)](https://opensource.org/license/apache-2-0)
 
 
-This branch targets Isaac Sim 6.1. For release installation instructions, see the
-[Isaac Lab v3.0.0 EA documentation](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/installation/index.html).
+This branch targets Isaac Sim 6.1. For installation instructions, see the
+[Isaac Lab documentation](https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html).
 
 Note that this branch is currently under active development and may experience breaking changes or error messages.
 Performance issues and regressions may also be observed in some use cases.
@@ -47,13 +47,13 @@ Isaac Lab offers a comprehensive set of tools and environments designed to facil
 
 ### Documentation
 
-Our [documentation page](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/) provides everything you need to get started, including
+Our [documentation page](https://isaac-sim.github.io/IsaacLab/develop/) provides everything you need to get started, including
 detailed tutorials and step-by-step guides. Follow these links to learn more about:
 
-- [Installation steps](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/installation/index.html)
-- [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/concepts/reinforcement_learning.html)
-- [Tutorials and how-to guides](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/how-to/index.html)
-- [Available environments](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/setup/environments.html)
+- [Installation steps](https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html)
+- [Reinforcement learning](https://isaac-sim.github.io/IsaacLab/develop/source/concepts/reinforcement_learning.html)
+- [Tutorials and how-to guides](https://isaac-sim.github.io/IsaacLab/develop/source/how-to/index.html)
+- [Available environments](https://isaac-sim.github.io/IsaacLab/develop/source/setup/environments.html)
 
 ## Performance Dashboard
 
@@ -84,7 +84,7 @@ dependency versions for Isaac Sim.
 
 We wholeheartedly welcome contributions from the community to make this framework mature and useful for everyone.
 These may happen as bug reports, feature requests, or code contributions. For details, please check our
-[contribution guidelines](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/refs/contributing.html).
+[contribution guidelines](https://isaac-sim.github.io/IsaacLab/develop/source/refs/contributing.html).
 
 ## Show & Tell: Share Your Inspiration
 
@@ -101,7 +101,7 @@ innovation in robotics and simulation.
 
 ## Troubleshooting
 
-Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/v3.0.0-EA/source/refs/troubleshooting.html) section for
+Please see the [troubleshooting](https://isaac-sim.github.io/IsaacLab/develop/source/refs/troubleshooting.html) section for
 common fixes or [submit an issue](https://github.com/isaac-sim/IsaacLab/issues).
 
 For issues related to Isaac Sim, we recommend checking its [documentation](https://docs.isaacsim.omniverse.nvidia.com/latest/index.html)


### PR DESCRIPTION
## Summary

- keep the `develop` README documentation links on the published `develop` documentation
- replace the repository-source RL link with the published reinforcement-learning page
- replace the obsolete Tutorials landing page with the current tutorials and how-to index
- remove the deleted `#local-installation` anchor
- replace the beta2 release-branch compatibility entry with the exact `v3.0.0-beta2` tag

## Cutover note

The compatibility table records the planned `v3.0.0-EA` tag, but this branch's README links intentionally continue to track `/develop/` before and after `develop` becomes the repository default.

The release-specific counterpart is #7771, whose links point to the immutable `/v3.0.0-EA/` documentation.

## Type of change

- Documentation update

## Validation

- verified every linked `develop` documentation URL returns HTTP 200
- verified every linked page source exists on both `develop` and `release/3.0.0`
- verified all local README targets exist
- passed the applicable pre-commit formatting, spelling, and Git LFS checks
- `uv run --isolated --extra test -- make -C docs current-docs` and `uv run isaaclab -f` cannot resolve on macOS arm64 because the project lockfile supports Linux and Windows; PR CI remains the authoritative full check

No package source changed, so no changelog fragment is required.
