### PR TITLE
[Fix] AppLauncher: leave SIGSEGV/SIGABRT dispositions untouched

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Guidelines for modifications:
 * Diego Ferigo
 * Dongxuan Fan
 * Dorsa Rohani
+* Dundy Pasupuleti
 * Ege Sekkin
 * Emily Sturman
 * Emmanuel Ferdman

--- a/source/isaaclab/changelog.d/fix-applauncher-fatal-signal-defaults.rst
+++ b/source/isaaclab/changelog.d/fix-applauncher-fatal-signal-defaults.rst
@@ -1,0 +1,6 @@
+Fixed
+^^^^^
+
+* Fixed :class:`~isaaclab.app.AppLauncher` registering a Python handler for
+  ``SIGABRT``. fatal signals stay at ``SIG_DFL`` so crashes terminate and can
+  produce core dumps; graceful shutdown remains on ``SIGTERM`` only.

--- a/source/isaaclab/changelog.d/fix-applauncher-fatal-signal-defaults.rst
+++ b/source/isaaclab/changelog.d/fix-applauncher-fatal-signal-defaults.rst
@@ -2,5 +2,5 @@ Fixed
 ^^^^^
 
 * Fixed :class:`~isaaclab.app.AppLauncher` registering a Python handler for
-  ``SIGABRT``. fatal signals stay at ``SIG_DFL`` so crashes terminate and can
-  produce core dumps; graceful shutdown remains on ``SIGTERM`` only.
+  ``SIGABRT``. fatal-signal dispositions are left untouched (default or
+  carb's crash handler); graceful shutdown remains on ``SIGTERM`` only.

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1535,15 +1535,15 @@ class AppLauncher:
 
         * Normal exit: the ``atexit`` hook closes the app once; a pending unhandled
           exception turns into exit code 1.
-        * ``SIGTERM`` / ``kill -ABRT``: ``close(exit_code=128 + signum)`` — full
-          teardown before exiting on isaacsim.simulation_app >= 2.18.5, truthful
-          status either way; if ``close()`` returns (fast shutdown disabled),
-          re-raise the signal with the default action.
+        * ``SIGTERM``: ``close(exit_code=128 + signum)``; full teardown before
+          exiting on isaacsim.simulation_app >= 2.18.5, truthful status either way;
+          if ``close()`` returns (fast shutdown disabled), re-raise the signal with
+          the default action.
         * Signal during a running close: fall back to the default action instead of
           re-entering ``close()``, which previously recursed until stack overflow.
-        * ``SIGSEGV``: not intercepted — a Python handler cannot run for main-thread
-          faults, reports success for worker-thread faults, and suppresses the carb
-          crash reporter's minidumps.
+        * ``SIGSEGV`` / ``SIGABRT``: not intercepted; left at ``SIG_DFL`` so fatal
+          faults terminate and can produce core dumps. a python handler that returns
+          from ``SIGSEGV`` re-faults forever and suppresses carb crash minidumps.
         * ``SIGINT``: Python's default handler, so Ctrl-C unwinds user code and
           exits nonzero.
 
@@ -1579,8 +1579,9 @@ class AppLauncher:
             # close on normal exit so Kit shuts down cleanly instead of via __del__
             atexit.register(self._close_at_exit)
             signal.signal(signal.SIGTERM, self._on_abort_signal)
-            signal.signal(signal.SIGABRT, self._on_abort_signal)
-            # no SIGSEGV handler and default SIGINT — see the class docstring
+            # leave SIGSEGV/SIGABRT at SIG_DFL; a python handler that returns from a
+            # synchronous fault re-executes forever and suppresses core dumps.
+            # restore default SIGINT so ctrl-c unwinds user code; see the class docstring
             signal.signal(signal.SIGINT, signal.default_int_handler)
 
         def _close_at_exit(self):
@@ -1593,7 +1594,7 @@ class AppLauncher:
                 self._close_app(exit_code)
 
         def _on_abort_signal(self, signum, frame):
-            """Handle SIGTERM/SIGABRT: close the app once, then die by the signal."""
+            """Handle SIGTERM: close the app once, then die by the signal."""
             if self._closing:
                 signal.signal(signum, signal.SIG_DFL)
                 signal.raise_signal(signum)

--- a/source/isaaclab/isaaclab/app/app_launcher.py
+++ b/source/isaaclab/isaaclab/app/app_launcher.py
@@ -1541,9 +1541,12 @@ class AppLauncher:
           the default action.
         * Signal during a running close: fall back to the default action instead of
           re-entering ``close()``, which previously recursed until stack overflow.
-        * ``SIGSEGV`` / ``SIGABRT``: not intercepted; left at ``SIG_DFL`` so fatal
-          faults terminate and can produce core dumps. a python handler that returns
-          from ``SIGSEGV`` re-faults forever and suppresses carb crash minidumps.
+        * ``SIGSEGV`` / ``SIGABRT``: not intercepted; dispositions are left
+          untouched (default or carb's crash handler). a python ``SIGSEGV``
+          handler that returns re-faults forever and suppresses carb crash
+          minidumps. the former ``SIGABRT`` handler restored ``SIG_DFL`` and
+          re-raised, so skipping registration leaves abort to the existing
+          disposition instead of a graceful-teardown path.
         * ``SIGINT``: Python's default handler, so Ctrl-C unwinds user code and
           exits nonzero.
 
@@ -1579,8 +1582,10 @@ class AppLauncher:
             # close on normal exit so Kit shuts down cleanly instead of via __del__
             atexit.register(self._close_at_exit)
             signal.signal(signal.SIGTERM, self._on_abort_signal)
-            # leave SIGSEGV/SIGABRT at SIG_DFL; a python handler that returns from a
-            # synchronous fault re-executes forever and suppresses core dumps.
+            # leave SIGSEGV/SIGABRT untouched (default or carb's crash handler);
+            # skipping signal.signal does not install SIG_DFL. a python SIGSEGV
+            # handler that returns re-executes the fault forever; the former
+            # SIGABRT handler restored SIG_DFL and re-raised.
             # restore default SIGINT so ctrl-c unwinds user code; see the class docstring
             signal.signal(signal.SIGINT, signal.default_int_handler)
 

--- a/source/isaaclab/test/app/test_simulation_app_lifecycle.py
+++ b/source/isaaclab/test/app/test_simulation_app_lifecycle.py
@@ -161,12 +161,15 @@ def test_atexit_close_falls_back_when_exit_code_unsupported(capfd):
     assert calls == [1]
     assert "does not accept exit_code" in capfd.readouterr().err
 
-def test_install_exit_handlers_leaves_fatal_signals_at_default(monkeypatch):
-    """SIGSEGV and SIGABRT must stay at SIG_DFL; only SIGTERM gets a custom handler.
 
-    Regression for issue #7774: a python SIGSEGV handler that returns re-faults
-    forever with no core dump. SIGABRT is left at the default disposition for the
-    same reason; graceful teardown stays on SIGTERM only.
+def test_install_exit_handlers_leaves_fatal_signals_at_default(monkeypatch):
+    """AppLauncher must not register SIGSEGV or SIGABRT; only SIGTERM gets a custom handler.
+
+    Regression for issue #7774: skipping signal.signal leaves those dispositions
+    untouched (default or carb's crash handler) rather than establishing SIG_DFL.
+    a python SIGSEGV handler that returns re-faults forever with no core dump;
+    the former SIGABRT handler restored SIG_DFL and re-raised. graceful teardown
+    stays on SIGTERM only.
     """
     actions = _capture_signal_actions(monkeypatch)
     lifecycle = _make_lifecycle(lambda exit_code=0: None)

--- a/source/isaaclab/test/app/test_simulation_app_lifecycle.py
+++ b/source/isaaclab/test/app/test_simulation_app_lifecycle.py
@@ -160,3 +160,33 @@ def test_atexit_close_falls_back_when_exit_code_unsupported(capfd):
 
     assert calls == [1]
     assert "does not accept exit_code" in capfd.readouterr().err
+
+def test_install_exit_handlers_leaves_fatal_signals_at_default(monkeypatch):
+    """SIGSEGV and SIGABRT must stay at SIG_DFL; only SIGTERM gets a custom handler.
+
+    Regression for issue #7774: a python SIGSEGV handler that returns re-faults
+    forever with no core dump. SIGABRT is left at the default disposition for the
+    same reason; graceful teardown stays on SIGTERM only.
+    """
+    actions = _capture_signal_actions(monkeypatch)
+    lifecycle = _make_lifecycle(lambda exit_code=0: None)
+    monkeypatch.setattr(
+        "isaaclab.app.app_launcher.atexit.register",
+        lambda callback: actions.append(("atexit", callback)),
+    )
+
+    lifecycle.install_exit_handlers()
+
+    registered = {
+        signum: handler
+        for action in actions
+        if action[0] == "set_handler"
+        for _, signum, handler in (action,)
+    }
+    assert signal.SIGTERM in registered
+    assert registered[signal.SIGTERM] == lifecycle._on_abort_signal
+    assert signal.SIGSEGV not in registered
+    assert signal.SIGABRT not in registered
+    assert registered.get(signal.SIGINT) == signal.default_int_handler
+    assert any(action[0] == "atexit" for action in actions)
+


### PR DESCRIPTION
# Description

`AppLauncher` previously registered a Python signal handler for `SIGABRT`
(and historically for `SIGSEGV`). returning from a Python `SIGSEGV` handler
re-executes the faulting instruction forever: the process spins, produces no
core dump, and cannot be stopped with `SIGTERM`. the former `SIGABRT` handler
restored `SIG_DFL` and re-raised rather than returning.

on `develop`, `#6636` already stopped intercepting `SIGSEGV`. this PR extends
that fatal-signal policy to `SIGABRT` as well: leave both untouched (default
or carb's crash handler), and keep graceful teardown on `SIGTERM` only via
`_on_abort_signal`. skipping `signal.signal` does not install `SIG_DFL`.

no `faulthandler.enable()` call was added; the project already enables
faulthandler for tests via `PYTHONFAULTHANDLER` in `tools/conftest.py`.

related open PR `#6531` only changes `SIGTERM` handling and is complementary;
it does not conflict with leaving fatal-signal dispositions untouched.

Fixes #7774

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Release backport

- [x] <!-- backport-active-release --> Backport this pull request to the active release branch after it merges into `develop`

## Validation

### Unit tests (kitless)

```bash
PYTHONPATH=source/isaaclab pytest \
  source/isaaclab/test/app/test_simulation_app_lifecycle.py -q
```

```text
.......                                                                  [100%]
7 passed in 0.05s
```

### Changelog

```bash
uv run python tools/changelog/cli.py check develop
```

```text
✓ All modified packages have valid changelog fragments.
```

### Gaps

- full Isaac Sim runtime not available in this environment; did not re-run the
  integration test in `test_app_launcher_exit_status.py` (needs Kit/`SimulationApp`).
- did not reproduce a live `ctypes.string_at(1)` segfault under AppLauncher here;
  the unit test locks the registration policy that causes the hang.
- `main` / `release/3.0.0-beta2` still use the pre-`#6636` signal registration
  pattern; a clean backport of this diff targets `develop`/`release/3.0.0`
  lifecycle code.

## Checklist

- [x] I have read and understood the [contribution guidelines](https://isaac-sim.github.io/IsaacLab/main/source/refs/contributing.html)
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./isaaclab.sh --format`
- [x] I have made corresponding changes to the documentation (no public docs change; changelog fragment added)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changelog fragment under `source/isaaclab/changelog.d/`
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there